### PR TITLE
Adjust reference docs after metadata changes

### DIFF
--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -140,22 +140,24 @@ example      | {{< highlight shell >}} "annotations": {
 {{< highlight json >}}
 {
   "type": "Asset",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check_script",
+    "namespace": "default",
+    "labels": {
+      "region": "us-west-1"
+    },
+    "annotations": {
+      "slack-channel" : "#monitoring"
+    }
+  },
   "spec": {
     "url": "http://example.com/asset.tar.gz",
     "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
     "filters": [
       "system.os == 'linux'",
       "system.arch == 'amd64'"
-    ],    "metadata": {
-      "name": "check_script",
-      "namespace": "default",
-      "labels": {
-        "region": "us-west-1"
-      },
-      "annotations": {
-        "slack-channel" : "#monitoring"
-      }
-    }
+    ],
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -400,6 +400,16 @@ example      | {{< highlight shell >}}"splay_coverage": 65{{< /highlight >}}
 {{< highlight json >}}
 {
   "type": "CheckConfig",
+  "metadata": {
+    "name": "collect-metrics",
+    "namespace": "default",
+    "labels": {
+      "region": "us-west-1"
+    },
+    "annotations": {
+      "slack-channel" : "#monitoring"
+    }
+  },
   "spec": {
     "command": "collect.sh",
     "handlers": [],
@@ -421,17 +431,7 @@ example      | {{< highlight shell >}}"splay_coverage": 65{{< /highlight >}}
     "output_metric_handlers": [
       "influx-db"
     ],
-    "env_vars": null,
-    "metadata": {
-      "name": "collect-metrics",
-      "namespace": "default",
-      "labels": {
-        "region": "us-west-1"
-      },
-      "annotations": {
-        "slack-channel" : "#monitoring"
-      }
-    }
+    "env_vars": null
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -329,6 +329,13 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
 {{< highlight json >}}
 {
   "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "webserver01",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
     "entity_class": "agent",
     "system": {
@@ -383,13 +390,7 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
       "secret_key",
       "private_key",
       "secret"
-    ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
+    ]
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -256,6 +256,11 @@ example      | {{< highlight json >}}
 {{< highlight json >}}
 {
   "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "webserver01",
+    "namespace": "default"
+  },
   "spec": {
     "timestamp": 1542667666,
     "entity": {
@@ -314,12 +319,6 @@ example      | {{< highlight json >}}
         "private_key",
         "secret"
       ],
-      "metadata": {
-        "name": "webserver01",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
     },
     "check": {
       "check_hooks": null,

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -101,15 +101,17 @@ To use the incidents filter, include the `is_incident` filter in the handler con
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack"
+    "namespace": "default"
+  },
   "spec": {
     "type": "pipe",
     "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
     "filters": [
       "is_incident"
     ],
-    "metadata": {
-      "name": "slack"
-    }
   }
 }
 {{< /highlight >}}
@@ -272,16 +274,15 @@ match event data with a custom entity definition attribute `"namespace":
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "production_filter",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "production_filter",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
-      "event.Entity.Namespace == 'production'"
+      "event.entity.namespace == 'production'"
     ],
     "runtime_assets": []
   }
@@ -299,13 +300,12 @@ returns false, the event will be handled.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "development_filter",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "development_filter",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "deny",
     "expressions": [
       "event.entity.metadata.namespace == 'production'"
@@ -324,13 +324,12 @@ old monitoring system which alerts only on state change. This
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "state_change_only",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "state_change_only",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "event.check.occurrences == 1"
@@ -352,13 +351,12 @@ operator](https://en.wikipedia.org/wiki/Modulo_operation) calculation
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "filter_interval_60_hourly",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "filter_interval_60_hourly",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "event.check.interval == 60",
@@ -375,13 +373,12 @@ checks with a 30 second `interval`.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "filter_interval_30_hourly",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "filter_interval_30_hourly",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "event.check.interval == 30",
@@ -402,13 +399,12 @@ will not be handled.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "nine_to_fiver",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "nine_to_fiver",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5",
@@ -429,13 +425,12 @@ expressions.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "deny_if_failure_in_history",
+    "namespace": "default",
+  },
   "spec": {
-    "metadata": {
-      "name": "deny_if_failure_in_history",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "deny",
     "expressions": [
       "_.reduce(event.check.history, function(memo, h) { return (memo || h.status != 0); })"

--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -233,13 +233,14 @@ configured webhook URL, using the `handler-slack` executable command.
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "slack",
+    "namespace": "default"
+  },
   "spec": {
     "type": "pipe",
     "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
-    "metadata" : {
-      "name": "slack",
-      "namespace": "default"
-    }
   }
 }
 {{< /highlight >}}
@@ -252,16 +253,17 @@ will timeout if an acknowledgement (`ACK`) is not received within 30 seconds.
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "tcp_handler",
+    "namespace": "default"
+  },
   "spec": {
     "type": "tcp",
     "socket": {
       "host": "10.0.1.99",
       "port": 4444
     },
-    "metadata" : {
-      "name": "tcp_handler",
-      "namespace": "default"
-    }
   }
 }
 {{< /highlight >}}
@@ -274,16 +276,17 @@ The following example will also forward event data but to UDP socket instead
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "udp_handler",
+    "namespace": "default"
+  },
   "spec": {
     "type": "udp",
     "socket": {
       "host": "10.0.1.99",
       "port": 4444
     },
-    "metadata" : {
-      "name": "udp_handler",
-      "namespace": "default"
-    }
   }
 }
 {{< /highlight >}}
@@ -296,6 +299,11 @@ The following example handler will execute three handlers: `slack`,
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "notify_all_the_things",
+    "namespace": "default"
+  },
   "spec": {
     "type": "set",
     "handlers": [
@@ -303,10 +311,6 @@ The following example handler will execute three handlers: `slack`,
       "tcp_handler",
       "udp_handler"
     ],
-    "metadata" : {
-      "name": "notify_all_the_things",
-      "namespace": "default"
-    }
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/reference/hooks.md
+++ b/content/sensu-go/5.0/reference/hooks.md
@@ -143,13 +143,12 @@ a process that is no longer running.
 {{< highlight json >}}
 {
   "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "restart_nginx",
+    "namespace": "default"
+  },
   "spec": {
-    "metadata": {
-      "name": "restart_nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "command": "sudo systemctl start nginx",
     "timeout": 60,
     "stdin": false
@@ -166,13 +165,12 @@ has been determined to be not running etc.
 {{< highlight json >}}
 {
   "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "process_tree",
+    "namespace": "default"
+  },
   "spec": {
-    "metadata": {
-      "name": "process_tree",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "command": "ps aux",
     "timeout": 60,
     "stdin": false

--- a/content/sensu-go/5.0/reference/mutators.md
+++ b/content/sensu-go/5.0/reference/mutators.md
@@ -135,13 +135,12 @@ to modify event data prior to handling the event.
 {{< highlight json >}}
 {
   "type": "Mutator",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "example-mutator",
+    "namespace": "default"
+  },
   "spec": {
-    "metadata": {
-      "name": "example-mutator",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "command": "example_mutator.go",
     "timeout": 0,
     "env_vars": [],

--- a/content/sensu-go/5.0/reference/silencing.md
+++ b/content/sensu-go/5.0/reference/silencing.md
@@ -184,13 +184,12 @@ do this by taking advantage of per-entity subscriptions:
 {{< highlight json >}}
 {
   "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "entity:i-424242:*",
+    "namespace": "default"
+  },
   "spec": {
-    "metadata": {
-      "name": "entity:i-424242:*",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",

--- a/content/sensu-go/5.0/reference/tokens.md
+++ b/content/sensu-go/5.0/reference/tokens.md
@@ -56,6 +56,11 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
 {{< highlight json >}}
 {
   "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check-disk-usage",
+    "namespace": "{{ .Namespace | default \"production\" }}"
+  },
   "spec": {
     "command": "check-disk-usage.rb -w {{.Disk.Warning | default 80}} -c {{.Disk.Critical | default 90}}",
     "handlers": [],
@@ -74,12 +79,6 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
     "timeout": 0,
     "round_robin": false,
     "env_vars": null,
-    "metadata": {
-      "name": "check-disk-usage",
-      "namespace": "{{ .Namespace | default \"production\" }}",
-      "labels": null,
-      "annotations": null
-    }
   }
 }{{< /highlight >}}
 
@@ -90,6 +89,11 @@ tokens declared above.
 {{< highlight json >}}
 {
   "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "example-hostname",
+    "namespace": "staging"
+  },
   "spec": {
     "entity_class": "agent",
     "system": {
@@ -146,12 +150,6 @@ tokens declared above.
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "example-hostname",
-      "namespace": "staging",
-      "labels": null,
-      "annotations": null
-    },
     "disk": {
       "warning": 75,
       "critical": 85


### PR DESCRIPTION
We now support placing metadata outside of the spec of a resource.
Object metadata will still be usable in the spec by filters, but
will display in the wrapper.

If users put object metadata in both places, the metadata will be
merged, with a preference for the metadata keys in the wrapper in
case of a conflict.

Some lingering filter errata have been dealt with as well.

Signed-off-by: Eric Chlebek <eric@sensu.io>