### PR TITLE
Update anchor to properly go to the right section

### DIFF
--- a/content/sensu-core/0.29/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/0.29/installation/install-rabbitmq-on-rhel-centos.md
@@ -80,7 +80,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. Install the RabbitMQ init scripts using the [`chkconfig` utility][5]:
    {{< highlight shell >}}

--- a/content/sensu-core/0.29/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/0.29/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -71,7 +71,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. To enable the RabbitMQ service, you'll need to install its init scripts using
    the `update-rc.d` utility (if you are using Ubuntu 16.04+ you will need to 

--- a/content/sensu-core/1.0/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.0/installation/install-rabbitmq-on-rhel-centos.md
@@ -80,7 +80,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. Install the RabbitMQ init scripts using the [`chkconfig` utility][5]:
    {{< highlight shell >}}

--- a/content/sensu-core/1.0/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.0/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -71,7 +71,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. To enable the RabbitMQ service, you'll need to install its init scripts using
    the `update-rc.d` utility (if you are using Ubuntu 16.04+ you will need to 

--- a/content/sensu-core/1.1/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.1/installation/install-rabbitmq-on-rhel-centos.md
@@ -80,7 +80,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. Install the RabbitMQ init scripts using the [`chkconfig` utility][5]:
    {{< highlight shell >}}

--- a/content/sensu-core/1.1/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.1/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -71,7 +71,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. To enable the RabbitMQ service, you'll need to install its init scripts using
    the `update-rc.d` utility (if you are using Ubuntu 16.04+ you will need to 

--- a/content/sensu-core/1.2/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.2/installation/install-rabbitmq-on-rhel-centos.md
@@ -80,7 +80,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. Install the RabbitMQ init scripts using the [`chkconfig` utility][5]:
    {{< highlight shell >}}

--- a/content/sensu-core/1.2/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.2/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -71,7 +71,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. To enable the RabbitMQ service, you'll need to install its init scripts using
    the `update-rc.d` utility (if you are using Ubuntu 16.04+ you will need to 

--- a/content/sensu-core/1.3/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.3/installation/install-rabbitmq-on-rhel-centos.md
@@ -80,7 +80,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. Install the RabbitMQ init scripts using the [`chkconfig` utility][5]:
    {{< highlight shell >}}

--- a/content/sensu-core/1.3/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.3/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -71,7 +71,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. To enable the RabbitMQ service, you'll need to install its init scripts using
    the `update-rc.d` utility (if you are using Ubuntu 16.04+ you will need to 

--- a/content/sensu-core/1.4/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.4/installation/install-rabbitmq-on-rhel-centos.md
@@ -80,7 +80,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. Install the RabbitMQ init scripts using the [`chkconfig` utility][5]:
    {{< highlight shell >}}

--- a/content/sensu-core/1.4/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.4/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -71,7 +71,7 @@ users, as the repository is labeled as a "testing" repo, because (according to
 the RabbitMQ website) "[they] release somewhat frequently", and there shouldn't
 be a reason to upgrade RabbitMQ versions frequently._
 
-## Managing the RabbitMQ service/process
+## Managing the RabbitMQ service/process {#managing-the-rabbitmq-serviceprocess}
 
 1. To enable the RabbitMQ service, you'll need to install its init scripts using
    the `update-rc.d` utility (if you are using Ubuntu 16.04+ you will need to 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently `Managing the RabbitMQ service/process` links within the table of contents of the RabbitMQ installation documentation does not go anywhere. This is due to that section having a `/` in name. The building of the website from Hugo to HTML puts a `-` in the header id of the section, `#managing-the-rabbitmq-service-process`, causing the linking not to work as the anchor expects to actually be `#managing-the-rabbitmq-serviceprocess`.

## Motivation and Context
Closes #468  

## How Has This Been Tested?
Manually tested locally all toc links for all pre-2.0 Sensu versions and OSs in the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All tests have passed.