### PR TITLE
update enterprise overview pages with link to core install guide

### DIFF
--- a/content/sensu-enterprise/2.6/_index.md
+++ b/content/sensu-enterprise/2.6/_index.md
@@ -10,8 +10,8 @@ layout: "single"
 ## Overview
 
 - [What is Sensu Enterprise?](#what-is-sensu-enterprise)
+- [Installing Sensu Enterprise](#installing-sensu-enterprise)
 - [Upgrading to Sensu Enterprise](#upgrading-to-sensu-enterprise)
-- [Reference documentation](#reference-documentation)
 
 ## What is Sensu Enterprise?
 
@@ -30,19 +30,26 @@ provide support for creating/resolving incidents, on-call rotation scheduling,
 storing time series data (metrics), relaying events, deregistering sensu-clients
 for terminated nodes, and/or notifying contacts via various media.
 
+## Installing Sensu Enterprise
+
+Sensu Enterprise and Sensu Core both depend on Redis and RabbitMQ to provide
+data store and transport architecture components. The Sensu Core monitoring
+agent (sensu-client) is used regardless of whether Sensu Core or Sensu
+Enterprise is used as the monitoring event processor.
+
+Please see the [Sensu Core installation guide][8] for instructions on installing
+Sensu Enterprise, Sensu Enterprise Dashboard and the `sensu-client` monitoring
+agent.
+
 ## Upgrading to Sensu Enterprise
 
-Sensu Enterprise is designed to be a drop-in replacement for the Sensu Core
-[server][6] and [API][7], so for users who are upgrading to Sensu Enterprise
-from Sensu Core, no configuration changes are required to resume – simply
-terminate the `sensu-server` and `sensu-api` processes, and start the
-`sensu-enterprise` process to resume  operation of Sensu (see the [Sensu Server
-and API installation guide][8] for  additional details). However, some
-configuration changes may be required to take  advantage of certain third-party
-integrations or added-value features (e.g. contact routing). Please refer to the
-Sensu Enterprise reference documentation (side bar), for more
-information.
-
+For those already running Sensu Core, Sensu Enterprise is designed to be a
+drop-in replacement for the Sensu Core [server][6] and [API][7]. Once installed,
+no configuration changes are required – simply terminate the
+`sensu-server` and `sensu-api` processes, and start the `sensu-enterprise`
+process to resume operation of your Sensu instance. Some configuration
+changes may be required to take advantage of [third-party integrations][9]
+or added-value features (e.g. [contact routing][2]).
 
 [1]:  /sensu-enterprise
 [2]:  contact-routing
@@ -52,3 +59,4 @@ information.
 [6]:  /sensu-core/latest/reference/server
 [7]:  /sensu-core/latest/api/overview
 [8]:  /sensu-core/latest/installation/install-sensu-server-api/#sensu-enterprise
+[9]:  integrations

--- a/content/sensu-enterprise/2.7/_index.md
+++ b/content/sensu-enterprise/2.7/_index.md
@@ -10,8 +10,8 @@ layout: "single"
 ## Overview
 
 - [What is Sensu Enterprise?](#what-is-sensu-enterprise)
+- [Installing Sensu Enterprise](#installing-sensu-enterprise)
 - [Upgrading to Sensu Enterprise](#upgrading-to-sensu-enterprise)
-- [Reference documentation](#reference-documentation)
 
 ## What is Sensu Enterprise?
 
@@ -30,20 +30,26 @@ provide support for creating/resolving incidents, on-call rotation scheduling,
 storing time series data (metrics), relaying events, deregistering sensu-clients
 for terminated nodes, and/or notifying contacts via various media.
 
+## Installing Sensu Enterprise
+
+Sensu Enterprise and Sensu Core both depend on Redis and RabbitMQ to provide
+data store and transport architecture components. The Sensu Core monitoring
+agent (sensu-client) is used regardless of whether Sensu Core or Sensu
+Enterprise is used as the monitoring event processor.
+
+Please see the [Sensu Core installation guide][8] for instructions on installing
+Sensu Enterprise, Sensu Enterprise Dashboard and the `sensu-client` monitoring
+agent.
+
 ## Upgrading to Sensu Enterprise
 
-Sensu Enterprise is designed to be a drop-in replacement for the Sensu Core
-[server][6] and [API][7], so for users who are upgrading to Sensu Enterprise
-from Sensu Core, no configuration changes are required to resume – simply
-terminate the `sensu-server` and `sensu-api` processes, and start the
-`sensu-enterprise` process to resume  operation of Sensu (see the [Sensu Server
-and API installation guide][8] for  additional details). However, some
-configuration changes may be required to take  advantage of certain third-party
-integrations or added-value features (e.g. contact routing). Please refer to the
-Sensu Enterprise reference documentation (sidebar), for more
-information.
-
-
+For those already running Sensu Core, Sensu Enterprise is designed to be a
+drop-in replacement for the Sensu Core [server][6] and [API][7]. Once installed,
+no configuration changes are required – simply terminate the
+`sensu-server` and `sensu-api` processes, and start the `sensu-enterprise`
+process to resume operation of your Sensu instance. Some configuration
+changes may be required to take advantage of [third-party integrations][9]
+or added-value features (e.g. [contact routing][2]).
 
 [1]:  /sensu-enterprise
 [2]:  contact-routing
@@ -53,3 +59,4 @@ information.
 [6]:  /sensu-core/latest/reference/server
 [7]:  /sensu-core/latest/api/overview
 [8]:  /sensu-core/latest/installation/install-sensu-server-api/#sensu-enterprise
+[9]:  integrations

--- a/content/sensu-enterprise/2.8/_index.md
+++ b/content/sensu-enterprise/2.8/_index.md
@@ -10,6 +10,7 @@ layout: "single"
 ## Overview
 
 - [What is Sensu Enterprise?](#what-is-sensu-enterprise)
+- [Installing Sensu Enterprise](#installing-sensu-enterprise)
 - [Upgrading to Sensu Enterprise](#upgrading-to-sensu-enterprise)
 
 ## What is Sensu Enterprise?
@@ -29,19 +30,26 @@ provide support for creating/resolving incidents, on-call rotation scheduling,
 storing time series data (metrics), relaying events, deregistering sensu-clients
 for terminated nodes, and/or notifying contacts via various media.
 
+## Installing Sensu Enterprise
+
+Sensu Enterprise and Sensu Core both depend on Redis and RabbitMQ to provide
+data store and transport architecture components. The Sensu Core monitoring
+agent (sensu-client) is used regardless of whether Sensu Core or Sensu
+Enterprise is used as the monitoring event processor.
+
+Please see the [Sensu Core installation guide][8] for instructions on installing
+Sensu Enterprise, Sensu Enterprise Dashboard and the `sensu-client` monitoring
+agent.
+
 ## Upgrading to Sensu Enterprise
 
-Sensu Enterprise is designed to be a drop-in replacement for the Sensu Core
-[server][6] and [API][7], so for users who are upgrading to Sensu Enterprise
-from Sensu Core, no configuration changes are required to resume – simply
-terminate the `sensu-server` and `sensu-api` processes, and start the
-`sensu-enterprise` process to resume  operation of Sensu (see the [Sensu Server
-and API installation guide][8] for  additional details). However, some
-configuration changes may be required to take  advantage of certain third-party
-integrations or added-value features (e.g. contact routing). Please refer to the
-[Sensu Enterprise reference documentation][9] (below), for more
-information.
-
+For those already running Sensu Core, Sensu Enterprise is designed to be a
+drop-in replacement for the Sensu Core [server][6] and [API][7]. Once installed,
+no configuration changes are required – simply terminate the
+`sensu-server` and `sensu-api` processes, and start the `sensu-enterprise`
+process to resume operation of your Sensu instance. Some configuration
+changes may be required to take advantage of [third-party integrations][9]
+or added-value features (e.g. [contact routing][2]).
 
 [1]:  /sensu-enterprise
 [2]:  contact-routing
@@ -51,3 +59,4 @@ information.
 [6]:  /sensu-core/latest/reference/server
 [7]:  /sensu-core/latest/api/overview
 [8]:  /sensu-core/latest/installation/install-sensu-server-api/#sensu-enterprise
+[9]:  integrations


### PR DESCRIPTION
## Description

Added "Installing Sensu Enterprise" section to the Sensu Enterprise overview (index) page in each Enterprise version.

## Motivation and Context

With the migration of documentation from the old monolithic site to new per-product documentation, we've made it harder to install Sensu Enterprise, as browsing the Enterprise product docs doesn't direct folks to the existing installation instructions under Sensu Core.

## How Has This Been Tested?

I used `yarn server` to preview my changes in a browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [x] Fixing errata

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.