### PR TITLE
Include loopback addresses to SANs when generating certificates via cfssl

### DIFF
--- a/content/sensu-go/5.0/guides/clustering.md
+++ b/content/sensu-go/5.0/guides/clustering.md
@@ -180,15 +180,15 @@ Then, using that CA, we can generate certificates and keys for each peer (backen
 {{< highlight shell >}}
 export ADDRESS=10.0.0.1,backend-1
 export NAME=backend-1
-echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" -profile=peer - | cfssljson -bare $NAME
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS,127.0.0.1,::" -profile=peer - | cfssljson -bare $NAME
 
 export ADDRESS=10.0.0.2,backend-2
 export NAME=backend-2
-echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" -profile=peer - | cfssljson -bare $NAME
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS,127.0.0.1,::" -profile=peer - | cfssljson -bare $NAME
 
 export ADDRESS=10.0.0.3,backend-3
 export NAME=backend-3
-echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" -profile=peer - | cfssljson -bare $NAME
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS,127.0.0.1,::" -profile=peer - | cfssljson -bare $NAME
 {{< /highlight >}}
 
 We will also create generate a *client* certificate that can be used by clients to connect to the etcd client URL. This time, we don't need to specify an address but simply a **Common Name (CN)** (here `client`). The files `client-key.pem`, `client.csr` and `client.pem` will be created.


### PR DESCRIPTION
## Description

Updates cfssl commands in clustering guide to work around issue described in https://github.com/sensu/sensu-go/issues/2458

## Motivation and Context

Closes #952 

## Review Instructions

1. Test the cfssl commands in local environment, generating certificates matching the `$NAME` variable
2. use `openssl x509 -in $NAME.pem -noout -text` to dump readable details on the certificate
3. ensure that `X509v3 Subject Alternative Name` section includes records for loopback addresses.

From my testing:

![image](https://user-images.githubusercontent.com/148017/49252991-c6e73600-f3e2-11e8-941d-c83546705cbc.png)

