### PR TITLE
Reduce space after code blocks within lists

### DIFF
--- a/static/stylesheets/docs-overrides.css
+++ b/static/stylesheets/docs-overrides.css
@@ -937,7 +937,7 @@ code {
 
 .article li > div > pre,
 .drawer li > div > pre {
-  margin: 10px 0 35px 0;
+  margin: 10px 0 15px 0;
 }
 
 .article pre code,


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Style fix for spacing after code blocks in lists

Before (left) and after (right)

![screen shot 2018-09-21 at 9 47 10 am](https://user-images.githubusercontent.com/11339965/45894525-72409280-bd83-11e8-931c-b4748e2b1bb7.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Better visual consistency for multi-component lists

## Review Instructions
<!--- Optional -->
Run the branch locally and ensure that this page http://localhost:1313/sensu-core/1.5/platforms/sensu-on-rhel-centos reflects the "After" view shown above. For bonus points, find a few more lists on the site and verify that the styling looks good.