### PR TITLE
Fix invalid example json

### DIFF
--- a/content/sensu-core/0.29/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/0.29/guides/snmp-sensu-guide.md
@@ -57,7 +57,7 @@ As well as change the configuration of the extension in `/etc/sensu/conf.d/snmp_
 {{< highlight json >}}
 {
   "snmp_trap": {
-    "community": "sensutest",
+    "community": "sensutest"
   }
 }{{< /highlight >}}
 

--- a/content/sensu-core/1.0/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/1.0/guides/snmp-sensu-guide.md
@@ -57,7 +57,7 @@ As well as change the configuration of the extension in `/etc/sensu/conf.d/snmp_
 {{< highlight json >}}
 {
   "snmp_trap": {
-    "community": "sensutest",
+    "community": "sensutest"
   }
 }{{< /highlight >}}
 

--- a/content/sensu-core/1.1/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/1.1/guides/snmp-sensu-guide.md
@@ -57,7 +57,7 @@ As well as change the configuration of the extension in `/etc/sensu/conf.d/snmp_
 {{< highlight json >}}
 {
   "snmp_trap": {
-    "community": "sensutest",
+    "community": "sensutest"
   }
 }{{< /highlight >}}
 

--- a/content/sensu-core/1.2/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/1.2/guides/snmp-sensu-guide.md
@@ -57,7 +57,7 @@ As well as change the configuration of the extension in `/etc/sensu/conf.d/snmp_
 {{< highlight json >}}
 {
   "snmp_trap": {
-    "community": "sensutest",
+    "community": "sensutest"
   }
 }{{< /highlight >}}
 

--- a/content/sensu-core/1.3/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/1.3/guides/snmp-sensu-guide.md
@@ -57,7 +57,7 @@ As well as change the configuration of the extension in `/etc/sensu/conf.d/snmp_
 {{< highlight json >}}
 {
   "snmp_trap": {
-    "community": "sensutest",
+    "community": "sensutest"
   }
 }{{< /highlight >}}
 

--- a/content/sensu-core/1.4/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/1.4/guides/snmp-sensu-guide.md
@@ -57,7 +57,7 @@ As well as change the configuration of the extension in `/etc/sensu/conf.d/snmp_
 {{< highlight json >}}
 {
   "snmp_trap": {
-    "community": "sensutest",
+    "community": "sensutest"
   }
 }{{< /highlight >}}
 


### PR DESCRIPTION
Nice guide! 
The trailing comma made for invalid example JSON.

## Description
Remove a trailing comma in example JSON. 

## Motivation and Context
Copying the example JSON made my Sensu configuration invalid. 

## How Has This Been Tested?
It hasn't. :) 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All tests have passed.