### PR TITLE
[config] set enableRobotsTXT to true

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,8 +6,8 @@ metadataformat = "yaml"
 canonifyURLs = true
 # Enable Google Analytics by entering your tracking id
 googleAnalytics = "UA-39138312-17"
-
-pygmentsUseClasses=true
+enableRobotsTXT = true
+pygmentsUseClasses = true
 ignoreFiles = [ "sensu-doc-template.md" ]
 
 [["menu.sensu-core-1.0"]]


### PR DESCRIPTION
We're currently logging a lot of 404s for `robots.txt`. This isn't functionally a problem but it would be nice to see fewer of these.

This change configures Hugo to generate its default `robots.txt` with the following content:

```
User-agent: *
```

This will allow any search engine to index the docs, functionally the same as having no `robots.txt`.

Per https://gohugo.io/templates/robots/ we can further customize this using a layout template, should the need arise.