### PR TITLE
Removed Uchiwa/plugins references from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ Contribution was too complicated when working with the now-deprecated [sensu-doc
 
 ## Known limitations
 
-- Uchiwa links to the existing website
 - There is no Extensions documentation at this time
-- Plugin documentation is very out of date. Help fix that by participating in [this issue](https://github.com/sensu-plugins/community/issues/58)
 - Sensu Core 2.0 documentation will be partially missing until the Beta milestone is reached
 
 ## Project wiki

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Contribution was too complicated when working with the now-deprecated [sensu-doc
 ## Known limitations
 
 - There is no Extensions documentation at this time
-- Sensu Core 2.0 documentation will be partially missing until the Beta milestone is reached
 
 ## Project wiki
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the following from the README:
```
- Uchiwa links to the existing website
- Plugin documentation is very out of date. Help fix that by participating in [this issue](https://github.com/sensu-plugins/community/issues/58)
```
As Uchiwa docs have been merged to this site and the community issue has been closed. 

## Motivation and Context
Removes outdated info

## How Has This Been Tested?
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.