### PR TITLE
Adding danger class

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -121,7 +121,11 @@ function applyTipBoxes() {
     } else if ($(this).text().includes("PRO TIP:")) {
       boldFirstTwoWords($(this));
       return '<div class="pro-tip"></div>';
+    } else if ($(this).text().includes("DANGER:")) {
+      boldFirstWord($(this));
+      return '<div class="danger"></div>';
     }
+    
   });
 }
 </script>

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -148,12 +148,20 @@ p code, li code, td code, h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
  border: 1px solid #d6e9c6
 }
 
+.danger {
+  margin: 10px 0;
+  padding: 10px;
+  background-color: #f39c9b;
+ color: #9e3937;
+ border: 1px solid #d6e9c6
+}
+
 .article h2 {
   margin-top: -70px;
   font-size: 30px;
 }
 
-table .note, table .warning, table .pro-tip {
+table .note, table .warning, table .pro-tip, table .danger {
   margin-top: 10px;
 }
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Adds a style for any note prefixed with `DANGER`. This is in relation to #887 . Rather than removing the content entirely, since this is a feature of the software, this will instead call attention to the fact that using RMQ as the transport is our recommended best practice. 

## Review Instructions
Add a note with `_DANGER: THIS IS A DANGER MESSAGE_` to content. This should show up like:

![danger](https://user-images.githubusercontent.com/898627/48150151-82ed8f00-e283-11e8-9ed7-0c6aa2c7e3d6.png)
