### PR TITLE
Remove note about asset tarballs, the bug has been fixed in sensu-go

### DIFF
--- a/content/sensu-core/2.0/reference/assets.md
+++ b/content/sensu-core/2.0/reference/assets.md
@@ -5,7 +5,7 @@ description: "The assets reference guide."
 weight: 1
 version: "2.0"
 product: "Sensu Core"
-platformContent: false
+platformContent: false 
 menu:
   sensu-core-2.0:
     parent: reference
@@ -37,51 +37,51 @@ The following are injected into the execution context:
 
 ### Attributes
 
-name         |
--------------|------
+name         | 
+-------------|------ 
 description  | The unique name of the asset, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
 required     | true
-type         | String
+type         | String 
 example      | {{< highlight shell >}}"name": "check_script"{{</ highlight >}}
 
 
-url          |
--------------|------
-description  | The URL location of the asset.
+url          | 
+-------------|------ 
+description  | The URL location of the asset. 
 required     | true
-type         | String
+type         | String 
 example      | {{< highlight shell >}}"url": "http://example.com/asset.tar.gz"{{</ highlight >}}
 
-sha512       |
--------------|------
-description  | The checksum of the asset.
+sha512       | 
+-------------|------ 
+description  | The checksum of the asset. 
 required     | true
-type         | String
+type         | String 
 example      | {{< highlight shell >}}"sha512": "4f926bf4328..."{{</ highlight >}}
 
-metadata     |
--------------|------
-description  | Information about the asset, in the form of key value pairs.
-required     | false
-type         | Map
+metadata     | 
+-------------|------ 
+description  | Information about the asset, in the form of key value pairs. 
+required     | false 
+type         | Map 
 example      | {{< highlight shell >}}"metadata": {
-"Content-Type": "application/zip",
+"Content-Type": "application/zip", 
 "X-Intended-Distribution": "trusty-14"}
 {{</ highlight >}}
 
-filters      |
--------------|------
-description  | A set of [filters][1] used by the agent to determine of the asset should be installed.
-required     | false
-type         | Array
+filters      | 
+-------------|------ 
+description  | A set of [filters][1] used by the agent to determine of the asset should be installed. 
+required     | false 
+type         | Array 
 example      | {{< highlight shell >}}"filters": ["System.OS=='linux'", "System.Arch=='amd64'"] {{</ highlight >}}
 
-organization |
--------------|------
+organization | 
+-------------|------ 
 description  | The Sensu RBAC organization that this asset belongs to.
-required     | false
+required     | false 
 type         | String
-default      | current organization value configured for `sensuctl` (ie `default`)
+default      | current organization value configured for `sensuctl` (ie `default`) 
 example      | {{< highlight shell >}}
   "organization": "default"
 {{</ highlight >}}

--- a/content/sensu-core/2.0/reference/assets.md
+++ b/content/sensu-core/2.0/reference/assets.md
@@ -5,7 +5,7 @@ description: "The assets reference guide."
 weight: 1
 version: "2.0"
 product: "Sensu Core"
-platformContent: false 
+platformContent: false
 menu:
   sensu-core-2.0:
     parent: reference
@@ -33,58 +33,55 @@ The following are injected into the execution context:
   variable.
 - `{PATH_TO_ASSET}/include` is injected into the `CPATH` environment variable.
 
-**N.B.** GitHub source code archives [can't currently be used][2] as Sensu
-assets archives.
-
 ## Assets specification
 
 ### Attributes
 
-name         | 
--------------|------ 
+name         |
+-------------|------
 description  | The unique name of the asset, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
 required     | true
-type         | String 
+type         | String
 example      | {{< highlight shell >}}"name": "check_script"{{</ highlight >}}
 
 
-url          | 
--------------|------ 
-description  | The URL location of the asset. 
+url          |
+-------------|------
+description  | The URL location of the asset.
 required     | true
-type         | String 
+type         | String
 example      | {{< highlight shell >}}"url": "http://example.com/asset.tar.gz"{{</ highlight >}}
 
-sha512       | 
--------------|------ 
-description  | The checksum of the asset. 
+sha512       |
+-------------|------
+description  | The checksum of the asset.
 required     | true
-type         | String 
+type         | String
 example      | {{< highlight shell >}}"sha512": "4f926bf4328..."{{</ highlight >}}
 
-metadata     | 
--------------|------ 
-description  | Information about the asset, in the form of key value pairs. 
-required     | false 
-type         | Map 
+metadata     |
+-------------|------
+description  | Information about the asset, in the form of key value pairs.
+required     | false
+type         | Map
 example      | {{< highlight shell >}}"metadata": {
-"Content-Type": "application/zip", 
+"Content-Type": "application/zip",
 "X-Intended-Distribution": "trusty-14"}
 {{</ highlight >}}
 
-filters      | 
--------------|------ 
-description  | A set of [filters][1] used by the agent to determine of the asset should be installed. 
-required     | false 
-type         | Array 
+filters      |
+-------------|------
+description  | A set of [filters][1] used by the agent to determine of the asset should be installed.
+required     | false
+type         | Array
 example      | {{< highlight shell >}}"filters": ["System.OS=='linux'", "System.Arch=='amd64'"] {{</ highlight >}}
 
-organization | 
--------------|------ 
+organization |
+-------------|------
 description  | The Sensu RBAC organization that this asset belongs to.
-required     | false 
+required     | false
 type         | String
-default      | current organization value configured for `sensuctl` (ie `default`) 
+default      | current organization value configured for `sensuctl` (ie `default`)
 example      | {{< highlight shell >}}
   "organization": "default"
 {{</ highlight >}}
@@ -106,4 +103,3 @@ example      | {{< highlight shell >}}
 {{</ highlight >}}
 
 [1]: ../../reference/filters/
-[2]: https://github.com/mholt/archiver/issues/27


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

Remove note about asset tarballs, the bug has been fixed in sensu-go

## Description
Removes note stating that asset tarballs cannot be extracted.

## Motivation and Context
Bug is fixed in https://github.com/sensu/sensu-go/pull/1980 so the note is irrelevant.

## How Has This Been Tested?
Locally, CI.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [x] Fixing errata
- [ ] Update (Add missing or refresh existing content)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.