### PR TITLE
add "update" type to issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,6 +5,7 @@
 - [ ] Bug (site functionality or styling)
 - [ ] Errata (fix needed for doc content)
 - [ ] New content (guide wanted)
+- [ ] Update (Add missing or refresh existing content)
 
 ## Expected Behavior
 <!--- If describing a bug, tell us what should happen -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] New doc/guide
 - [ ] Fixing errata
+- [ ] Update (Add missing or refresh existing content)
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


### PR DESCRIPTION
## Description

Adds `Update` as a type for Issue and Pull Request templates

## Motivation and Context

We have an `update` label which describes some changes better than `errata`, so it makes sense to me that we would also allow for these in our templates.

## How Has This Been Tested?

Untested 😇 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.