### PR TITLE
make handle_when page match menu used by other built-in filters

### DIFF
--- a/content/sensu-enterprise/2.6/filters/handle-when.md
+++ b/content/sensu-enterprise/2.6/filters/handle-when.md
@@ -4,7 +4,9 @@ description: "The handle_when Enterprise filter is used to reduce notification n
 product: "Sensu Enterprise"
 version: "2.6"
 weight: 1
-menu: "sensu-enterprise-2.6"
+menu:
+  sensu-enterprise-2.6:
+    parent: filters
 ---
 **ENTERPRISE: Built-in filters are available for [Sensu Enterprise][0]
 users only.**

--- a/content/sensu-enterprise/2.7/filters/handle-when.md
+++ b/content/sensu-enterprise/2.7/filters/handle-when.md
@@ -4,7 +4,9 @@ description: "The handle_when Enterprise filter is used to reduce notification n
 product: "Sensu Enterprise"
 version: "2.7"
 weight: 1
-menu: "sensu-enterprise-2.7"
+menu:
+  sensu-enterprise-2.7:
+    parent: filters
 ---
 **ENTERPRISE: Built-in filters are available for [Sensu Enterprise][0]
 users only.**


### PR DESCRIPTION
prevents handle_when from showing up as a top-level link in the enterprise documentation menu