### PR TITLE
Remove ubuntu 14.04 from Sensu Go platforms

### DIFF
--- a/content/sensu-go/5.0/getting-started/platforms.md
+++ b/content/sensu-go/5.0/getting-started/platforms.md
@@ -20,7 +20,6 @@ See the [backend installation guide][1] for more information.
 | CentOS/RHEL 5      | ✅     |      | | |
 | CentOS/RHEL 6      | ✅     |      | | |
 | CentOS/RHEL 7      | ✅     |      | | |
-| Ubuntu 14.04       | ✅     |      | | |
 | Ubuntu 16.04       | ✅     |      | | |
 | Ubuntu 18.04       | ✅     |      | | |
 | Ubuntu 18.10       | ✅     |      | | |
@@ -35,7 +34,6 @@ See the [agent installation guide][2] for more information.
 | CentOS 5/RHEL      | ✅     |    | | |
 | CentOS 6/RHEL      | ✅     |     | | |
 | CentOS 7/RHEL      | ✅     |     | | |
-| Ubuntu 14.04       | ✅     |      | | |
 | Ubuntu 16.04       | ✅     |     | | |
 | Ubuntu 18.04       | ✅     |     | | |
 | Ubuntu 18.10       | ✅     |     | | |
@@ -51,7 +49,6 @@ See the [sensuctl installation guide][3] for more information.
 | CentOS 5/RHEL      | ✅     |     | | |
 | CentOS 6/RHEL      | ✅     |     | | |
 | CentOS 7/RHEL      | ✅     |     | | |
-| Ubuntu 14.04       | ✅     |      | | |
 | Ubuntu 16.04       | ✅     |     | | |
 | Ubuntu 18.04       | ✅     |     | | |
 | Ubuntu 18.10       | ✅     |     | | |


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Removes Ubuntu 14.04 from supported versions of Sensu Go
