### PR TITLE
Add metadata wrapper for Sensu Go types

### DIFF
--- a/content/sensu-go/5.0/reference/assets.md
+++ b/content/sensu-go/5.0/reference/assets.md
@@ -54,12 +54,26 @@ The following are injected into the execution context:
 
 ## Assets specification
 
-### Attributes
+### Top-level attributes
 
-|metadata     |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the asset, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][5] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Assets should always be of type `Asset`.
+required     | Required for asset definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Asset"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For assets in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for asset definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the asset, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the asset definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][5] for details.
+required     | Required for asset definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"metadata": {
   "name": "check_script",
@@ -71,6 +85,22 @@ example      | {{< highlight shell >}}"metadata": {
     "slack-channel" : "#monitoring"
   }
 }{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the asset [spec attributes][sp].
+required     | Required for asset definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"spec": {
+  "url": "http://example.com/asset.tar.gz",
+  "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
+  "filters": [
+    "system.os == 'linux'",
+    "system.arch == 'amd64'"
+  ]
+}{{< /highlight >}}
+
+### Spec attributes
 
 url          | 
 -------------|------ 
@@ -140,22 +170,24 @@ example      | {{< highlight shell >}} "annotations": {
 {{< highlight json >}}
 {
   "type": "Asset",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check_script",
+    "namespace": "default",
+    "labels": {
+      "region": "us-west-1"
+    },
+    "annotations": {
+      "slack-channel" : "#monitoring"
+    }
+  },
   "spec": {
     "url": "http://example.com/asset.tar.gz",
     "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
     "filters": [
       "system.os == 'linux'",
       "system.arch == 'amd64'"
-    ],    "metadata": {
-      "name": "check_script",
-      "namespace": "default",
-      "labels": {
-        "region": "us-west-1"
-      },
-      "annotations": {
-        "slack-channel" : "#monitoring"
-      }
-    }
+    ]
   }
 }
 {{< /highlight >}}
@@ -165,3 +197,5 @@ example      | {{< highlight shell >}} "annotations": {
 [3]: ../filters
 [4]: ../tokens
 [5]: #metadata-attributes
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -157,12 +157,26 @@ enabled directly with the [round_robin][13] attribute in the check configuration
 
 ## Check specification
 
-### Check attributes
+### Top-level attributes
 
-|metadata     |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the check, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][25] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Checks should always be of type `CheckConfig`.
+required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "CheckConfig"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For checks in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the check, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][25] for details.
+required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"metadata": {
   "name": "collect-metrics",
@@ -174,6 +188,16 @@ example      | {{< highlight shell >}}"metadata": {
     "slack-channel" : "#monitoring"
   }
 }{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the check [spec attributes][sp].
+required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+{{< /highlight >}}
+
+### Spec attributes
 
 |command     |      |
 -------------|------
@@ -400,6 +424,17 @@ example      | {{< highlight shell >}}"splay_coverage": 65{{< /highlight >}}
 {{< highlight json >}}
 {
   "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "collect-metrics",
+    "namespace": "default",
+    "labels": {
+      "region": "us-west-1"
+    },
+    "annotations": {
+      "slack-channel" : "#monitoring"
+    }
+  },
   "spec": {
     "command": "collect.sh",
     "handlers": [],
@@ -421,17 +456,7 @@ example      | {{< highlight shell >}}"splay_coverage": 65{{< /highlight >}}
     "output_metric_handlers": [
       "influx-db"
     ],
-    "env_vars": null,
-    "metadata": {
-      "name": "collect-metrics",
-      "namespace": "default",
-      "labels": {
-        "region": "us-west-1"
-      },
-      "annotations": {
-        "slack-channel" : "#monitoring"
-      }
-    }
+    "env_vars": null
   }
 }
 {{< /highlight >}}
@@ -470,3 +495,5 @@ example      | {{< highlight shell >}}"splay_coverage": 65{{< /highlight >}}
 [25]: #metadata-attributes
 [26]: ../rbac#namespaces
 [27]: ../filters
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -32,14 +32,29 @@ An `entity`, formally known as a `client` in Sensu 1.x, represents anything (ex:
 
 ## Entities specification
 
-### Entity Attributes
+### Top-level attributes
 
-|metadata    |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the entity, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][8] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Entities should always be of type `Entity`.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Entity"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For entities in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the entity, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the entity definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][8] for details.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
-example      | {{< highlight shell >}}"metadata": {
+example      | {{< highlight shell >}}
+"metadata": {
   "name": "webserver01",
   "namespace": "default",
   "labels": {
@@ -48,7 +63,18 @@ example      | {{< highlight shell >}}"metadata": {
   "annotations": {
     "slack-channel" : "#monitoring"
   }
-}{{< /highlight >}}
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the entity [spec attributes][sp].
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+{{< /highlight >}}
+
+### Spec Attributes
 
 entity_class |     |
 -------------|------ 
@@ -329,6 +355,13 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
 {{< highlight json >}}
 {
   "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "webserver01",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
     "entity_class": "agent",
     "system": {
@@ -383,13 +416,7 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
       "secret_key",
       "private_key",
       "secret"
-    ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
+    ]
   }
 }
 {{< /highlight >}}
@@ -402,3 +429,5 @@ example      | {{< highlight shell >}}"handler": "email-handler"{{< /highlight >
 [6]: ../filters
 [7]: ../tokens
 [8]: #metadata-attributes
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -256,6 +256,13 @@ example      | {{< highlight json >}}
 {{< highlight json >}}
 {
   "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "webserver01",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
     "timestamp": 1542667666,
     "entity": {
@@ -313,13 +320,7 @@ example      | {{< highlight json >}}
         "secret_key",
         "private_key",
         "secret"
-      ],
-      "metadata": {
-        "name": "webserver01",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
+      ]
     },
     "check": {
       "check_hooks": null,

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -133,16 +133,17 @@ To allow silencing for an event handler, add the `not_silenced` filter to the ha
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack"
+  },
   "spec": {
     "type": "pipe",
     "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
     "filters": [
       "is_incident",
       "not_silenced"
-    ],
-    "metadata": {
-      "name": "slack"
-    }
+    ]
   }
 }
 {{< /highlight >}}
@@ -177,14 +178,29 @@ When applied to a handler configuration, the `has_metrics` filter allows only ev
 
 ## Filter specification
 
-### Filter attributes
+### Top-level attributes
 
-|metadata    |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the filter, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][11] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Filters should always be of type `EventFilter`.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "EventFilter"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For filters in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the filter, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the filter definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][11] for details.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
-example      | {{< highlight shell >}}"metadata": {
+example      | {{< highlight shell >}}
+"metadata": {
   "name": "filter-weekdays-only",
   "namespace": "default",
   "labels": {
@@ -193,7 +209,18 @@ example      | {{< highlight shell >}}"metadata": {
   "annotations": {
     "slack-channel" : "#monitoring"
   }
-}{{< /highlight >}}
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the filter [spec attributes][sp].
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+{{< /highlight >}}
+
+### Spec attributes
 
 action       | 
 -------------|------
@@ -272,16 +299,17 @@ match event data with a custom entity definition attribute `"namespace":
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "production_filter",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "production_filter",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
-      "event.Entity.Namespace == 'production'"
+      "event.entity.namespace == 'production'"
     ],
     "runtime_assets": []
   }
@@ -299,13 +327,14 @@ returns false, the event will be handled.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "development_filter",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "development_filter",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "deny",
     "expressions": [
       "event.entity.metadata.namespace == 'production'"
@@ -324,13 +353,14 @@ old monitoring system which alerts only on state change. This
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "state_change_only",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "state_change_only",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "event.check.occurrences == 1"
@@ -352,13 +382,14 @@ operator](https://en.wikipedia.org/wiki/Modulo_operation) calculation
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "filter_interval_60_hourly",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "filter_interval_60_hourly",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "event.check.interval == 60",
@@ -375,13 +406,14 @@ checks with a 30 second `interval`.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "filter_interval_30_hourly",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "filter_interval_30_hourly",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "event.check.interval == 30",
@@ -402,13 +434,14 @@ will not be handled.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "nine_to_fiver",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "nine_to_fiver",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "allow",
     "expressions": [
       "weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5",
@@ -429,13 +462,14 @@ expressions.
 {{< highlight json >}}
 {
   "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "deny_if_failure_in_history",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "deny_if_failure_in_history",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "action": "deny",
     "expressions": [
       "_.reduce(event.check.history, function(memo, h) { return (memo || h.status != 0); })"
@@ -456,3 +490,5 @@ expressions.
 [9]: ../events
 [10]: ../rbac#namespaces
 [11]: #metadata-attributes
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -84,14 +84,29 @@ built-in `is_incident` filter.
 
 ## Handler specification
 
-### Handler attributes
+### Top-level attributes
 
-|metadata    |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the handler, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][8] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Handlers should always be of type `Handler`.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Handler"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For handlers in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the handler, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the handler definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See the [metadata attributes reference][8] for details.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
-example      | {{< highlight shell >}}"metadata": {
+example      | {{< highlight shell >}}
+"metadata": {
   "name": "handler-slack",
   "namespace": "default",
   "labels": {
@@ -100,7 +115,29 @@ example      | {{< highlight shell >}}"metadata": {
   "annotations": {
     "slack-channel" : "#monitoring"
   }
-}{{< /highlight >}}
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the handler [spec attributes][sp].
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"spec": {
+  "type": "tcp",
+  "socket": {
+    "host": "10.0.1.99",
+    "port": 4444
+  },
+  "metadata" : {
+    "name": "tcp_handler",
+    "namespace": "default"
+  }
+}
+{{< /highlight >}}
+
+### Spec attributes
 
 type         | 
 -------------|------
@@ -233,13 +270,14 @@ configured webhook URL, using the `handler-slack` executable command.
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "slack",
+    "namespace": "default"
+  },
   "spec": {
     "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
-    "metadata" : {
-      "name": "slack",
-      "namespace": "default"
-    }
+    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring"
   }
 }
 {{< /highlight >}}
@@ -252,6 +290,11 @@ will timeout if an acknowledgement (`ACK`) is not received within 30 seconds.
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "tcp_handler",
+    "namespace": "default"
+  },
   "spec": {
     "type": "tcp",
     "socket": {
@@ -274,15 +317,16 @@ The following example will also forward event data but to UDP socket instead
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "udp_handler",
+    "namespace": "default"
+  },
   "spec": {
     "type": "udp",
     "socket": {
       "host": "10.0.1.99",
       "port": 4444
-    },
-    "metadata" : {
-      "name": "udp_handler",
-      "namespace": "default"
     }
   }
 }
@@ -296,17 +340,18 @@ The following example handler will execute three handlers: `slack`,
 {{< highlight json >}}
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "notify_all_the_things",
+    "namespace": "default"
+  },
   "spec": {
     "type": "set",
     "handlers": [
       "slack",
       "tcp_handler",
       "udp_handler"
-    ],
-    "metadata" : {
-      "name": "notify_all_the_things",
-      "namespace": "default"
-    }
+    ]
   }
 }
 {{< /highlight >}}
@@ -322,3 +367,5 @@ The following example handler will execute three handlers: `slack`,
 [9]: ../rbac#namespaces
 [10]: ../filters
 [11]: ../tokens
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/hooks.md
+++ b/content/sensu-go/5.0/reference/hooks.md
@@ -52,14 +52,29 @@ Sensu for auto-remediation tasks!
 
 ## Hooks specification
 
-### Hook attributes
+### Top-level attributes
 
-|metadata    |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the hook, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][2] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Hooks should always be of type `HookConfig`.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "HookConfig"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For hooks in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the hook, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the hook definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][2] for details.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
-example      | {{< highlight shell >}}"metadata": {
+example      | {{< highlight shell >}}
+"metadata": {
   "name": "process_tree",
   "namespace": "default",
   "labels": {
@@ -68,7 +83,23 @@ example      | {{< highlight shell >}}"metadata": {
   "annotations": {
     "slack-channel" : "#monitoring"
   }
-}{{< /highlight >}}
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the hook [spec attributes][sp].
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"spec": {
+  "command": "ps aux",
+  "timeout": 60,
+  "stdin": false
+}
+{{< /highlight >}}
+
+### Spec attributes
 
 command      | 
 -------------|------
@@ -143,13 +174,14 @@ a process that is no longer running.
 {{< highlight json >}}
 {
   "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "restart_nginx",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "restart_nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "command": "sudo systemctl start nginx",
     "timeout": 60,
     "stdin": false
@@ -166,13 +198,14 @@ has been determined to be not running etc.
 {{< highlight json >}}
 {
   "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "process_tree",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "process_tree",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "command": "ps aux",
     "timeout": 60,
     "stdin": false
@@ -186,3 +219,5 @@ has been determined to be not running etc.
 [4]: ../filters
 [5]: ../tokens
 [6]: ../checks#check-attributes
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/mutators.md
+++ b/content/sensu-go/5.0/reference/mutators.md
@@ -47,14 +47,31 @@ As mentioned above, all mutator commands are executed by a Sensu server as the `
 
 _NOTE: By default, the Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`. As a result, executable scripts (like plugins) located in `/etc/sensu/plugins` will be valid commands. This allows `command` attributes to use “relative paths” for Sensu plugin commands, for example: `"command": "check-http.go -u https://sensuapp.org"`._
 
-### Attributes
+## Mutators specification
 
-|metadata    |      |
+### Top-level attributes
+
+type         | 
 -------------|------
-description  | Collection of metadata about the mutator, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][2] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Mutators should always be of type `Mutator`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Mutator"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For mutators in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the mutator, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the mutator definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][2] for details.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
-example      | {{< highlight shell >}}"metadata": {
+example      | {{< highlight shell >}}
+"metadata": {
   "name": "example-mutator",
   "namespace": "default",
   "labels": {
@@ -63,7 +80,24 @@ example      | {{< highlight shell >}}"metadata": {
   "annotations": {
     "slack-channel" : "#monitoring"
   }
-}{{< /highlight >}}
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the mutator [spec attributes][sp].
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"spec": {
+  "command": "example_mutator.go",
+  "timeout": 0,
+  "env_vars": [],
+  "runtime_assets": []
+}
+{{< /highlight >}}
+
+### Spec attributes
 
 command      | 
 -------------|------ 
@@ -135,13 +169,14 @@ to modify event data prior to handling the event.
 {{< highlight json >}}
 {
   "type": "Mutator",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "example-mutator",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },  
   "spec": {
-    "metadata": {
-      "name": "example-mutator",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "command": "example_mutator.go",
     "timeout": 0,
     "env_vars": [],
@@ -157,3 +192,5 @@ to modify event data prior to handling the event.
 [3]: ../rbac#namespaces
 [4]: ../filters
 [5]: ../tokens
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/silencing.md
+++ b/content/sensu-go/5.0/reference/silencing.md
@@ -62,23 +62,54 @@ identified by the combination of `$SUBSCRIPTION:$CHECK`. If a check or
 subscription is not provided, it will be substituted with a wildcard (asterisk):
 `$SUBSCRIPTION:*` or `*:$CHECK`.
 
-### Attributes
+### Top-level attributes
 
-|metadata    |      |
+type         | 
 -------------|------
-description  | Collection of metadata about the silencing entry, including the `name` and `namespace` as well as custom `labels` and `annotations`. See the [metadata attributes reference][3] for details.
-required     | true
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Silencing entries should always be of type `Silenced`.
+required     | Required for silencing entry definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Silenced"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute specifying the Sensu API group and version. For silencing entries in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for silencing entry definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the silencing entry, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the silencing entry definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference][3] for details.
+required     | Required for silencing entry definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | Map of key-value pairs
-example      | {{< highlight shell >}}"metadata": {
+example      | {{< highlight shell >}}
+"metadata": {
   "name": "appserver:mysql_status",
   "namespace": "default",
   "labels": {
     "region": "us-west-1"
-  },
-  "annotations": {
-    "slack-channel" : "#monitoring"
   }
-}{{< /highlight >}}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the silencing entry [spec attributes][sp].
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"spec": {
+  "expire": -1,
+  "expire_on_resolve": false,
+  "creator": "admin",
+  "reason": null,
+  "check": null,
+  "subscription": "entity:i-424242",
+  "begin": 1542671205
+}
+{{< /highlight >}}
+
+### Spec attributes
 
 check        | 
 -------------|------ 
@@ -184,13 +215,14 @@ do this by taking advantage of per-entity subscriptions:
 {{< highlight json >}}
 {
   "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "entity:i-424242:*",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
-    "metadata": {
-      "name": "entity:i-424242:*",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
@@ -259,6 +291,7 @@ regardless of subscriptions, we only need to provide the check name:
 ### Deleting silencing entries
 To delete a silencing entry, you will need to provide its name. Subscription only
 silencing entry names will be similar to this:
+
 {{< highlight json >}}
 {
   "name": "appserver:*"
@@ -266,6 +299,7 @@ silencing entry names will be similar to this:
 {{< /highlight >}}
 
 Check only silencing entry names will be similar to this:
+
 {{< highlight json >}}
 {
   "name": "*:mysql_status"
@@ -275,3 +309,5 @@ Check only silencing entry names will be similar to this:
 [1]: ../events/#attributes
 [2]: ../rbac#namespaces
 [3]: #metadata-attributes
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes

--- a/content/sensu-go/5.0/reference/tokens.md
+++ b/content/sensu-go/5.0/reference/tokens.md
@@ -56,6 +56,13 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
 {{< highlight json >}}
 {
   "type": "CheckConfig",
+  "api_version": "core/v1",
+  "metadata": {
+    "name": "check-disk-usage",
+    "namespace": "{{ .Namespace | default \"production\" }}",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
     "command": "check-disk-usage.rb -w {{.Disk.Warning | default 80}} -c {{.Disk.Critical | default 90}}",
     "handlers": [],
@@ -73,13 +80,7 @@ arguments to indicate the thresholds (as percentages) for creating warning or cr
     "ttl": 0,
     "timeout": 0,
     "round_robin": false,
-    "env_vars": null,
-    "metadata": {
-      "name": "check-disk-usage",
-      "namespace": "{{ .Namespace | default \"production\" }}",
-      "labels": null,
-      "annotations": null
-    }
+    "env_vars": null
   }
 }{{< /highlight >}}
 
@@ -90,6 +91,13 @@ tokens declared above.
 {{< highlight json >}}
 {
   "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "example-hostname",
+    "namespace": "staging",
+    "labels": null,
+    "annotations": null
+  },
   "spec": {
     "entity_class": "agent",
     "system": {
@@ -146,12 +154,6 @@ tokens declared above.
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "example-hostname",
-      "namespace": "staging",
-      "labels": null,
-      "annotations": null
-    },
     "disk": {
       "warning": 75,
       "critical": 85


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Adds the new top-level metadata scope to reference docs
- Add the api_version attribute
- Doesn't include the RBAC reference

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #932 

## Review Instructions
<!--- Optional -->
