### PR TITLE
Sensu Enterprise 3.0 OpsGenie changes

### DIFF
--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -64,6 +64,8 @@ event handler (integration).
 The following attributes are configured within the `{"opsgenie": {} }`
 [configuration scope][3].
 
+_NOTE: Some attributes are only available for certain tiers of OpsGenie._
+
 api_key      | 
 -------------|------
 description  | The OpsGenie Alert API key to use when creating/closing alerts.

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -22,7 +22,7 @@ users only.**
 Create and close [OpsGenie][2] alerts for events.
 
 _NOTE: As of Sensu Enterprise 3.0, the OpsGenie integration uses version 2 of the OpsGenie API.
-Visit the [Sensu Enterprise changelog][4] and the [OpsGenie API docs][5] for more information._
+Visit the [Sensu Enterprise 3.0 upgrade guide][4] and the [OpsGenie API docs][5] for more information._
 
 ## Configuration
 
@@ -184,5 +184,5 @@ example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 [1]:  /sensu-enterprise
 [2]:  https://www.opsgenie.com?ref=sensu-enterprise
 [3]: /sensu-core/1.2/reference/configuration#configuration-scopes
-[4]: ../../changelog
+[4]: /sensu-enterprise/3.0/upgrading#changes-in-opsgenie-integration
 [5]: https://docs.opsgenie.com/docs/alert-api

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -33,8 +33,6 @@ event handler (integration).
   "opsgenie": {
     "api_key": "eed02a0d-85a4-427b-851a-18dd8fd80d93",
     "source": "Sensu Enterprise (AWS)",
-    "teams": ["ops", "web"],
-    "recipients": ["afterhours"],
     "tags": ["production"],
     "overwrites_quiet_hours": true,
     "timeout": 10
@@ -64,21 +62,12 @@ type         | String
 default      | `Sensu Enterprise`
 example      | {{< highlight shell >}}"source": "Sensu (us-west-1)"{{< /highlight >}}
 
-teams        | 
 -------------|------
-description  | An array of OpsGenie team names to be used to calculate which users will be responsible for created alerts.
 required     | false
-type         | Array
-default      | `[]`
-example      | {{< highlight shell >}}"teams": ["ops", "web"]{{< /highlight >}}
 
-recipients   | 
 -------------|------
-description  | An array of OpsGenie group, schedule, or escalation names to be used to calculate which users will be responsible for created alerts.
 required     | false
 type         | Array
-default      | `[]`
-example      | {{< highlight shell >}}"recipients": ["web", "afterhours"]{{< /highlight >}}
 
 tags         | 
 -------------|------

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -33,6 +33,19 @@ event handler (integration).
   "opsgenie": {
     "api_key": "eed02a0d-85a4-427b-851a-18dd8fd80d93",
     "source": "Sensu Enterprise (AWS)",
+    "responders":[
+      {
+        "name":"afterhours",
+        "type":"schedule"
+      }
+    ],
+    "visible_to":[
+      {
+        "name":"ops",
+        "type":"team"
+      }
+    ],
+    "actions": ["ShowProcesses"],
     "tags": ["production"],
     "overwrites_quiet_hours": true,
     "timeout": 10
@@ -62,12 +75,64 @@ type         | String
 default      | `Sensu Enterprise`
 example      | {{< highlight shell >}}"source": "Sensu (us-west-1)"{{< /highlight >}}
 
+responders   | 
 -------------|------
+description  | The OpsGenie teams, users, schedules, or escalations that receive alert notifications. Each responder requires an `id` or `name` and a `type` (`team`, `user`, `escalation`, or `schedule`). _NOTE: For `"type":"user"`, use `username` instead of `name`._
 required     | false
+type         | Array of objects
+example      | {{< highlight shell >}}
+"responders":[
+  {
+    "name":"afterhours",
+    "type":"schedule"
+  },
+  {
+    "id":"bb4d9938-c3c2-455d-aaab-727aa701c0d8",
+    "type":"user"
+  },
+  {
+    "username":"alice@company.com",
+    "type":"user"
+  },
+  {
+    "id":"aee8a0de-c80f-4515-a232-501c0bc9d715",
+    "type":"escalation"
+  }
+]
+{{< /highlight >}}
 
+visible_to   | 
 -------------|------
+description  | The OpsGenie teams and users that can see alerts but won't receive notifications. Teams require an `id` or `name` and `"type":"team"`. Users require an `id` or `username` and `"type":"user"`.
+required     | false
+type         | Array of objects
+example      | {{< highlight shell >}}
+"visible_to":[
+  {
+    "name":"ops",
+    "type":"team"
+  },
+  {
+    "id":"4513b7ea-3b91-438f-b7e4-e3e54af9147c",
+    "type":"team"
+  },
+  {
+    "id":"bb4d9938-c3c2-455d-aaab-727aa701c0d8",
+    "type":"user"
+  },
+  {
+    "username":"alice@company.com",
+    "type":"user"
+  }
+]
+{{< /highlight >}}
+
+actions      | 
+-------------|------
+description  | Custom actions available for the alert
 required     | false
 type         | Array
+example      | {{< highlight shell >}}"actions": ["ViewLogs", "ShowProcesses"]{{< /highlight >}}
 
 tags         | 
 -------------|------

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -23,6 +23,7 @@ Create and close [OpsGenie][2] alerts for events.
 
 _NOTE: As of Sensu Enterprise 3.0, the OpsGenie integration uses version 2 of the OpsGenie API.
 OpsGenie API v2 deprecates the `recipients` and `teams` attributes from version 1 and adds `responders`, `visible_to`, and `actions`.
+The naming of Sensu Enterprise's `overwrites_quiet_hours` attribute has changed to `overwrite_quiet_hours` as well.
 Visit the [Sensu Enterprise changelog][4] and the [OpsGenie API docs][5] for more information._
 
 ## Configuration
@@ -51,7 +52,7 @@ event handler (integration).
     ],
     "actions": ["ShowProcesses"],
     "tags": ["production"],
-    "overwrites_quiet_hours": true,
+    "overwrite_quiet_hours": true,
     "timeout": 10
   }
 }
@@ -148,13 +149,13 @@ type         | Array
 default      | `[]`
 example      | {{< highlight shell >}}"tags": ["production"]{{< /highlight >}}
 
-overwrites_quiet_hours | 
+overwrite_quiet_hours  | 
 -----------------------|------
-description            | If events with a critical severity should be tagged with "OverwritesQuietHours". This tag can be used to bypass quiet (or off) hour alert notification filtering.
+description            | When configured, critical severity events will be tagged with "OverwriteQuietHours". This tag indicates that OpsGenie should bypass configured "quiet hours" that would otherwise filter alert notifications.
 required               | false
 type                   | Boolean
 default                | `false`
-example                | {{< highlight shell >}}"overwrites_quiet_hours": true{{< /highlight >}}
+example                | {{< highlight shell >}}"overwrite_quiet_hours": true{{< /highlight >}}
 
 filters        | 
 ---------------|------

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -22,8 +22,6 @@ users only.**
 Create and close [OpsGenie][2] alerts for events.
 
 _NOTE: As of Sensu Enterprise 3.0, the OpsGenie integration uses version 2 of the OpsGenie API.
-OpsGenie API v2 deprecates the `recipients` and `teams` attributes from version 1 and adds `responders`, `visible_to`, and `actions`.
-Additionally, the naming of Sensu Enterprise's `overwrites_quiet_hours` attribute has changed to `overwrite_quiet_hours`.
 Visit the [Sensu Enterprise changelog][4] and the [OpsGenie API docs][5] for more information._
 
 ## Configuration

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -23,7 +23,7 @@ Create and close [OpsGenie][2] alerts for events.
 
 _NOTE: As of Sensu Enterprise 3.0, the OpsGenie integration uses version 2 of the OpsGenie API.
 OpsGenie API v2 deprecates the `recipients` and `teams` attributes from version 1 and adds `responders`, `visible_to`, and `actions`.
-The naming of Sensu Enterprise's `overwrites_quiet_hours` attribute has changed to `overwrite_quiet_hours` as well.
+Additionally, the naming of Sensu Enterprise's `overwrites_quiet_hours` attribute has changed to `overwrite_quiet_hours`.
 Visit the [Sensu Enterprise changelog][4] and the [OpsGenie API docs][5] for more information._
 
 ## Configuration

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -64,7 +64,7 @@ event handler (integration).
 The following attributes are configured within the `{"opsgenie": {} }`
 [configuration scope][3].
 
-_NOTE: Some attributes are only available for certain tiers of OpsGenie._
+_NOTE: Some attributes are only available for certain OpsGenie subscription tiers._
 
 api_key      | 
 -------------|------

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -21,6 +21,10 @@ users only.**
 
 Create and close [OpsGenie][2] alerts for events.
 
+_NOTE: As of Sensu Enterprise 3.0, the OpsGenie integration uses version 2 of the OpsGenie API.
+OpsGenie API v2 deprecates the `recipients` and `teams` attributes from version 1 and adds `responders`, `visible_to`, and `actions`.
+Visit the [Sensu Enterprise changelog][4] and the [OpsGenie API docs][5] for more information._
+
 ## Configuration
 
 ### Example(s) {#examples}
@@ -179,3 +183,5 @@ example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 [1]:  /sensu-enterprise
 [2]:  https://www.opsgenie.com?ref=sensu-enterprise
 [3]: /sensu-core/1.2/reference/configuration#configuration-scopes
+[4]: ../../changelog
+[5]: https://docs.opsgenie.com/docs/alert-api


### PR DESCRIPTION
OpsGenie is deprecating their version 1 API later this month. This PR updates the Sensu Enterprise docs to reflect the OpsGenie version 2 API based on the [OpsGenie docs](https://docs.opsgenie.com/docs/alert-api).

## Description

- Removes `recipients` and `teams` attributes
- Adds `responders`, `visible_to`, and `actions` attributes

Source: [Google doc](https://docs.google.com/document/d/1AiN-o1QwJ_2iL4JMF52J0EaQKpV_P15rSfEJSJfUZTg/edit)

Closes #457 

## Motivation and Context
Accurate content for Sensu Enterprise 3.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Docs tested locally via `yarn run server`. Code samples not tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.