### PR TITLE
Update state-dir and example config files

### DIFF
--- a/content/sensu-go/5.0/installation/install-sensu.md
+++ b/content/sensu-go/5.0/installation/install-sensu.md
@@ -66,7 +66,11 @@ sudo yum install sensu-go-backend
 
 ### 2. Create the configuration file
 
-Download the [example configuration file][11] and save it as `/etc/sensu/backend.yml`.
+Copy the example backend config file to the default config path.
+
+{{< highlight shell >}}
+sudo cp /usr/share/doc/sensu-go-backend-5.0.0/backend.yml.example /etc/sensu/backend.yml
+{{< /highlight >}}
 
 _NOTE: The Sensu backend can be configured using a `/etc/sensu/backend.yml` configuration file or using `sensu-backend start` configuration flags. For more information, see the [backend reference][6]._
 
@@ -160,7 +164,11 @@ Download the [Sensu agent for Windows](https://s3-us-west-2.amazonaws.com/sensu.
 
 #### Ubuntu/RHEL/CentOS
 
-Download the [example configuration file][2] and save it as `/etc/sensu/agent.yml`.
+Copy the example agent config file to the default config path.
+
+{{< highlight shell >}}
+sudo cp /usr/share/doc/sensu-go-agent-5.0.0/agent.yml.example /etc/sensu/agent.yml
+{{< /highlight >}}
 
 _NOTE: The Sensu agent can be configured using a `/etc/sensu/agent.yml` configuration file or using `sensu-agent start` configuration flags. For more information, see the [agent reference][7]._
 

--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -287,7 +287,7 @@ To see available configuration flags and defaults:
 sensu-agent start --help
 {{< /highlight >}}
 
-If no configuration flags are provided, the agent loads configuration from [`/etc/sensu/agent.yml`][25] by default.
+If no configuration flags are provided, the agent loads configuration from `/etc/sensu/agent.yml` by default.
 
 To start the agent using a service manager:
 
@@ -420,8 +420,8 @@ Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the
 
 ## Configuration
 
-You can specify the agent configuration using a [`/etc/sensu/agent.yml`][25] file or using `sensu-agent start` [configuration flags][24].
-See the example [`/etc/sensu/agent.yml`][25] file used during the [installation process][1] on [GitHub][25].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+See the example config file provided with Sensu at `/usr/share/doc/sensu-go-agent-5.0.0/agent.yml.example`.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary
@@ -818,7 +818,6 @@ statsd-metrics-port: 6125{{< /highlight >}}
 [22]: #statsd-configuration-flags
 [23]: https://github.com/etsy/statsd#key-concepts
 [24]: #configuration
-[25]: https://github.com/sensu/sensu-go/blob/master/packaging/files/agent.yml.example
 [26]: #keepalives
 [27]: ../tokens
 [28]: #subscriptions-flag

--- a/content/sensu-go/5.0/reference/backend.md
+++ b/content/sensu-go/5.0/reference/backend.md
@@ -62,7 +62,7 @@ Use the `sensu-backend` tool to start the backend and apply configuration flags.
 To start the backend with [configuration flags][15]:
 
 {{< highlight shell >}}
-sensu-backend start --state-dir /data/sensu --log-level debug
+sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
 To see available configuration flags and defaults:
@@ -71,7 +71,7 @@ To see available configuration flags and defaults:
 sensu-backend start --help
 {{< /highlight >}}
 
-If no configuration flags are provided, the backend loads configuration from [`/etc/sensu/backend.yml`][14] by default.
+If no configuration flags are provided, the backend loads configuration from `/etc/sensu/backend.yml` by default.
 
 To start the backend using a service manager:
 
@@ -153,9 +153,9 @@ To configure a cluster, see:
 
 ## Configuration
 
-You can specify the backend configuration using a [`/etc/sensu/backend.yml`][14] file or using `sensu-backend start` [configuration flags][15].
-See the example [`/etc/sensu/backend.yml`][14] file used during the [installation process][1] on [GitHub][14].
-All required configuration flags have assigned defaults, so no manual configuration is required to start the backend.
+You can specify the backend configuration using a `/etc/sensu/backend.yml` file or using `sensu-backend start` [configuration flags][15].
+The backend requires that the `state-dir` flag be set before starting; all other required flags have default values.
+See the example config file provided with Sensu at `/usr/share/doc/sensu-go-backend-5.0.0/backend.yml.example`.
 The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
 
 ### Configuration summary
@@ -258,15 +258,15 @@ log-level: "debug"{{< /highlight >}}
 
 | state-dir  |      |
 -------------|------
-description  | Path to Sensu state storage
+description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend` for Linux and `C:\\ProgramData\sensu\data` for Windows.
 type         | String
-default      | <ul><li>Linux: `/var/lib/sensu`</li><li>Windows: `C:\\ProgramData\sensu\data`</li></ul>
+required     | true
 example      | {{< highlight shell >}}# Command line example
-sensu-backend start --state-dir /var/lib/sensu
-sensu-backend start -d /var/lib/sensu
+sensu-backend start --state-dir /var/lib/sensu/sensu-backend
+sensu-backend start -d /var/lib/sensu/sensu-backend
 
 # /etc/sensu/backend.yml example
-state-dir: "/var/lib/sensu"{{< /highlight >}}
+state-dir: "/var/lib/sensu/sensu-backend"{{< /highlight >}}
 
 
 | api-listen-address  |      |
@@ -604,5 +604,4 @@ no-embed-etcd: true{{< /highlight >}}
 [11]: ../../reference/handlers
 [12]: #datastore-and-cluster-configuration-flags
 [13]: ../../guides/clustering
-[14]: https://github.com/sensu/sensu-go/blob/master/packaging/files/backend.yml.example
 [15]: #general-configuration-flags


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Updates `state-dir` attribute in the Sensu backend config to to `/var/lib/sensu/sensu-backend`
- Uses new example config files

## Context
https://github.com/sensu/sensu-go/issues/2495
