### PR TITLE
Add keepalive handler to handler reference

### DIFF
--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -260,8 +260,12 @@ The resulting `keepalive` handler set configuration looks like this:
 {{< highlight json >}}
 {
   "type": "Handler",
-  "spec": {
+  "api_version": "core/v2",
+  "metadata" : {
     "name": "keepalive",
+    "namespace": "default"
+  },
+  "spec": {
     "type": "set",
     "handlers": [
       "slack"

--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -10,7 +10,17 @@ menu:
     parent: reference
 ---
 
+- [How do Sensu handlers work?](#how-do-sensu-handlers-work)
+	- [Pipe handlers](#pipe-handlers)
+	- [TCP/UDP handlers](#tcp-udp-handlers)
+	- [Handler sets](#handler-sets)
+- [New and improved handlers](#new-and-improved-handlers)
+- [Handling keepalive events](#handling-keepalive-events)
 - [Specification](#handler-specification)
+	- [Top-level attributes](#top-level-attributes)
+	- [Spec attributes](#spec-attributes)
+	- [Metadata attributes](#metadata-attributes)
+	- [`socket` attributes](#socket-attributes)
 - [Examples](#handler-examples)
 
 ## How do Sensu handlers work?
@@ -81,6 +91,33 @@ Sensu 1.x.
 
 That being said, 1.x behavior can be replicated in Sensu Go by using the
 built-in `is_incident` filter.
+
+## Handling keepalive events
+
+Sensu [keepalives][12] are the heartbeat mechanism used to ensure that all registered [Sensu agents][13] are operational and able to reach the [Sensu backend][14].
+You can connect keepalive events to your monitoring workflows using a keepalive handler.
+Sensu looks for an event handler named `keepalive` and automatically uses it to process keepalive events.
+
+Let's say you want to receive Slack notifications for keepalive alerts, and you already have a [Slack handler set up to process events][15].
+To process keepalive events using the Slack pipeline, create a handler set named `keepalive` and add the `slack` handler to the `handlers` array.
+The resulting `keepalive` handler set configuration looks like this:
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata" : {
+    "name": "keepalive",
+    "namespace": "default"
+  },
+  "spec": {
+    "type": "set",
+    "handlers": [
+      "slack"
+    ]
+  }
+}
+{{< /highlight >}}
 
 ## Handler specification
 
@@ -369,3 +406,7 @@ The following example handler will execute three handlers: `slack`,
 [11]: ../tokens
 [sc]: ../../sensuctl/reference#creating-resources
 [sp]: #spec-attributes
+[12]: ../agent#keepalive-monitoring
+[13]: ../agent
+[14]: ../backend
+[15]: ../../guides/send-slack-alerts


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
For discoverability, adds a section on keepalive monitoring to the handler reference. Also updates the example keepalive handler in the agent reference to use the metadata scope.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #947 