### PR TITLE
Add note about an interval timer's initial offset

### DIFF
--- a/content/sensu-core/2.0/reference/checks.md
+++ b/content/sensu-core/2.0/reference/checks.md
@@ -63,7 +63,7 @@ mapping.
 Checks can be scheduled in an interval or cron fashion. It's important to note
 that for interval checks, an initial offset is calculated to splay the check's
 _first_ scheduled request. This helps to balance the load of both the backend
-and the agent.
+and the agent, and may result in a delay before initial check execution.
 
 ### Check result specification
 

--- a/content/sensu-core/2.0/reference/checks.md
+++ b/content/sensu-core/2.0/reference/checks.md
@@ -60,6 +60,11 @@ on a file server. Subscriptions also allow you to configure check requests for
 an entire group or subgroup of systems rather than require a traditional 1:1
 mapping.
 
+Checks can be scheduled in an interval or cron fashion. It's important to note
+that for interval checks, an initial offset is calculated to splay the check's
+_first_ scheduled request. This helps to balance the load of both the backend
+and the agent.
+
 ### Check result specification
 
 Although the Sensu agent will attempt to execute any


### PR DESCRIPTION
## Description
Adds a note to `Check Scheduling` regarding interval and cron schedules. Briefly describes an interval timer's initial offset.

## Motivation and Context
Helps solve some confusion discovered in https://github.com/sensu/sensu-go/issues/2053 and addressed in https://github.com/sensu/sensu-go/pull/2087.