### PR TITLE
Add notice for build-essential prerequisite

### DIFF
--- a/content/sensu-core/1.4/quick-start/learn-sensu-basics.md
+++ b/content/sensu-core/1.4/quick-start/learn-sensu-basics.md
@@ -456,6 +456,8 @@ sudo sensu-install -p mailer{{< /highlight >}}
 With this plugin package installed, the `handler-mailer.rb`
 executable is now available at `/opt/sensu/embedded/bin/handler-mailer.rb`.
 
+_NOTE: Some Sensu plugins and extensions require standard build tools like gcc and make, which may not be installed on a brand-new system. Without these build tools, installation will fail. You can obtain these tools using your package manager. Debian/Ubuntu users can install the build-essential metapackage, while RHEL/CentOS users can install gcc, gcc-c++, and make._
+
 * Similar to the check definition we wrote above, we will now need a
 definition to describe execution of the mailer handler.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As the 5-minute guide suggests installation on a brand-new system, minimal installations of the supported OSes will not include build-essential tools, and the mail handler given in the example will fail to install. It was easy enough to figure out from the output, but a notice would have made my installation smoother.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The change is required to solve a problem of breaking immersion while installing Sensu for the first time in a common scenario where a minimally installed OS does not have the required tools.

<!--- If it fixes an open issue, please link to the issue here. -->

No open issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Though it's documentation, I have tested this in CentOS 7 while installing.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [X] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] All tests have passed.