### PR TITLE
Remove the asset.Metadata field for 2.0 documentation

### DIFF
--- a/content/sensu-core/2.0/reference/assets.md
+++ b/content/sensu-core/2.0/reference/assets.md
@@ -78,16 +78,6 @@ required     | true
 type         | String 
 example      | {{< highlight shell >}}"sha512": "4f926bf4328..."{{< /highlight >}}
 
-metadata     | 
--------------|------ 
-description  | Information about the asset, in the form of key value pairs. 
-required     | false 
-type         | Map 
-example      | {{< highlight shell >}}"metadata": {
-"Content-Type": "application/zip", 
-"X-Intended-Distribution": "trusty-14"}
-{{< /highlight >}}
-
 filters      | 
 -------------|------ 
 description  | A set of [Sensu query expressions][1] used by the agent to determine if the asset should be installed. If multiple expressions are included, each expression must return true in order for the agent to install the asset. [Modifier operators][2] (for example: `+`, `-`, and `!`) _cannot_ be used in asset filters.


### PR DESCRIPTION
The Metadata field is unused and being replaced by a field with a conflicting name. Remove the unused field in preparation for new object metadata documentation.

Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## Motivation and Context

5.0 objects will have a standard metadata field, in preparation for that change, we're removing the unused metadata field.
