### PR TITLE
Update aggregates reference docs to include aggregates check definition

### DIFF
--- a/content/sensu-core/0.29/reference/aggregates.md
+++ b/content/sensu-core/0.29/reference/aggregates.md
@@ -144,8 +144,14 @@ aggregate    |
 description  | Create a named aggregate for the check. Check result data will be aggregated and exposed via the [Sensu Aggregates API][2].
 required     | false
 type         | String
-default      | false
 example      | {{< highlight shell >}}"aggregate": "elasticsearch"{{< /highlight >}}
+
+aggregates   | 
+-------------|------
+description  | An array of strings defining one or more named aggregates (described above).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"aggregates": [ "webservers", "production" ]{{< /highlight >}}
 
 handle       | 
 -------------|------

--- a/content/sensu-core/1.0/reference/aggregates.md
+++ b/content/sensu-core/1.0/reference/aggregates.md
@@ -144,8 +144,15 @@ aggregate    |
 description  | Create a named aggregate for the check. Check result data will be aggregated and exposed via the [Sensu Aggregates API][2].
 required     | false
 type         | String
-default      | false
 example      | {{< highlight shell >}}"aggregate": "elasticsearch"{{< /highlight >}}
+
+aggregates   | 
+-------------|------
+description  | An array of strings defining one or more named aggregates (described above).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"aggregates": [ "webservers", "production" ]{{< /highlight >}}
+
 
 handle       | 
 -------------|------

--- a/content/sensu-core/1.1/reference/aggregates.md
+++ b/content/sensu-core/1.1/reference/aggregates.md
@@ -144,8 +144,15 @@ aggregate    |
 description  | Create a named aggregate for the check. Check result data will be aggregated and exposed via the [Sensu Aggregates API][2].
 required     | false
 type         | String
-default      | false
 example      | {{< highlight shell >}}"aggregate": "elasticsearch"{{< /highlight >}}
+
+aggregates   | 
+-------------|------
+description  | An array of strings defining one or more named aggregates (described above).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"aggregates": [ "webservers", "production" ]{{< /highlight >}}
+
 
 handle       | 
 -------------|------

--- a/content/sensu-core/1.2/reference/aggregates.md
+++ b/content/sensu-core/1.2/reference/aggregates.md
@@ -144,8 +144,15 @@ aggregate    |
 description  | Create a named aggregate for the check. Check result data will be aggregated and exposed via the [Sensu Aggregates API][2].
 required     | false
 type         | String
-default      | false
 example      | {{< highlight shell >}}"aggregate": "elasticsearch"{{< /highlight >}}
+
+aggregates   | 
+-------------|------
+description  | An array of strings defining one or more named aggregates (described above).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"aggregates": [ "webservers", "production" ]{{< /highlight >}}
+
 
 handle       | 
 -------------|------

--- a/content/sensu-core/1.3/reference/aggregates.md
+++ b/content/sensu-core/1.3/reference/aggregates.md
@@ -144,8 +144,15 @@ aggregate    |
 description  | Create a named aggregate for the check. Check result data will be aggregated and exposed via the [Sensu Aggregates API][2].
 required     | false
 type         | String
-default      | false
 example      | {{< highlight shell >}}"aggregate": "elasticsearch"{{< /highlight >}}
+
+aggregates   | 
+-------------|------
+description  | An array of strings defining one or more named aggregates (described above).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"aggregates": [ "webservers", "production" ]{{< /highlight >}}
+
 
 handle       | 
 -------------|------

--- a/content/sensu-core/1.4/reference/aggregates.md
+++ b/content/sensu-core/1.4/reference/aggregates.md
@@ -144,8 +144,15 @@ aggregate    |
 description  | Create a named aggregate for the check. Check result data will be aggregated and exposed via the [Sensu Aggregates API][2].
 required     | false
 type         | String
-default      | false
 example      | {{< highlight shell >}}"aggregate": "elasticsearch"{{< /highlight >}}
+
+aggregates   | 
+-------------|------
+description  | An array of strings defining one or more named aggregates (described above).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"aggregates": [ "webservers", "production" ]{{< /highlight >}}
+
 
 handle       | 
 -------------|------


### PR DESCRIPTION
## Description
The check attributes listed in the aggregates reference section do not include `aggregates`, the check attribute to pass an array of aggregates, instead of using `aggregate` which only accepts a single aggregate string.

`default: false` has also been removed from the `aggregate` check definition reference as this is not a boolean option with a default value

## Motivation and Context
Provides full list of aggregate check attributes within the aggregates reference section; bringing in line with the aggregate related options outlined in the `checks` reference documentation.

## How Has This Been Tested?
`hugo build`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [x] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.