### PR TITLE
Add last_ok attribute to event reference

### DIFF
--- a/content/sensu-core/0.29/reference/events.md
+++ b/content/sensu-core/0.29/reference/events.md
@@ -122,6 +122,12 @@ possible values | `create`, `resolve`, `flapping`
 default         | `create`
 example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
+last_ok       | 
+--------------|-----
+description   | The most recent time a check result indicated an 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+type          | Integer
+example       | `1528150592`
+
 occurrences  | 
 -------------|------
 description  | The occurrence count for the event; the number of times an event has been created for a client/check pair with the same state (check status).

--- a/content/sensu-core/1.0/reference/events.md
+++ b/content/sensu-core/1.0/reference/events.md
@@ -122,6 +122,12 @@ possible values | `create`, `resolve`, `flapping`
 default         | `create`
 example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
+last_ok       | 
+--------------|-----
+description   | The most recent time a check result indicated an 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+type          | Integer
+example       | `1528150592`
+
 occurrences  | 
 -------------|------
 description  | The occurrence count for the event; the number of times an event has been created for a client/check pair with the same state (check status).

--- a/content/sensu-core/1.1/reference/events.md
+++ b/content/sensu-core/1.1/reference/events.md
@@ -122,6 +122,12 @@ possible values | `create`, `resolve`, `flapping`
 default         | `create`
 example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
+last_ok       | 
+--------------|-----
+description   | The most recent time a check result indicated an 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+type          | Integer
+example       | `1528150592`
+
 occurrences  | 
 -------------|------
 description  | The occurrence count for the event; the number of times an event has been created for a client/check pair with the same state (check status).

--- a/content/sensu-core/1.2/reference/events.md
+++ b/content/sensu-core/1.2/reference/events.md
@@ -122,6 +122,12 @@ possible values | `create`, `resolve`, `flapping`
 default         | `create`
 example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
+last_ok       | 
+--------------|-----
+description   | The most recent time a check result indicated an 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+type          | Integer
+example       | `1528150592`
+
 occurrences  | 
 -------------|------
 description  | The occurrence count for the event; the number of times an event has been created for a client/check pair with the same state (check status).

--- a/content/sensu-core/1.3/reference/events.md
+++ b/content/sensu-core/1.3/reference/events.md
@@ -122,6 +122,12 @@ possible values | `create`, `resolve`, `flapping`
 default         | `create`
 example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
+last_ok       | 
+--------------|-----
+description   | The most recent time a check result indicated an 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+type          | Integer
+example       | `1528150592`
+
 occurrences  | 
 -------------|------
 description  | The occurrence count for the event; the number of times an event has been created for a client/check pair with the same state (check status).

--- a/content/sensu-core/1.4/reference/events.md
+++ b/content/sensu-core/1.4/reference/events.md
@@ -122,6 +122,12 @@ possible values | `create`, `resolve`, `flapping`
 default         | `create`
 example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
+last_ok       | 
+--------------|-----
+description   | The time of the most recent check execution indicating 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+type          | Integer
+example       | `1528150592`
+
 occurrences  | 
 -------------|------
 description  | The occurrence count for the event; the number of times an event has been created for a client/check pair with the same state (check status).

--- a/content/sensu-core/1.4/reference/events.md
+++ b/content/sensu-core/1.4/reference/events.md
@@ -124,7 +124,7 @@ example         | {{< highlight shell >}}"action": "create"{{< /highlight >}}
 
 last_ok       | 
 --------------|-----
-description   | The time of the most recent check execution indicating 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
+description   | The most recent time a check result indicated an 'OK' status for this client/check pair (generated via Ruby `Time.now.to_i`).
 type          | Integer
 example       | `1528150592`
 


### PR DESCRIPTION
## Description

Add `last_ok` attribute to event reference doc

## Motivation and Context

Closes #121 

## How Has This Been Tested?

Manual `yarn server`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.