### PR TITLE
Update frontmatter on `_index.md` pages

### DIFF
--- a/content/plugins/1.0/developer-guidelines.md
+++ b/content/plugins/1.0/developer-guidelines.md
@@ -26,7 +26,7 @@ menu: "plugins-1.0"
 - Any repos created need to follow the format of *sensu-plugins-app*, where *app* is the name such as windows, disk-checks, or influxdb.  The exception to the rule are repos used for the site or tooling such as GIR or sensu-plugins.github.io.  This is done so that the rake tasks and other automation tools can easily parse Github and effectively work with the 150+ repos.
 
 ## Coding Style
-- When developing plugins please use the [sensu plugin class][1], this ensures all plugins have an identical run structure.
+- When developing plugins please use the [Sensu plugin class][1], this ensures all plugins have an identical run structure.
 - When using options please use the following structure.  At the very least the option needs to include a description to assist the user with configuration and deployment.
 
 {{< highlight ruby >}}
@@ -90,11 +90,11 @@ If you see something wrong or come across a bug please open up an issue, try to 
 
 Pull requests need to follow the guidelines below for the quickest possible merge.  These not only make our lives easier, but also keep the repo and commit history as clean as possible.
 - Please do a  `git pull --rebase` both before you start working on the repo and then before you commit.  This will help ensure the most up to date codebase, Rubocop rules, and documentation is available.  It will also go along way towards cutting down or eliminating(hopefully) annoying merge commits.
-- The CHANGELOG follows the standard conventions laid out [here][20]. Every PR has to include an updated CHANGELOG and README (if needed), this makes our lives eaiser, increases the accuracy of the codebase, and gets your PR deployed much faster.
+- The CHANGELOG follows the standard conventions laid out [here][20]. Every PR has to include an updated CHANGELOG and README (if needed), this makes our lives easier, increases the accuracy of the codebase, and gets your PR deployed much faster.
 - When updating the version in the changelog please keep the following in mind
     - the patch version is for any **non-breaking** changes to existing scripts or the addition of minor functionality to existing scripts
-    - the minor version is for the addition of **any* new scripts.  Even though this is generally non-breaking, it is a major change to the gem and should be indicitated as such
-    - the major version should only be bumped by a core contributor.  This is for major breaking or non-breaking changes that affect widespreadspread functionality.  Examples of this would be a wholesale refactor of the repo or a switch away from an established method such as going from SOAP to REST across multiple checks.
+    - the minor version is for the addition of **any* new scripts.  Even though this is generally non-breaking, it is a major change to the gem and should be indicated as such
+    - the major version should only be bumped by a core contributor.  This is for major breaking or non-breaking changes that affect widespread functionality.  Examples of this would be a wholesale refactor of the repo or a switch away from an established method such as going from SOAP to REST across multiple checks.
 - All new scripts, modules, or classes must be fully tested. There are well documented examples in the [pagerduty][21] plugin
 
 Tracking the status of your PR or issue, or seeing all open tickets in the org regardless of repo is simple using Github [filters][16].  To get started click on the Github logo in the upper left and select either _Pull Requests_ or _Issues_.  In the search box you will see several terms predefined for you, change **author:name** to **user:sensu-plugins** to see across the entire org.

--- a/content/sensu-core/0.29/api/_index.md
+++ b/content/sensu-core/0.29/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/0.29/api" >}}

--- a/content/sensu-core/0.29/guides/_index.md
+++ b/content/sensu-core/0.29/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/0.29/guides" >}}

--- a/content/sensu-core/0.29/installation/_index.md
+++ b/content/sensu-core/0.29/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/0.29/installation" >}}

--- a/content/sensu-core/0.29/overview/_index.md
+++ b/content/sensu-core/0.29/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/0.29/overview" >}}

--- a/content/sensu-core/0.29/platforms/_index.md
+++ b/content/sensu-core/0.29/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/0.29/platforms" >}}

--- a/content/sensu-core/0.29/quick-start/_index.md
+++ b/content/sensu-core/0.29/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick-Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/0.29/quick-start" >}}

--- a/content/sensu-core/0.29/reference/_index.md
+++ b/content/sensu-core/0.29/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "0.29"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-0.29:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/0.29/reference" >}}

--- a/content/sensu-core/1.0/api/_index.md
+++ b/content/sensu-core/1.0/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu: 
   sensu-core-1.0:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/1.0/api" >}}

--- a/content/sensu-core/1.0/guides/_index.md
+++ b/content/sensu-core/1.0/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.0:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/1.0/guides" >}}

--- a/content/sensu-core/1.0/installation/_index.md
+++ b/content/sensu-core/1.0/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.0:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/1.0/installation" >}}

--- a/content/sensu-core/1.0/overview/_index.md
+++ b/content/sensu-core/1.0/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.0:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/1.0/overview" >}}

--- a/content/sensu-core/1.0/platforms/_index.md
+++ b/content/sensu-core/1.0/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.0:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/1.0/platforms" >}}

--- a/content/sensu-core/1.0/quick-start/_index.md
+++ b/content/sensu-core/1.0/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick-Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.0:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/1.0/quick-start" >}}

--- a/content/sensu-core/1.0/reference/_index.md
+++ b/content/sensu-core/1.0/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "1.0"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.0:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/1.0/reference" >}}

--- a/content/sensu-core/1.1/api/_index.md
+++ b/content/sensu-core/1.1/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu: 
   sensu-core-1.1:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/1.1/api" >}}

--- a/content/sensu-core/1.1/guides/_index.md
+++ b/content/sensu-core/1.1/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.1:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/1.1/guides" >}}

--- a/content/sensu-core/1.1/installation/_index.md
+++ b/content/sensu-core/1.1/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.1:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/1.1/installation" >}}

--- a/content/sensu-core/1.1/overview/_index.md
+++ b/content/sensu-core/1.1/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.1:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/1.1/overview" >}}

--- a/content/sensu-core/1.1/platforms/_index.md
+++ b/content/sensu-core/1.1/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.1:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/1.1/platforms" >}}

--- a/content/sensu-core/1.1/quick-start/_index.md
+++ b/content/sensu-core/1.1/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick-Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.1:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/1.1/quick-start" >}}

--- a/content/sensu-core/1.1/reference/_index.md
+++ b/content/sensu-core/1.1/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "1.1"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.1:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/1.1/reference" >}}

--- a/content/sensu-core/1.2/api/_index.md
+++ b/content/sensu-core/1.2/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu: 
   sensu-core-1.2:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/1.2/api" >}}

--- a/content/sensu-core/1.2/guides/_index.md
+++ b/content/sensu-core/1.2/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.2:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/1.2/guides" >}}

--- a/content/sensu-core/1.2/installation/_index.md
+++ b/content/sensu-core/1.2/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.2:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/1.2/installation" >}}

--- a/content/sensu-core/1.2/overview/_index.md
+++ b/content/sensu-core/1.2/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.2:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/1.2/overview" >}}

--- a/content/sensu-core/1.2/platforms/_index.md
+++ b/content/sensu-core/1.2/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.2:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/1.2/platforms" >}}

--- a/content/sensu-core/1.2/quick-start/_index.md
+++ b/content/sensu-core/1.2/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick-Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.2:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/1.2/quick-start" >}}

--- a/content/sensu-core/1.2/reference/_index.md
+++ b/content/sensu-core/1.2/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "1.2"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.2:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/1.2/reference" >}}

--- a/content/sensu-core/1.3/api/_index.md
+++ b/content/sensu-core/1.3/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu: 
   sensu-core-1.3:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/1.3/api" >}}

--- a/content/sensu-core/1.3/guides/_index.md
+++ b/content/sensu-core/1.3/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.3:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/1.3/guides" >}}

--- a/content/sensu-core/1.3/installation/_index.md
+++ b/content/sensu-core/1.3/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.3:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/1.3/installation" >}}

--- a/content/sensu-core/1.3/overview/_index.md
+++ b/content/sensu-core/1.3/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.3:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/1.3/overview" >}}

--- a/content/sensu-core/1.3/platforms/_index.md
+++ b/content/sensu-core/1.3/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.3:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/1.3/platforms" >}}

--- a/content/sensu-core/1.3/quick-start/_index.md
+++ b/content/sensu-core/1.3/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick-Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.3:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/1.3/quick-start" >}}

--- a/content/sensu-core/1.3/reference/_index.md
+++ b/content/sensu-core/1.3/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "1.3"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.3:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/1.3/reference" >}}

--- a/content/sensu-core/1.4/api/_index.md
+++ b/content/sensu-core/1.4/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu: 
   sensu-core-1.4:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/1.4/api" >}}

--- a/content/sensu-core/1.4/guides/_index.md
+++ b/content/sensu-core/1.4/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.4:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/1.4/guides" >}}

--- a/content/sensu-core/1.4/installation/_index.md
+++ b/content/sensu-core/1.4/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.4:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/1.4/installation" >}}

--- a/content/sensu-core/1.4/overview/_index.md
+++ b/content/sensu-core/1.4/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.4:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/1.4/overview" >}}

--- a/content/sensu-core/1.4/platforms/_index.md
+++ b/content/sensu-core/1.4/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.4:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/1.4/platforms" >}}

--- a/content/sensu-core/1.4/quick-start/_index.md
+++ b/content/sensu-core/1.4/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.4:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/1.4/quick-start" >}}

--- a/content/sensu-core/1.4/reference/_index.md
+++ b/content/sensu-core/1.4/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "1.4"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.4:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/1.4/reference" >}}

--- a/content/sensu-core/1.5/api/_index.md
+++ b/content/sensu-core/1.5/api/_index.md
@@ -1,11 +1,13 @@
 ---
 title: "API"
+description: "Sensu API reference documentation"
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 50
+layout: "base-for-directory-listing"
 menu: 
   sensu-core-1.5:
-    parent: api
+    identifier: api
 ---
 
 {{< directoryListing "content/sensu-core/1.5/api" >}}

--- a/content/sensu-core/1.5/guides/_index.md
+++ b/content/sensu-core/1.5/guides/_index.md
@@ -3,11 +3,11 @@ title: "Guides"
 description: "Guides documentation for Sensu."
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 40
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.5:
-    parent: guides
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/1.5/guides" >}}

--- a/content/sensu-core/1.5/installation/_index.md
+++ b/content/sensu-core/1.5/installation/_index.md
@@ -3,11 +3,11 @@ title: "Installation"
 description: "Installation documentation for Sensu."
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 30
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.5:
-    parent: installation
+    identifier: installation
 ---
 
 {{< directoryListing "content/sensu-core/1.5/installation" >}}

--- a/content/sensu-core/1.5/overview/_index.md
+++ b/content/sensu-core/1.5/overview/_index.md
@@ -3,11 +3,11 @@ title: "Overview"
 description: "Overview documentation for Sensu."
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 20
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.5:
-    parent: overview
+    identifier: overview
 ---
 
 {{< directoryListing "content/sensu-core/1.5/overview" >}}

--- a/content/sensu-core/1.5/platforms/_index.md
+++ b/content/sensu-core/1.5/platforms/_index.md
@@ -3,11 +3,11 @@ title: "Platforms"
 description: "Platform documentation for Sensu."
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 80
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.5:
-    parent: platforms
+    identifier: platforms
 ---
 
 {{< directoryListing "content/sensu-core/1.5/platforms" >}}

--- a/content/sensu-core/1.5/quick-start/_index.md
+++ b/content/sensu-core/1.5/quick-start/_index.md
@@ -3,11 +3,11 @@ title: "Quick Start"
 description: "Quick start documentation for Sensu."
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 10
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.5:
-    parent: quick-start
+    identifier: quick-start
 ---
 
 {{< directoryListing "content/sensu-core/1.5/quick-start" >}}

--- a/content/sensu-core/1.5/reference/_index.md
+++ b/content/sensu-core/1.5/reference/_index.md
@@ -3,11 +3,11 @@ title: "Reference"
 description: "Reference documentation for Sensu."
 product: "Sensu Core"
 version: "1.5"
-weight: -1
+weight: 100
 layout: "base-for-directory-listing"
 menu:
   sensu-core-1.5:
-    parent: reference
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/1.5/reference" >}}

--- a/content/sensu-core/2.0/getting-started/_index.md
+++ b/content/sensu-core/2.0/getting-started/_index.md
@@ -5,6 +5,9 @@ product: "Sensu Core"
 version: "2.0"
 weight: -1
 layout: "base-for-directory-listing"
+menu:
+  sensu-core-2.0:
+    identifier: getting-started
 ---
 
 {{< directoryListing "content/sensu-core/2.0/getting-started" >}}

--- a/content/sensu-core/2.0/guides/_index.md
+++ b/content/sensu-core/2.0/guides/_index.md
@@ -5,6 +5,9 @@ product: "Sensu Core"
 version: "2.0"
 weight: -1
 layout: "base-for-directory-listing"
+menu:
+  sensu-core-2.0:
+    identifier: guides
 ---
 
 {{< directoryListing "content/sensu-core/2.0/guides" >}}

--- a/content/sensu-core/2.0/reference/_index.md
+++ b/content/sensu-core/2.0/reference/_index.md
@@ -5,6 +5,9 @@ product: "Sensu Core"
 version: "2.0"
 weight: -1
 layout: "base-for-directory-listing"
+menu:
+  sensu-core-2.0:
+    identifier: reference
 ---
 
 {{< directoryListing "content/sensu-core/2.0/reference" >}}

--- a/content/sensu-enterprise-dashboard/2.10/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.10/rbac/_index.md
@@ -2,11 +2,11 @@
 title: "RBAC"
 product: "Sensu Enterprise Dashboard"
 version: "2.10"
-weight: -1
+weight: 1
 layout: "base-for-directory-listing"
 menu:
   sensu-enterprise-dashboard-2.10:
-    parent: rbac
+    identifier: rbac
 ---
 
 {{< directoryListing "content/sensu-enterprise-dashboard/2.10/rbac" >}}

--- a/content/sensu-enterprise-dashboard/2.11/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.11/rbac/_index.md
@@ -2,11 +2,11 @@
 title: "RBAC"
 product: "Sensu Enterprise Dashboard"
 version: "2.11"
-weight: -1
+weight: 1
 layout: "base-for-directory-listing"
 menu:
   sensu-enterprise-dashboard-2.11:
-    parent: rbac
+    identifier: rbac
 ---
 
 {{< directoryListing "content/sensu-enterprise-dashboard/2.11/rbac" >}}

--- a/content/sensu-enterprise-dashboard/2.12/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.12/rbac/_index.md
@@ -2,11 +2,11 @@
 title: "RBAC"
 product: "Sensu Enterprise Dashboard"
 version: "2.12"
-weight: -1
+weight: 1
 layout: "base-for-directory-listing"
 menu:
   sensu-enterprise-dashboard-2.12:
-    parent: rbac
+    identifier: rbac
 ---
 
 {{< directoryListing "content/sensu-enterprise-dashboard/2.12/rbac" >}}

--- a/content/sensu-enterprise-dashboard/2.9/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.9/rbac/_index.md
@@ -2,11 +2,11 @@
 title: "RBAC"
 product: "Sensu Enterprise Dashboard"
 version: "2.9"
-weight: -1
+weight: 1
 layout: "base-for-directory-listing"
 menu:
   sensu-enterprise-dashboard-2.9:
-    parent: rbac
+    identifier: rbac
 ---
 
 {{< directoryListing "content/sensu-enterprise-dashboard/2.9/rbac" >}}

--- a/content/uchiwa/1.0/api/_index.md
+++ b/content/uchiwa/1.0/api/_index.md
@@ -1,0 +1,11 @@
+---
+title: "API"
+product: "Uchiwa"
+version: "1.0"
+weight: 20
+menu: 
+  uchiwa-1.0:
+    identifier: api
+---
+
+{{< directoryListing "content/uchiwa/1.0/api" >}}

--- a/content/uchiwa/1.0/getting-started/_index.md
+++ b/content/uchiwa/1.0/getting-started/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Getting Started"
+product: "Uchiwa"
+version: "1.0"
+weight: 1
+menu: 
+  uchiwa-1.0:
+    identifier: getting-started
+---
+
+{{< directoryListing "content/uchiwa/1.0/getting-started" >}}

--- a/content/uchiwa/1.0/guides/_index.md
+++ b/content/uchiwa/1.0/guides/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Guides"
+product: "Uchiwa"
+version: "1.0"
+weight: 10
+menu: 
+  uchiwa-1.0:
+    identifier: guides
+---
+
+{{< directoryListing "content/uchiwa/1.0/guides" >}}

--- a/content/uchiwa/1.0/reference/_index.md
+++ b/content/uchiwa/1.0/reference/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Reference"
+product: "Uchiwa"
+version: "1.0"
+weight: 30
+menu: 
+  uchiwa-1.0:
+    identifier: reference
+---
+
+{{< directoryListing "content/uchiwa/1.0/reference" >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Updates frontmatter on `_index.md` pages within sections to use `identifier` instead of `parent` to enforce section ordering by weight
- Fixes typos in plugin docs
- Implements the following section ordering for Sensu Core docs

![screen shot 2018-09-18 at 12 24 52 pm](https://user-images.githubusercontent.com/11339965/45711272-e7bb2180-bb3d-11e8-9c6b-d1ed8b08ad40.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #728 and Closes #624 

## Review Instructions
<!--- Optional -->
Run the branch locally and verify that the section ordering shown above applies to each 1.x version within Sensu Core
