### PR TITLE
Add note about operator case in Sensu Enterprise Dashbaord Collections guide

### DIFF
--- a/content/sensu-enterprise-dashboard/2.10/collections.md
+++ b/content/sensu-enterprise-dashboard/2.10/collections.md
@@ -59,6 +59,10 @@ The familiar operators, `AND`, `OR`, and `NOT`, are supported. You may use
 multiple operators within a single query. Be aware that the use of many
 operators may cause higher than normal resource usage.
 
+_NOTE: When using operators, all letters must be capitalized. Operators in lowercase letters are not supported._
+
+#### Examples
+
 `dc:us-east-1 AND name:centos`
 Includes all items from the datacenter **us-east-1** that have **centos** in
 their name.

--- a/content/sensu-enterprise-dashboard/2.11/collections.md
+++ b/content/sensu-enterprise-dashboard/2.11/collections.md
@@ -59,6 +59,10 @@ The familiar operators, `AND`, `OR`, and `NOT`, are supported. You may use
 multiple operators within a single query. Be aware that the use of many
 operators may cause higher than normal resource usage.
 
+_NOTE: When using operators, all letters must be capitalized. Operators in lowercase letters are not supported._
+
+#### Examples
+
 `dc:us-east-1 AND name:centos`
 Includes all items from the datacenter **us-east-1** that have **centos** in
 their name.

--- a/content/sensu-enterprise-dashboard/2.12/collections.md
+++ b/content/sensu-enterprise-dashboard/2.12/collections.md
@@ -59,6 +59,10 @@ The familiar operators, `AND`, `OR`, and `NOT`, are supported. You may use
 multiple operators within a single query. Be aware that the use of many
 operators may cause higher than normal resource usage.
 
+_NOTE: When using Operators, they must have all letters capitalized. Operators with any lowercase letter are not supported._
+
+#### Examples
+
 `dc:us-east-1 AND name:centos`
 Includes all items from the datacenter **us-east-1** that have **centos** in
 their name.

--- a/content/sensu-enterprise-dashboard/2.12/collections.md
+++ b/content/sensu-enterprise-dashboard/2.12/collections.md
@@ -59,7 +59,7 @@ The familiar operators, `AND`, `OR`, and `NOT`, are supported. You may use
 multiple operators within a single query. Be aware that the use of many
 operators may cause higher than normal resource usage.
 
-_NOTE: When using Operators, they must have all letters capitalized. Operators with any lowercase letter are not supported._
+_NOTE: When using operators, all letters must be capitalized. Operators in lowercase letters are not supported._
 
 #### Examples
 

--- a/content/sensu-enterprise-dashboard/2.9/collections.md
+++ b/content/sensu-enterprise-dashboard/2.9/collections.md
@@ -59,6 +59,10 @@ The familiar operators, `AND`, `OR`, and `NOT`, are supported. You may use
 multiple operators within a single query. Be aware that the use of many
 operators may cause higher than normal resource usage.
 
+_NOTE: When using operators, all letters must be capitalized. Operators in lowercase letters are not supported._
+
+#### Examples
+
 `dc:us-east-1 AND name:centos`
 Includes all items from the datacenter **us-east-1** that have **centos** in
 their name.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Adds a note to collections guide that operators must be uppercase.

## Motivation and Context
Clear up confusion when writing search queries to be save as collections and what is supported.

## Review Instructions
Make sure note renders 👌 locally.
