### PR TITLE
Sensu 1.x guide typo and heading fixes

### DIFF
--- a/content/sensu-core/0.29/guides/adding-a-client.md
+++ b/content/sensu-core/0.29/guides/adding-a-client.md
@@ -15,7 +15,7 @@ menu:
 
 Infrastructure sometimes includes hardware or services that don't necessarily support running the **Sensu client software** but still needs to be monitored. For those cases, [**proxy clients**](#proxy-clients) let you monitor anything you can tell Sensu about.
 
-# Adding a Sensu Client
+## Adding a Sensu Client
 
 One of the first challenges new Sensu users often encounter is learning what
 is required to get a remote [Sensu client][1] to communicate with the [Sensu

--- a/content/sensu-core/0.29/guides/intro-to-checks.md
+++ b/content/sensu-core/0.29/guides/intro-to-checks.md
@@ -11,8 +11,6 @@ menu:
     parent: guides
 ---
 
-# An Introduction to Checks
-
 The purpose of this guide is to help Sensu users create monitoring checks. At
 the conclusion of this guide, you - the user - should have several Sensu checks
 in place to monitor and measure machine resources, applications, and services.

--- a/content/sensu-core/0.29/guides/intro-to-filters.md
+++ b/content/sensu-core/0.29/guides/intro-to-filters.md
@@ -11,8 +11,6 @@ menu:
     parent: guides
 ---
 
-# Getting Started with Filters
-
 The purpose of this guide is to help Sensu users create event filters. At the
 conclusion of this guide, you - the user - should have several Sensu event
 filters in place to filter events for one or more event handlers. Each Sensu

--- a/content/sensu-core/0.29/guides/intro-to-handlers.md
+++ b/content/sensu-core/0.29/guides/intro-to-handlers.md
@@ -10,8 +10,6 @@ menu:
     parent: guides
 ---
 
-# Getting Started with Handlers
-
 The purpose of this guide is to help Sensu users create event handlers. At the
 conclusion of this guide, you - the user - should have several Sensu handlers in
 place to handle events. Each Sensu event handler in this guide demonstrates one

--- a/content/sensu-core/0.29/guides/intro-to-mutators.md
+++ b/content/sensu-core/0.29/guides/intro-to-mutators.md
@@ -11,8 +11,6 @@ menu:
     parent: guides
 ---
 
-# Getting Started with Mutators
-
 The purpose of this guide is to help Sensu users create event data mutators. At
 the conclusion of this guide, you - the user - should have several Sensu
 mutators in place to mutate (transform) event data for one or more event
@@ -44,7 +42,6 @@ error will be logged.
 
 Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
-
 
 [1]:  ../../reference/mutators/
 [2]:  http://helpdesk.sensuapp.com

--- a/content/sensu-core/0.29/guides/overview.md
+++ b/content/sensu-core/0.29/guides/overview.md
@@ -10,8 +10,6 @@ menu:
     parent: guides
 ---
 
-# Getting Started Guide
-
 ## The complete getting started guide
 
 The purpose of this guide is to help new Sensu users to obtain a basic

--- a/content/sensu-core/0.29/guides/pre-compile-plugins.md
+++ b/content/sensu-core/0.29/guides/pre-compile-plugins.md
@@ -9,7 +9,6 @@ menu:
     parent: guides
 ---
 
-
 This guide will walk you through an example on how to pre-compile Sensu Plugins for distribution among clients.
 The goal of this guide is to showcase how you can quickly install plugins on ephemeral instances where time to compile can affect time to production.
 We'll be using `sensu-plugins-aws` as it requires `nokogiri`,  usually requiring a longer build time.

--- a/content/sensu-core/0.29/guides/securing-rabbitmq.md
+++ b/content/sensu-core/0.29/guides/securing-rabbitmq.md
@@ -15,7 +15,7 @@ As the supported transport mechanism for any Sensu deployment, RabbitMQ has its 
 
 Before we dive too deep in the article, you may want to familiarize yourself with [RabbitMQ permissions][1]. It's important to note that RabbitMQ makes a distinction between _configure_, _write_, and _read_ permissions. With that in mind, let's move on to what we'll cover in this guide.
 
-# Objectives
+## Objectives
 
 This guide will discuss the following:
 

--- a/content/sensu-core/0.29/guides/securing-redis.md
+++ b/content/sensu-core/0.29/guides/securing-redis.md
@@ -15,7 +15,7 @@ Redis is a key-value database, which describes itself as “an open source, BSD 
 
 This guide will discuss best practices to use with Redis for use with Sensu.
 
-### Objectives
+## Objectives
 
 This guide will discuss the following:
 

--- a/content/sensu-core/0.29/guides/securing-sensu.md
+++ b/content/sensu-core/0.29/guides/securing-sensu.md
@@ -18,7 +18,7 @@ Securing Sensu is a multifaceted process that requires several different compone
 
 We'll also walk through securing the additional components like RabbitMQ and Redis in the guides following this one.
 
-# Objectives
+## Objectives
 
 We'll cover the following in this guide:
 

--- a/content/sensu-core/0.29/guides/snmp-sensu-guide.md
+++ b/content/sensu-core/0.29/guides/snmp-sensu-guide.md
@@ -10,12 +10,12 @@ menu:
    parent: guides
 ---
 
-# Objectives
+## Objectives
 - Set up a Sensu client as an SNMP trap receiver
 - Send a test SNMP trap to simulate a real world circumstance
 - Demonstrate the results of the SNMP trap test in Uchiwa/Sensu Enterprise Dashboard
 
-# Prerequisites
+## Prerequisites
 - A working Sensu deployment including sensu-server/sensu-api (or sensu-enterprise), sensu-client, and transport/datastore components
 - [Uchiwa][1], or [Sensu Enterprise Dashboard][2] installed and configured
 - `snmptrap` command installed on a Linux device (we’ll use CentOS 7) 
@@ -27,11 +27,11 @@ For installing the `snmptrap` command, you’ll want to run the following to ins
 {{< highlight shell >}}
 sudo yum install -y net-snmp-utils{{< /highlight >}}
 
-# Additional Resources
+## Additional Resources
 - DigitalOcean's [Intro to SNMP][4]
 - [SNMP extension Github repository][5] 
 
-# Sensu Client Configuration
+## Sensu Client Configuration
 As the Sensu monitoring agent cannot be installed on most networking gear, hosts that send SNMP traps in Sensu function as [proxy clients][6]. In this example, the general flow will be as follows:
 
 SNMP trap generated→ SNMP trap received by Sensu client → Sensu client sends result to transport/Sensu server → event is created
@@ -83,7 +83,7 @@ sudo netstat -plunt | grep 1062{{< /highlight >}}
 
 At this point, it’s worth noting that the configuration provided here is a basic, bare-minimum configuration. There are additional options you can add to your SNMP extension configuration to suit your needs. We cover those [here](#additional-snmp-extension-options). But to get a general sense of how SNMP traps function with Sensu, continue reading below.
 
-# Testing the SNMP Extension
+## Testing the SNMP Extension
 So far, we’ve done the following:
 - Installed the SNMP trap extension
 - Configured the extension
@@ -129,7 +129,7 @@ Which yields:
 
 You can then delete the result from the dashboard. 
 
-# Additional SNMP Extension Options{#additional-snmp-extension-options}
+## Additional SNMP Extension Options{#additional-snmp-extension-options}
 Earlier in the guide, we mentioned that there are some additional options you can configure for the SNMP trap listener. Let's take a look starting with some of the more basic ones:
 
 bind         | 
@@ -246,7 +246,7 @@ The configurable result status map allows you to define SNMP trap varbind to num
 
 Configuring a result status map does not replace the built-in mappings, the configured mappings take precedence over them.
 
-# Wrapping Up
+## Wrapping Up
 Congratulations! You've successfully set up Sensu to act as an SNMP trap receiver. To recap, we covered the following:
 
 - Setting up a Sensu client as an SNMP trap receiver


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fixes #465 

## Motivation and Context
- Fixes some white space and makes guide headings more consistent. 
- Removes unneeded lines.

## Review Instructions
Run locally with `yarn`.
