### PR TITLE
Correct license to reflect original copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Sensu Inc.
+Copyright (c) 2011 Sonian Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
This PR reverts the license copyright to Sonian as listed in the [license for the legacy docs project](https://github.com/sensu/sensu-docs-legacy/blob/master/MIT-LICENSE.txt). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
The license text "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." leads me to believe that we should include the original copyright.
