### PR TITLE
add redirect rule for /uchiwa/latest

### DIFF
--- a/static.json
+++ b/static.json
@@ -7,6 +7,10 @@
             "url": "/sensu-core/1.4/$1",
             "status": 302
         },
+        "~ ^/uchiwa/latest/?(.*)$": {
+            "url": "/uchiwa/1.0/$1",
+            "status": 302
+        },
         "~ ^/sensu-enterprise/latest/?(.*)$": {
             "url": "/sensu-enterprise/3.0/$1",
             "status": 302


### PR DESCRIPTION
## Description

Adds a redirect rule for `/uchiwa/latest`

## Motivation and Context

We want to have a redirect for `latest` under each product which takes the visitor to the most recent version.

## How Has This Been Tested?

JSON validated with `jq` 😇 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.