### PR TITLE
Add retry attributes for Graphite, OpenTSDB, and Wavefront integrations

### DIFF
--- a/content/sensu-enterprise/2.6/integrations/graphite.md
+++ b/content/sensu-enterprise/2.6/integrations/graphite.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
+_PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The Graphite Carbon host address.
@@ -86,3 +88,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [2]:  http://graphite.wikidot.com?ref=sensu-enterprise
 [3]:  https://www.hostedgraphite.com?ref=sensu-enterprise
 [4]:  /sensu-core/1.0/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/2.6/integrations/opentsdb.md
+++ b/content/sensu-enterprise/2.6/integrations/opentsdb.md
@@ -46,6 +46,8 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The OpenTSDB host address.
@@ -88,3 +90,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [1]:  /sensu-enterprise
 [2]:  http://opentsdb.net?ref=sensu-enterprise
 [3]:  /sensu-core/1.0/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/2.6/integrations/wavefront.md
+++ b/content/sensu-enterprise/2.6/integrations/wavefront.md
@@ -51,6 +51,8 @@ handler (integration).
 The following attributes are configured within the `{"wavefront": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `wavefront` attributes on a per-contact basis using [contact routing][6]._
+
 host         | 
 -------------|------
 description  | The Wavefront host address.
@@ -73,3 +75,4 @@ example      | {{< highlight shell >}}"port": 2878{{< /highlight >}}
 [3]:  /sensu-core/1.0/reference/configuration#configuration-scopes
 [4]:  https://community.wavefront.com/docs/DOC-1031
 [5]:  https://community.wavefront.com/docs/DOC-1041
+[6]: ../../contact-routing

--- a/content/sensu-enterprise/2.7/integrations/graphite.md
+++ b/content/sensu-enterprise/2.7/integrations/graphite.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
+_PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The Graphite Carbon host address.
@@ -86,3 +88,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [2]:  http://graphite.wikidot.com?ref=sensu-enterprise
 [3]:  https://www.hostedgraphite.com?ref=sensu-enterprise
 [4]:  /sensu-core/1.0/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/2.7/integrations/opentsdb.md
+++ b/content/sensu-enterprise/2.7/integrations/opentsdb.md
@@ -46,6 +46,8 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The OpenTSDB host address.
@@ -88,3 +90,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [1]:  /sensu-enterprise
 [2]:  http://opentsdb.net?ref=sensu-enterprise
 [3]:  /sensu-core/1.0/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/2.7/integrations/wavefront.md
+++ b/content/sensu-enterprise/2.7/integrations/wavefront.md
@@ -51,6 +51,8 @@ handler (integration).
 The following attributes are configured within the `{"wavefront": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `wavefront` attributes on a per-contact basis using [contact routing][6]._
+
 host         | 
 -------------|------
 description  | The Wavefront host address.
@@ -73,3 +75,4 @@ example      | {{< highlight shell >}}"port": 2878{{< /highlight >}}
 [3]:  /sensu-core/1.0/reference/configuration#configuration-scopes
 [4]:  https://community.wavefront.com/docs/DOC-1031
 [5]:  https://community.wavefront.com/docs/DOC-1041
+[6]: ../../contact-routing

--- a/content/sensu-enterprise/2.8/integrations/graphite.md
+++ b/content/sensu-enterprise/2.8/integrations/graphite.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
+_PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The Graphite Carbon host address.
@@ -86,3 +88,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [2]:  http://graphite.wikidot.com?ref=sensu-enterprise
 [3]:  https://www.hostedgraphite.com?ref=sensu-enterprise
 [4]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/2.8/integrations/opentsdb.md
+++ b/content/sensu-enterprise/2.8/integrations/opentsdb.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The OpenTSDB host address.
@@ -103,3 +105,4 @@ example        | {{< highlight shell >}}
 [1]:  /sensu-enterprise
 [2]:  http://opentsdb.net?ref=sensu-enterprise
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/2.8/integrations/wavefront.md
+++ b/content/sensu-enterprise/2.8/integrations/wavefront.md
@@ -54,6 +54,8 @@ handler (integration).
 The following attributes are configured within the `{"wavefront": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `wavefront` attributes on a per-contact basis using [contact routing][6]._
+
 host         | 
 -------------|------
 description  | The Wavefront host address.
@@ -88,3 +90,4 @@ example        | {{< highlight shell >}}
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
 [4]:  https://community.wavefront.com/docs/DOC-1031
 [5]:  https://community.wavefront.com/docs/DOC-1041
+[6]: ../../contact-routing

--- a/content/sensu-enterprise/3.0/integrations/graphite.md
+++ b/content/sensu-enterprise/3.0/integrations/graphite.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
+_PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The Graphite Carbon host address.
@@ -86,3 +88,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [2]:  http://graphite.wikidot.com?ref=sensu-enterprise
 [3]:  https://www.hostedgraphite.com?ref=sensu-enterprise
 [4]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/3.0/integrations/opentsdb.md
+++ b/content/sensu-enterprise/3.0/integrations/opentsdb.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The OpenTSDB host address.
@@ -103,3 +105,4 @@ example        | {{< highlight shell >}}
 [1]:  /sensu-enterprise
 [2]:  http://opentsdb.net?ref=sensu-enterprise
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/3.0/integrations/wavefront.md
+++ b/content/sensu-enterprise/3.0/integrations/wavefront.md
@@ -54,6 +54,8 @@ handler (integration).
 The following attributes are configured within the `{"wavefront": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `wavefront` attributes on a per-contact basis using [contact routing][6]._
+
 host         | 
 -------------|------
 description  | The Wavefront host address.
@@ -88,3 +90,4 @@ example        | {{< highlight shell >}}
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
 [4]:  https://community.wavefront.com/docs/DOC-1031
 [5]:  https://community.wavefront.com/docs/DOC-1041
+[6]: ../../contact-routing

--- a/content/sensu-enterprise/3.1/integrations/graphite.md
+++ b/content/sensu-enterprise/3.1/integrations/graphite.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
+_PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The Graphite Carbon host address.
@@ -86,3 +88,4 @@ example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 [2]:  http://graphite.wikidot.com?ref=sensu-enterprise
 [3]:  https://www.hostedgraphite.com?ref=sensu-enterprise
 [4]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/3.1/integrations/opentsdb.md
+++ b/content/sensu-enterprise/3.1/integrations/opentsdb.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The OpenTSDB host address.
@@ -103,3 +105,4 @@ example        | {{< highlight shell >}}
 [1]:  /sensu-enterprise
 [2]:  http://opentsdb.net?ref=sensu-enterprise
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/3.1/integrations/wavefront.md
+++ b/content/sensu-enterprise/3.1/integrations/wavefront.md
@@ -54,6 +54,8 @@ handler (integration).
 The following attributes are configured within the `{"wavefront": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `wavefront` attributes on a per-contact basis using [contact routing][6]._
+
 host         | 
 -------------|------
 description  | The Wavefront host address.
@@ -88,3 +90,4 @@ example        | {{< highlight shell >}}
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
 [4]:  https://community.wavefront.com/docs/DOC-1031
 [5]:  https://community.wavefront.com/docs/DOC-1041
+[6]: ../../contact-routing

--- a/content/sensu-enterprise/3.2/integrations/graphite.md
+++ b/content/sensu-enterprise/3.2/integrations/graphite.md
@@ -49,7 +49,7 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
- _PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+_PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
 
 host         | 
 -------------|------

--- a/content/sensu-enterprise/3.2/integrations/graphite.md
+++ b/content/sensu-enterprise/3.2/integrations/graphite.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"graphite": {} }`
 [configuration scope][4].
 
+ _PRO TIP: You can override `graphite` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The Graphite Carbon host address.
@@ -80,9 +82,25 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"prefix": "production"{{< /highlight >}}
 
+retry_limit    | 
+---------------|------
+description    | The number of times the integration will attempt to re-send metrics after encountering an error.
+required       | false
+type           | Integer
+default        | `3`
+example        | {{< highlight shell >}} "retry_limit": "3"{{< /highlight >}}
+
+retry_delay    | 
+---------------|------
+description    | How long the integration will wait between retries, in seconds.
+required       | false
+type           | Integer
+default        | `1`
+example        | {{< highlight shell >}} "retry_delay": "1"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise
 [2]:  http://graphite.wikidot.com?ref=sensu-enterprise
 [3]:  https://www.hostedgraphite.com?ref=sensu-enterprise
 [4]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/3.2/integrations/opentsdb.md
+++ b/content/sensu-enterprise/3.2/integrations/opentsdb.md
@@ -49,6 +49,8 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
+ _PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+
 host         | 
 -------------|------
 description  | The OpenTSDB host address.
@@ -100,6 +102,23 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+retry_limit    | 
+---------------|------
+description    | The number of times the integration will attempt to re-send metrics after encountering an error.
+required       | false
+type           | Integer
+default        | `3`
+example        | {{< highlight shell >}} "retry_limit": "3"{{< /highlight >}}
+
+retry_delay    | 
+---------------|------
+description    | How long the integration will wait between retries, in seconds.
+required       | false
+type           | Integer
+default        | `1`
+example        | {{< highlight shell >}} "retry_delay": "1"{{< /highlight >}}
+
 [1]:  /sensu-enterprise
 [2]:  http://opentsdb.net?ref=sensu-enterprise
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
+[5]: ../../contact-routing

--- a/content/sensu-enterprise/3.2/integrations/opentsdb.md
+++ b/content/sensu-enterprise/3.2/integrations/opentsdb.md
@@ -49,7 +49,7 @@ handler (integration).
 The following attributes are configured within the `{"opentsdb": {} }`
 [configuration scope][3].
 
- _PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
+_PRO TIP: You can override `opentsdb` attributes on a per-contact basis using [contact routing][5]._
 
 host         | 
 -------------|------

--- a/content/sensu-enterprise/3.2/integrations/wavefront.md
+++ b/content/sensu-enterprise/3.2/integrations/wavefront.md
@@ -54,6 +54,8 @@ handler (integration).
 The following attributes are configured within the `{"wavefront": {} }`
 [configuration scope][3].
 
+_PRO TIP: You can override `wavefront` attributes on a per-contact basis using [contact routing][6]._
+
 host         | 
 -------------|------
 description  | The Wavefront host address.
@@ -82,9 +84,25 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+retry_limit    | 
+---------------|------
+description    | The number of times the integration will attempt to re-send metrics after encountering an error.
+required       | false
+type           | Integer
+default        | `3`
+example        | {{< highlight shell >}} "retry_limit": "3"{{< /highlight >}}
+
+retry_delay    | 
+---------------|------
+description    | How long the integration will wait between retries, in seconds.
+required       | false
+type           | Integer
+default        | `1`
+example        | {{< highlight shell >}} "retry_delay": "1"{{< /highlight >}}
 
 [1]:  /sensu-enterprise
 [2]:  https://www.wavefront.com?ref=sensu-enterprise
 [3]:  /sensu-core/1.2/reference/configuration#configuration-scopes
 [4]:  https://community.wavefront.com/docs/DOC-1031
 [5]:  https://community.wavefront.com/docs/DOC-1041
+[6]: ../../contact-routing


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
For the Sensu Enterprise 3.2 Graphite, OpenTSDB, and Wavefront integrations:

- Adds `retry_limit` and `retry_delay` attributes
- Adds a pro tip about overriding integration attributes using contact routing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #781 