### PR TITLE
Adding sudo note and minor change to validation output in run-auto-remediation.md

### DIFF
--- a/content/sensu-core/2.0/guides/run-auto-remediation.md
+++ b/content/sensu-core/2.0/guides/run-auto-remediation.md
@@ -42,6 +42,8 @@ sensuctl hook create nginx-restart  \
 --timeout 10
 {{< /highlight >}}
 
+**NOTE** - If running hook commands as sudo you may need to update your /etc/sudoers to allow the sensu user to run the commands without a password, otherwise you may get a '**_sudo: no tty present and no askpass program specified_**' error.
+
 ### Assigning the hook to a check
 
 Now that the `nginx-restart` hook has been created, it can be assigned to a
@@ -73,7 +75,7 @@ $ sensuctl event info i-424242 nginx_process --format json
       {
         "config": {
           "name": "nginx-restart",
-          "command": "systemctl restart nginx",
+          "command": "sudo systemctl restart nginx",
           "timeout": 10,
           "environment": "default",
           "organization": "default"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- adding a note about editing sudoers to allow sensu user to run commands without a password to avoid errors
- changed sample validation output (specifically the command subsection) to be consistent with what was specified in the creation of the hook

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since I encountered the sudo askpass error when setting up auto-remediation, I figured a note on avoiding it was warranted. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I forked the repo, added in my changes, ran **yarn run server** and made sure it all looked good.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New doc/guide
- [ ] Fixing errata
- [x] Update (Add missing or refresh existing content)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All tests have passed.