### PR TITLE
Use proper flags along with no-embed-etcd in Sensu Go clustering

### DIFF
--- a/content/sensu-go/5.0/guides/clustering.md
+++ b/content/sensu-go/5.0/guides/clustering.md
@@ -386,7 +386,7 @@ sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./client.pem \
 --etcd-key-file=./client-key.pem \
---etcd-listen-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-advertise-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /highlight >}}
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon.plourde@gmail.com>

<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
The `--etcd-listen-client-urls` flag was misused to specify the URLs to connect to, which is rather the job of `--etcd-advertise-client-urls`. We forgot to update this particular documentation when the change was made to sensu-go, which caused some issues.

## Motivation and Context
Related to https://github.com/sensu/sensu-go/issues/2499.
Related to https://github.com/sensu/sensu-enterprise-go/issues/151.

## Review Instructions
<!--- Optional -->
