### PR TITLE
redirect to docs.uchiwa.io instead of top-level site

### DIFF
--- a/content/uchiwa/1.0/_index.md
+++ b/content/uchiwa/1.0/_index.md
@@ -7,4 +7,4 @@ menu: "uchiwa-1.0"
 layout: "base-for-directory-listing"
 ---
 
-{{< redirect "https://uchiwa.io" >}}
+{{< redirect "https://docs.uchiwa.io" >}}

--- a/content/uchiwa/_index.md
+++ b/content/uchiwa/_index.md
@@ -7,4 +7,4 @@ menu: "uchiwa"
 layout: "product-versions"
 ---
 
-{{< redirect "https://uchiwa.io" >}}
+{{< redirect "https://docs.uchiwa.io" >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,7 +39,7 @@
         <div class="content">
           {{ $.Scratch.Set "url" "" }}
           {{ if eq .identifier "uchiwa" }}
-            {{ $.Scratch.Set "url" "https://uchiwa.io/" }}
+            {{ $.Scratch.Set "url" "https://docs.uchiwa.io/" }}
           {{ else }}
             {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
           {{ end }}

--- a/layouts/partials/productVersionDrawer.html
+++ b/layouts/partials/productVersionDrawer.html
@@ -37,7 +37,7 @@
         {{ range sort .Site.Params.Products "weight" }} 
           {{ $.Scratch.Set "url" "" }}
           {{ if eq .identifier "uchiwa" }}
-            {{ $.Scratch.Set "url" "https://uchiwa.io/" }}
+            {{ $.Scratch.Set "url" "https://docs.uchiwa.io/" }}
           {{ else }}
             {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
           {{ end }}

--- a/layouts/partials/productVersionDropdown.html
+++ b/layouts/partials/productVersionDropdown.html
@@ -37,7 +37,7 @@
         {{ range sort .Site.Params.Products "weight" }} 
           {{ $.Scratch.Set "url" "" }}
           {{ if eq .identifier "uchiwa" }}
-            {{ $.Scratch.Set "url" "https://uchiwa.io/" }}
+            {{ $.Scratch.Set "url" "https://docs.uchiwa.io/" }}
           {{ else }}
             {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
           {{ end }}


### PR DESCRIPTION
After merging #87 I realized we want to link directly to the Uchiwa docs site.

This PR changes links to https://uchiwa.io to https://docs.uchiwa.io so that folks will find docs instead of landing page.