### PR TITLE
Allow subscription/check pairs in check dependencies filter

### DIFF
--- a/content/sensu-core/1.5/reference/filters.md
+++ b/content/sensu-core/1.5/reference/filters.md
@@ -372,8 +372,8 @@ Here's an example of a handler definition that uses the checks dependencies filt
 #### Check dependencies filter attributes {#check-dependencies-attributes}
 
 The check dependencies filter uses a custom check definition attribute: `dependencies`.
-The `dependencies` attribute should define an array containing names of checks or
-client/check pairs.
+The `dependencies` attribute should define an array containing names of checks,
+client/check pairs, or subscription/check pairs.
 
 Here's an example of a check definition that will be filtered if a check named `mysql` from the same client is already alerting:
 
@@ -390,7 +390,7 @@ Here's an example of a check definition that will be filtered if a check named `
 }
 {{< /highlight >}}
 
-You can also define a more detailed dependency by specifying the client and check pair.
+You can also define a dependency by specifying the client and the check.
 Here's an example of a check definition that will be filtered if a check named `mysql` from client `db-01` is already alerting:
 
 {{< highlight json >}}
@@ -406,12 +406,31 @@ Here's an example of a check definition that will be filtered if a check named `
 }
 {{< /highlight >}}
 
+Or, define a dependency by specifying the subscription and the check.
+Here's an example of a check definition that will be filtered if any check named `mysql` on any client subscribed to the `db-nodes` subscription is already alerting:
+
+{{< highlight json >}}
+{
+  "checks": {
+    "web_application_api": {
+      "command": "check-http.rb -u https://localhost:8080/api/v1/health",
+      "subscribers": ["web_application"],
+      "interval": 20,
+      "dependencies": ["subscription:db-nodes/mysql"]
+    }
+  }
+}
+{{< /highlight >}}
+
+_WARNING: Specifying a subscription/check pair in the check dependencies filter
+may impact Sensu's performance in large-scale installations._
+
 dependencies | 
 -------------|------
-description  | An array containing names of checks or client/check pairs
+description  | An array containing names of checks, client/check pairs, or subscription/check pairs. Subscription/check pairs must be in the format `subscription:subscription-name/check-name`.
 required     | True if specified handler uses the check dependencies filter
 type         | Array
-example      | {{< highlight shell >}}"dependencies": ["db-01/mysql", "apache"]{{< /highlight >}}
+example      | {{< highlight shell >}}"dependencies": ["db-01/mysql", "apache", "subscription:db-nodes/mysql"]{{< /highlight >}}
 
 ## Filter configuration
 

--- a/content/sensu-core/1.5/reference/filters.md
+++ b/content/sensu-core/1.5/reference/filters.md
@@ -407,7 +407,8 @@ Here's an example of a check definition that will be filtered if a check named `
 {{< /highlight >}}
 
 Or, define a dependency by specifying the subscription and the check.
-Here's an example of a check definition that will be filtered if any check named `mysql` on any client subscribed to the `db-nodes` subscription is already alerting:
+Here's an example of a check definition that will be filtered if a check named `mysql`
+is already alerting on any client subscribed to the `db-nodes` subscription:
 
 {{< highlight json >}}
 {
@@ -423,7 +424,8 @@ Here's an example of a check definition that will be filtered if any check named
 {{< /highlight >}}
 
 _WARNING: Specifying a subscription/check pair in the check dependencies filter
-may impact Sensu's performance in large-scale installations._
+may impact Sensu's performance in cases where the [events API][17] regularly
+returns thousands of events._
 
 dependencies | 
 -------------|------
@@ -579,3 +581,4 @@ example      | {{< highlight shell >}}"days": {
 [14]: #when-attributes
 [15]: #filter-naming
 [16]: ../handlers#handler-sets
+[17]: ../../api/events#events-get


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Sensu Core 1.5 includes support for specifying a subscription/check pair in the check dependencies filter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #707

## Review Instructions
<!--- Optional -->
- Does the `db-notes` subscription example make sense?
- For the performance warning, is there any way to provide rough figures or guidance on when you might want to avoid using this?
