### PR TITLE
Use travis-ci.com badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the Sensu Docs project! This repository is the home of [docs.sensu.io
 
 [Read the docs][site] | [Contributing guide](CONTRIBUTING.md) | [Style guide][wiki] | [Code of conduct][coc] | [Contact admins][email] | [Open an issue][issue]
 
-![Travis build status](https://travis-ci.org/sensu/sensu-docs.svg?branch=master)
+![Travis build status](https://travis-ci.com/sensu/sensu-docs.svg?branch=master)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the Sensu Docs project! This repository is the home of [docs.sensu.io
 
 [Read the docs][site] | [Contributing guide](CONTRIBUTING.md) | [Style guide][wiki] | [Code of conduct][coc] | [Contact admins][email] | [Open an issue][issue]
 
-![Travis build status](https://travis-ci.com/sensu/sensu-docs.svg?branch=master)
+[![Travis build status](https://travis-ci.com/sensu/sensu-docs.svg?branch=master)](https://travis-ci.com/sensu/sensu-docs)
 
 ---
 


### PR DESCRIPTION
## Description

Update CI status badge in README

## Motivation and Context

In #826 we described the need to move our project from the Travis CI service to the Travis CI GitHub App. What we didn't realize at the time is that this requires moving the CI project from travis-ci.org to travis-ci.com. With the help of the Travis CI support team, we've completed this migration and future PRs should be visible in the travis-ci.com project at https://travis-ci.com/sensu/sensu-docs

This change updates the badge to use travis-ci.com

## Review Instructions

Please ensure the badge link takes you to the new .com project. 
