### PR TITLE
Disable travis deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,3 @@ before_install:
   - export PATH="$TRAVIS_BUILD_DIR/bin:$PATH"
 
 cache: yarn
-
-deploy:
-  provider: heroku
-  app: sensu-docs-site
-  api_key:
-    secure: lkbs3btmm5PAgSeZ0gl0cUykzf9umFLD/r0SnHEEpKvxm90tXaZBhMXaLr/i6kl3sIFjJacaJnF6TdVXcRJWuXKRxF8d0xdzLRpvsW4lety4yKeVtB+NZ69NT1WRCWFYM+UhFzBoeXQXQzatrn7snckjzRx+PUYpY8OCDo9law3DQIea90A+0P9gFM4DblO649BMW4pMVoGyKsr2k91f5RoM+biNALXIUqh5NvDdszwfdXvOmsqcrCIM0cEwfglAIHJhsY6rGz7T4I4Hsu556k5wBocU6dJAM2ziACn5gj+T74upldi95KTHYdUN1aXBM1ea1iidwDiUrGBX1XLw9gMPIR1iIkLLyh+o2UFOdic1pBTYK3RThcNvQiiMcfwoSImu4TmgQ1dM67lW+luLj0A6TbCBCCuow5HYYdazXGxYRth3UPVSVEgBS0ADQyu9kNhmPkBqBf8lPiaWN6o1xD5Nto99U0P5jcpo7MvsTFiw12Mrfid+x+cocPOFCI9KEfrnsTcXcyQh3t8oZDmdZGySxuY9gEFkHttz8U5ie86eGVm2s17jw/NOFNiBoPpuLfwksUXQJa8IouPM0GUbMac4gKQHDc97hVKp8rRM0kymUL574qxluIOtdFOO4oOxJgXSP1+Afm371ZgIdjuyrmdON1+zA4jOGm3UHEhYjII=
-  on:
-    branch: master

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ This project uses the [hugo-material-docs](https://github.com/digitalcraftsman/h
 This is the same as any other project. Follow GitHub's instructions if you're unsure. No additional steps are needed.
 
 ### Deploying to Heroku
-This project uses [Travis CI Deployment support for Heroku](https://docs.travis-ci.com/user/deployment/heroku/) to automatically deploy the site once changes are merged to `master`. For additional details on Heroku configuration and deployment, see [our wiki page](https://github.com/sensu/sensu-docs/wiki/Heroku-Configuration-and-Publishing).
+Any time changes are merged to `master` branch, this project is automatically deployed to https://docs.sensu.io using Heroku's own Github integration. For additional details on Heroku configuration and deployment, see [our wiki page](https://github.com/sensu/sensu-docs/wiki/Heroku-Configuration-and-Publishing).


### PR DESCRIPTION
## Description

This change disables automatic deployments as part of the Travis CI pipeline.

## Motivation and Context

Builds recently started failing to deploy via Travis. As part of ongoing “robustification” efforts we’re going to move this responsibility to Heroku’s own Github integration.

## How Has This Been Tested?

Not tested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.