### PR TITLE
add Upgrading Sensu Enterprise pages

### DIFF
--- a/content/sensu-enterprise/2.6/upgrading.md
+++ b/content/sensu-enterprise/2.6/upgrading.md
@@ -22,8 +22,6 @@ _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the
 repositories and keep them up-to-date._
 
-### Sensu Enterprise
-
 #### Ubuntu/Debian
 
 {{< highlight shell >}}

--- a/content/sensu-enterprise/2.6/upgrading.md
+++ b/content/sensu-enterprise/2.6/upgrading.md
@@ -1,0 +1,38 @@
+---
+title: "Upgrading Sensu Enterprise"
+weight: 14
+product: "Sensu Enterprise"
+version: "2.6"
+menu: "sensu-enterprise-2.6"
+---
+
+Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
+upgrading Sensu Enterprise only requires upgrading to the
+latest package. Certain versions of Sensu Enterprise emay include changes that
+are *not backwards compatible* and require additional steps be taken when
+upgrading.
+
+## Upgrading the Sensu Enterprise package
+
+The following instructions assume that you have already installed
+Sensu and/or Sensu Enterprise by using the steps detailed in the
+[Sensu Installation Guide][overview].
+
+_NOTE: If your machines do not have direct access to the internet and
+cannot reach the Sensu software repositories, you must mirror the
+repositories and keep them up-to-date._
+
+### Sensu Enterprise
+
+#### Ubuntu/Debian
+
+{{< highlight shell >}}
+sudo apt-get update
+sudo apt-get -y install sensu-enterprise{{< /highlight >}}
+
+#### CentOS/RHEL
+
+{{< highlight shell >}}
+sudo yum install sensu-enterprise{{< /highlight >}}
+
+[overview]:  /sensu-core/latest/installation/install-sensu-server-api/#sensu-enterprise

--- a/content/sensu-enterprise/2.6/upgrading.md
+++ b/content/sensu-enterprise/2.6/upgrading.md
@@ -6,17 +6,16 @@ version: "2.6"
 menu: "sensu-enterprise-2.6"
 ---
 
-Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
-upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise may include changes that
-are *not backwards compatible* and require additional steps be taken when
-upgrading.
+In most cases, you can upgrade Sensu Enterprise by installing the
+latest package. Certain versions of Sensu Enterprise may include
+changes that are *not backwards compatible* and require additional
+steps be taken when upgrading.
 
 ## Upgrading the Sensu Enterprise package
 
 The following instructions assume that you have already installed
-Sensu and/or Sensu Enterprise by using the steps detailed in the
-[Sensu Installation Guide][overview].
+Sensu Enterprise by using the steps detailed in the[Sensu Installation
+Guide][overview].
 
 _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the

--- a/content/sensu-enterprise/2.6/upgrading.md
+++ b/content/sensu-enterprise/2.6/upgrading.md
@@ -8,7 +8,7 @@ menu: "sensu-enterprise-2.6"
 
 Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
 upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise emay include changes that
+latest package. Certain versions of Sensu Enterprise may include changes that
 are *not backwards compatible* and require additional steps be taken when
 upgrading.
 

--- a/content/sensu-enterprise/2.7/upgrading.md
+++ b/content/sensu-enterprise/2.7/upgrading.md
@@ -22,8 +22,6 @@ _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the
 repositories and keep them up-to-date._
 
-### Sensu Enterprise
-
 #### Ubuntu/Debian
 
 {{< highlight shell >}}

--- a/content/sensu-enterprise/2.7/upgrading.md
+++ b/content/sensu-enterprise/2.7/upgrading.md
@@ -6,17 +6,16 @@ version: "2.7"
 menu: "sensu-enterprise-2.7"
 ---
 
-Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
-upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise may include changes that
-are *not backwards compatible* and require additional steps be taken when
-upgrading.
+In most cases, you can upgrade Sensu Enterprise by installing the
+latest package. Certain versions of Sensu Enterprise may include
+changes that are *not backwards compatible* and require additional
+steps be taken when upgrading.
 
 ## Upgrading the Sensu Enterprise package
 
 The following instructions assume that you have already installed
-Sensu and/or Sensu Enterprise by using the steps detailed in the
-[Sensu Installation Guide][overview].
+Sensu Enterprise by using the steps detailed in the[Sensu Installation
+Guide][overview].
 
 _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the

--- a/content/sensu-enterprise/2.7/upgrading.md
+++ b/content/sensu-enterprise/2.7/upgrading.md
@@ -1,0 +1,38 @@
+---
+title: "Upgrading Sensu Enterprise"
+weight: 14
+product: "Sensu Enterprise"
+version: "2.7"
+menu: "sensu-enterprise-2.7"
+---
+
+Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
+upgrading Sensu Enterprise only requires upgrading to the
+latest package. Certain versions of Sensu Enterprise emay include changes that
+are *not backwards compatible* and require additional steps be taken when
+upgrading.
+
+## Upgrading the Sensu Enterprise package
+
+The following instructions assume that you have already installed
+Sensu and/or Sensu Enterprise by using the steps detailed in the
+[Sensu Installation Guide][overview].
+
+_NOTE: If your machines do not have direct access to the internet and
+cannot reach the Sensu software repositories, you must mirror the
+repositories and keep them up-to-date._
+
+### Sensu Enterprise
+
+#### Ubuntu/Debian
+
+{{< highlight shell >}}
+sudo apt-get update
+sudo apt-get -y install sensu-enterprise{{< /highlight >}}
+
+#### CentOS/RHEL
+
+{{< highlight shell >}}
+sudo yum install sensu-enterprise{{< /highlight >}}
+
+[overview]:  /sensu-core/latest/installation/install-sensu-server-api/#sensu-enterprise

--- a/content/sensu-enterprise/2.7/upgrading.md
+++ b/content/sensu-enterprise/2.7/upgrading.md
@@ -8,7 +8,7 @@ menu: "sensu-enterprise-2.7"
 
 Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
 upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise emay include changes that
+latest package. Certain versions of Sensu Enterprise may include changes that
 are *not backwards compatible* and require additional steps be taken when
 upgrading.
 

--- a/content/sensu-enterprise/2.8/upgrading.md
+++ b/content/sensu-enterprise/2.8/upgrading.md
@@ -6,17 +6,16 @@ version: "2.8"
 menu: "sensu-enterprise-2.8"
 ---
 
-Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
-upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise may include changes that
-are *not backwards compatible* and require additional steps be taken when
-upgrading.
+In most cases, you can upgrade Sensu Enterprise by installing the
+latest package. Certain versions of Sensu Enterprise may include
+changes that are *not backwards compatible* and require additional
+steps be taken when upgrading.
 
 ## Upgrading the Sensu Enterprise package
 
 The following instructions assume that you have already installed
-Sensu and/or Sensu Enterprise by using the steps detailed in the
-[Sensu Installation Guide][overview].
+Sensu Enterprise by using the steps detailed in the[Sensu Installation
+Guide][overview].
 
 _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the

--- a/content/sensu-enterprise/2.8/upgrading.md
+++ b/content/sensu-enterprise/2.8/upgrading.md
@@ -1,0 +1,38 @@
+---
+title: "Upgrading Sensu Enterprise"
+weight: 14
+product: "Sensu Enterprise"
+version: "2.8"
+menu: "sensu-enterprise-2.8"
+---
+
+Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
+upgrading Sensu Enterprise only requires upgrading to the
+latest package. Certain versions of Sensu Enterprise emay include changes that
+are *not backwards compatible* and require additional steps be taken when
+upgrading.
+
+## Upgrading the Sensu Enterprise package
+
+The following instructions assume that you have already installed
+Sensu and/or Sensu Enterprise by using the steps detailed in the
+[Sensu Installation Guide][overview].
+
+_NOTE: If your machines do not have direct access to the internet and
+cannot reach the Sensu software repositories, you must mirror the
+repositories and keep them up-to-date._
+
+### Sensu Enterprise
+
+#### Ubuntu/Debian
+
+{{< highlight shell >}}
+sudo apt-get update
+sudo apt-get -y install sensu-enterprise{{< /highlight >}}
+
+#### CentOS/RHEL
+
+{{< highlight shell >}}
+sudo yum install sensu-enterprise{{< /highlight >}}
+
+[overview]:  /sensu-core/latest/installation/install-sensu-server-api/#sensu-enterprise

--- a/content/sensu-enterprise/2.8/upgrading.md
+++ b/content/sensu-enterprise/2.8/upgrading.md
@@ -22,8 +22,6 @@ _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the
 repositories and keep them up-to-date._
 
-### Sensu Enterprise
-
 #### Ubuntu/Debian
 
 {{< highlight shell >}}

--- a/content/sensu-enterprise/2.8/upgrading.md
+++ b/content/sensu-enterprise/2.8/upgrading.md
@@ -8,7 +8,7 @@ menu: "sensu-enterprise-2.8"
 
 Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
 upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise emay include changes that
+latest package. Certain versions of Sensu Enterprise may include changes that
 are *not backwards compatible* and require additional steps be taken when
 upgrading.
 

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -6,11 +6,10 @@ version: "3.0"
 menu: "sensu-enterprise-3.0"
 ---
 
-Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
-upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise may include changes that
-are *not backwards compatible* and require additional steps be taken when
-upgrading.
+In most cases, you can upgrade Sensu Enterprise by installing the
+latest package. Certain versions of Sensu Enterprise may include
+changes that are *not backwards compatible* and require additional
+steps be taken when upgrading.
 
 - [Upgrading from Sensu Enterprise < 3.0](#upgrading-from-sensu-enterprise-3-0)
 	- [Changes in OpsGenie integration](#changes-in-opsgenie-integration)
@@ -124,19 +123,13 @@ Enterprise Linux (EPEL) repository][epel] to provide OpenJDK version
 
 The aim of this change is to help our customers stay up-to-date with
 their chosen Linux distributions and remain in compliance with security
-policies which may require packages like OpenJDK 1.7 to be removed
-once their end-of-support date is reached.
-
-Until recently [Redhat’s OpenJDK Life
-Cycle and Support Policy][rhel-openjdk-policy] listed June 2018 as
-the end-of-support date for OpenJDK 1.7. That date has since changed
-to June 2020.
+policies.
 
 ## Upgrading the Sensu Enterprise package
 
 The following instructions assume that you have already installed
-Sensu and/or Sensu Enterprise by using the steps detailed in the
-[Sensu Installation Guide][overview].
+Sensu Enterprise by using the steps detailed in the [Sensu
+Installation Guide][overview].
 
 _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the
@@ -156,4 +149,3 @@ sudo yum install sensu-enterprise{{< /highlight >}}
 [overview]: /sensu-core/installation/overview
 [opsgenie-api-migration]: https://docs.opsgenie.com/docs/migration-guide-for-alert-rest-api
 [epel]: https://www.fedoraproject.org/wiki/EPEL
-[rhel-openjdk-policy]: https://access.redhat.com/articles/1299013

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -1,0 +1,136 @@
+---
+title: "Upgrading Sensu Enterprise"
+weight: 14
+product: "Sensu Enterprise"
+version: "3.0"
+menu: "sensu-enterprise-3.0"
+---
+
+Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
+upgrading Sensu Enterprise only requires upgrading to the
+latest package. Certain versions of Sensu Enterprise emay include changes that
+are *not backwards compatible* and require additional steps be taken when
+upgrading.
+
+## Upgrading from Sensu Enterprise < 3.0
+
+The following documentation provides steps necessary when upgrading
+from a Sensu Enterprise version prior to 3.0.
+
+### Update OpsGenie integration configuration
+
+OpsGenie has deprecated and will shut down their v1 API on
+June 30th, 2018.
+
+_NOTE: To continue using the Sensu Enterprise OpsGenie integration, you must
+upgrade to Sensu Enterprise 3.0 before June 30, 2018._
+
+Sensu Enterprise 3.0 updates the OpsGenie integration to use
+OpsGenie's new v2 Alert, necessitating a breaking change to Sensu
+Enterprise's OpsGenie configuration specification.
+
+#### Configuring OpsGenie for `responders`
+
+_NOTE: To continue routing events to specific OpsGenie teams and other
+entities you must upgrade your Sensu Enterprise configuration when
+upgrading Sensu Enterprise 3.0 or later_
+
+The OpsGenie v2 Alert API replaces the `teams` and `recipients` attributes with
+a new `responders` attribute. As a result you must upgrade your Sensu
+Enterprise configuration for OpsGenie in order to correctly route
+alerts using the new API.
+
+Example OpsGenie configuration for Sensu Enterprise prior to 3.0:
+
+{{< highlight json >}}
+{
+  "opsgenie": {
+    "api_key": "eed02a0d-85a4-427b-851a-18dd8fd80d93",
+    "teams": ["ops", "web"],
+    "recipients": ["afterhours"]
+  }
+}
+{{</ highlight >}}
+
+Assuming `afterhours` is an escalation plan, the values supplied for
+`teams` and `recipients` above can be translated to the new
+`responders` attribute like so:
+
+{{< highlight json >}}
+{
+  "opsgenie": {
+    "api_key": "eed02a0d-85a4-427b-851a-18dd8fd80d93",
+    "responders": [
+      {
+        "type": "team",
+        "name": "ops"
+      },
+      {
+        "type": "team",
+        "name": "web"
+      },
+      {
+        "type": "escalation",
+        "name": "afterhours"
+      }
+    ]
+  }
+}
+{{</ highlight >}}
+
+As shown above, the `responders` attribute expects an array of hashes
+specifying the `type` and `name` for each object. Depending on the
+given type of a responder, the identifying attribute (e.g. `name`) may
+vary. Please see [OpsGenie's Alert API Migration
+Guide][opsgenie-api-migration] for more details.
+
+### Changes in Java package dependency
+
+With the release of Sensu Enterprise 3.0 the `sensu-enterprise` package
+dependency the Java Virtual Machinee will change from OpenJDK 1.7 to
+OpenJDK 1.8. This dependency will typically be satified
+automatically by your distribution's package management system,
+e.g. `yum` or `apt`.
+
+_NOTE: Users running Sensu Enterprise on RHEL/Centos 6 or similar
+distributions will need to install the [Extra Packages for
+Enterprise Linux (EPEL) repository][epel] to provide OpenJDK version
+1.8 when upgrading to Sensu Enterprise 3.0._
+
+The aim of this change is to help our customers stay up-to-date with
+their chosen Linux distributions and remain in compliance with security
+policies which may require packages like OpenJDK 1.7 to be removed
+once their end-of-support date is reached.
+
+Until recently [Redhat’s OpenJDK Life
+Cycle and Support Policy][rhel-openjdk-policy] reflected June 2018 as
+the end-of-support date for OpenJDK 1.7. That date has since changed
+to June 2020.
+
+## Upgrading the Sensu Enterprise package
+
+The following instructions assume that you have already installed
+Sensu and/or Sensu Enterprise by using the steps detailed in the
+[Sensu Installation Guide][overview].
+
+_NOTE: If your machines do not have direct access to the internet and
+cannot reach the Sensu software repositories, you must mirror the
+repositories and keep them up-to-date._
+
+### Sensu Enterprise
+
+#### Ubuntu/Debian
+
+{{< highlight shell >}}
+sudo apt-get update
+sudo apt-get -y install sensu-enterprise{{< /highlight >}}
+
+#### CentOS/RHEL
+
+{{< highlight shell >}}
+sudo yum install sensu-enterprise{{< /highlight >}}
+
+[overview]: /sensu-core/installation/overview
+[opsgenie-api-migration]: https://docs.opsgenie.com/docs/migration-guide-for-alert-rest-api
+[epel]: https://www.fedoraproject.org/wiki/EPEL
+[rhel-openjdk-policy]: https://access.redhat.com/articles/1299013

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -17,7 +17,7 @@ upgrading.
 The following documentation provides steps necessary when upgrading
 from a Sensu Enterprise version prior to 3.0.
 
-### Update OpsGenie integration configuration
+### Changes in OpsGenie integration
 
 OpsGenie has deprecated and will shut down their v1 API on
 June 30th, 2018.
@@ -29,7 +29,7 @@ Sensu Enterprise 3.0 updates the OpsGenie integration to use
 OpsGenie's new v2 Alert, necessitating a breaking change to Sensu
 Enterprise's OpsGenie configuration specification.
 
-#### Configuring OpsGenie for `responders`
+#### Configure OpsGenie for `responders`
 
 _NOTE: To continue routing events to specific OpsGenie teams and other
 entities you must upgrade your Sensu Enterprise configuration when
@@ -116,8 +116,6 @@ Sensu and/or Sensu Enterprise by using the steps detailed in the
 _NOTE: If your machines do not have direct access to the internet and
 cannot reach the Sensu software repositories, you must mirror the
 repositories and keep them up-to-date._
-
-### Sensu Enterprise
 
 #### Ubuntu/Debian
 

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -20,7 +20,7 @@ from a Sensu Enterprise version prior to 3.0.
 ### Changes in OpsGenie integration
 
 OpsGenie has deprecated and will shut down their v1 API on
-June 30th, 2018.
+June 30, 2018.
 
 _NOTE: To continue using the Sensu Enterprise OpsGenie integration, you must
 upgrade to Sensu Enterprise 3.0 before June 30, 2018._
@@ -32,8 +32,8 @@ Enterprise's OpsGenie configuration specification.
 #### Configure OpsGenie for `responders`
 
 _NOTE: To continue routing events to specific OpsGenie teams and other
-entities you must upgrade your Sensu Enterprise configuration when
-upgrading Sensu Enterprise 3.0 or later_
+entities you must upgrade your Sensu Enterprise OpsGenie configuration when
+upgrading to Sensu Enterprise 3.0 or later_
 
 The OpsGenie v2 Alert API replaces the `teams` and `recipients` attributes with
 a new `responders` attribute. As a result you must upgrade your Sensu
@@ -90,7 +90,7 @@ With the release of Sensu Enterprise 3.0 the `sensu-enterprise` package
 dependency on the Java Virtual Machine will change from OpenJDK 1.7 to
 OpenJDK 1.8. This dependency will typically be satisfied
 automatically by your distribution's package management system,
-e.g. `yum` or `apt`.
+such as `yum` or `apt`.
 
 _NOTE: Users running Sensu Enterprise on RHEL/Centos 6 or similar
 distributions will need to install the [Extra Packages for
@@ -103,7 +103,7 @@ policies which may require packages like OpenJDK 1.7 to be removed
 once their end-of-support date is reached.
 
 Until recently [Redhat’s OpenJDK Life
-Cycle and Support Policy][rhel-openjdk-policy] reflected June 2018 as
+Cycle and Support Policy][rhel-openjdk-policy] listed June 2018 as
 the end-of-support date for OpenJDK 1.7. That date has since changed
 to June 2020.
 

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -28,18 +28,15 @@ from a Sensu Enterprise version prior to 3.0.
 OpsGenie has deprecated and will shut down their v1 API on
 June 30, 2018.
 
-_NOTE: To continue using the Sensu Enterprise OpsGenie integration, you must
-upgrade to Sensu Enterprise 3.0 before June 30, 2018._
+_WARNING: To continue using the Sensu Enterprise OpsGenie integration, you must
+upgrade to Sensu Enterprise 3.0 and update your Sensu Enterprise
+OpsGenie configuration before June 30, 2018._
 
 Sensu Enterprise 3.0 updates the OpsGenie integration to use
 OpsGenie's new v2 Alert, necessitating a breaking change to Sensu
 Enterprise's OpsGenie configuration specification.
 
-#### Configure OpsGenie for `responders`
-
-_NOTE: To continue routing events to specific OpsGenie teams and other
-entities you must upgrade your Sensu Enterprise OpsGenie configuration when
-upgrading to Sensu Enterprise 3.0 or later_
+#### Update OpsGenie configuration for `responders`
 
 The OpsGenie v2 Alert API replaces the `teams` and `recipients` attributes with
 a new `responders` attribute. As a result you must upgrade your Sensu
@@ -90,7 +87,7 @@ given type of a responder, the identifying attribute (e.g. `name`) may
 vary. Please see [OpsGenie's Alert API Migration
 Guide][opsgenie-api-migration] for more details.
 
-#### Update `overwrites_quiet_hours`
+#### Update OpsGenie configuration for `overwrites_quiet_hours`
 
 Sensu Enterprise 3.0 updates the name of the `overwrites_quiet_hours` attribute
 to `overwrite_quiet_hours`. The singular form of this attribute is required to

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -8,7 +8,7 @@ menu: "sensu-enterprise-3.0"
 
 Upgrading Sensu Enterprise is usually a straightforward process. In most cases,
 upgrading Sensu Enterprise only requires upgrading to the
-latest package. Certain versions of Sensu Enterprise emay include changes that
+latest package. Certain versions of Sensu Enterprise may include changes that
 are *not backwards compatible* and require additional steps be taken when
 upgrading.
 
@@ -87,8 +87,8 @@ Guide][opsgenie-api-migration] for more details.
 ### Changes in Java package dependency
 
 With the release of Sensu Enterprise 3.0 the `sensu-enterprise` package
-dependency the Java Virtual Machinee will change from OpenJDK 1.7 to
-OpenJDK 1.8. This dependency will typically be satified
+dependency on the Java Virtual Machine will change from OpenJDK 1.7 to
+OpenJDK 1.8. This dependency will typically be satisfied
 automatically by your distribution's package management system,
 e.g. `yum` or `apt`.
 

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -12,6 +12,13 @@ latest package. Certain versions of Sensu Enterprise may include changes that
 are *not backwards compatible* and require additional steps be taken when
 upgrading.
 
+- [Upgrading from Sensu Enterprise < 3.0](#upgrading-from-sensu-enterprise-3-0)
+	- [Changes in OpsGenie integration](#changes-in-opsgenie-integration)
+		- [Configure OpsGenie for `responders`](#configure-opsgenie-for-responders)
+		- [Update `overwrites_quiet_hours`](#update-overwrites-quiet-hours)
+	- [Changes in Java package dependency](#changes-in-java-package-dependency)
+- [Upgrading the Sensu Enterprise package](#upgrading-the-sensu-enterprise-package)
+
 ## Upgrading from Sensu Enterprise < 3.0
 
 The following documentation provides steps necessary when upgrading

--- a/content/sensu-enterprise/3.0/upgrading.md
+++ b/content/sensu-enterprise/3.0/upgrading.md
@@ -84,6 +84,24 @@ given type of a responder, the identifying attribute (e.g. `name`) may
 vary. Please see [OpsGenie's Alert API Migration
 Guide][opsgenie-api-migration] for more details.
 
+#### Update `overwrites_quiet_hours`
+
+Sensu Enterprise 3.0 updates the name of the `overwrites_quiet_hours` attribute
+to `overwrite_quiet_hours`. The singular form of this attribute is required to
+achieve the desired result of overriding alert filtering that would otherwise
+prevent OpsGenie from notifying recipient(s) during their configured quiet hours.
+
+Example OpsGenie configuration for Sensu Enterprise 3.0:
+
+{{< highlight json >}}
+{
+  "opsgenie": {
+    "api_key": "eed02a0d-85a4-427b-851a-18dd8fd80d93",
+    "overwrite_quiet_hours": true
+  }
+}
+{{</ highlight >}}
+
 ### Changes in Java package dependency
 
 With the release of Sensu Enterprise 3.0 the `sensu-enterprise` package


### PR DESCRIPTION
## Description

Adds an "upgrading" page to each version of the Sensu Enterprise documentation.

## Motivation and Context

Sensu Core has an "upgrading" page which covers the potential breaking changes when upgrading between versions of that product.

Sensu Enterprise 3.0 release will include breaking changes which merit their own upgrade notes, separate from the changelog which documents the high-level changes.

Adding this page provides product-specific upgrade directions for Sensu Enterprise prior to 3.0, and provides advice on changes needed for upgrading to Sensu Enterprise 3.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [X] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] All tests have passed.