### PR TITLE
Fixed reference example event json syntax

### DIFF
--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -84,6 +84,7 @@ example      | {{< highlight shell >}}
       {
         "executed": 1522100915
       }
+    ],
     "command": "http_check.sh http://localhost:80",
     "handlers": [
       "slack"


### PR DESCRIPTION
Missing `],`, this PR closes the array, fixing the JSON.