### PR TITLE
[feature] homepage link goes to latest version

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
       <div class="product-holder" id="product-{{ .identifier }}">
         <div class="mask"></div>
         <div class="content">
-          <a class="homepage-product" href="/{{ .identifier }}/"><span class="product-title">{{ .name }}</span>
+          <a class="homepage-product" href="/{{ .identifier }}/{{ .latest }}"><span class="product-title">{{ .name }}</span>
             <span class="description">
               <br>
               {{ .description }}


### PR DESCRIPTION
## What is this change?
Closes #29  

Clicking the links on the homepage will now take you to the latest version defined in the `config.toml`.

## Why is this change necessary?
The previous page you were directed to brought you to a listing of all versions. Most people will just want the latest version.

## Reviewer Notes
N/A

## Were there any complications while making this change?
None, this was a simple one line change.