### PR TITLE
Migrated nikkiki/sensu-influxdb-handler to sensu/sensu-influxdb-handler

### DIFF
--- a/content/sensu-core/2.0/guides/influx-db-metric-handler.md
+++ b/content/sensu-core/2.0/guides/influx-db-metric-handler.md
@@ -94,11 +94,11 @@ and extract metrics using Sensu checks.
 [1]: ../../reference/events/
 [2]: https://github.com/influxdata/influxdb
 [3]: ../aggregate-metrics-statsd/
-[4]: https://github.com/nikkiki/sensu-influxdb-handler#installation
+[4]: https://github.com/sensu/sensu-influxdb-handler#installation
 [5]: https://rakyll.org/cross-compilation/
 [6]: https://golang.org/doc/install
 [7]: https://en.wikipedia.org/wiki/PATH_(variable)
 [8]: ../../getting-started/installation-and-configuration/#validating-the-services
 [9]: ../../reference/handlers
 [10]: ../extract-metrics-with-checks
-[11]: https://github.com/nikkiki/sensu-influxdb-handler/releases
+[11]: https://github.com/sensu/sensu-influxdb-handler/releases

--- a/content/sensu-core/2.0/reference/checks.md
+++ b/content/sensu-core/2.0/reference/checks.md
@@ -337,7 +337,7 @@ example      | {{< highlight shell >}}"output_metric_format": "graphite_plaintex
 
 |output_metric_handlers    |      |
 -------------|------
-description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string. `output_metric_handlers` should be used in place of the `handlers` attribute if `output_metric_format` is configured. Metric handlers must be able to process [Sensu metric format][sensu-metric-format]. For an example, see the [Sensu InfluxDB handler](https://github.com/nikkiki/sensu-influxdb-handler).
+description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string. `output_metric_handlers` should be used in place of the `handlers` attribute if `output_metric_format` is configured. Metric handlers must be able to process [Sensu metric format][sensu-metric-format]. For an example, see the [Sensu InfluxDB handler](https://github.com/sensu/sensu-influxdb-handler).
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"output_metric_handlers": ["influx-db"]{{< /highlight >}}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## Description
Changes links from nikkiki/sensu-influxdb-handler to sensu/sensu-influxdb-handler now that the repository has changed ownership.

## Motivation and Context
Fixes broken links in the docs.