### PR TITLE
Update Sensu Go types: metadata and names

### DIFF
--- a/content/sensu-go/5.0/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.0/guides/monitor-external-resources.md
@@ -13,9 +13,9 @@ menu:
 ## What are Sensu proxy requests and entities?
 
 Sensu [proxy entities][1] are **entities** dynamically created via either the
-API (and **sensuctl**) or the [`proxy_entity_id` attribute][2] of a check.
+API (and **sensuctl**) or the [`proxy_entity_name` attribute][2] of a check.
 
-Check definitions that include the `proxy_entity_id` attribute will have their
+Check definitions that include the `proxy_entity_name` attribute will have their
 results reported under this proxy entity ID instead of the agent's entity that
 emitted the result. In comparison, check definitions including the
 [`proxy_requests` attribute][3] will trigger a check request for each entity

--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -63,7 +63,7 @@ This makes it possible to generate ad-hoc check requests targeting specific enti
 
 Sensu proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed (such a network switch).
 Unlike agent entities, proxy entity definitions are stored by the [Sensu backend][2].
-When the backend requests a check that includes a [`proxy_entity_id`][14], the agent includes the provided entity information in the event data in place of the agent entity data.
+When the backend requests a check that includes a [`proxy_entity_name`][14], the agent includes the provided entity information in the event data in place of the agent entity data.
 See the [entity reference][3] and the [guide to monitoring external resources][33] for more information about monitoring proxy entities.
 
 ## Creating monitoring events using the agent socket

--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -55,8 +55,8 @@ After receiving a check request from the Sensu backend, the agent:
 To configure subscriptions for an agent, set [the `subscriptions` flag][28].
 To configure subscriptions for a check, set the [check definition attribute `subscriptions`][14].
 
-In addition to the subscriptions defined in the agent configuration, Sensu agent entities also subscribe automatically to a subscription matching their [entity `id`][38].
-For example, an agent entity with the `id: "i-424242"` subscribes to check requests with the subscription `entity:i-424242`.
+In addition to the subscriptions defined in the agent configuration, Sensu agent entities also subscribe automatically to a subscription matching their [entity `name`][38].
+For example, an agent entity with the `name: "i-424242"` subscribes to check requests with the subscription `entity:i-424242`.
 This makes it possible to generate ad-hoc check requests targeting specific entities via the API.
 
 ### Proxy entities
@@ -89,7 +89,7 @@ You can also use the [Netcat][19] utility to send monitoring data to the agent s
 echo '{"name": "web_service02", "output": "error!", "status": 1, "handlers": ["slack"]}' | nc localhost 3030
 {{< /highlight >}}
 
-At a minimum, the agent TCP socket requires the `name`, `output`, and `status` attributes to be set in the payload, but you can also add any attributes allowed in the [check definition][14], like `handlers` and `extended_attributes`.
+At a minimum, the agent TCP socket requires the `name`, `output`, and `status` attributes to be set in the payload, but you can also add any attributes allowed in the [check definition][14], like `handlers` and `subscriptions`.
 
 #### Socket input specification
 
@@ -388,7 +388,7 @@ sensu-agent start --help
 
 ## Registration
 
-In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `id`).
+In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `name`).
 This agent registry is stored in the Sensu [backend][2], and is accessible via [`sensuctl entity list`][6].
 
 All Sensu agent data provided in keepalive events gets stored in the agent registry and used to add context to Sensu [events][7] and detect Sensu agents in an unhealthy state.
@@ -433,33 +433,33 @@ Usage:
   sensu-agent start [flags]
 
 Flags:
-      --api-host string                     address to bind the Sensu client HTTP API to (default "127.0.0.1")
-      --api-port int                        port the Sensu client HTTP API listens on (default 3031)
-      --backend-url stringSlice             ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
-      --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-agent")
-  -c, --config-file string                  path to sensu-agent config file
-      --deregister                          ephemeral agent
-      --deregistration-handler string       deregistration handler that should process the entity deregistration event.
-      --disable-api                         disable the Agent HTTP API
-      --disable-sockets                     disable the Agent TCP and UDP event sockets
-      --extended-attributes string          extended attributes to include in the agent entity in serialized json format (ex: {"team":"ops"})
-  -h, --help                                help for start
-      --id string                           agent ID (defaults to hostname) (default "sensu2-centos")
-      --keepalive-interval int              number of seconds to send between keepalive events (default 20)
-      --keepalive-timeout uint32            number of seconds until agent is considered dead by backend (default 120)
-      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
-      --namespace string                    agent namespace (default "default")
-      --password string                     agent password (default "P@ssw0rd!")
-      --redact string                       comma-delimited customized list of fields to redact
-      --socket-host string                  address to bind the Sensu client socket to (default "127.0.0.1")
-      --socket-port int                     port the Sensu client socket listens on (default 3030)
-      --statsd-disable                      disables the statsd listener and metrics server
-      --statsd-event-handlers stringSlice   comma-delimited list of event handlers for statsd metrics
-      --statsd-flush-interval int           number of seconds between statsd flush (default 10)
-      --statsd-metrics-host string          address used for the statsd metrics server (default "127.0.0.1")
-      --statsd-metrics-port int             port used for the statsd metrics server (default 8125)
-      --subscriptions string                comma-delimited list of agent subscriptions
-      --user string                         agent user (default "agent")
+      --api-host string                 address to bind the Sensu client HTTP API to (default "127.0.0.1")
+      --api-port int                    port the Sensu client HTTP API listens on (default 3031)
+      --backend-url strings             ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
+      --cache-dir string                path to store cached data (default "/var/cache/sensu/sensu-agent")
+  -c, --config-file string              path to sensu-agent config file
+      --deregister                      ephemeral agent
+      --deregistration-handler string   deregistration handler that should process the entity deregistration event.
+      --disable-api                     disable the Agent HTTP API
+      --disable-sockets                 disable the Agent TCP and UDP event sockets
+  -h, --help                            help for start
+      --keepalive-interval int          number of seconds to send between keepalive events (default 20)
+      --keepalive-timeout uint32        number of seconds until agent is considered dead by backend (default 120)
+      --labels stringToString           entity labels map (default [])
+      --log-level string                logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --name string                     agent name (defaults to hostname) (default "sensu2-centos")
+      --namespace string                agent namespace (default "default")
+      --password string                 agent password (default "P@ssw0rd!")
+      --redact string                   comma-delimited customized list of fields to redact
+      --socket-host string              address to bind the Sensu client socket to (default "127.0.0.1")
+      --socket-port int                 port the Sensu client socket listens on (default 3030)
+      --statsd-disable                  disables the statsd listener and metrics server
+      --statsd-event-handlers strings   comma-delimited list of event handlers for statsd metrics
+      --statsd-flush-interval int       number of seconds between statsd flush (default 10)
+      --statsd-metrics-host string      address used for the statsd metrics server (default "127.0.0.1")
+      --statsd-metrics-port int         port used for the statsd metrics server (default 8125)
+      --subscriptions string            comma-delimited list of agent subscriptions
+      --user string                     agent user (default "agent")
 {{< /highlight >}}
 
 ### General configuration flags
@@ -503,28 +503,32 @@ sensu-agent start --c /sensu/agent.yml
 config-file: "/sensu/agent.yml"{{< /highlight >}}
 
 
-| extended-attributes |      |
-----------------------|------
-description           | Extended attributes to include in the agent entity in serialized JSON format
-type                  | Serialized JSON object
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize entities into meaningful collections that can be selected using [filters][9] and [tokens][27].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example               | {{< highlight shell >}}# Command line example
-sensu-agent start --extended-attributes '{"team":"ops"}'
+sensu-agent start --labels region=us-west-2
 
 # /etc/sensu/agent.yml example
-extended-attributes: '{"team":"ops"}'{{< /highlight >}}
+labels:
+  region: us-west-2
+{{< /highlight >}}
 
-<a name="id">
+<a name="name">
 
-| id          |      |
+| name        |      |
 --------------|------
-description   | Entity ID assigned to the agent entity
+description   | Entity name assigned to the agent entity
 type          | String
-default       | Defaults to hostname, for example: `sensu2-centos`
+default       | Defaults to hostname, for example: `sensu-centos`
 example       | {{< highlight shell >}}# Command line example
-sensu-agent start --id agent-01
+sensu-agent start --name agent-01
 
 # /etc/sensu/agent.yml example
-id: "agent-01" {{< /highlight >}}
+name: "agent-01" {{< /highlight >}}
 
 
 | log-level   |      |
@@ -826,6 +830,6 @@ statsd-metrics-port: 6125{{< /highlight >}}
 [35]: ../backend#datastore-and-cluster-configuration-flags
 [36]: ../../guides/clustering
 [37]: ../backend#general-configuration-flags
-[38]: #id
+[38]: #name
 [39]: ../checks#check-result-specification
 [40]: ../../guides/send-slack-alerts

--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -144,7 +144,7 @@ example      | {{< highlight shell >}} "annotations": {
     "url": "http://example.com/asset.tar.gz",
     "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
     "filters": [
-      "System.OS==linux",
+      "system.os == 'linux'",
       "System.Arch=='amd64'"
     ],    "metadata": {
       "name": "check_script",

--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -145,7 +145,7 @@ example      | {{< highlight shell >}} "annotations": {
     "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
     "filters": [
       "system.os == 'linux'",
-      "System.Arch=='amd64'"
+      "system.arch == 'amd64'"
     ],    "metadata": {
       "name": "check_script",
       "namespace": "default",

--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -56,13 +56,21 @@ The following are injected into the execution context:
 
 ### Attributes
 
-name         | 
--------------|------ 
-description  | The unique name of the asset, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
+|metadata     |      |
+-------------|------
+description  | Collection of metadata about the asset, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][5] for details.
 required     | true
-type         | String 
-example      | {{< highlight shell >}}"name": "check_script"{{< /highlight >}}
-
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "check_script",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
 
 url          | 
 -------------|------ 
@@ -85,15 +93,45 @@ required     | false
 type         | Array 
 example      | {{< highlight shell >}}"filters": ["System.OS=='linux'", "System.Arch=='amd64'"] {{< /highlight >}}
 
-namespace | 
+### Metadata attributes
+
+name         |      |
 -------------|------ 
-description  | The Sensu RBAC namespace that this asset belongs to.
-required     | false 
+description  | The unique name of the asset, validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2).
+required     | true
 type         | String
-default      | current namespace value configured for `sensuctl` (ie `default`) 
-example      | {{< highlight shell >}}
-  "namespace": "default"
-{{< /highlight >}}
+example      | {{< highlight shell >}}"name": "check_script"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The [Sensu RBAC namespace][2] that this asset belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize assets into meaningful collections that can be selected using [filters][3] and [tokens][4].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations | |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are _not_ used internally by Sensu and cannot be used to identify assets. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ## Examples
 
@@ -123,3 +161,7 @@ example      | {{< highlight shell >}}
 {{< /highlight >}}
 
 [1]: ../../reference/sensu-query-expressions/
+[2]: ../rbac#namespaces
+[3]: ../filters
+[4]: ../tokens
+[5]: #metadata-attributes

--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -98,17 +98,27 @@ example      | {{< highlight shell >}}
 ## Examples
 
 ### Asset definition
+
 {{< highlight json >}}
 {
-  "name": "check_script",
-  "url": "http://example.com/asset.tar.gz",
-  "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
-  "metadata": null,
-  "filters": [
-    "System.OS==linux",
-    "System.Arch=='amd64'"
-  ],
-  "namespace": "default"
+  "type": "Asset",
+  "spec": {
+    "url": "http://example.com/asset.tar.gz",
+    "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
+    "filters": [
+      "System.OS==linux",
+      "System.Arch=='amd64'"
+    ],    "metadata": {
+      "name": "check_script",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1"
+      },
+      "annotations": {
+        "slack-channel" : "#monitoring"
+      }
+    }
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -387,18 +387,41 @@ example      | {{< highlight shell >}}"days": {
 {
   "type": "CheckConfig",
   "spec": {
-    "name": "collect-metrics",
-    "namespace": "default",
+    "command": "collect.sh",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 10,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": null,
     "subscriptions": [
       "system"
     ],
-    "command": "collect.sh",
-    "interval": 10,
-    "publish": true,
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
     "output_metric_format": "graphite_plaintext",
-    "output_metric_handlers": ["influx-db"]
+    "output_metric_handlers": [
+      "influx-db"
+    ],
+    "env_vars": null,
+    "metadata": {
+      "name": "collect-metrics",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1"
+      },
+      "annotations": {
+        "slack-channel" : "#monitoring"
+      }
+    }
   }
-}{{< /highlight >}}
+}
+{{< /highlight >}}
 
 [1]: #subscription-checks
 [2]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -339,7 +339,7 @@ description  | Sensu entity attributes to match entities in the registry, using 
 required     | false
 type         | Array
 default      | current namespace value configured for `sensuctl` (ie `default`)
-example      | {{< highlight shell >}}"entity_attributes": ["entity.Class == 'proxy'"]{{< /highlight >}}
+example      | {{< highlight shell >}}"entity_attributes": ["entity.EntityClass == 'proxy'"]{{< /highlight >}}
 
 |splay       |      |
 -------------|------

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -157,15 +157,23 @@ enabled directly with the [round_robin][13] attribute in the check configuration
 
 ## Check specification
 
-### Check naming
-
-Each check definition must have a unique name within its namespace.
-
-* A unique string used to name/identify the check
-* Cannot contain special characters or spaces
-* Validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
-
 ### Check attributes
+
+|metadata     |      |
+-------------|------
+description  | Collection of metadata about the check, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][25] for details.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "collect-metrics",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
 
 |command     |      |
 -------------|------
@@ -288,22 +296,6 @@ required     | false
 type         | Boolean
 example      | {{< highlight shell >}}"round_robin": false{{< /highlight >}}
 
-|extended_attributes|      |
--------------|------
-description  | Custom attributes to include with the event data, which can be queried like regular attributes.
-required     | false
-type         | Serialized JSON object
-example      | {{< highlight shell >}}"{\"team\":\"ops\"}"{{< /highlight >}}
-
-|namespace|      |
--------------|------
-description  | The Sensu RBAC namespace that this check belongs to.
-required     | false
-type         | String
-example      | {{< highlight shell >}}
-  "namespace": "default"
-{{< /highlight >}}
-
 |silenced    |      |
 -------------|------
 description  | If the event is to be silenced.
@@ -330,6 +322,46 @@ description  | An array of Sensu handlers to use for events created by the check
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"output_metric_handlers": ["influx-db"]{{< /highlight >}}
+
+### Metadata attributes
+
+| name       |      |
+-------------|------
+description  | A unique string used to identify the check. Check names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)). Each check must have a unique name within its namespace.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "check-cpu"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][26] that this check belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize checks into meaningful collections that can be selected using [filters][27] and [tokens][5].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |     |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are _not_ used internally by Sensu and cannot be used to identify checks. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ### Proxy requests attributes
 
@@ -453,3 +485,6 @@ example      | {{< highlight shell >}}"days": {
 [influx]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [open]: http://opentsdb.net/docs/build/html/user_guide/writing.html#data-specification
 [sensu-metric-format]: ../../reference/events/#metrics
+[25]: #metadata-attributes
+[26]: ../rbac#namespaces
+[27]: ../filters

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -266,13 +266,13 @@ required     | false
 type         | Hash
 example      | {{< highlight shell >}}"subdue": {}{{< /highlight >}}
 
-|proxy_entity_id|   |
+|proxy_entity_name|   |
 -------------|------
 description  | The check ID, used to create a [proxy entity][18] for an external resource (i.e., a network switch).
 required     | false
 type         | String
 validated    | [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
-example      | {{< highlight shell >}}"proxy_entity_id": "switch-dc-01"{{< /highlight >}}
+example      | {{< highlight shell >}}"proxy_entity_name": "switch-dc-01"{{< /highlight >}}
 
 |proxy_requests|    |
 -------------|------

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -34,12 +34,21 @@ An `entity`, formally known as a `client` in Sensu 1.x, represents anything (ex:
 
 ### Entity Attributes
 
-ID           | 
--------------|------ 
-description  | The unique ID of the entity, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
+|metadata    |      |
+-------------|------
+description  | Collection of metadata about the entity, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][8] for details.
 required     | true
-type         | string 
-example      | {{< highlight shell >}}"ID": "example-hostname"{{< /highlight >}}
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "webserver01",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
 
 entity_class |     |
 -------------|------ 
@@ -50,7 +59,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | A list of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{ID}` where `ID` is the entity's hostname.
+description  | A list of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
 required     | false 
 type         | array 
 default      | The entity-specific subscription.
@@ -128,20 +137,6 @@ type         | integer
 default      | 120
 example      | {{< highlight shell >}}"keepalive_timeout": 120 {{< /highlight >}}
 
-namespace | 
--------------|------ 
-description  | The Sensu RBAC namespace that this entity belongs to.
-required     | false 
-type         | string 
-example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
-
-extended_attributes | 
--------------|------ 
-description  | Custom attributes to include with the entity, which can be queried like regular attributes.
-required     | false 
-type         | JSON object
-example      | {{< highlight shell >}}{"team":"ops"}{{< /highlight >}}
-
 redact       | 
 -------------|------ 
 description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
@@ -153,6 +148,46 @@ example      | {{< highlight json >}}
   "redact": [
     "extra_secret_tokens"
   ]
+}{{< /highlight >}}
+
+### Metadata attributes
+
+| name       |      |
+-------------|------
+description  | The unique name of the entity, validated with Go regex `\A[\w\.\-]+\z`.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "example-hostname"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The [Sensu RBAC namespace][5] that this entity belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize entities into meaningful collections that can be selected using [filters][6] and [tokens][7].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |     |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are _not_ used internally by Sensu and cannot be used to identify entities. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
 }{{< /highlight >}}
 
 ### System Attributes
@@ -363,3 +398,7 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
 [2]: #deregistration-attributes
 [3]: #network-attributes
 [4]: #networkinterface-attributes
+[5]: ../rbac#namespaces
+[6]: ../filters
+[7]: ../tokens
+[8]: #metadata-attributes

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -41,12 +41,12 @@ required     | true
 type         | string 
 example      | {{< highlight shell >}}"ID": "example-hostname"{{< /highlight >}}
 
-class        | 
+entity_class |     |
 -------------|------ 
 description  | The entity type, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2). This value is not user configurable; it is set directly by the agent. An entity that runs an agent will be of `agent`, while a proxy entity will have class `proxy`.
 required     | true
 type         | string 
-example      | {{< highlight shell >}}"class": "agent"{{< /highlight >}}
+example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -24,7 +24,7 @@ Agent entities are monitoring agents, which are installed and run on every syste
 
 ## Proxy Entities
 
-Proxy entities (formerly known as proxy clients, "Just-in-time" or "JIT" clients) are dynamically created entities, added to the entity store if an entity does not already exist for a check result. Proxy entity registration differs from keepalive-based registration because the registration event happens while processing a check result (not a keepalive message). Sensu proxy entities allow Sensu to monitor external resources on systems and/or devices where a sensu-agent cannot be installed (such a network switch) using the defined check ProxyEntityID to create a proxy entity for the external resource. Once created, proxy entities work much in the same way as any other Sensu entity.
+Proxy entities (formerly known as proxy clients, "Just-in-time" or "JIT" clients) are dynamically created entities, added to the entity store if an entity does not already exist for a check result. Proxy entity registration differs from keepalive-based registration because the registration event happens while processing a check result (not a keepalive message). Sensu proxy entities allow Sensu to monitor external resources on systems and/or devices where a sensu-agent cannot be installed (such a network switch) using the defined check ProxyEntityName to create a proxy entity for the external resource. Once created, proxy entities work much in the same way as any other Sensu entity.
 
 ## New and improved entities
 

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -293,58 +293,71 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
 
 {{< highlight json >}}
 {
-  "class": "agent",
-  "deregister": false,
-  "deregistration": {},
-  "id": "example-hostname",
-  "keepalive_timeout": 60,
-  "last_seen": 1523387195,
-  "namespace": "default",
-  "redact": [
-    "password",
-    "passwd",
-    "pass",
-    "api_key",
-    "api_token",
-    "access_key",
-    "secret_key",
-    "private_key",
-    "secret"
-  ],
-  "subscriptions": [
-    "entity:example-hostname"
-  ],
-  "system": {
-    "hostname": "example-hostname",
-    "os": "linux",
-    "platform": "ubuntu",
-    "platform_family": "debian",
-    "platform_version": "16.04",
-    "network": {
-      "interfaces": [
-        {
-          "name": "lo",
-          "addresses": [
-            "127.0.0.1/8",
-            "::1/128"
-          ]
-        },
-        {
-          "name": "eth0",
-          "mac": "52:54:00:20:1b:3c",
-          "addresses": [
-            "93.184.216.34/24",
-            "2606:2800:220:1:248:1893:25c8:1946/10"
-          ]
-        }
-      ]
+  "type": "Entity",
+  "spec": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu2-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.4.1708",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "enp0s3",
+            "mac": "08:00:27:11:ad:d2",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::26a5:54ec:cf0d:9704/64"
+            ]
+          },
+          {
+            "name": "enp0s8",
+            "mac": "08:00:27:bc:be:60",
+            "addresses": [
+              "172.28.128.3/24",
+              "fe80::a00:27ff:febc:be60/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64"
     },
-    "arch": "amd64"
-  },
-  "user": "agent",
-  "region": "us-west-1",
-  "team": "ops"
-}{{< /highlight >}}
+    "subscriptions": [
+      "entity:webserver01"
+    ],
+    "last_seen": 1542667231,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "webserver01",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    }
+  }
+}
+{{< /highlight >}}
 
 [1]: #system-attributes
 [2]: #deregistration-attributes

--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -71,43 +71,50 @@ _NOTE: Silenced has been deprecated from Event. Please see [check specification]
 description  | The [Check attributes][1] used to obtain the check result.
 type         | Check
 example      | {{< highlight json >}}
-{
-  "check": {
-    "check_hooks": null,
-    "command": "check-http-response-time.rb -a example.com -C 5000 -w 3000",
-    "duration": 1.903135228,
-    "executed": 1522100915,
-    "handlers": [],
-    "high_flap_threshold": 0,
-    "history": [
-      {
-        "executed": 1522100315
-      },
-      {
-        "executed": 1522100915
-      }
-    ],
-    "interval": 300,
-    "last_ok": 1522100916,
-    "low_flap_threshold": 0,
-    "name": "example-check",
-    "occurrences": 1,
-    "occurrences_watermark": 1,
+"check": {
+  "command": "http_check.sh http://localhost:80",
+  "handlers": [
+    "slack"
+  ],
+  "high_flap_threshold": 0,
+  "interval": 20,
+  "low_flap_threshold": 0,
+  "publish": true,
+  "runtime_assets": [],
+  "subscriptions": [
+    "testing"
+  ],
+  "proxy_entity_name": "",
+  "check_hooks": null,
+  "stdin": false,
+  "subdue": null,
+  "ttl": 0,
+  "timeout": 0,
+  "round_robin": false,
+  "duration": 0.010849143,
+  "executed": 1542667666,
+  "history": [
+    {
+      "status": 1,
+      "executed": 1542667666
+    }
+  ],
+  "issued": 1542667666,
+  "output": "",
+  "state": "failing",
+  "status": 1,
+  "total_state_change": 0,
+  "last_ok": 0,
+  "occurrences": 1,
+  "occurrences_watermark": 1,
+  "output_metric_format": "",
+  "output_metric_handlers": [],
+  "env_vars": null,
+  "metadata": {
+    "name": "check-nginx",
     "namespace": "default",
-    "output": "CheckHttpResponseTime OK: 1635 is acceptable\n",
-    "proxy_entity_id": "",
-    "publish": true,
-    "round_robin": false,
-    "runtime_assets": [],
-    "state": "passing",
-    "status": 0,
-    "stdin": false,
-    "subdue": null,
-    "subscriptions": [
-      "web"
-    ],
-    "timeout": 30,
-    "total_state_change": 0
+    "labels": null,
+    "annotations": null
   }
 }
 {{< /highlight >}}
@@ -165,57 +172,67 @@ example      | {{< highlight json >}}
 description  | The [entity attributes][2] from the originating entity (agent or proxy).
 type         | Entity
 example      | {{< highlight json >}}
-{
-  "entity": {
-    "class": "agent",
-    "deregister": false,
-    "deregistration": {},
-    "id": "example-entity",
-    "keepalive_timeout": 120,
-    "namespace": "default",
-    "redact": [
-      "password",
-      "passwd",
-      "pass",
-      "api_key",
-      "api_token",
-      "access_key",
-      "secret_key",
-      "private_key",
-      "secret"
-    ],
-    "subscriptions": [
-      "web",
-      "entity:example-entity"
-    ],
-    "system": {
-      "hostname": "example",
-      "os": "linux",
-      "platform": "ubuntu",
-      "platform_family": "debian",
-      "platform_version": "16.04",
-      "network": {
-        "interfaces": [
-          {
-            "name": "lo",
-            "addresses": [
-              "127.0.0.1/8",
-              "::1/128"
-            ]
-          },
-          {
-            "name": "eth0",
-            "mac": "52:54:00:20:1b:3c",
-            "addresses": [
-              "93.184.216.34/24",
-              "2606:2800:220:1:248:1893:25c8:1946/10"
-            ]
-          }
-        ]
-      },
-      "arch": "amd64"
+"entity": {
+  "entity_class": "agent",
+  "system": {
+    "hostname": "webserver01",
+    "os": "linux",
+    "platform": "centos",
+    "platform_family": "rhel",
+    "platform_version": "7.4.1708",
+    "network": {
+      "interfaces": [
+        {
+          "name": "lo",
+          "addresses": [
+            "127.0.0.1/8",
+            "::1/128"
+          ]
+        },
+        {
+          "name": "enp0s3",
+          "mac": "08:00:27:11:ad:d2",
+          "addresses": [
+            "10.0.2.15/24",
+            "fe80::26a5:54ec:cf0d:9704/64"
+          ]
+        },
+        {
+          "name": "enp0s8",
+          "mac": "08:00:27:bc:be:60",
+          "addresses": [
+            "172.28.128.3/24",
+            "fe80::a00:27ff:febc:be60/64"
+          ]
+        }
+      ]
     },
-    "user": "agent"
+    "arch": "amd64"
+  },
+  "subscriptions": [
+    "testing",
+    "entity:webserver01"
+  ],
+  "last_seen": 1542667635,
+  "deregister": false,
+  "deregistration": {},
+  "user": "agent",
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "metadata": {
+    "name": "webserver01",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
   }
 }
 {{< /highlight >}}
@@ -223,15 +240,55 @@ example      | {{< highlight json >}}
 ## Example check-only event data
 
 {{< highlight json >}}
-  {
-    "timestamp": 1522170515,
+{
+  "type": "Event",
+  "spec": {
+    "timestamp": 1542667666,
     "entity": {
-      "class": "agent",
+      "entity_class": "agent",
+      "system": {
+        "hostname": "webserver01",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.4.1708",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "enp0s3",
+              "mac": "08:00:27:11:ad:d2",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::26a5:54ec:cf0d:9704/64"
+              ]
+            },
+            {
+              "name": "enp0s8",
+              "mac": "08:00:27:bc:be:60",
+              "addresses": [
+                "172.28.128.3/24",
+                "fe80::a00:27ff:febc:be60/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64"
+      },
+      "subscriptions": [
+        "testing",
+        "entity:webserver01"
+      ],
+      "last_seen": 1542667635,
       "deregister": false,
       "deregistration": {},
-      "id": "example-entity",
-      "keepalive_timeout": 120,
-      "namespace": "default",
+      "user": "agent",
       "redact": [
         "password",
         "passwd",
@@ -243,88 +300,61 @@ example      | {{< highlight json >}}
         "private_key",
         "secret"
       ],
-      "subscriptions": [
-        "web",
-        "entity:example-entity"
-      ],
-      "system": {
-        "hostname": "example-entity",
-        "os": "linux",
-        "platform": "ubuntu",
-        "platform_family": "debian",
-        "platform_version": "16.04",
-        "network": {
-          "interfaces": [
-            {
-              "name": "lo",
-              "addresses": [
-                "127.0.0.1/8",
-                "::1/128"
-              ]
-            },
-            {
-              "name": "eth0",
-              "mac": "52:54:00:20:1b:3c",
-              "addresses": [
-                "192.168.1.1/25",
-                "fd9e:a92d:eddd:12d1:119/10"
-              ]
-            }
-          ]
-        },
-        "arch": "amd64"
-      },
-      "user": "agent"
+      "metadata": {
+        "name": "webserver01",
+        "namespace": "default",
+        "labels": null,
+        "annotations": null
+      }
     },
     "check": {
-      "check_hooks": null,
-      "command": "check-http-response-time.rb -a example.com -C 5000 -w 3000",
-      "duration": 2.033888684,
-      "executed": 1522170513,
+      "command": "http_check.sh http://localhost:80",
       "handlers": [
-        "example-handler"
+        "slack"
       ],
       "high_flap_threshold": 0,
-      "history": [
-        {
-          "executed": 1522169313
-        },
-        {
-          "executed": 1522169613
-        },
-        {
-          "executed": 1522169913
-        },
-        {
-          "executed": 1522170213
-        },
-        {
-          "executed": 1522170513
-        }
-      ],
-      "interval": 300,
-      "last_ok": 1522170515,
+      "interval": 20,
       "low_flap_threshold": 0,
-      "name": "example-http-check",
-      "occurrences": 1,
-      "occurrences_watermark": 1,
-      "namespace": "default",
-      "output": "CheckHttpResponseTime OK: 1771 is acceptable\n",
-      "proxy_entity_id": "",
       "publish": true,
-      "round_robin": false,
       "runtime_assets": [],
-      "state": "passing",
-      "status": 0,
+      "subscriptions": [
+        "testing"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
       "stdin": false,
       "subdue": null,
-      "subscriptions": [
-        "web"
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 0.010849143,
+      "executed": 1542667666,
+      "history": [
+        {
+          "status": 1,
+          "executed": 1542667666
+        }
       ],
-      "timeout": 30,
-      "total_state_change": 0
+      "issued": 1542667666,
+      "output": "",
+      "state": "failing",
+      "status": 1,
+      "total_state_change": 0,
+      "last_ok": 0,
+      "occurrences": 1,
+      "occurrences_watermark": 1,
+      "output_metric_format": "",
+      "output_metric_handlers": [],
+      "env_vars": null,
+      "metadata": {
+        "name": "check-nginx",
+        "namespace": "default",
+        "labels": null,
+        "annotations": null
+      }
     }
   }
+}
 {{< /highlight >}}
 
 [1]: ../checks/#check-attributes

--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -70,51 +70,53 @@ _NOTE: Silenced has been deprecated from Event. Please see [check specification]
 -------------|------
 description  | The [Check attributes][1] used to obtain the check result.
 type         | Check
-example      | {{< highlight json >}}
-"check": {
-  "command": "http_check.sh http://localhost:80",
-  "handlers": [
-    "slack"
-  ],
-  "high_flap_threshold": 0,
-  "interval": 20,
-  "low_flap_threshold": 0,
-  "publish": true,
-  "runtime_assets": [],
-  "subscriptions": [
-    "testing"
-  ],
-  "proxy_entity_name": "",
-  "check_hooks": null,
-  "stdin": false,
-  "subdue": null,
-  "ttl": 0,
-  "timeout": 0,
-  "round_robin": false,
-  "duration": 0.010849143,
-  "executed": 1542667666,
-  "history": [
-    {
-      "status": 1,
-      "executed": 1542667666
+example      | {{< highlight shell >}}
+{
+  "check": {
+    "command": "http_check.sh http://localhost:80",
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 20,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [],
+    "subscriptions": [
+      "testing"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 0.010849143,
+    "executed": 1542667666,
+    "history": [
+      {
+        "status": 1,
+        "executed": 1542667666
+      }
+    ],
+    "issued": 1542667666,
+    "output": "",
+    "state": "failing",
+    "status": 1,
+    "total_state_change": 0,
+    "last_ok": 0,
+    "occurrences": 1,
+    "occurrences_watermark": 1,
+    "output_metric_format": "",
+    "output_metric_handlers": [],
+    "env_vars": null,
+    "metadata": {
+      "name": "check-nginx",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
     }
-  ],
-  "issued": 1542667666,
-  "output": "",
-  "state": "failing",
-  "status": 1,
-  "total_state_change": 0,
-  "last_ok": 0,
-  "occurrences": 1,
-  "occurrences_watermark": 1,
-  "output_metric_format": "",
-  "output_metric_handlers": [],
-  "env_vars": null,
-  "metadata": {
-    "name": "check-nginx",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
   }
 }
 {{< /highlight >}}
@@ -172,67 +174,69 @@ example      | {{< highlight json >}}
 description  | The [entity attributes][2] from the originating entity (agent or proxy).
 type         | Entity
 example      | {{< highlight json >}}
-"entity": {
-  "entity_class": "agent",
-  "system": {
-    "hostname": "webserver01",
-    "os": "linux",
-    "platform": "centos",
-    "platform_family": "rhel",
-    "platform_version": "7.4.1708",
-    "network": {
-      "interfaces": [
-        {
-          "name": "lo",
-          "addresses": [
-            "127.0.0.1/8",
-            "::1/128"
-          ]
-        },
-        {
-          "name": "enp0s3",
-          "mac": "08:00:27:11:ad:d2",
-          "addresses": [
-            "10.0.2.15/24",
-            "fe80::26a5:54ec:cf0d:9704/64"
-          ]
-        },
-        {
-          "name": "enp0s8",
-          "mac": "08:00:27:bc:be:60",
-          "addresses": [
-            "172.28.128.3/24",
-            "fe80::a00:27ff:febc:be60/64"
-          ]
-        }
-      ]
+{
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "webserver01",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.4.1708",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "enp0s3",
+            "mac": "08:00:27:11:ad:d2",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::26a5:54ec:cf0d:9704/64"
+            ]
+          },
+          {
+            "name": "enp0s8",
+            "mac": "08:00:27:bc:be:60",
+            "addresses": [
+              "172.28.128.3/24",
+              "fe80::a00:27ff:febc:be60/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64"
     },
-    "arch": "amd64"
-  },
-  "subscriptions": [
-    "testing",
-    "entity:webserver01"
-  ],
-  "last_seen": 1542667635,
-  "deregister": false,
-  "deregistration": {},
-  "user": "agent",
-  "redact": [
-    "password",
-    "passwd",
-    "pass",
-    "api_key",
-    "api_token",
-    "access_key",
-    "secret_key",
-    "private_key",
-    "secret"
-  ],
-  "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "subscriptions": [
+      "testing",
+      "entity:webserver01"
+    ],
+    "last_seen": 1542667635,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "webserver01",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    }
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -102,12 +102,14 @@ To use the incidents filter, include the `is_incident` filter in the handler con
 {
   "type": "Handler",
   "spec": {
-    "name": "slack",
     "type": "pipe",
     "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
     "filters": [
       "is_incident"
-    ]
+    ],
+    "metadata": {
+      "name": "slack"
+    }
   }
 }
 {{< /highlight >}}
@@ -132,13 +134,15 @@ To allow silencing for an event handler, add the `not_silenced` filter to the ha
 {
   "type": "Handler",
   "spec": {
-    "name": "slack",
     "type": "pipe",
     "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
     "filters": [
       "is_incident",
       "not_silenced"
-    ]
+    ],
+    "metadata": {
+      "name": "slack"
+    }
   }
 }
 {{< /highlight >}}
@@ -157,12 +161,14 @@ To use the metrics filter, include the `has_metrics` filter in the handler confi
 {
   "type": "Handler",
   "spec": {
-    "name": "influx-db",
     "type": "pipe",
     "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'myDB' --username 'foo' --password 'bar'",
     "filters": [
       "has_metrics"
-    ]
+    ],
+    "metadata": {
+      "name": "slack"
+    }
   }
 }
 {{< /highlight >}}
@@ -171,15 +177,23 @@ When applied to a handler configuration, the `has_metrics` filter allows only ev
 
 ## Filter specification
 
-### Filter naming
-
-Each filter definition must have a unique name within its namespace.
-
-* A unique string used to name/identify the filter
-* Cannot contain special characters or spaces
-* Validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
-
 ### Filter attributes
+
+|metadata    |      |
+-------------|------
+description  | Collection of metadata about the filter, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][11] for details.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "filter-weekdays-only",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
 
 action       | 
 -------------|------
@@ -216,14 +230,6 @@ example      | {{< highlight shell >}}"when": {
 }
 {{< /highlight >}}
 
-namespace | 
--------------|------ 
-description  | The Sensu RBAC namespace that this filter belongs to.
-required     | false 
-type         | String
-default      | current namespace value configured for `sensuctl` (for example: `default`) 
-example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
-
 runtime_assets |
 ---------------|------
 description    | Assets to be applied to the filter's execution context. JavaScript files in the lib directory of the asset will be evaluated.
@@ -231,6 +237,46 @@ required       | false
 type           | Array of String
 default        | []
 example        | {{< highlight shell >}}"runtime_assets": ["underscore"]{{< /highlight >}}
+
+### Metadata attributes
+
+| name       |      |
+-------------|------
+description  | A unique string used to identify the filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)). Each filter must have a unique name within its namespace.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "filter-weekdays-only"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][10] that this filter belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |     |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are _not_ used internally by Sensu and cannot be used to identify filters. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ### `when` attributes
 
@@ -452,3 +498,5 @@ expressions.
 [7]: #built-in-filter-only-incidents
 [8]: ../backend
 [9]: ../events
+[10]: ../rbac#namespaces
+[11]: #metadata-attributes

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -348,7 +348,7 @@ returns false, the event will be handled.
     },
     "action": "deny",
     "expressions": [
-      "event.Entity.Namespace == 'production'"
+      "event.entity.metadata.namespace == 'production'"
     ],
     "runtime_assets": []
   }

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -265,11 +265,20 @@ match event data with a custom entity definition attribute `"namespace":
 
 {{< highlight json >}}
 {
-  "name": "production_filter",
-  "action": "allow",
-  "expressions": [
-    "event.Entity.Namespace == 'production'"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "production_filter",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "allow",
+    "expressions": [
+      "event.Entity.Namespace == 'production'"
+    ],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 
@@ -283,11 +292,20 @@ Note that `action` is `deny`, making this an exclusive filter; if evaluation
 returns false, the event will be handled.
 {{< highlight json >}}
 {
-  "name": "development_filter",
-  "action": "deny",
-  "expressions": [
-    "event.Entity.Namespace == 'production'"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "development_filter",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "deny",
+    "expressions": [
+      "event.Entity.Namespace == 'production'"
+    ],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 
@@ -299,11 +317,20 @@ old monitoring system which alerts only on state change. This
 
 {{< highlight json >}}
 {
-  "name": "state_change_only",
-  "action": "allow",
-  "expressions": [
-    "event.check.occurrences == 1"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 
@@ -318,12 +345,21 @@ operator](https://en.wikipedia.org/wiki/Modulo_operation) calculation
 
 {{< highlight json >}}
 {
-  "name": "filter_interval_60_hourly",
-  "action": "allow",
-  "expressions": [
-    "event.check.interval == 60",
-    "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 
@@ -332,12 +368,21 @@ checks with a 30 second `interval`.
 
 {{< highlight json >}}
 {
-  "name": "filter_interval_30_hourly",
-  "action": "allow",
-  "expressions": [
-    "event.check.interval == 30",
-    "event.check.occurrences == 1 || event.check.occurrences % 120 == 0"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "filter_interval_30_hourly",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 30",
+      "event.check.occurrences == 1 || event.check.occurrences % 120 == 0"
+    ],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 
@@ -351,12 +396,21 @@ same result.
 
 {{< highlight json >}}
 {
-  "name": "nine_to_fiver",
-  "action": "allow",
-  "expressions": [
-    "weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5",
-    "hour(event.timestamp) >= 9 && hour(event.timestamp) <= 17"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "nine_to_fiver",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "allow",
+    "expressions": [
+      "weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5",
+      "hour(event.timestamp) >= 9 && hour(event.timestamp) <= 17"
+    ],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 
@@ -372,12 +426,20 @@ expressions.
 
 {{< highlight json >}}
 {
-  "name": "deny_if_failure_in_history",
-  "action": "deny",
-  "runtime_assets": ["underscore"],
-  "expressions": [
-    "_.reduce(event.check.history, function(memo, h) { return (memo || h.status != 0); })"
-  ]
+  "type": "EventFilter",
+  "spec": {
+    "metadata": {
+      "name": "deny_if_failure_in_history",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "action": "deny",
+    "expressions": [
+      "_.reduce(event.check.history, function(memo, h) { return (memo || h.status != 0); })"
+    ],
+    "runtime_assets": ["underscore"]
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -194,9 +194,15 @@ configured webhook URL, using the `handler-slack` executable command.
 
 {{< highlight json >}}
 {
-  "name": "slack",
-  "type": "pipe",
-  "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring"
+  "type": "Handler",
+  "spec": {
+    "type": "pipe",
+    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring'",
+    "metadata" : {
+      "name": "slack",
+      "namespace": "default"
+    }
+  }
 }
 {{< /highlight >}}
 
@@ -207,13 +213,18 @@ will timeout if an acknowledgement (`ACK`) is not received within 30 seconds.
 
 {{< highlight json >}}
 {
-  "name": "tcp_handler",
-  "type": "tcp",
-  "socket": {
-    "host": "10.0.1.99",
-    "port": 4444
-  },
-  "timeout": 30
+  "type": "Handler",
+  "spec": {
+    "type": "tcp",
+    "socket": {
+      "host": "10.0.1.99",
+      "port": 4444
+    },
+    "metadata" : {
+      "name": "tcp_handler",
+      "namespace": "default"
+    }
+  }
 }
 {{< /highlight >}}
 
@@ -224,11 +235,17 @@ The following example will also forward event data but to UDP socket instead
 
 {{< highlight json >}}
 {
-  "name": "udp_handler",
-  "type": "udp",
-  "socket": {
-    "host": "10.0.1.99",
-    "port": 4444
+  "type": "Handler",
+  "spec": {
+    "type": "udp",
+    "socket": {
+      "host": "10.0.1.99",
+      "port": 4444
+    },
+    "metadata" : {
+      "name": "udp_handler",
+      "namespace": "default"
+    }
   }
 }
 {{< /highlight >}}
@@ -240,13 +257,19 @@ The following example handler will execute three handlers: `slack`,
 
 {{< highlight json >}}
 {
-  "name": "notify_all_the_things",
-  "type": "set",
-  "handlers": [
-    "slack",
-    "tcp_handler",
-    "udp_handler"
-  ]
+  "type": "Handler",
+  "spec": {
+    "type": "set",
+    "handlers": [
+      "slack",
+      "tcp_handler",
+      "udp_handler"
+    ],
+    "metadata" : {
+      "name": "notify_all_the_things",
+      "namespace": "default"
+    }
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -84,15 +84,23 @@ built-in `is_incident` filter.
 
 ## Handler specification
 
-### Handler naming
-
-Each handler definition must have a unique name within its namespace.
-
-* A unique string used to name/identify the handler
-* Cannot contain special characters or spaces
-* Validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
-
 ### Handler attributes
+
+|metadata    |      |
+-------------|------
+description  | Collection of metadata about the handler, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][8] for details.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "handler-slack",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
 
 type         | 
 -------------|------
@@ -152,22 +160,52 @@ required     | true (if `type` equals `set`)
 type         | Array
 example      | {{< highlight shell >}}"handlers": ["pagerduty", "email", "ec2"]{{< /highlight >}}
 
-namespace | 
--------------|------ 
-description  | The Sensu RBAC namespace that this handler belongs to.
-required     | false 
-type         | String
-default      | current namespace value configured for `sensuctl` (i.e., `default`) 
-example      | {{< highlight shell >}}
-  "namespace": "default"
-{{< /highlight >}}
-
 runtime_assets | 
 ---------------|------
 description    | An array of [Sensu assets][7] (names), required at runtime for the execution of the `command`
 required       | false
 type           | Array
 example        | {{< highlight shell >}}"runtime_assets": ["ruby-2.5.0"]{{< /highlight >}}
+
+### Metadata attributes
+
+| name       |      |
+-------------|------
+description  | A unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)). Each handler must have a unique name within its namespace.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "handler-slack"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][9] that this handler belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize handlers into meaningful collections that can be selected using [filters][10] and [tokens][11].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |     |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are _not_ used internally by Sensu and cannot be used to identify handlers. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ### `socket` attributes
 
@@ -280,3 +318,7 @@ The following example handler will execute three handlers: `slack`,
 [5]: ../../../1.2/reference/handlers/#transport-handlers
 [6]: #socket-attributes
 [7]: ../assets
+[8]: #metadata-attributes
+[9]: ../rbac#namespaces
+[10]: ../filters
+[11]: ../tokens

--- a/content/sensu-go/5.0/reference/hooks.md
+++ b/content/sensu-go/5.0/reference/hooks.md
@@ -101,10 +101,18 @@ a process that is no longer running.
 
 {{< highlight json >}}
 {
-  "name": "restart_nginx",
-  "command": "sudo systemctl start nginx",
-  "timeout": 60,
-  "namespace": "default"
+  "type": "HookConfig",
+  "spec": {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false
+  }
 }
 {{< /highlight >}}
 
@@ -116,10 +124,18 @@ has been determined to be not running etc.
 
 {{< highlight json >}}
 {
-  "name": "process_tree",
-  "command": "ps aux",
-  "timeout": 60,
-  "namespace": "default"
+  "type": "HookConfig",
+  "spec": {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "command": "ps aux",
+    "timeout": 60,
+    "stdin": false
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/hooks.md
+++ b/content/sensu-go/5.0/reference/hooks.md
@@ -49,15 +49,23 @@ Sensu for auto-remediation tasks!
 
 ## Hooks specification
 
-### Hook naming
-
-Each hook definition must have a unique name within its namespace.
-
-* A unique string used to name/identify the hook
-* Cannot contain special characters or spaces
-* Validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
-
 ### Hook attributes
+
+|metadata    |      |
+-------------|------
+description  | Collection of metadata about the hook, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][2] for details.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "process_tree",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
 
 command      | 
 -------------|------
@@ -82,15 +90,45 @@ type         | Boolean
 default      | false
 example      | {{< highlight shell >}}"stdin": true{{< /highlight >}}
 
-namespace | 
--------------|------ 
-description  | The Sensu RBAC namespace that this hook belongs to.
-required     | false 
+### Metadata attributes
+
+| name       |      |
+-------------|------
+description  | A unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)). Each hook must have a unique name within its namespace.
+required     | true
 type         | String
-default      | current namespace value configured for `sensuctl` (ex: `default`) 
-example      | {{< highlight shell >}}
-  "namespace": "default"
-{{< /highlight >}}
+example      | {{< highlight shell >}}"name": "process_tree"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize hooks into meaningful collections that can be selected using [filters][4] and [tokens][5].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |     |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are _not_ used internally by Sensu and cannot be used to identify hooks. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ## Examples
 
@@ -140,3 +178,7 @@ has been determined to be not running etc.
 {{< /highlight >}}
 
 [1]: https://blog.sensuapp.org/using-check-hooks-a739a362961f
+[2]: #metadata-attributes
+[3]: ../rbac#namespaces
+[4]: ../filters
+[5]: ../tokens

--- a/content/sensu-go/5.0/reference/mutators.md
+++ b/content/sensu-go/5.0/reference/mutators.md
@@ -85,11 +85,19 @@ to modify event data prior to handling the event.
 ### Mutator definition
 {{< highlight json >}}
 {
-  "name": "example-mutator",
-  "command": "example_mutator.rb",
-  "timeout": 60,
-  "env_vars": null,
-  "namespace": "default"
+  "type": "Mutator",
+  "spec": {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": [],
+    "runtime_assets": []
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/mutators.md
+++ b/content/sensu-go/5.0/reference/mutators.md
@@ -35,13 +35,6 @@ fails to execute, an error will be logged, and the handler will not be executed.
   * `0` indicates OK status
   * exit codes other than `0` indicate failure
 
-### Naming
-Each mutator definition must have a unique name within its namespace.
-
-* A unique string used to identify the mutator
-* Cannot contain special characters or spaces
-* Validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)
-
 ### Commands
 Each Sensu mutator definition defines a command to be executed. Mutator commands are executable commands which will be executed on a Sensu server, run as the `sensu user`. Most mutator commands are provided by Sensu Plugins.
 
@@ -55,6 +48,23 @@ As mentioned above, all mutator commands are executed by a Sensu server as the `
 _NOTE: By default, the Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`. As a result, executable scripts (like plugins) located in `/etc/sensu/plugins` will be valid commands. This allows `command` attributes to use “relative paths” for Sensu plugin commands, for example: `"command": "check-http.rb -u https://sensuapp.org"`._
 
 ### Attributes
+
+|metadata    |      |
+-------------|------
+description  | Collection of metadata about the mutator, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][2] for details.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "example-mutator",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
+
 command      | 
 -------------|------ 
 description  | The mutator command to be executed by Sensu server. 
@@ -76,6 +86,45 @@ required       | false
 type           | Array
 example        | {{< highlight shell >}}"runtime_assets": ["ruby-2.5.0"]{{< /highlight >}}
 
+### Metadata attributes
+
+| name       |      |
+-------------|------
+description  | A unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2)). Each mutator must have a unique name within its namespace.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "example-mutator"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][3] that this mutator belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes. You can use labels to organize mutators into meaningful collections that can be selected using [filters][4] and [tokens][5].
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |    |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. In contrast to labels, annotations are not used internally by Sensu and cannot be used to identify mutators. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ## Examples
 
@@ -101,4 +150,10 @@ to modify event data prior to handling the event.
 }
 {{< /highlight >}}
 
+
+
 [1]: ../assets
+[2]: #metadata-attributes
+[3]: ../rbac#namespaces
+[4]: ../filters
+[5]: ../tokens

--- a/content/sensu-go/5.0/reference/silencing.md
+++ b/content/sensu-go/5.0/reference/silencing.md
@@ -32,19 +32,19 @@ subscription described in a silencing entry match an event and a handler use the
 These silencing entries are persisted in the Sensu data store. When the Sensu
 server processes subsequent check results, matching silencing entries are
 retrieved from the store. If one or more matching entries exist, the event is
-updated with a list of silenced entry ids. The presence of silencing entries
+updated with a list of silenced entry names. The presence of silencing entries
 indicates that the event is silenced.
 
 When creating a silencing entry, a combination of check and subscription can be
 specified, but only one or the other is strictly required.
 
-For example, when a silencing entry is created specifying only a check, its ID
+For example, when a silencing entry is created specifying only a check, its name
 will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position. This
 indicates that any event with a matching check name will be marked as silenced,
 regardless of the originating entities’ subscriptions.
 
-Conversely, a silencing entry which specifies only a subscription will have an
-ID with an asterisk in the `$CHECK` position. This indicates that any event
+Conversely, a silencing entry which specifies only a subscription will have a
+name with an asterisk in the `$CHECK` position. This indicates that any event
 where the originating entities’ subscriptions match the subscription specified
 in the entry will be marked as silenced, regardless of the check name.
 
@@ -56,13 +56,30 @@ handled accordingly.
 
 ## Silencing specification
 
-### Silenced entry ID 
-Silencing entries must contain either a subscription or check id, and are
+### Silenced entry names
+Silencing entries must contain either a subscription or check name, and are
 identified by the combination of `$SUBSCRIPTION:$CHECK`. If a check or
 subscription is not provided, it will be substituted with a wildcard (asterisk):
 `$SUBSCRIPTION:*` or `*:$CHECK`.
 
 ### Attributes
+
+|metadata    |      |
+-------------|------
+description  | Collection of metadata about the silencing entry, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][3] for details.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "name": "appserver:mysql_status",
+  "namespace": "default",
+  "labels": {
+    "region": "us-west-1"
+  },
+  "annotations": {
+    "slack-channel" : "#monitoring"
+  }
+}{{< /highlight >}}
+
 check        | 
 -------------|------ 
 description  | The name of the check the entry should match 
@@ -77,13 +94,6 @@ description  | The name of the subscription the entry should match
 required     | true, unless `check` is provided
 type         | String
 example      | {{< highlight shell >}}"subscription": "entity:i-424242"{{</highlight>}}
-
-id           | 
--------------|------ 
-description  | Silencing identifier generated from the combination of a subsription name and check name. 
-required     | false - this value cannot be modified 
-type         | String
-example      | {{< highlight shell >}}"id": "appserver:mysql_status"{{< /highlight >}}
 
 begin        | 
 -------------|------ 
@@ -125,13 +135,45 @@ type         | String
 default      | null 
 example      | {{< highlight shell >}}"reason": "rebooting the world"{{< /highlight >}}
 
-namespace | 
+### Metadata attributes
+
+| name       |      |
 -------------|------ 
-description  | The Sensu RBAC namespace that this check belongs to.
-required     | false 
-type         | String 
-default      | current namespace value configured for `sensuctl` (ie `default`) 
-example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
+description  | Silencing identifier generated from the combination of a subscription name and check name.
+required     | false - This value cannot be modified.
+type         | String
+example      | {{< highlight shell >}}"name": "appserver:mysql_status"{{< /highlight >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][2] that this silencing entry belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| labels     |      |
+-------------|------
+description  | Custom attributes to include with event data, which can be queried like regular attributes.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}}"labels": {
+  "environment": "development",
+  "region": "us-west-2"
+}{{< /highlight >}}
+
+| annotations |     |
+-------------|------
+description  | Arbitrary, non-identifying metadata to include with event data. You can use annotations to add data that helps people or external tools interacting with Sensu.
+required     | false
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
+example      | {{< highlight shell >}} "annotations": {
+  "managed-by": "ops",
+  "slack-channel": "#monitoring",
+  "playbook": "www.example.url"
+}{{< /highlight >}}
 
 ## Examples
 
@@ -215,19 +257,21 @@ regardless of subscriptions, we only need to provide the check name:
 {{< /highlight >}}
 
 ### Deleting silencing entries
-To delete a silencing entry, you will need to provide its id. Subscription only
-silencing entry ids will be similar to this:
+To delete a silencing entry, you will need to provide its name. Subscription only
+silencing entry names will be similar to this:
 {{< highlight json >}}
 {
-  "id": "appserver:*"
+  "name": "appserver:*"
 }
 {{< /highlight >}}
 
-Check only silencing entry ids will be similar to this:
+Check only silencing entry names will be similar to this:
 {{< highlight json >}}
 {
-  "id": "*:mysql_status"
+  "name": "*:mysql_status"
 }
 {{< /highlight >}}
 
 [1]: ../events/#attributes
+[2]: ../rbac#namespaces
+[3]: #metadata-attributes

--- a/content/sensu-go/5.0/reference/silencing.md
+++ b/content/sensu-go/5.0/reference/silencing.md
@@ -141,13 +141,22 @@ do this by taking advantage of per-entity subscriptions:
 
 {{< highlight json >}}
 {
-  "expire": -1,
-  "expire_on_resolve": false,
-  "creator": null,
-  "reason": null,
-  "check": null,
-  "subscription": "entity:i-424242",
-  "id": "entity:i-424242:*"
+  "type": "Silenced",
+  "spec": {
+    "metadata": {
+      "name": "entity:i-424242:*",
+      "namespace": "default",
+      "labels": null,
+      "annotations": null
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "reason": null,
+    "check": null,
+    "subscription": "entity:i-424242",
+    "begin": 1542671205
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/tokens.md
+++ b/content/sensu-go/5.0/reference/tokens.md
@@ -55,24 +55,33 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
 
 {{< highlight json >}}
 {
-  "check_hooks": null,
-  "command": "check-disk-usage.rb -w {{.Disk.Warning | default 80}} -c {{.Disk.Critical | default 90}}",
-  "namespace": "{{ .Namespace | default \"production\" }}",
-  "handlers": [],
-  "high_flap_threshold": 0,
-  "interval": 60,
-  "low_flap_threshold": 0,
-  "name": "check-disk-usage",
-  "proxy_entity_id": "",
-  "publish": true,
-  "round_robin": false,
-  "runtime_assets": [],
-  "stdin": false,
-  "subdue": null,
-  "subscriptions": [
+  "type": "CheckConfig",
+  "spec": {
+    "command": "check-disk-usage.rb -w {{.Disk.Warning | default 80}} -c {{.Disk.Critical | default 90}}",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 10,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": null,
+    "subscriptions": [
     "staging"
-  ],
-  "timeout": 0
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "env_vars": null,
+    "metadata": {
+      "name": "check-disk-usage",
+      "namespace": "{{ .Namespace | default \"production\" }}",
+      "labels": null,
+      "annotations": null
+    }
+  }
 }{{< /highlight >}}
 
 The following example [entity][4] would provide the necessary
@@ -81,61 +90,73 @@ tokens declared above.
 
 {{< highlight json >}}
 {
-  "class": "agent",
-  "deregister": false,
-  "deregistration": {},
-  "namespace": "staging",
-  "id": "example-hostname",
-  "keepalive_timeout": 60,
-  "last_seen": 1523387195,
-  "redact": [
-    "password",
-    "passwd",
-    "pass",
-    "api_key",
-    "api_token",
-    "access_key",
-    "secret_key",
-    "private_key",
-    "secret"
-  ],
-  "subscriptions": [
-    "entity:example-hostname",
-    "staging"
-  ],
-  "system": {
-    "hostname": "example-hostname",
-    "os": "linux",
-    "platform": "ubuntu",
-    "platform_family": "debian",
-    "platform_version": "16.04",
-    "network": {
-      "interfaces": [
-        {
-          "name": "lo",
-          "addresses": [
-            "127.0.0.1/8",
-            "::1/128"
-          ]
-        },
-        {
-          "name": "eth0",
-          "mac": "52:54:00:20:1b:3c",
-          "addresses": [
-            "93.184.216.34/24",
-            "2606:2800:220:1:248:1893:25c8:1946/10"
-          ]
-        }
-      ]
+  "type": "Entity",
+  "spec": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "example-hostname",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.4.1708",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "enp0s3",
+            "mac": "08:00:27:11:ad:d2",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::26a5:54ec:cf0d:9704/64"
+            ]
+          },
+          {
+            "name": "enp0s8",
+            "mac": "08:00:27:bc:be:60",
+            "addresses": [
+              "172.28.128.3/24",
+              "fe80::a00:27ff:febc:be60/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64"
     },
-    "arch": "amd64"
-  },
-  "user": "agent",
-  "region": "us-west-1",
-  "team": "ops",
-  "disk": {
-    "warning": 75,
-    "critical": 85
+    "subscriptions": [
+      "entity:example-hostname",
+      "staging"
+    ],
+    "last_seen": 1542667231,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "example-hostname",
+      "namespace": "staging",
+      "labels": null,
+      "annotations": null
+    },
+    "disk": {
+      "warning": 75,
+      "critical": 85
+    }
   }
 }{{< /highlight >}}
 

--- a/content/sensu-go/5.0/sensuctl/reference.md
+++ b/content/sensu-go/5.0/sensuctl/reference.md
@@ -168,22 +168,27 @@ sensuctl can be configured to return JSON instead of the default human-readable
 format:
 
 {{< highlight shell >}}
-sensuctl check info marketing-site --format json
+sensuctl check info marketing-site --format wrapped-json
 {{< /highlight >}}
 
 {{< highlight json >}}
 {
-  "name": "marketing-site",
-  "interval": 10,
-  "subscriptions": [
-    "web"
-  ],
-  "command": "check-http.rb -u https://dean-learner.book",
-  "handlers": [
-    "slack"
-  ],
-  "runtime_assets": [],
-  "namespace": "default"
+  "type": "CheckConfig",
+  "spec": {
+    "interval": 10,
+    "subscriptions": [
+      "web"
+    ],
+    "command": "check-http.rb -u https://dean-learner.book",
+    "handlers": [
+      "slack"
+    ],
+    "runtime_assets": [],
+    "metadata" : {
+      "name": "marketing-site",
+      "namespace": "default"
+    }
+  }
 }
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/sensuctl/reference.md
+++ b/content/sensu-go/5.0/sensuctl/reference.md
@@ -287,20 +287,24 @@ an example, and [this table][3] for a list of supported types).
 {
   "type": "CheckConfig",
   "spec": {
-    "name": "marketing-site",
     "command": "check-http.rb -u https://dean-learner.book",
     "subscriptions": ["demo"],
     "interval": 15,
     "handlers": ["slack"],
-    "namespace": "default"   }
+    "metadata" : {
+      "name": "marketing-site",
+      "namespace": "default"
+    }
 }
 {
   "type": "Handler",
   "spec": {
-    "name": "slack",
     "type": "pipe",
     "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring'",
-    "namespace": "default"
+    "metadata" : {
+      "name": "slack",
+      "namespace": "default"
+    }
   }
 }
 {{< /highlight >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Updates the Sensu Go docs to use:

- The `metadata` scope containing `name`, `namespace`, `labels`, and `annotations`. For now, this information lives in the reference docs for each resource type, but in the future, it'd be awesome to put together a guide or a conceptual overview for getting the most out of these attributes.
- The name changes described in https://github.com/sensu/sensu-go/pull/2308, including `entity_class` and `proxy_entity_name`
- Updates to JSON examples across resource docs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #874 
Closes #892

## Review Instructions
<!--- Optional -->
Start with https://github.com/sensu/sensu-docs/commit/07690fadbcfe64e419b66f6d4b85e577abce5504
