### PR TITLE
Add api-only mode to Sensu Enterprise

### DIFF
--- a/content/sensu-enterprise/3.0/configuration.md
+++ b/content/sensu-enterprise/3.0/configuration.md
@@ -52,4 +52,16 @@ required       | false
 default        | `16384`
 example        | {{< highlight shell >}}MAX_OPEN_FILES=32768{{< /highlight >}}
 
+## Sensu Enterprise command line interfaces and arguments
+
+The following command line options are unique to Sensu Enterprise.
+For command line options shared with `sensu-server`, `sensu-api`, and `sensu-client`,
+visit the [Sensu Core configuration reference docs][1].
+
+-a (-\-api_only) | 
+----------------|------
+description     | Run only the Sensu Enterprise API. You can use API-only mode to deploy Sensu Enterprise API instances that don't process events from transport queues.
+example         | {{< highlight shell >}}$ /opt/sensu/bin/sensu-enterprise -a
+{{< /highlight >}}
+
 [1]: /sensu-core/1.2/reference/configuration


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Documenting API-only mode as part of Sensu Enterprise 3.0. Content based on https://github.com/sensu/sensu-enterprise/pull/343 and https://github.com/sensu/sensu-docs/pull/467/files#diff-4b16a72722c9a6bfed27561908426312R95

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #469 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally via `yarn run server`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.