### PR TITLE
[WIP] add sensu definition and spawn attribute to configuration reference

### DIFF
--- a/content/sensu-core/0.29/reference/configuration.md
+++ b/content/sensu-core/0.29/reference/configuration.md
@@ -26,6 +26,7 @@ menu:
 - [Sensu configuration specification](#sensu-configuration-specification)
   - [Example sensu configuration](#example-sensu-configuration)
   - [Top-level configuration scopes](#top-level-configuration-scopes)
+- [Sensu definition specification](#sensu-definition-specification)
 
 ## How does Sensu load configuration?
 
@@ -662,6 +663,18 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+sensu        | 
+-------------|-----
+description  | The Sensu global definition scope (see: [Sensu definition scope](#sensu-definition-specification))
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "sensu": {
+     "spawn": 24
+  }
+}
+{{< /highlight >}}
+
 client       | 
 -------------|------
 description  | The Sensu Client definition scope (see: [Clients][3])
@@ -728,6 +741,27 @@ example      | {{< highlight json >}}{
   "mutators": {
     "example_mutator": {},
     "another_mutator": {}
+  }
+}
+{{< /highlight >}}
+
+## Sensu definition specification
+
+Sensu uses the `"sensu": {}` definition scope.
+
+### Sensu attributes
+
+The following attributes are defined within the `"sensu": {}` definition scope.
+
+spawn          | 
+---------------|------
+description    | Number of processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+required       | false
+type           | Integer
+default        | 12
+example        | {{< highlight json >}}{
+  "sensu": {
+    "spawn": 24
   }
 }
 {{< /highlight >}}

--- a/content/sensu-core/1.0/reference/configuration.md
+++ b/content/sensu-core/1.0/reference/configuration.md
@@ -26,6 +26,7 @@ menu:
 - [Sensu configuration specification](#sensu-configuration-specification)
   - [Example sensu configuration](#example-sensu-configuration)
   - [Top-level configuration scopes](#top-level-configuration-scopes)
+- [Sensu definition specification](#sensu-definition-specification)
 
 ## How does Sensu load configuration?
 
@@ -662,6 +663,18 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+sensu        | 
+-------------|-----
+description  | The Sensu global definition scope (see: [Sensu definition scope](#sensu-definition-specification))
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "sensu": {
+     "spawn": 24
+  }
+}
+{{< /highlight >}}
+
 client       | 
 -------------|------
 description  | The Sensu Client definition scope (see: [Clients][3])
@@ -728,6 +741,27 @@ example      | {{< highlight json >}}{
   "mutators": {
     "example_mutator": {},
     "another_mutator": {}
+  }
+}
+{{< /highlight >}}
+
+## Sensu definition specification
+
+Sensu uses the `"sensu": {}` definition scope.
+
+### Sensu attributes
+
+The following attributes are defined within the `"sensu": {}` definition scope.
+
+spawn          | 
+---------------|------
+description    | Number of processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+required       | false
+type           | Integer
+default        | 12
+example        | {{< highlight json >}}{
+  "sensu": {
+    "spawn": 24
   }
 }
 {{< /highlight >}}

--- a/content/sensu-core/1.1/reference/configuration.md
+++ b/content/sensu-core/1.1/reference/configuration.md
@@ -26,6 +26,7 @@ menu:
 - [Sensu configuration specification](#sensu-configuration-specification)
   - [Example sensu configuration](#example-sensu-configuration)
   - [Top-level configuration scopes](#top-level-configuration-scopes)
+- [Sensu definition specification](#sensu-definition-specification)
 
 ## How does Sensu load configuration?
 
@@ -662,6 +663,18 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+sensu        | 
+-------------|-----
+description  | The Sensu global definition scope (see: [Sensu definition scope](#sensu-definition-specification))
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "sensu": {
+     "spawn": 24
+  }
+}
+{{< /highlight >}}
+
 client       | 
 -------------|------
 description  | The Sensu Client definition scope (see: [Clients][3])
@@ -728,6 +741,27 @@ example      | {{< highlight json >}}{
   "mutators": {
     "example_mutator": {},
     "another_mutator": {}
+  }
+}
+{{< /highlight >}}
+
+## Sensu definition specification
+
+Sensu uses the `"sensu": {}` definition scope.
+
+### Sensu attributes
+
+The following attributes are defined within the `"sensu": {}` definition scope.
+
+spawn          | 
+---------------|------
+description    | Number of processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+required       | false
+type           | Integer
+default        | 12
+example        | {{< highlight json >}}{
+  "sensu": {
+    "spawn": 24
   }
 }
 {{< /highlight >}}

--- a/content/sensu-core/1.2/reference/configuration.md
+++ b/content/sensu-core/1.2/reference/configuration.md
@@ -26,6 +26,7 @@ menu:
 - [Sensu configuration specification](#sensu-configuration-specification)
   - [Example sensu configuration](#example-sensu-configuration)
   - [Top-level configuration scopes](#top-level-configuration-scopes)
+- [Sensu definition specification](#sensu-definition-specification)
 
 ## How does Sensu load configuration?
 
@@ -662,6 +663,18 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+sensu        | 
+-------------|-----
+description  | The Sensu global definition scope (see: [Sensu definition scope](#sensu-definition-specification))
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "sensu": {
+     "spawn": 24
+  }
+}
+{{< /highlight >}}
+
 client       | 
 -------------|------
 description  | The Sensu Client definition scope (see: [Clients][3])
@@ -728,6 +741,27 @@ example      | {{< highlight json >}}{
   "mutators": {
     "example_mutator": {},
     "another_mutator": {}
+  }
+}
+{{< /highlight >}}
+
+## Sensu definition specification
+
+Sensu uses the `"sensu": {}` definition scope.
+
+### Sensu attributes
+
+The following attributes are defined within the `"sensu": {}` definition scope.
+
+spawn          | 
+---------------|------
+description    | Number of processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+required       | false
+type           | Integer
+default        | 12
+example        | {{< highlight json >}}{
+  "sensu": {
+    "spawn": 24
   }
 }
 {{< /highlight >}}

--- a/content/sensu-core/1.3/reference/configuration.md
+++ b/content/sensu-core/1.3/reference/configuration.md
@@ -26,6 +26,7 @@ menu:
 - [Sensu configuration specification](#sensu-configuration-specification)
   - [Example sensu configuration](#example-sensu-configuration)
   - [Top-level configuration scopes](#top-level-configuration-scopes)
+- [Sensu definition specification](#sensu-definition-specification)
 
 ## How does Sensu load configuration?
 
@@ -662,6 +663,18 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+sensu        | 
+-------------|-----
+description  | The Sensu global definition scope (see: [Sensu definition scope](#sensu-definition-specification))
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "sensu": {
+     "spawn": 24
+  }
+}
+{{< /highlight >}}
+
 client       | 
 -------------|------
 description  | The Sensu Client definition scope (see: [Clients][3])
@@ -728,6 +741,27 @@ example      | {{< highlight json >}}{
   "mutators": {
     "example_mutator": {},
     "another_mutator": {}
+  }
+}
+{{< /highlight >}}
+
+## Sensu definition specification
+
+Sensu uses the `"sensu": {}` definition scope.
+
+### Sensu attributes
+
+The following attributes are defined within the `"sensu": {}` definition scope.
+
+spawn          | 
+---------------|------
+description    | Number of processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+required       | false
+type           | Integer
+default        | 12
+example        | {{< highlight json >}}{
+  "sensu": {
+    "spawn": 24
   }
 }
 {{< /highlight >}}

--- a/content/sensu-core/1.4/reference/configuration.md
+++ b/content/sensu-core/1.4/reference/configuration.md
@@ -663,6 +663,18 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+sensu        | 
+-------------|-----
+description  | The Sensu global definition scope (see: [Sensu definition scope](#sensu-definition-specification))
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "sensu": {
+     "spawn": 24
+  }
+}
+{{< /highlight >}}
+
 client       | 
 -------------|------
 description  | The Sensu Client definition scope (see: [Clients][3])

--- a/content/sensu-core/1.4/reference/configuration.md
+++ b/content/sensu-core/1.4/reference/configuration.md
@@ -743,7 +743,7 @@ The following attributes are defined within the `"sensu": {}` definition scope.
 
 spawn          | 
 ---------------|------
-description    | Number processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+description    | Number of processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
 required       | false
 type           | Integer
 default        | 12

--- a/content/sensu-core/1.4/reference/configuration.md
+++ b/content/sensu-core/1.4/reference/configuration.md
@@ -26,6 +26,7 @@ menu:
 - [Sensu configuration specification](#sensu-configuration-specification)
   - [Example sensu configuration](#example-sensu-configuration)
   - [Top-level configuration scopes](#top-level-configuration-scopes)
+- [Sensu definition specification](#sensu-definition-specification)
 
 ## How does Sensu load configuration?
 
@@ -728,6 +729,27 @@ example      | {{< highlight json >}}{
   "mutators": {
     "example_mutator": {},
     "another_mutator": {}
+  }
+}
+{{< /highlight >}}
+
+## Sensu definition specification
+
+Sensu uses the `"sensu": {}` definition scope.
+
+### Sensu attributes
+
+The following attributes are defined within the `"sensu": {}` definition scope.
+
+spawn          | 
+---------------|------
+description    | Number processes Sensu will execute simultaneously. This setting affects execution of both checks and pipe handlers.
+required       | false
+type           | Integer
+default        | 12
+example        | {{< highlight json >}}{
+  "sensu": {
+    "spawn": 24
   }
 }
 {{< /highlight >}}


### PR DESCRIPTION
## Description

Adds a section on the `sensu` definition specification to our configuration reference

## Motivation and Context

Closes #116 

I chose to put this in the overall configuration reference as this is a “global” setting which controls number of simultaneous command executions for both sensu-client and sensu-server/sensu-enterprise. I’m open to other ideas if there seems like a better fit for this elsewhere.

## How Has This Been Tested?

Manual `yarn server`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.