### PR TITLE
Search page content

### DIFF
--- a/static/javascripts/application.js
+++ b/static/javascripts/application.js
@@ -757,7 +757,7 @@ if ("document" in self && ("classList" in document.createElement("_") ? ! functi
                 var o = lunr(function() {
                         this.field("title", {
                             boost: 10
-                        }), this.field("text"), this.ref("location")
+                        }), this.field("content"), this.ref("location")
                     }),
                     s = {};
                 e.map(function(t) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current search functionality searches page titles and URLs, but not the content of the page even though page content _is_ indexed. This PR fixes a bug where the variable to point the search at the page content was set to `text` instead of `content`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #380 (but doesn't resolve all issues with search functionality)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally via yarn

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All tests have passed.