### PR TITLE
Implement GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
 *.js    @sensu/services
+
+# Sensu Plugins documentation.
+
+/content/plugins/*      @sensu/plugin-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @sensu/success
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+*.js    @sensu/services


### PR DESCRIPTION
This pull-request adds a GitHub [CODEOWNERS file](https://help.github.com/articles/about-codeowners/), defining which individuals and/or teams are responsible for what documentation in the project.