### PR TITLE
Order menu sections by weight

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -31,7 +31,7 @@
           <li><a class="menu-title" href="/{{ $url }}/{{ $.Params.version }}">{{ $niceName }}</a><ul class="toc-menu-container">
 
           <!-- Loop through the menus pages -->
-          {{ range $y, $x := $v }}
+          {{ range $y, $x := sort $v "Weight" }}
 
           <!-- Determine if one the children of this menu is active so we can apply the proper styling -->
             {{ $isCurrent := ($currentNode.HasMenuCurrent $k $x) }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds sorting by weight for menu entries.

Right now, entries for a given menu (e.g. sensu-core-1.4) are alphabetically sorted, even if a weight is specified in a `_index.md` file, for example:

```
[...]
menu:
  sensu-core-1.4:
    identifier: getting-started
    weight: 100
```

## Motivation and Context
Related to https://github.com/sensu/sensu-docs/issues/581.

## How Has This Been Tested?
Locally tested with 2.0 documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.