### PR TITLE
[feature] remove redundant material theme notice

### DIFF
--- a/layouts/_default/index-2.html
+++ b/layouts/_default/index-2.html
@@ -41,16 +41,6 @@
         </div>
       </div>
 
-      <aside class="copyright" role="note">
-        {{ with .Site.Params.copyright }}
-          &copy; {{ now.Format "2006" }} {{ . }} &ndash;
-        {{ end }}
-        Documentation built with
-        <a href="https://www.gohugo.io" target="_blank">Hugo</a>
-        using the
-        <a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">Material</a> theme.
-      </aside>
-
       <footer class="footer">
         {{ partial "footer" . }}
       </footer>

--- a/layouts/_default/index-3.html
+++ b/layouts/_default/index-3.html
@@ -28,16 +28,6 @@
         
         {{ .Content }}
         
-      <aside class="copyright" role="note">
-        {{ with .Site.Params.copyright }}
-          &copy; {{ now.Format "2006" }} {{ . }} &ndash;
-        {{ end }}
-        Documentation built with
-        <a href="https://www.gohugo.io" target="_blank">Hugo</a>
-        using the
-        <a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">Material</a> theme.
-      </aside>
-
       <footer class="footer">
         {{ partial "footer" . }}
       </footer>

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -39,16 +39,6 @@
         </div>
       </div>
 
-      <aside class="copyright" role="note">
-        {{ with .Site.Params.copyright }}
-          &copy; {{ now.Format "2006" }} {{ . }} &ndash;
-        {{ end }}
-        Documentation built with
-        <a href="https://www.gohugo.io" target="_blank">Hugo</a>
-        using the
-        <a href="http://github.com/digitalcraftsman/hugo-material-docs" target="_blank">Material</a> theme.
-      </aside>
-
       <footer class="footer">
         {{ partial "footer" . }}
       </footer>


### PR DESCRIPTION
The footer content was updated, but some of the landing pages didn't have it removed from it's previous location