### PR TITLE
Update entity_class spec to reflect current state

### DIFF
--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -52,7 +52,7 @@ example      | {{< highlight shell >}}"metadata": {
 
 entity_class |     |
 -------------|------ 
-description  | The entity type, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2). Class names have special meaning. An entity that runs an agent will be of `agent` and is reserved. A proxy entity will have class `proxy`, otherwise the field isn’t required or the user can use it to indicate an arbitrary type of entity. E.g. “lambda” “switch” etc.
+description  | The entity type, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2). Class names have special meaning. An entity that runs an agent is of class `agent` and is reserved. Setting the value of `entity_class` to `proxy` creates a proxy entity. For other types of entities, the `entity_class` attribute isn’t required, and you can use it to indicate an arbitrary type of entity (like `lambda` or `switch`).
 required     | true
 type         | string 
 example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -52,7 +52,7 @@ example      | {{< highlight shell >}}"metadata": {
 
 entity_class |     |
 -------------|------ 
-description  | The entity type, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2). This value is not user configurable; it is set directly by the agent. An entity that runs an agent will be of `agent`, while a proxy entity will have class `proxy`.
+description  | The entity type, validated with go regex [`\A[\w\.\-]+\z`](https://regex101.com/r/zo9mQU/2). Class names have special meaning. An entity that runs an agent will be of `agent` and is reserved. A proxy entity will have class `proxy`, otherwise the field isn’t required or the user can use it to indicate an arbitrary type of entity. E.g. “lambda” “switch” etc.
 required     | true
 type         | string 
 example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}


### PR DESCRIPTION
It is user configurable and can have a variety of values. This became clear based on discussion in https://github.com/sensu/sensu-go-chef/pull/38

## Description
Update to indicate `entity_class` is configurable

## Motivation and Context
fixes #928 

## Review Instructions
Look it over and tell me if I'm wrong, thanks for the review!
