### PR TITLE
Added reference doc for tokens

### DIFF
--- a/content/sensu-core/2.0/reference/checks.md
+++ b/content/sensu-core/2.0/reference/checks.md
@@ -333,7 +333,7 @@ example      | {{< highlight shell >}}"splay_coverage": 65{{</ highlight >}}
 [2]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [3]: https://en.wikipedia.org/wiki/Standard_streams
 [4]: #check-commands
-[5]: #
+[5]: ../tokens
 [6]: ../hooks/
 [7]: ../../../1.2/reference/checks/#standalone-checks
 [8]: ../rbac

--- a/content/sensu-core/2.0/reference/entities.md
+++ b/content/sensu-core/2.0/reference/entities.md
@@ -133,7 +133,7 @@ type         | string
 default      | current environment value configured for `sensuctl` (ie `default`) 
 example      | {{< highlight shell >}}"environment": "default"{{</ highlight >}}
 
-extended_attributes | 
+extended_attributes |
 -------------|------ 
 description  | Custom attributes to include as with the entity, that appear as outer-level attributes.
 required     | false 
@@ -290,62 +290,60 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{</ highlight >
 ### Entity definition
 
 {{< highlight json >}}
-[
-  {
-    "class": "agent",
-    "deregister": false,
-    "deregistration": {},
-    "environment": "default",
-    "id": "example-hostname",
-    "keepalive_timeout": 60,
-    "last_seen": 1523387195,
-    "organization": "default",
-    "redact": [
-      "password",
-      "passwd",
-      "pass",
-      "api_key",
-      "api_token",
-      "access_key",
-      "secret_key",
-      "private_key",
-      "secret"
-    ],
-    "subscriptions": [
-      "entity:example-hostname"
-    ],
-    "system": {
-      "hostname": "example-hostname",
-      "os": "linux",
-      "platform": "ubuntu",
-      "platform_family": "debian",
-      "platform_version": "16.04",
-      "network": {
-        "interfaces": [
-        {
-          "name": "lo",
-          "addresses": [
-            "127.0.0.1/8",
-          "::1/128"
-          ]
-        },
-        {
-          "name": "eth0",
-          "mac": "52:54:00:20:1b:3c",
-          "addresses": [
-            "93.184.216.34/24",
-          "2606:2800:220:1:248:1893:25c8:1946/10"
-          ]
-        }
+{
+  "class": "agent",
+  "deregister": false,
+  "deregistration": {},
+  "environment": "default",
+  "id": "example-hostname",
+  "keepalive_timeout": 60,
+  "last_seen": 1523387195,
+  "organization": "default",
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:example-hostname"
+  ],
+  "system": {
+    "hostname": "example-hostname",
+    "os": "linux",
+    "platform": "ubuntu",
+    "platform_family": "debian",
+    "platform_version": "16.04",
+    "network": {
+      "interfaces": [
+      {
+        "name": "lo",
+        "addresses": [
+          "127.0.0.1/8",
+        "::1/128"
         ]
       },
-      "arch": "amd64"
-    }
-    "user": "agent",
-    "region": "us-west-1",
-    "team": "ops"
+      {
+        "name": "eth0",
+        "mac": "52:54:00:20:1b:3c",
+        "addresses": [
+          "93.184.216.34/24",
+        "2606:2800:220:1:248:1893:25c8:1946/10"
+        ]
+      }
+      ]
+    },
+    "arch": "amd64"
   }
-]
+  "user": "agent",
+  "region": "us-west-1",
+  "team": "ops"
+}
 {{< /highlight >}}
 
 [1]: #system-attributes

--- a/content/sensu-core/2.0/reference/tokens.md
+++ b/content/sensu-core/2.0/reference/tokens.md
@@ -13,7 +13,7 @@ menu:
 When a check is scheduled to be executed by an agent, it first goes through a token substitution step. Any tokens matching attribute values in the check are applied, and then the check is executed. Invalid templates or unmatched tokens will return an error, which is logged and sent to the Sensu backend message transport. Checks with token matching errors will not be executed.
 
 ## New and improved tokens
-Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces around the token, and a dot before the attribute to be subtituted, such as: `{{ .System.hostname }}`.
+Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces around the token, and a dot before the attribute to be subtituted, such as: `{{ .System.hostname }}`
 
 ## Sensu tokens specification
 
@@ -23,7 +23,7 @@ Tokens are invoked by wrapping references to entity or custom attributes with do
 
 - `{{ .ID }}` would be replaced with the [entity `ID` attribute][3]
 - `{{ .URL }}` would be replaced with a custom attribute called `url`
-- `{{ Disk.Warning }}` would be replaced with a custom attribute called
+- `{{ .Disk.Warning }}` would be replaced with a custom attribute called
   `warning` nested inside of a JSON hash called `disk`
 
 ### Token substitution default values
@@ -76,7 +76,7 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
 {{< /highlight >}}
 
 The following example [entity][4] would provide the necessary
-attributes to override the `.Disk.Warning`, `.Disk.Critical`, and `environment`
+attributes to override the `.Disk.Warning`, `.Disk.Critical`, and `.Environment`
 tokens declared above.
 
 {{< highlight json >}}

--- a/content/sensu-core/2.0/reference/tokens.md
+++ b/content/sensu-core/2.0/reference/tokens.md
@@ -19,11 +19,11 @@ Sensu 2.0 uses the [Go template][1] package to implement token substitution. Ins
 
 ### Token substitution syntax
 
-Tokens are invoked by wrapping references to entity or custom attributes with double curly braces, such as `{{ .ID }}` to substitute an entity's ID value. Nested Sensu [entity attributes][3] can be accessed via dot notation (e.g. `system.arch`).
+Tokens are invoked by wrapping references to entity or custom attributes with double curly braces, such as `{{ .ID }}` to substitute an entity's ID value. Nested Sensu [entity attributes][3] can be accessed via dot notation (e.g. `System.arch`).
 
-- `{{ system.network.interfaces.addresses }}` would be replaced with the [entity `system.network.interfaces.address` attribute][26]
-- `{{ url }}` would be replaced with a custom attribute called `url`
-- `{{ disk.warning }}` would be replaced with a custom attribute called
+- `{{ .ID }}` would be replaced with the [entity `ID` attribute][3]
+- `{{ .URL }}` would be replaced with a custom attribute called `url`
+- `{{ Disk.Warning }}` would be replaced with a custom attribute called
   `warning` nested inside of a JSON hash called `disk`
 
 ### Token substitution default values
@@ -31,7 +31,7 @@ Tokens are invoked by wrapping references to entity or custom attributes with do
 In the event that an attribute is not provided by the [entity][3], a token's default
 value will be substituted. Token default values are separated by a pipe character (`|`), and can be used to provide a "fallback value" for entities that are missing a specified token attribute.
 
-- `{{url|https://sensu.io}}` would be replaced with a [custom  attribute][3] called `url`. If no such attribute called `url` is included in the client definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.
+- `{{.URL | default "https://sensu.io"}}` would be replaced with a [custom  attribute][3] called `url`. If no such attribute called `url` is included in the client definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.
 
 ### Unmatched tokens
 
@@ -48,13 +48,13 @@ Check config token errors will be logged by the agent, and sent to Sensu backend
 ### Token substitution for check thresholds 
 
 In this example [check configuration][5], the `check-disk-usage.rb` command accepts `-w` (warning) and `-c` (critical)
-arguments to indicate the thresholds (as percentages) for creating warning or critical events. If no token substitutions are provided by a check configuration, it will use default values to create a warning event at 80% disk capacity (i.e. `{{ disk.warning|80 }}`), and a critical event at 90% capacity (i.e. `{{ disk.critical|90 }}`).
+arguments to indicate the thresholds (as percentages) for creating warning or critical events. If no token substitutions are provided by a check configuration, it will use default values to create a warning event at 80% disk capacity (i.e. `{{ Disk.Warning | default 80 }}`), and a critical event at 90% capacity (i.e. `{{ Disk.Critical | default 90 }}`).
 
 {{< highlight json >}}
 {
   "check_hooks": null,
-  "command": "check-disk-usage.rb -w {{disk.warning|80}} -c {{disk.critical|90}}"
-  "environment": "{{ environment|production }}",
+  "command": "check-disk-usage.rb -w {{Disk.Warning | default 80}} -c {{Disk.Critical | default 90}}"
+  "environment": "{{ environment | default production }}",
   "handlers": [],
   "high_flap_threshold": 0,
   "interval": 60,
@@ -76,7 +76,7 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
 {{< /highlight >}}
 
 The following example [entity][4] would provide the necessary
-attributes to override the `disk.warning`, `disk.critical`, and `environment`
+attributes to override the `Disk.Warning`, `Disk.Critical`, and `environment`
 tokens declared above.
 
 {{< highlight json >}}

--- a/content/sensu-core/2.0/reference/tokens.md
+++ b/content/sensu-core/2.0/reference/tokens.md
@@ -13,7 +13,7 @@ menu:
 When a check is scheduled to be executed by an agent, it first goes through a token substitution step. Any tokens matching attribute values in the check are applied, and then the check is executed. Invalid templates or unmatched tokens will return an error, which is logged and sent to the Sensu backend message transport. Checks with token matching errors will not be executed.
 
 ## New and improved tokens
-Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces `{{` around tokens to be substituted.
+Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces around the token, and a dot before the attribute to be subtituted, such as: `{{ .System.hostname }}`.
 
 ## Sensu tokens specification
 
@@ -29,7 +29,7 @@ Tokens are invoked by wrapping references to entity or custom attributes with do
 ### Token substitution default values
 
 In the event that an attribute is not provided by the [entity][3], a token's default
-value will be substituted. Token default values are separated by a pipe character (`|`), and can be used to provide a "fallback value" for entities that are missing a specified token attribute.
+value will be substituted. Token default values are separated by a pipe character and the word `default` (`| default`), and can be used to provide a "fallback value" for entities that are missing a specified token attribute.
 
 - `{{.URL | default "https://sensu.io"}}` would be replaced with a [custom  attribute][3] called `url`. If no such attribute called `url` is included in the client definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.
 
@@ -48,13 +48,13 @@ Check config token errors will be logged by the agent, and sent to Sensu backend
 ### Token substitution for check thresholds 
 
 In this example [check configuration][5], the `check-disk-usage.rb` command accepts `-w` (warning) and `-c` (critical)
-arguments to indicate the thresholds (as percentages) for creating warning or critical events. If no token substitutions are provided by a check configuration, it will use default values to create a warning event at 80% disk capacity (i.e. `{{ Disk.Warning | default 80 }}`), and a critical event at 90% capacity (i.e. `{{ Disk.Critical | default 90 }}`).
+arguments to indicate the thresholds (as percentages) for creating warning or critical events. If no token substitutions are provided by a check configuration, it will use default values to create a warning event at 80% disk capacity (i.e. `{{ .Disk.Warning | default 80 }}`), and a critical event at 90% capacity (i.e. `{{ .Disk.Critical | default 90 }}`).
 
 {{< highlight json >}}
 {
   "check_hooks": null,
-  "command": "check-disk-usage.rb -w {{Disk.Warning | default 80}} -c {{Disk.Critical | default 90}}"
-  "environment": "{{ environment | default production }}",
+  "command": "check-disk-usage.rb -w {{.Disk.Warning | default 80}} -c {{.Disk.Critical | default 90}}"
+  "environment": "{{ .Environment | default "production" }}",
   "handlers": [],
   "high_flap_threshold": 0,
   "interval": 60,
@@ -76,7 +76,7 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
 {{< /highlight >}}
 
 The following example [entity][4] would provide the necessary
-attributes to override the `Disk.Warning`, `Disk.Critical`, and `environment`
+attributes to override the `.Disk.Warning`, `.Disk.Critical`, and `environment`
 tokens declared above.
 
 {{< highlight json >}}

--- a/content/sensu-core/2.0/reference/tokens.md
+++ b/content/sensu-core/2.0/reference/tokens.md
@@ -1,0 +1,148 @@
+---
+title: "Tokens"
+description: "The tokens reference guide."
+weight: 1
+version: "2.0"
+product: "Sensu Core"
+menu: 
+  sensu-core-2.0:
+    parent: reference
+---
+
+## How do tokens work?
+When a check is scheduled to be executed by an agent, it first goes through a token substitution step. Any tokens matching attribute values in the check are applied, and then the check is executed. Invalid templates or unmatched tokens will return an error, which is logged and sent to the Sensu backend message transport. Checks with token matching errors will not be executed.
+
+## New and improved tokens
+Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces `{{` around tokens to be substituted.
+
+## Sensu tokens specification
+
+### Token substitution syntax
+
+Tokens are invoked by wrapping references to entity or custom attributes with double curly braces, such as `{{ .ID }}` to substitute an entity's ID value. Nested Sensu [entity attributes][3] can be accessed via dot notation (e.g. `system.arch`).
+
+- `{{ system.network.interfaces.addresses }}` would be replaced with the [entity `system.network.interfaces.address` attribute][26]
+- `{{ url }}` would be replaced with a custom attribute called `url`
+- `{{ disk.warning }}` would be replaced with a custom attribute called
+  `warning` nested inside of a JSON hash called `disk`
+
+### Token substitution default values
+
+In the event that an attribute is not provided by the [entity][3], a token's default
+value will be substituted. Token default values are separated by a pipe character (`|`), and can be used to provide a "fallback value" for entities that are missing a specified token attribute.
+
+- `{{url|https://sensu.io}}` would be replaced with a [custom  attribute][3] called `url`. If no such attribute called `url` is included in the client definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.
+
+### Unmatched tokens
+
+If a token is unmatched during check preparation, the agent check handler will return an error, and the check will not be executed. Unmatched token errors will look similar to the following:
+
+{{< highlight shell >}}
+error: unmatched token: template: :1:22: executing "" at <.System.Hostname>: map has no entry for key "System"
+{{</ highlight >}}
+
+Check config token errors will be logged by the agent, and sent to Sensu backend message transport as a check failure.
+
+## Examples
+
+### Token substitution for check thresholds 
+
+In this example [check configuration][5], the `check-disk-usage.rb` command accepts `-w` (warning) and `-c` (critical)
+arguments to indicate the thresholds (as percentages) for creating warning or critical events. If no token substitutions are provided by a check configuration, it will use default values to create a warning event at 80% disk capacity (i.e. `{{ disk.warning|80 }}`), and a critical event at 90% capacity (i.e. `{{ disk.critical|90 }}`).
+
+{{< highlight json >}}
+{
+  "check_hooks": null,
+  "command": "check-disk-usage.rb -w {{disk.warning|80}} -c {{disk.critical|90}}"
+  "environment": "{{ environment|production }}",
+  "handlers": [],
+  "high_flap_threshold": 0,
+  "interval": 60,
+  "low_flap_threshold": 0,
+  "name": "check-disk-usage",
+  "organization": "default",
+  "proxy_entity_id": "",
+  "publish": true,
+  "round_robin": false,
+  "runtime_assets": [],
+  "stdin": false,
+  "subdue": null,
+  "subscriptions": [
+    "staging"
+  ],
+  "timeout": 0
+}
+
+{{< /highlight >}}
+
+The following example [entity][4] would provide the necessary
+attributes to override the `disk.warning`, `disk.critical`, and `environment`
+tokens declared above.
+
+{{< highlight json >}}
+{
+  "class": "agent",
+  "deregister": false,
+  "deregistration": {},
+  "environment": "staging",
+  "id": "example-hostname",
+  "keepalive_timeout": 60,
+  "last_seen": 1523387195,
+  "organization": "default",
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:example-hostname",
+    "staging"
+  ],
+  "system": {
+    "hostname": "example-hostname",
+    "os": "linux",
+    "platform": "ubuntu",
+    "platform_family": "debian",
+    "platform_version": "16.04",
+    "network": {
+      "interfaces": [
+      {
+        "name": "lo",
+        "addresses": [
+          "127.0.0.1/8",
+        "::1/128"
+        ]
+      },
+      {
+        "name": "eth0",
+        "mac": "52:54:00:20:1b:3c",
+        "addresses": [
+          "93.184.216.34/24",
+        "2606:2800:220:1:248:1893:25c8:1946/10"
+        ]
+      }
+      ]
+    },
+    "arch": "amd64"
+  }
+  "user": "agent",
+  "region": "us-west-1",
+  "team": "ops"
+  "disk": {
+    "warning": 75,
+    "critical": 85
+  },
+}
+{{< /highlight >}}
+
+[1]: https://golang.org/pkg/text/template/
+[2]: ../../../1.2/reference/checks/#check-token-substitution
+[3]: ../entities/#entity-attributes
+[4]: ../entities/
+[5]: ../checks/

--- a/content/sensu-core/2.0/reference/tokens.md
+++ b/content/sensu-core/2.0/reference/tokens.md
@@ -13,13 +13,13 @@ menu:
 When a check is scheduled to be executed by an agent, it first goes through a token substitution step. Any tokens matching attribute values in the check are applied, and then the check is executed. Invalid templates or unmatched tokens will return an error, which is logged and sent to the Sensu backend message transport. Checks with token matching errors will not be executed.
 
 ## New and improved tokens
-Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces around the token, and a dot before the attribute to be subtituted, such as: `{{ .System.hostname }}`
+Sensu 2.0 uses the [Go template][1] package to implement token substitution. Instead of using triple colons `:::` as in [1.x token substitution][2], 2.0 token substitution uses double curly braces around the token, and a dot before the attribute to be subtituted, such as: `{{ .System.Hostname }}`
 
 ## Sensu tokens specification
 
 ### Token substitution syntax
 
-Tokens are invoked by wrapping references to entity or custom attributes with double curly braces, such as `{{ .ID }}` to substitute an entity's ID value. Nested Sensu [entity attributes][3] can be accessed via dot notation (e.g. `System.arch`).
+Tokens are invoked by wrapping references to entity or custom attributes with double curly braces, such as `{{ .ID }}` to substitute an entity's ID value. Nested Sensu [entity attributes][3] can be accessed via dot notation (e.g. `System.Arch`).
 
 - `{{ .ID }}` would be replaced with the [entity `ID` attribute][3]
 - `{{ .URL }}` would be replaced with a custom attribute called `url`


### PR DESCRIPTION
Also fixed link in checks reference doc and extra brackets around a json
example in the entities reference documentation.

I think these docs are the correct behavior for tokens, but I just learned about them yesterday, so please correct me if I got it wrong anywhere :)

Closes https://github.com/sensu/sensu-docs/issues/332