### PR TITLE
Dismissible & customizable alert banner

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -61,6 +61,12 @@
   {{ $params := slice "#cc7d7c" $message $link }}
   {{ partial "alert" $params }}
 {{ end }}
+{{ $params2 := slice "#000" "I'm a second alert!" }}
+{{ partial "alert" $params2 }}
+{{ $params3 := slice "#81c000" "I'm a third alert!" }}
+{{ partial "alert" $params3 }}
+{{ $params4 := slice "#fff" "I'm a fourth alert!" }}
+{{ partial "alert" $params4 }}
 
 <script>
 $( document ).ready(function() {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -52,13 +52,15 @@
 </footer>
 
 
+<!-- May not render, used for old versions,  -->
 {{ $product := .Section }}
 {{ $product2 := replace $product "-" "_" }}
 {{ $product_info := (index .Site.Params.products $product2) }}
 {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
-  <div class="versionBanner">
-    <a class="versionBannerText" href="/{{ .Section }}/{{ $product_info.latest }}/">You're viewing documentation for an older or pre-release version of {{ .Params.product }}. Click here for the latest.</a>
-  </div>
+  {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
+  {{ $link := (printf "/%s/%s/" .Section $product_info.latest) }}
+  {{ $params := slice "#000" $message $link }}
+  {{ partial "alert" $params }}
 {{ end }}
 
 <script>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -57,8 +57,8 @@
 {{ $product_info := (index .Site.Params.products $product2) }}
 {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
   {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
-  {{ $link := (printf "/%s/%s/" .Section $product_info.latest) }}
-  {{ $params := slice "#cc7d7c" $message  }}
+  {{ $link := replace .URL .Params.version $product_info.latest }}
+  {{ $params := slice "#cc7d7c" $message $link  }}
   {{ partial "alert" $params }}
 {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -58,7 +58,7 @@
 {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
   {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
   {{ $link := replace .URL .Params.version $product_info.latest }}
-  {{ $params := slice "#cc7d7c" $message $link  }}
+  {{ $params := slice "#cc7d7c" $message $link }}
   {{ partial "alert" $params }}
 {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,17 +51,6 @@
   {{ partial "footer" . }}
 </footer>
 
-<!-- May not render, used for old/pre release versions -->
-{{ $product := .Section }}
-{{ $product2 := replace $product "-" "_" }}
-{{ $product_info := (index .Site.Params.products $product2) }}
-{{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
-  {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
-  {{ $link := replace .URL .Params.version $product_info.latest }}
-  {{ $params := slice "#cc7d7c" $message $link }}
-  {{ partial "alert" $params }}
-{{ end }}
-
 <script>
 $( document ).ready(function() {
   // select all heading with an ID attribute

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,7 +51,6 @@
   {{ partial "footer" . }}
 </footer>
 
-
 <!-- May not render, used for old versions,  -->
 {{ $product := .Section }}
 {{ $product2 := replace $product "-" "_" }}
@@ -59,7 +58,7 @@
 {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
   {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
   {{ $link := (printf "/%s/%s/" .Section $product_info.latest) }}
-  {{ $params := slice "#000" $message $link }}
+  {{ $params := slice "#cc7d7c" $message  }}
   {{ partial "alert" $params }}
 {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,7 +51,7 @@
   {{ partial "footer" . }}
 </footer>
 
-<!-- May not render, used for old versions,  -->
+<!-- May not render, used for old/pre release versions -->
 {{ $product := .Section }}
 {{ $product2 := replace $product "-" "_" }}
 {{ $product_info := (index .Site.Params.products $product2) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -61,12 +61,6 @@
   {{ $params := slice "#cc7d7c" $message $link }}
   {{ partial "alert" $params }}
 {{ end }}
-{{ $params2 := slice "#000" "I'm a second alert!" }}
-{{ partial "alert" $params2 }}
-{{ $params3 := slice "#81c000" "I'm a third alert!" }}
-{{ partial "alert" $params3 }}
-{{ $params4 := slice "#fff" "I'm a fourth alert!" }}
-{{ partial "alert" $params4 }}
 
 <script>
 $( document ).ready(function() {

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -5,8 +5,17 @@
 <div class="alertBanner" style="background-color: {{ $color }}">
   {{ if $link }}
     <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
   {{ else }}
     <span class="alertBannerText">{{ $message }}</span>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
   {{ end }}
 </div>
 
+
+<script>
+  function closeAlert() {
+    var $banner = document.getElementsByClassName("alertBanner");
+    $banner[0].style.display = 'none';
+  }
+</script>

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -2,11 +2,11 @@
 {{ $message := index . 1 }}
 {{ $link := index . 2 }}
 
-<div class="versionBanner" style="background-color: {{ $color }}">
+<div class="alertBanner" style="background-color: {{ $color }}">
   {{ if $link }}
-    <a class="versionBannerText" href="{{ $link }}">{{ $message }}</a>
+    <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
   {{ else }}
-    <span class="versionBannerText">{{ $message }}</span>
+    <span class="alertBannerText">{{ $message }}</span>
   {{ end }}
 </div>
 

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -18,11 +18,13 @@
 <script>
   alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
   currentBanner = $(document.getElementById({{ $uniqueness }}));
+  // 10px is a small hack for different screen sizes
+  // semi-breaks if you're scaling the page large to small, but is fine on refresh
+  height = currentBanner.height() + 10;
 
   // stack the alerts as needed
   for (i = 1; i <= alerts.length; i++) {
     lastLocation = parseInt($(alerts[i]).css('top'), 10);
-    height = 28;
     newLocation = lastLocation + height;
     currentBanner.css('top', newLocation + "px");
     // double incrementing is a little weird, but we get gaps otherwise
@@ -39,10 +41,8 @@
 
     // unstack the alerts as needed
     for (i = arrLocation + 1; i <= alerts.length; i++){
-      height = 28;
       (i == arrLocation + 1) ? newLocation = lastLocation : newLocation = lastLocation + height;
       lastLocation = newLocation;
-      console.log(i);
       $(alerts[i]).css('top', newLocation + "px");
     };
   }

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -2,20 +2,46 @@
 {{ $message := index . 1 }}
 {{ $link := index . 2 }}
 
-<div class="alertBanner" style="background-color: {{ $color }}">
+<!-- creates a unique id if there's multiple alerts -->
+{{ $uniqueness := replace $message " " "" }}
+
+<div class="alertBanner" id="{{ $uniqueness }}" style="background-color: {{ $color }}">
   {{ if $link }}
     <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
   {{ else }}
     <span class="alertBannerText">{{ $message }}</span>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
   {{ end }}
 </div>
 
-
 <script>
-  function closeAlert() {
-    var $banner = document.getElementsByClassName("alertBanner");
-    $banner[0].style.display = 'none';
+  alerts = document.getElementsByClassName("alertBanner");
+  i = 0;
+  // stack the alerts as needed
+  Array.prototype.forEach.call(alerts, alert => {
+    lastLocation = parseInt($(alerts[i]).css('top'), 10);
+    height = 28;
+    (i == 0) ? newLocation = lastLocation : newLocation = lastLocation + height;
+    alert.style.top = newLocation + "px";
+    i++;
+  });
+
+  function closeAlert(id) {
+    currentBanner = $(document.getElementById(id));
+    lastLocation = parseInt(currentBanner.css('top'), 10);
+    document.getElementById(id).remove();
+
+    alerts = document.getElementsByClassName("alertBanner");
+    i = 0;
+    // unstack the alerts as needed
+    Array.prototype.forEach.call(alerts, alert => {
+      // wat am I doing
+      (i == 0) ? lastLocation = lastLocation : lastLocation = parseInt($(alerts[i]).css('top'), 10);
+      height = 28;
+      (i == 0) ? newLocation = lastLocation : newLocation = lastLocation - height;
+      alert.style.top = newLocation + "px";
+      i++;
+    });
   }
 </script>

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -4,46 +4,36 @@
 
 <!-- creates a "mostly" unique id if there's multiple alerts -->
 {{ $uniqueness := replace $message " " "" }}
-
-<div class="alertBanner" id="{{ $uniqueness }}" style="background-color: {{ $color }}">
-  {{ if $link }}
-    <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
-  {{ else }}
-    <span class="alertBannerText">{{ $message }}</span>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
-  {{ end }}
-</div>
+{{ $uniqueness := replace $uniqueness "'" "" }}
 
 <script>
-  alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
-  currentBanner = $(document.getElementById({{ $uniqueness }}));
-  // 10px is a small hack for different screen sizes
-  // semi-breaks if you're scaling the page large to small, but is fine on refresh
-  height = currentBanner.height() + 10;
-
-  // stack the alerts as needed
-  for (i = 1; i <= alerts.length; i++) {
-    lastLocation = parseInt($(alerts[i]).css('top'), 10);
-    newLocation = lastLocation + height;
-    currentBanner.css('top', newLocation + "px");
-    // double incrementing is a little weird, but we get gaps otherwise
-    i++;
-  };
-
+  // close the alert
   function closeAlert(id) {
-    // grab information before delete
-    alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
-    currentBanner = $(document.getElementById(id));
-    arrLocation = alerts.findIndex(alert => alert.id == currentBanner[0].id);
-    lastLocation = parseInt(currentBanner.css('top'), 10);
-    document.getElementById(id).remove();
+    // remove additional margin so we don't leave empty space
+    currentPos = parseInt($(".main").css('margin-top'), 10);
+    $(".main").css('margin-top', currentPos - 28);
 
-    // unstack the alerts as needed
-    for (i = arrLocation + 1; i <= alerts.length; i++){
-      (i == arrLocation + 1) ? newLocation = lastLocation : newLocation = lastLocation + height;
-      lastLocation = newLocation;
-      $(alerts[i]).css('top', newLocation + "px");
-    };
+    // remove the alert
+    document.getElementById(id).remove();
   }
+
+  $(document).ready(function() {
+    // build the alert if it has a link or not
+    alertElement = "<div class='alertBanner' id='{{ $uniqueness }}' style='background-color: {{ $color }}'>";
+    {{ if $link }}
+      alertElement += "<a class='alertBannerText' href='{{ $link }}'>{{ $message }}</a>";
+    {{ else }}
+      alertElement += "<span class='alertBannerText'>{{ $message }}</span>";
+    {{ end }}
+      alertElement += "<span class='closeAlert'>" +
+              "<i class='fa fa-times' aria-hidden='true' onClick='closeAlert(\"{{ $uniqueness }}\")'></i>" +
+              "</span></div>";
+
+    // append the alert to the alert section
+    $("#alertSection").append(alertElement);
+
+    // add additional margin so we don't cover page content
+    currentPos = parseInt($(".main").css("margin-top"), 10);
+    $(".main").css("margin-top", currentPos + 28);
+  });
 </script>

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -25,6 +25,7 @@
     height = 28;
     newLocation = lastLocation + height;
     currentBanner.css('top', newLocation + "px");
+    // double incrementing is a little weird, but we get gaps otherwise
     i++;
   };
 

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,7 +1,12 @@
+{{ $color := index . 0 }}
 {{ $message := index . 1 }}
 {{ $link := index . 2 }}
 
-<div class="versionBanner">
-  <a class="versionBannerText" href="{{ $link }}">{{ $message }}</a>
+<div class="versionBanner" style="background-color: {{ $color }}">
+  {{ if $link }}
+    <a class="versionBannerText" href="{{ $link }}">{{ $message }}</a>
+  {{ else }}
+    <span class="versionBannerText">{{ $message }}</span>
+  {{ end }}
 </div>
 

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,0 +1,7 @@
+{{ $message := index . 1 }}
+{{ $link := index . 2 }}
+
+<div class="versionBanner">
+  <a class="versionBannerText" href="{{ $link }}">{{ $message }}</a>
+</div>
+

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -2,7 +2,7 @@
 {{ $message := index . 1 }}
 {{ $link := index . 2 }}
 
-<!-- creates a unique id if there's multiple alerts -->
+<!-- creates a "mostly" unique id if there's multiple alerts -->
 {{ $uniqueness := replace $message " " "" }}
 
 <div class="alertBanner" id="{{ $uniqueness }}" style="background-color: {{ $color }}">
@@ -16,32 +16,33 @@
 </div>
 
 <script>
-  alerts = document.getElementsByClassName("alertBanner");
-  i = 0;
+  alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
+  currentBanner = $(document.getElementById({{ $uniqueness }}));
+
   // stack the alerts as needed
-  Array.prototype.forEach.call(alerts, alert => {
+  for (i = 1; i <= alerts.length; i++) {
     lastLocation = parseInt($(alerts[i]).css('top'), 10);
     height = 28;
-    (i == 0) ? newLocation = lastLocation : newLocation = lastLocation + height;
-    alert.style.top = newLocation + "px";
+    newLocation = lastLocation + height;
+    currentBanner.css('top', newLocation + "px");
     i++;
-  });
+  };
 
   function closeAlert(id) {
+    // grab information before delete
+    alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
     currentBanner = $(document.getElementById(id));
+    arrLocation = alerts.findIndex(alert => alert.id == currentBanner[0].id);
     lastLocation = parseInt(currentBanner.css('top'), 10);
     document.getElementById(id).remove();
 
-    alerts = document.getElementsByClassName("alertBanner");
-    i = 0;
     // unstack the alerts as needed
-    Array.prototype.forEach.call(alerts, alert => {
-      // wat am I doing
-      (i == 0) ? lastLocation = lastLocation : lastLocation = parseInt($(alerts[i]).css('top'), 10);
+    for (i = arrLocation + 1; i <= alerts.length; i++){
       height = 28;
-      (i == 0) ? newLocation = lastLocation : newLocation = lastLocation - height;
-      alert.style.top = newLocation + "px";
-      i++;
-    });
+      (i == arrLocation + 1) ? newLocation = lastLocation : newLocation = lastLocation + height;
+      lastLocation = newLocation;
+      console.log(i);
+      $(alerts[i]).css('top', newLocation + "px");
+    };
   }
 </script>

--- a/layouts/partials/alertSection.html
+++ b/layouts/partials/alertSection.html
@@ -1,0 +1,12 @@
+<!-- May not render, used for old/pre release versions -->
+<div id="alertSection">
+  {{ $product := .Section }}
+  {{ $product2 := replace $product "-" "_" }}
+  {{ $product_info := (index .Site.Params.products $product2) }}
+  {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
+    {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
+    {{ $link := replace .URL .Params.version $product_info.latest }}
+    {{ $params := slice "#cc7d7c" $message $link }}
+    {{ partial "alert" $params }}
+  {{ end }}
+</div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -40,6 +40,9 @@
   </div>
 </nav>
 
+<!-- div containing all alerts -->
+{{ partial "alertSection.html" . }}
+
 <!-- Scripts for the search bar -->
 <script>
   function closeResults() {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -41,7 +41,9 @@
 </nav>
 
 <!-- div containing all alerts -->
-{{ partial "alertSection.html" . }}
+{{ if not .IsHome }}
+  {{ partial "alertSection.html" . }}
+{{ end }}
 
 <!-- Scripts for the search bar -->
 <script>

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -18,11 +18,13 @@
 <script>
   alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
   currentBanner = $(document.getElementById({{ $uniqueness }}));
+  // 10px is a small hack for different screen sizes
+  // semi-breaks if you're scaling the page large to small, but is fine on refresh
+  height = currentBanner.height() + 10;
 
   // stack the alerts as needed
   for (i = 1; i <= alerts.length; i++) {
     lastLocation = parseInt($(alerts[i]).css('top'), 10);
-    height = 28;
     newLocation = lastLocation + height;
     currentBanner.css('top', newLocation + "px");
     // double incrementing is a little weird, but we get gaps otherwise
@@ -39,10 +41,8 @@
 
     // unstack the alerts as needed
     for (i = arrLocation + 1; i <= alerts.length; i++){
-      height = 28;
       (i == arrLocation + 1) ? newLocation = lastLocation : newLocation = lastLocation + height;
       lastLocation = newLocation;
-      console.log(i);
       $(alerts[i]).css('top', newLocation + "px");
     };
   }

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,0 +1,21 @@
+{{ $color := index . 0 }}
+{{ $message := index . 1 }}
+{{ $link := index . 2 }}
+
+<div class="alertBanner" style="background-color: {{ $color }}">
+  {{ if $link }}
+    <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
+  {{ else }}
+    <span class="alertBannerText">{{ $message }}</span>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
+  {{ end }}
+</div>
+
+
+<script>
+  function closeAlert() {
+    var $banner = document.getElementsByClassName("alertBanner");
+    $banner[0].style.display = 'none';
+  }
+</script>

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,49 +1,6 @@
-{{ $color := index . 0 }}
-{{ $message := index . 1 }}
-{{ $link := index . 2 }}
+{{ $color := .Get 0 }}
+{{ $message := .Get 1 }}
+{{ $link := .Get 2 }}
+{{ $params := slice $color $message $link }}
 
-<!-- creates a "mostly" unique id if there's multiple alerts -->
-{{ $uniqueness := replace $message " " "" }}
-
-<div class="alertBanner" id="{{ $uniqueness }}" style="background-color: {{ $color }}">
-  {{ if $link }}
-    <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
-  {{ else }}
-    <span class="alertBannerText">{{ $message }}</span>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
-  {{ end }}
-</div>
-
-<script>
-  alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
-  currentBanner = $(document.getElementById({{ $uniqueness }}));
-  // 10px is a small hack for different screen sizes
-  // semi-breaks if you're scaling the page large to small, but is fine on refresh
-  height = currentBanner.height() + 10;
-
-  // stack the alerts as needed
-  for (i = 1; i <= alerts.length; i++) {
-    lastLocation = parseInt($(alerts[i]).css('top'), 10);
-    newLocation = lastLocation + height;
-    currentBanner.css('top', newLocation + "px");
-    // double incrementing is a little weird, but we get gaps otherwise
-    i++;
-  };
-
-  function closeAlert(id) {
-    // grab information before delete
-    alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
-    currentBanner = $(document.getElementById(id));
-    arrLocation = alerts.findIndex(alert => alert.id == currentBanner[0].id);
-    lastLocation = parseInt(currentBanner.css('top'), 10);
-    document.getElementById(id).remove();
-
-    // unstack the alerts as needed
-    for (i = arrLocation + 1; i <= alerts.length; i++){
-      (i == arrLocation + 1) ? newLocation = lastLocation : newLocation = lastLocation + height;
-      lastLocation = newLocation;
-      $(alerts[i]).css('top', newLocation + "px");
-    };
-  }
-</script>
+{{ partial "alert" $params }}

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -2,20 +2,48 @@
 {{ $message := index . 1 }}
 {{ $link := index . 2 }}
 
-<div class="alertBanner" style="background-color: {{ $color }}">
+<!-- creates a "mostly" unique id if there's multiple alerts -->
+{{ $uniqueness := replace $message " " "" }}
+
+<div class="alertBanner" id="{{ $uniqueness }}" style="background-color: {{ $color }}">
   {{ if $link }}
     <a class="alertBannerText" href="{{ $link }}">{{ $message }}</a>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
   {{ else }}
     <span class="alertBannerText">{{ $message }}</span>
-    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert()"></i></span>
+    <span class="closeAlert"><i class="fa fa-times" aria-hidden="true" onClick="closeAlert({{ $uniqueness }})"></i></span>
   {{ end }}
 </div>
 
-
 <script>
-  function closeAlert() {
-    var $banner = document.getElementsByClassName("alertBanner");
-    $banner[0].style.display = 'none';
+  alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
+  currentBanner = $(document.getElementById({{ $uniqueness }}));
+
+  // stack the alerts as needed
+  for (i = 1; i <= alerts.length; i++) {
+    lastLocation = parseInt($(alerts[i]).css('top'), 10);
+    height = 28;
+    newLocation = lastLocation + height;
+    currentBanner.css('top', newLocation + "px");
+    // double incrementing is a little weird, but we get gaps otherwise
+    i++;
+  };
+
+  function closeAlert(id) {
+    // grab information before delete
+    alerts = Array.prototype.slice.call(document.getElementsByClassName("alertBanner"));
+    currentBanner = $(document.getElementById(id));
+    arrLocation = alerts.findIndex(alert => alert.id == currentBanner[0].id);
+    lastLocation = parseInt(currentBanner.css('top'), 10);
+    document.getElementById(id).remove();
+
+    // unstack the alerts as needed
+    for (i = arrLocation + 1; i <= alerts.length; i++){
+      height = 28;
+      (i == arrLocation + 1) ? newLocation = lastLocation : newLocation = lastLocation + height;
+      lastLocation = newLocation;
+      console.log(i);
+      $(alerts[i]).css('top', newLocation + "px");
+    };
   }
 </script>

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -551,7 +551,7 @@ button.accordion.active, button.accordion:hover {
   background-color: #dbdbdb; 
 }
 
-/* Version Banner ----------------------------------------------------------------- */
+/* Version Banner/Alerts ----------------------------------------------------------------- */
 
 .versionBanner {
   background-color: #cc7d7c;
@@ -563,7 +563,7 @@ button.accordion.active, button.accordion:hover {
   text-align: center;
 }
 
-.versionBanner a {
+.versionBanner a, .versionBanner span {
   color: #dedede;
 }
 

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -559,6 +559,7 @@ button.accordion.active, button.accordion:hover {
   position: fixed;
   width: 100%;
   top: 64px;
+  right: 0;
   padding: 5px;
   text-align: center;
 }

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -551,9 +551,9 @@ button.accordion.active, button.accordion:hover {
   background-color: #dbdbdb; 
 }
 
-/* Version Banner/Alerts ----------------------------------------------------------------- */
+/* Alerts ----------------------------------------------------------------- */
 
-.versionBanner {
+.alertBanner {
   background-color: #cc7d7c;
   box-shadow: 0 3px 8px rgba(0,0,0,.05);
   position: absolute;
@@ -563,15 +563,15 @@ button.accordion.active, button.accordion:hover {
   text-align: center;
 }
 
-.versionBanner a, .versionBanner span {
+.alertBanner a, .alertBanner span {
   color: #dedede;
 }
 
-.versionBanner a:hover {
+.alertBanner a:hover {
   color: #ffffff;
 }
 
-.versionBannerText {
+.alertBannerText {
   font-size: 14px;
 }
 
@@ -750,7 +750,7 @@ button.accordion.active, button.accordion:hover {
     top: 50px;
   }
 
-  .versionBanner {
+  .alertBanner {
     top: 55px;
   }
 }
@@ -872,9 +872,17 @@ button.accordion.active, button.accordion:hover {
   
   #results.query.resultsList {
     top: 50px;
+
+  #productVersionNav #productButton {
+    width: 190px;
   }
 
-  .versionBanner {
+  #productVersionNav #versionButton {
+    margin-left: 200px;
+    width: 70px;
+  }
+
+  .alertBanner {
     top: 50px;
   }
 }
@@ -916,7 +924,7 @@ button.accordion.active, button.accordion:hover {
   //  margin-left: 0;
   //}
 
-  //.versionBanner {
+  //.alertBanner {
   //  top: 64px;
   //}
 

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -575,6 +575,12 @@ button.accordion.active, button.accordion:hover {
   font-size: 14px;
 }
 
+.closeAlert {
+  float: right;
+  margin-right: 20px;
+  font-size: 16px;
+}
+
 /* Non-Homepage Index Buttons ----------------------------------------------------------------- */
 
 .landingButtonHolder {

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -556,7 +556,7 @@ button.accordion.active, button.accordion:hover {
 .alertBanner {
   background-color: #cc7d7c;
   box-shadow: 0 3px 8px rgba(0,0,0,.05);
-  position: absolute;
+  position: fixed;
   width: 100%;
   top: 64px;
   padding: 5px;
@@ -875,9 +875,10 @@ button.accordion.active, button.accordion:hover {
   .product-holder {
     height: 200px;
   }
-  
+
   #results.query.resultsList {
     top: 50px;
+  }
 
   #productVersionNav #productButton {
     width: 190px;

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -53,7 +53,6 @@
   background: #89C967;
   font-size: 20px;
   font-weight: 200;
-  //display: table-caption;
   height: 0;
   width: 1000%;
 }
@@ -70,16 +69,6 @@
   background: #618B25;
 }
 
-.palette-primary-green .article code {
-  //color: #6a5fc7;
-  //background-color: unset;
-}
-
-pre code {
-  //color: #89C967 !important;
-}
-
-
 p code, li code, td code, h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
   color: #000080 !important;
 }
@@ -87,6 +76,10 @@ p code, li code, td code, h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
 .article pre {
   margin-top: 30px;
   margin-bottom: 20px;
+}
+
+.main {
+  margin-top: 0;
 }
 
 .main article {
@@ -196,18 +189,6 @@ table tr td:first-child {
 
 table pre {
   max-width: 720px;
-}
-
-.article pre code {
-  //background-color: #333;
-}
-
-.highlight pre {
-  //background-color: #333 !important;
-}
-
-.highlight pre code span {
-  //background-color: #333;
 }
 
 .article .data table {
@@ -360,30 +341,9 @@ a .project {
 
 /* Sidebar Stuff ----------------------------------------------------------------- */
 
-/*.drawer .scrollable .wrapper .toc {
-  margin: 0;
-}*/
-
 .project .banner {
   margin-bottom: -20px;
 }
-
-.main {
- //width: 1360px;
-}
-
-/*.drawer .toc li a.menu-title {
-  font-size: 19px;
-  padding: 10px;
-  padding-left: 5px;
-  cursor: pointer;
-}
-
-.drawer .toc li a.menu-child {
-  font-size: 17px;
-  font-weight: 100 !important;
-  padding: 5px;
-}*/
 
 .project .logo+.name {
   padding-left: 15px;
@@ -396,26 +356,11 @@ a .project {
 .drawer {
   overflow: auto;
   height: 100%;
-  //font-size: 14px;
-  //left: 0;
   padding-left: 80px;
   position: fixed;
   margin-left: -120px;
   width: 380px;
 }
-
-/*nav .scrollable {
-  margin-bottom: 160px;
-}
-
-.project .logo {
-  padding-right: 0;
-  padding-bottom: 20px;
-}
-
-.repo {
-  margin-top: 10px;
-}*/
 
 #productVersionDrawerHolder {
   opacity: 0;
@@ -553,12 +498,17 @@ button.accordion.active, button.accordion:hover {
 
 /* Alerts ----------------------------------------------------------------- */
 
+#alertSection {
+  z-index: -1;
+  position: fixed;
+  top: 64px;
+  width: 100%;
+}
+
 .alertBanner {
   background-color: #cc7d7c;
   box-shadow: 0 3px 8px rgba(0,0,0,.05);
-  position: fixed;
   width: 100%;
-  top: 64px;
   right: 0;
   padding: 5px;
   text-align: center;
@@ -718,7 +668,7 @@ button.accordion.active, button.accordion:hover {
     width: 200px;
     font-size: 14px;
   }
-  
+
   #versionButtonDrawer {
     margin: 30px 10px 0 20px;
     font-size: 14px;
@@ -752,12 +702,12 @@ button.accordion.active, button.accordion:hover {
   .product-holder {
     height: 200px;
   }
-  
+
   #results.query.resultsList {
     top: 50px;
   }
 
-  .alertBanner {
+  #alertSection {
     top: 55px;
   }
 }
@@ -890,7 +840,7 @@ button.accordion.active, button.accordion:hover {
     width: 70px;
   }
 
-  .alertBanner {
+  #alertSection {
     top: 50px;
   }
 }
@@ -906,35 +856,9 @@ button.accordion.active, button.accordion:hover {
     padding-top: 2px;
   }
 
-  .button .icon {
-    //margin-top: 0;
-    //padding-top: 4px;
-  }
-
   .header .stretch .title {
     display: block;
   }
-
-  .title {
-    //padding: 7px 0px!important;
-  }
-
-  .buttonHolder {
-    //margin-top: -2px;
-    //background: #383838;
-    //padding-top: 0;
-    //padding-left: 0;
-    //height: 35px;
-    //width: 100%;
-  }
-
-  //#productButton {
-  //  margin-left: 0;
-  //}
-
-  //.alertBanner {
-  //  top: 64px;
-  //}
 
   nav .scrollable {
     padding-top: 95px;
@@ -964,7 +888,7 @@ button.accordion.active, button.accordion:hover {
     width: 200px;
     font-size: 14px;
   }
-  
+
   #versionButtonDrawer {
     margin: 30px 10px 0 20px;
     font-size: 14px;


### PR DESCRIPTION
## Details
Closes #94 (finally)

Adds:
- Ability to dismiss alert
- Ability to pass text, colour, and optionally a link to the partial

We now have customizable banners! (In both partial and shortcode form)
```
{{ $message := "WOW! That's neat!" }}
{{ $link := "Any url you like! You don't even NEED one!" }}
{{ $params := slice "#cc7d7c" $message $link }}
{{ partial "alert" $params }}
```

Just pass colour, message, and OPTIONALLY a link (in that order)!
```
{{ $color := index . 0 }}
{{ $message := index . 1 }}
{{ $link := index . 2 }}
```
They stack and unstack! Wow! That was actually kinda tricky to program them to stack properly!

Single alert with link
![image](https://user-images.githubusercontent.com/1707663/38646761-20742c42-3d9e-11e8-985e-4746010d0959.png)

Multiple alerts
![image](https://user-images.githubusercontent.com/1707663/38709907-75770316-3e72-11e8-9c16-661597a9cb89.png)

Dismissed alert
![image](https://user-images.githubusercontent.com/1707663/38709929-8bd6a760-3e72-11e8-82b9-ac1bd25ee0c4.png)