### PR TITLE
Use relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,17 @@ If the site builds successfully, you can run the Hugo server and view the site i
 yarn run server
 ```
 
+Then visit http://127.0.0.1:1313/ in the browser of your choice.
+
 #### Troubleshooting Hugo
 Here are some things you might try if you encounter an issue working with the site:
 
 * Run `yarn hugo-version` to print the running version of Hugo. Version 0.34 or newer is required.
 * If you are seeing stale page content, try using `yarn server --disableFastRender` to ensure all pages are rebuilt as you make changes.
 * If you're still having trouble viewing the site, open an issue, and we'll be happy to help!
+
+#### Updating the theme
+This project uses the [hugo-material-docs](https://github.com/digitalcraftsman/hugo-material-docs) theme with some local modifications. Should you choose to update the theme, please take care to ensure leading slashes are not removed from links to Javascript, CSS and other assets.
 
 ### Pushing to GitHub
 This is the same as any other project. Follow GitHub's instructions if you're unsure. No additional steps are needed.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If the site builds successfully, you can run the Hugo server and view the site i
 yarn run server
 ```
 
-Then visit http://127.0.0.1:1313/ in the browser of your choice.
+Then visit http://localhost:1313/ in the browser of your choice.
 
 #### Troubleshooting Hugo
 Here are some things you might try if you encounter an issue working with the site:

--- a/config.toml
+++ b/config.toml
@@ -26,8 +26,8 @@ ignoreFiles = [ "sensu-doc-template.md" ]
 	repo_url = "https://github.com/sensu/sensu-docs"
 
 	version = "1.0"
-	logo = "images/sensu-logo-icon-dark@128px.png"
-	favicon = "images/favicon.png"
+	logo = "/images/sensu-logo-icon-dark@128px.png"
+	favicon = "/images/favicon.png"
 
 	permalink = "#"
 
@@ -36,7 +36,7 @@ ignoreFiles = [ "sensu-doc-template.md" ]
 	custom_js  = []
 
 	# Syntax highlighting theme
-	highlight_css  = "stylesheets/syntax.css"
+	highlight_css  = "/stylesheets/syntax.css"
 
 	[params.palette]
     	primary = "green"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
-baseurl = "//docs.sensu.io/"
+baseurl = ""
+relativeurls = true
 languageCode = "en-us"
 title = "Sensu Docs"
 theme = "hugo-material-docs"

--- a/content/uchiwa/1.0/getting-started/basic-concepts.md
+++ b/content/uchiwa/1.0/getting-started/basic-concepts.md
@@ -12,4 +12,4 @@ menu:
 A datacenter is a logical representation of a Sensu cluster. Datacenters can be used, for example, to organize physical datacenters or environments.
 
 ## Sensu
-See [Sensu documentation](https://docs.sensu.io/sensu-core/latest/overview/what-is-sensu) for more concepts.
+See [Sensu documentation](/sensu-core/latest/overview/what-is-sensu) for more concepts.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ partial "head" . }}
 
-<script type="text/javascript" src="{{ "javascripts/application.js" | absURL }}"></script>
+<script type="text/javascript" src="{{ "/javascripts/application.js" | absURL }}"></script>
 
 {{ if (eq (trim .Site.Params.provider " " | lower) "github") | and (isset .Site.Params "repo_url") }}
   {{ $repo_id := replace .Site.Params.repo_url "https://github.com/" ""}}

--- a/layouts/partials/drawer.html
+++ b/layouts/partials/drawer.html
@@ -3,7 +3,7 @@
   <!-- Logo and link to home -->
   <a href="{{ .Site.BaseURL }}" class="project">
     <div class="drawer-title">
-      <img src="{{ "images/sensu-logo-icon-dark@2x.png" | absURL }}" alt="Sensu Logo">
+      <img src="{{ "/images/sensu-logo-icon-dark@2x.png" | absURL }}" alt="Sensu Logo">
       <h2>Navigation</h2>
     </div>
   </a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="su-footer">
-  <img src="{{ "images/footer-symbol.png" | absURL }}" class="footer-symbol">
+  <img src="{{ "/images/footer-symbol.png" | absURL }}" class="footer-symbol">
   <div class="su-container">
     <div class="su-row">
         <div class="su-footer-left">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,48 +31,48 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
-    <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
-    <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "/images/favicon.ico" | absURL }}{{ end }}">
+    <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "/images/favicon.ico" | absURL }}{{ end }}">
 
     <style>
       @font-face {
         font-family: 'Icon';
-        src: url('{{ "fonts/icon.eot?52m981" | absURL }}');
-        src: url('{{ "fonts/icon.eot?#iefix52m981" | absURL }}')
+        src: url('{{ "/fonts/icon.eot?52m981" | absURL }}');
+        src: url('{{ "/fonts/icon.eot?#iefix52m981" | absURL }}')
                format('embedded-opentype'),
-             url('{{ "fonts/icon.woff?52m981" | absURL }}')
+             url('{{ "/fonts/icon.woff?52m981" | absURL }}')
                format('woff'),
-             url('{{ "fonts/icon.ttf?52m981" | absURL }}')
+             url('{{ "/fonts/icon.ttf?52m981" | absURL }}')
                format('truetype'),
-             url('{{ "fonts/icon.svg?52m981#icon" | absURL }}')
+             url('{{ "/fonts/icon.svg?52m981#icon" | absURL }}')
                format('svg');
         font-weight: normal;
         font-style: normal;
       }
     </style>
 
-    <link rel="stylesheet" href="{{ "stylesheets/application.css" | absURL }}">
-    <link rel="stylesheet" href="{{ "stylesheets/temporary.css" | absURL }}">
-    <link rel="stylesheet" href="{{ "stylesheets/palettes.css" | absURL }}">
-    <link rel="stylesheet" href="{{ with .Site.Params.highlight_css }}{{ . | absURL }}{{ else }}{{ "stylesheets/highlight/highlight.css" | absURL }}{{ end }}">
-    <link rel="stylesheet" href="{{ "stylesheets/override.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/application.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/temporary.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/palettes.css" | absURL }}">
+    <link rel="stylesheet" href="{{ with .Site.Params.highlight_css }}{{ . | absURL }}{{ else }}{{ "/stylesheets/highlight/highlight.css" | absURL }}{{ end }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/override.css" | absURL }}">
     {{ if .IsHome }}
-        <link rel="stylesheet" href="{{ "stylesheets/homepage.css" | absURL }}">
+        <link rel="stylesheet" href="{{ "/stylesheets/homepage.css" | absURL }}">
     {{ end }}
-    <link rel="stylesheet" href="{{ "stylesheets/docs-overrides.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/docs-overrides.css" | absURL }}">
 
     {{ range .Site.Params.custom_css }}
     <link rel="stylesheet" href="{{ . | absURL }}">
     {{ end }}
-    <script src="{{ "javascripts/modernizr.js" | absURL }}"></script>
+    <script src="{{ "/javascripts/modernizr.js" | absURL }}"></script>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
       crossorigin="anonymous"></script>
     <script src="https://use.fontawesome.com/ea9395e21e.js"></script>
-    <script type="text/javascript" src="{{ "js/vendor/lunr.min.js" | absURL }}"></script>
-    <script type="text/javascript" src="{{ "js/js-cookie.js" | absURL }}"></script>
-    <script type="text/javascript" src="{{ "js/platformDropdowns.js" | absURL }}"></script>
-    <script type="text/javascript" src="{{ "js/noframework.waypoints.min.js" | absURL }}"></script>
-    <!-- <script type="text/javascript" src="{{ "javascripts/application.js" | absURL }}"></script> -->
+    <script type="text/javascript" src="{{ "/js/vendor/lunr.min.js" | absURL }}"></script>
+    <script type="text/javascript" src="{{ "/js/js-cookie.js" | absURL }}"></script>
+    <script type="text/javascript" src="{{ "/js/platformDropdowns.js" | absURL }}"></script>
+    <script type="text/javascript" src="{{ "/js/noframework.waypoints.min.js" | absURL }}"></script>
+    <!-- <script type="text/javascript" src="{{ "/javascripts/application.js" | absURL }}"></script> -->
     {{ with .RSSLink }}
     <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
     <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />

--- a/themes/hugo-material-docs/layouts/partials/footer_js.html
+++ b/themes/hugo-material-docs/layouts/partials/footer_js.html
@@ -8,7 +8,7 @@
     {{ end }}
     </script>
 
-    <script src="{{ "javascripts/application.js" | absURL }}"></script>
+    <script src="{{ "/javascripts/application.js" | absURL }}"></script>
     {{ range .Site.Params.custom_js }}
     <script src="{{ . | absURL }}"></script>
     {{ end }}

--- a/themes/hugo-material-docs/layouts/partials/head.html
+++ b/themes/hugo-material-docs/layouts/partials/head.html
@@ -33,24 +33,24 @@
     <style>
       @font-face {
         font-family: 'Icon';
-        src: url('{{ "fonts/icon.eot?52m981" | absURL }}');
-        src: url('{{ "fonts/icon.eot?#iefix52m981" | absURL }}')
+        src: url('{{ "/fonts/icon.eot?52m981" | absURL }}');
+        src: url('{{ "/fonts/icon.eot?#iefix52m981" | absURL }}')
                format('embedded-opentype'),
-             url('{{ "fonts/icon.woff?52m981" | absURL }}')
+             url('{{ "/fonts/icon.woff?52m981" | absURL }}')
                format('woff'),
-             url('{{ "fonts/icon.ttf?52m981" | absURL }}')
+             url('{{ "/fonts/icon.ttf?52m981" | absURL }}')
                format('truetype'),
-             url('{{ "fonts/icon.svg?52m981#icon" | absURL }}')
+             url('{{ "/fonts/icon.svg?52m981#icon" | absURL }}')
                format('svg');
         font-weight: normal;
         font-style: normal;
       }
     </style>
 
-    <link rel="stylesheet" href="{{ "stylesheets/application.css" | absURL }}">
-    <link rel="stylesheet" href="{{ "stylesheets/temporary.css" | absURL }}">
-    <link rel="stylesheet" href="{{ "stylesheets/palettes.css" | absURL }}">
-    <link rel="stylesheet" href="{{ with .Site.Params.highlight_css }}{{ . | absURL }}{{ else }}{{ "stylesheets/highlight/highlight.css" | absURL }}{{ end }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/application.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/temporary.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/stylesheets/palettes.css" | absURL }}">
+    <link rel="stylesheet" href="{{ with .Site.Params.highlight_css }}{{ . | absURL }}{{ else }}{{ "/stylesheets/highlight/highlight.css" | absURL }}{{ end }}">
 
     {{/* set default values if no custom ones are defined */}}
     {{ $text := or .Site.Params.font.text "Roboto" }}
@@ -68,7 +68,7 @@
     {{ range .Site.Params.custom_css }}
     <link rel="stylesheet" href="{{ . | absURL }}">
     {{ end }}
-    <script src="{{ "javascripts/modernizr.js" | absURL }}"></script>
+    <script src="{{ "/javascripts/modernizr.js" | absURL }}"></script>
 
     {{ with .RSSLink }}
     <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />

--- a/themes/hugo-material-docs/layouts/partials/head.html
+++ b/themes/hugo-material-docs/layouts/partials/head.html
@@ -28,7 +28,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
     <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
-    <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
+    <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "/images/favicon.ico" | absURL }}{{ end }}">
 
     <style>
       @font-face {


### PR DESCRIPTION
## Description

This change set modifies Hugo configuration, as well as our theme, layouts and partials to support using relative URLs.

## Motivation and Context

With this change in place, I believe we'll be better positioned to make use of Heroku's app pipeline capabilities, meaning we can deploy the site to staging for evaluation and then promote that build to the production app.

## How Has This Been Tested?

Currently deployed to https://sensu-docs-stage.herokuapp.com

I ran the W3C link validator against this staging deployment, which did not turned up any broken links internal to the docs content.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.