### PR TITLE
Specify the RBAC requirements for --all-namespaces

### DIFF
--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -317,7 +317,7 @@ To create and manage roles within a namespace, [create a role][25] with `roles` 
 
 ### Cluster roles
 
-Cluster roles can specify access permissions for [cluster-wide resources][18] like users and namespaces as well as [namespaced resources][17] like checks and handlers.
+Cluster roles can specify access permissions for [cluster-wide resources][18] like users and namespaces as well as [namespaced resources][17] like checks and handlers. They can also be used to grant access to namespaced resources across all namespaces (needed to run `sensuctl check list --all-namespacess`, for example) when used in conjunction with cluster role bindings.
 Cluster roles use the same [specification][24] as roles and can be managed using the same sensuctl commands with `cluster-role` substituted for `role`.
 
 To create and manage cluster roles, [configure sensuctl][26] as the [default `admin` user][20] or [create a cluster role][25] with permissions for `clusterroles`.

--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -317,7 +317,7 @@ To create and manage roles within a namespace, [create a role][25] with `roles` 
 
 ### Cluster roles
 
-Cluster roles can specify access permissions for [cluster-wide resources][18] like users and namespaces as well as [namespaced resources][17] like checks and handlers. They can also be used to grant access to namespaced resources across all namespaces (needed to run `sensuctl check list --all-namespacess`, for example) when used in conjunction with cluster role bindings.
+Cluster roles can specify access permissions for [cluster-wide resources][18] like users and namespaces as well as [namespaced resources][17] like checks and handlers. They can also be used to grant access to namespaced resources across all namespaces (needed to run `sensuctl check list --all-namespaces`, for example) when used in conjunction with cluster role bindings.
 Cluster roles use the same [specification][24] as roles and can be managed using the same sensuctl commands with `cluster-role` substituted for `role`.
 
 To create and manage cluster roles, [configure sensuctl][26] as the [default `admin` user][20] or [create a cluster role][25] with permissions for `clusterroles`.


### PR DESCRIPTION
## Description
Specify the requirements for using the `--all-namespaces` flag in sensuctl.

## Motivation and Context
A user need a cluster role in conjunction with a cluster role binding for the specified resource (e.g. checks) to list the resource across all namespaces.

## Review Instructions
<!--- Optional -->
