### PR TITLE
Update Enterprise 3.1 PagerDuty integration

### DIFF
--- a/content/sensu-enterprise/3.1/integrations/pagerduty.md
+++ b/content/sensu-enterprise/3.1/integrations/pagerduty.md
@@ -19,8 +19,8 @@ users only.**
 ## Overview
 
 Create and resolve [PagerDuty][2] incidents for events. After [configuring a
-service in PagerDuty][3], configure the handler (integration) with the provided
-service key.
+service in PagerDuty for Events API v2][3], configure the handler (integration) with the provided
+integration key.
 
 ## Configuration
 
@@ -32,7 +32,7 @@ event handler (integration).
 {{< highlight json >}}
 {
   "pagerduty": {
-    "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE",
+    "routing_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE",
     "timeout": 10
   }
 }
@@ -45,12 +45,12 @@ event handler (integration).
 The following attributes are configured within the `{"pagerduty": {} }`
 [configuration scope][4].
 
-service_key  | 
+routing_key  | 
 -------------|------
-description  | The PagerDuty service key to use when creating and resolving incidents.
+description  | The PagerDuty integration key to use when creating and resolving incidents.
 required     | true
 type         | String
-example      | {{< highlight shell >}}"service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"{{< /highlight >}}
+example      | {{< highlight shell >}}"routing_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"{{< /highlight >}}
 
 filters        | 
 ---------------|------

--- a/content/sensu-enterprise/3.1/integrations/pagerduty.md
+++ b/content/sensu-enterprise/3.1/integrations/pagerduty.md
@@ -47,7 +47,7 @@ The following attributes are configured within the `{"pagerduty": {} }`
 
 routing_key  | 
 -------------|------
-description  | The PagerDuty integration key to use when creating and resolving incidents.
+description  | The PagerDuty integration key to use when creating and resolving incidents. _NOTE: If you're using an integration key for PagerDuty's Events API v1, you can continue to use `service_key` instead of `routing_key`._
 required     | true
 type         | String
 example      | {{< highlight shell >}}"routing_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"{{< /highlight >}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sensu Enterprise v3.1 uses PagerDuty API v2. This PR updates the integration docs to use `routing_key` (integration key in PagerDuty) instead of `service key`.

Also added an instruction for users to select the v2 API per this doc: https://support.pagerduty.com/docs/services-and-integrations#section-events-api-v2

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #611, based on https://github.com/sensu/sensu-enterprise/pull/374

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally via yarn

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All tests have passed.