### PR TITLE
Fix errors when running locally

### DIFF
--- a/content/sensu-core/0.29/guides/overview.md
+++ b/content/sensu-core/0.29/guides/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Getting Started"
 version: "0.29"
 product: "Sensu Core"
 weight: 1

--- a/content/sensu-core/0.29/overview/platforms.md
+++ b/content/sensu-core/0.29/overview/platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Platforms"
+title: "Supported Platforms"
 description: "Supported platforms"
 product: "Sensu Core"
 version: "0.29"

--- a/content/sensu-core/1.0/guides/overview.md
+++ b/content/sensu-core/1.0/guides/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Getting Started"
 version: "1.0"
 product: "Sensu Core"
 weight: 1

--- a/content/sensu-core/1.0/overview/platforms.md
+++ b/content/sensu-core/1.0/overview/platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Platforms"
+title: "Supported Platforms"
 description: "Supported platforms"
 product: "Sensu Core"
 version: "1.0"

--- a/content/sensu-core/1.1/guides/overview.md
+++ b/content/sensu-core/1.1/guides/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Getting Started"
 version: "1.1"
 product: "Sensu Core"
 weight: 1

--- a/content/sensu-core/1.1/overview/platforms.md
+++ b/content/sensu-core/1.1/overview/platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Platforms"
+title: "Supported Platforms"
 description: "Supported platforms"
 product: "Sensu Core"
 version: "1.1"

--- a/content/sensu-core/1.2/guides/overview.md
+++ b/content/sensu-core/1.2/guides/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Getting Started"
 product: "Sensu Core"
 version: "1.2"
 weight: 1

--- a/content/sensu-core/1.2/overview/platforms.md
+++ b/content/sensu-core/1.2/overview/platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Platforms"
+title: "Supported Platforms"
 description: "Supported platforms"
 product: "Sensu Core"
 version: "1.2"

--- a/content/sensu-core/1.3/guides/overview.md
+++ b/content/sensu-core/1.3/guides/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Getting Started"
 product: "Sensu Core"
 version: "1.3"
 weight: 1

--- a/content/sensu-core/1.3/overview/platforms.md
+++ b/content/sensu-core/1.3/overview/platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Platforms"
+title: "Supported Platforms"
 description: "Supported platforms"
 product: "Sensu Core"
 version: "1.3"

--- a/content/sensu-core/1.4/guides/overview.md
+++ b/content/sensu-core/1.4/guides/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Getting Started"
 product: "Sensu Core"
 version: "1.4"
 weight: 1

--- a/content/sensu-core/1.4/overview/platforms.md
+++ b/content/sensu-core/1.4/overview/platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Platforms"
+title: "Supported Platforms"
 description: "Supported platforms"
 product: "Sensu Core"
 version: "1.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Running the docs locally produces the following errors:

```
ERROR 2018/05/23 16:19:33 Two or more menu items have the same name/identifier in Menu "sensu-core-0.29": "Overview".
Rename or set an unique identifier.
...
ERROR 2018/05/23 16:19:33 Two or more menu items have the same name/identifier in Menu "sensu-core-0.29": "Platforms".
Rename or set an unique identifier.
```

This is a result of [overview/platforms](https://docs.sensu.io/sensu-core/1.4/overview/platforms/) and [guides/overview](https://docs.sensu.io/sensu-core/1.4/guides/overview/) sharing titles with the platforms and overview sections respectively. This was also causing these articles not to appear in the sidebar menu.

This PR changes the article titles from "Platforms" to "Supported Platforms" and from "Overview" to "Getting Started". 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix and improved contributor experience

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally via `yarn` and `yarn run server`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.