### PR TITLE
Update documentation for javascript filtering.

### DIFF
--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -80,7 +80,7 @@ example      | {{< highlight shell >}}"sha512": "4f926bf4328..."{{< /highlight >
 
 filters      | 
 -------------|------ 
-description  | A set of [Sensu query expressions][1] used by the agent to determine if the asset should be installed. If multiple expressions are included, each expression must return true in order for the agent to install the asset. [Modifier operators][2] (for example: `+`, `-`, and `!`) _cannot_ be used in asset filters.
+description  | A set of [Sensu query expressions][1] used by the agent to determine if the asset should be installed. If multiple expressions are included, each expression must return true in order for the agent to install the asset.
 required     | false 
 type         | Array 
 example      | {{< highlight shell >}}"filters": ["System.OS=='linux'", "System.Arch=='amd64'"] {{< /highlight >}}
@@ -113,4 +113,3 @@ example      | {{< highlight shell >}}
 {{< /highlight >}}
 
 [1]: ../../reference/sensu-query-expressions/
-[2]: https://github.com/Knetic/govaluate/blob/master/MANUAL.md#modifiers

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -147,6 +147,14 @@ type         | String
 default      | current environment value configured for `sensuctl` (for example: `default`) 
 example      | {{< highlight shell >}}"environment": "default"{{< /highlight >}}
 
+runtime_assets |
+---------------|------
+description    | Assets to be applied to the filter's execution context. JavaScript files in the lib directory of the asset will be evaluated.
+required       | false
+type           | Array of String
+default        | []
+example        | {{< highlight shell >}}"runtime_assets": ["underscore"]{{< /highlight >}}
+
 ### `when` attributes
 
 days         | 

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -70,15 +70,15 @@ additional filters (if defined), mutators (if defined), and handlers.
 
 When more complex conditional logic is needed than direct filter expression
 comparison, Sensu filters provide support for expression evaluation using
-[otto](https://github.com/robertkrimen/otto). Otto is an ECMA5 (Javascript) VM,
-and will evaluate javascript expressions that are provided in the filter.
+[Otto](https://github.com/robertkrimen/otto). Otto is an ECMAScript 5 (JavaScript) VM,
+and evaluates javascript expressions that are provided in the filter.
 There are some caveats to using Otto; most notably, the regular expressions
-specified in ECMA5 do not all work. See the Otto readme for more details.
+specified in ECMAScript 5 do not all work. See the Otto README for more details.
 
 ### Filter Assets
 
 Sensu filters can have assets that are included in their execution context.
-When valid assets are associated with a filter, Sensu will evaluate any
+When valid assets are associated with a filter, Sensu evaluates any
 files it finds that have a ".js" extension before executing a filter. The
 result of evaluating the scripts is cached for a given asset set, for the
 sake of performance.
@@ -278,11 +278,11 @@ same result.
 _NOTE: Sensu handles dates and times in UTC (Coordinated Universal Time), therefore
 when comparing the weekday or the hour, you should provide values in UTC._
 
-### Using javascript libraries with Sensu filters
+### Using JavaScript libraries with Sensu filters
 
-Users can include javascript libraries in their filter execution context with
-assets. For instance, assuming a user packaged underscore.js into a Sensu
-asset, they could then use functions from the underscore library for filter
+You can include JavaScript libraries in their filter execution context with
+assets. For instance, assuming you've packaged underscore.js into a Sensu
+asset, you could then use functions from the underscore library for filter
 expressions.
 
 {{< highlight json >}}

--- a/content/sensu-go/5.0/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.0/reference/sensu-query-expressions.md
@@ -15,25 +15,24 @@ menu:
 
 ## How do Sensu query expressions work?
 
-Sensu query expressions (**SQE**) are based on [javascript][3] expressions, and
+Sensu query expressions (**SQE**) are based on [JavaScript][3] expressions, and
 provide additional functionalities for Sensu usage (like nested parameters and
 custom functions) so Sensu resources can be directly evaluated. SQE should
 always return **true** or **false**.
 
-## Javascript for expressions instead of Ruby
+## New and improved expressions
 
 Sensu 1 uses [Ruby expressions][2], which are not available in Sensu 2, being
-written in Go. The existence of a Go library that provides a Javascript VM has
+written in Go. The existence of a Go library that provides a JavaScript VM has
 allowed us to embed a Javascript execution engine for filters instead. Sadly,
 there is no equivalent Ruby VM library.
 
-## Sensu Query Expressions specification
+## Sensu query expressions specification
 
-### Javascript 
 
-Sensu query expressions are valid ECMA5 (Javascript) expressions that return
+Sensu query expressions are valid ECMAScript 5 (JavaScript) expressions that return
 **true** or **false**. Other values are not allowed. If other values are
-returned, an error will be logged and the filter will evaluate to false.
+returned, an error is logged and the filter evaluates to false.
 
 ### Custom functions
 
@@ -55,7 +54,7 @@ hour(event.timestamp) >= 17
 weekday(event.timestamp) == 0
 {{< /highlight >}}
 
-## Sensu Query Expressions examples
+## Sensu query expressions examples
 
 ### Simple evaluation of an event attribute
 

--- a/content/sensu-go/5.0/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.0/reference/sensu-query-expressions.md
@@ -15,23 +15,25 @@ menu:
 
 ## How do Sensu query expressions work?
 
-Sensu query expressions (**SQE**) are based on [govaluate][1] expressions, and
+Sensu query expressions (**SQE**) are based on [javascript][3] expressions, and
 provide additional functionalities for Sensu usage (like nested parameters and
 custom functions) so Sensu resources can be directly evaluated. SQE should
 always return **true** or **false**.
 
-## New and improved expressions
+## Javascript for expressions instead of Ruby
 
 Sensu 1 uses [Ruby expressions][2], which are not available in Sensu 2, being
-written in Go. Therefore, the syntax has been changed a bit but in return, it is
-now possible to use custom functions, which allow more complex expressions.
+written in Go. The existence of a Go library that provides a Javascript VM has
+allowed us to embed a Javascript execution engine for filters instead. Sadly,
+there is no equivalent Ruby VM library.
 
-## Sensu query expressions specification
+## Sensu Query Expressions specification
 
-### Govaluate operators
+### Javascript 
 
-All [govaluate operators][3] are available in Sensu query expressions. However
-**modifier operators** may not be used in Sensu **assets**.
+Sensu query expressions are valid ECMA5 (Javascript) expressions that return
+**true** or **false**. Other values are not allowed. If other values are
+returned, an error will be logged and the filter will evaluate to false.
 
 ### Custom functions
 
@@ -39,21 +41,21 @@ All [govaluate operators][3] are available in Sensu query expressions. However
   Epoch time.
 
 {{< highlight go >}}
-// event.Timestamp equals to 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC
+// event.timestamp equals to 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC
 // The following expression returns true
-hour(event.Timestamp) >= 17
+hour(event.timestamp) >= 17
 {{< /highlight >}}
 
 * `weekday`: returns a number representing the day of the week, where Sunday
   equals `0`, of a UNIX Epoch time.
 
 {{< highlight go >}}
-// event.Timestamp equals to 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC
+// event.timestamp equals to 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC
 // The following expression returns false
-weekday(event.Timestamp) == 0
+weekday(event.timestamp) == 0
 {{< /highlight >}}
 
-## Sensu query expressions examples
+## Sensu Query Expressions examples
 
 ### Simple evaluation of an event attribute
 
@@ -64,12 +66,12 @@ attribute named `Environment` that is equal to `production`.
 event.Entity.Environment == 'production'
 {{< /highlight >}}
 
-### Evaluating the weekday
+### Evaluating the day of the week
 
 The following example returns true if the event occurred on a weekday.
 
 {{< highlight javascript >}}
-weekday(event.Timestamp) >= 1 && weekday(event.Timestamp) <= 5
+weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5
 {{< /highlight >}}
 
 
@@ -79,9 +81,8 @@ The following example returns true if the event occurred between 9 AM and 5 PM
 UTC.
 
 {{< highlight javascript >}}
-hour(event.Timestamp) >= 9 && hour(event.Timestamp) <= 17
+hour(event.timestamp) >= 9 && hour(event.timestamp) <= 17
 {{< /highlight >}}
 
-[1]: https://github.com/Knetic/govaluate
 [2]: ../../../latest/reference/filters/#what-are-filter-attribute-eval-tokens
-[3]: https://github.com/Knetic/govaluate/blob/master/MANUAL.md#operators
+[3]: https://github.com/robertkrimen/otto


### PR DESCRIPTION
The filtering engine in sensu-go has been replaced with Javascript. This PR updates the documentation accordingly.

The PR is here and is expected to be included in Beta 8: https://github.com/sensu/sensu-go/pull/2336