### PR TITLE
Correct attribute specifications and names

### DIFF
--- a/content/sensu-go/5.0/api/cluster-roles.md
+++ b/content/sensu-go/5.0/api/cluster-roles.md
@@ -42,7 +42,7 @@ curl -s http://127.0.0.1:8080/api/core/v2/cluster-roles -H "Authorization: Beare
         "resources": [
           "events"
         ],
-        "resourceNames": [
+        "resource_names": [
           ""
         ]
       }
@@ -72,7 +72,7 @@ output         | {{< highlight shell >}}
         "resources": [
           "events"
         ],
-        "resourceNames": [
+        "resource_names": [
           ""
         ]
       }
@@ -99,7 +99,7 @@ payload         | {{< highlight shell >}}
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }
@@ -133,7 +133,7 @@ curl -s http://127.0.0.1:8080/api/core/v2/cluster-roles/global-event-reader -H "
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }
@@ -161,7 +161,7 @@ output               | {{< highlight json >}}
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }
@@ -189,7 +189,7 @@ payload         | {{< highlight shell >}}
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }

--- a/content/sensu-go/5.0/reference/checks.md
+++ b/content/sensu-go/5.0/reference/checks.md
@@ -399,7 +399,7 @@ description  | Sensu entity attributes to match entities in the registry, using 
 required     | false
 type         | Array
 default      | current namespace value configured for `sensuctl` (ie `default`)
-example      | {{< highlight shell >}}"entity_attributes": ["entity.EntityClass == 'proxy'"]{{< /highlight >}}
+example      | {{< highlight shell >}}"entity_attributes": ["entity.entity_class == 'proxy'"]{{< /highlight >}}
 
 |splay       |      |
 -------------|------

--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -298,14 +298,6 @@ example      | {{< highlight json >}}
   }
 }{{< /highlight >}}
 
-keepalive_timeout  | 
--------------|------ 
-description  | The time in seconds until an entity keepalive is considered stale. 
-required     | false 
-type         | integer 
-default      | 120
-example      | {{< highlight shell >}}"keepalive_timeout": 120 {{< /highlight >}}
-
 redact       | 
 -------------|------ 
 description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.

--- a/content/sensu-go/5.0/reference/mutators.md
+++ b/content/sensu-go/5.0/reference/mutators.md
@@ -106,6 +106,13 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"command": "/etc/sensu/plugins/mutated.go"{{</highlight>}}
 
+env_vars      | 
+-------------|------
+description  | An array of environment variables to use with command execution.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"env_vars": ["RUBY_VERSION=2.5.0"]{{< /highlight >}}
+
 timeout      | 
 -------------|------ 
 description  | The mutator execution duration timeout in seconds (hard stop). 

--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -444,7 +444,7 @@ example      | {{< highlight shell >}}"rules": [
   {
     "verbs": ["get", "list"],
     "resources": ["checks"],
-    "resourceNames": [""]
+    "resource_names": [""]
   }
 ]{{< /highlight >}}
 
@@ -465,12 +465,12 @@ required     | true
 type         | Array
 example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
-resourceNames    | 
+resource_names    | 
 -------------|------ 
 description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
 required     | false
 type         | Array
-example      | {{< highlight shell >}}"resourceNames": ["check-cpu"]{{< /highlight >}}
+example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}
 
 ### Role examples
 

--- a/content/sensu-go/5.1/api/cluster-roles.md
+++ b/content/sensu-go/5.1/api/cluster-roles.md
@@ -42,7 +42,7 @@ curl -s http://127.0.0.1:8080/api/core/v2/cluster-roles -H "Authorization: Beare
         "resources": [
           "events"
         ],
-        "resourceNames": [
+        "resource_names": [
           ""
         ]
       }
@@ -72,7 +72,7 @@ output         | {{< highlight shell >}}
         "resources": [
           "events"
         ],
-        "resourceNames": [
+        "resource_names": [
           ""
         ]
       }
@@ -99,7 +99,7 @@ payload         | {{< highlight shell >}}
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }
@@ -133,7 +133,7 @@ curl -s http://127.0.0.1:8080/api/core/v2/cluster-roles/global-event-reader -H "
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }
@@ -161,7 +161,7 @@ output               | {{< highlight json >}}
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }
@@ -189,7 +189,7 @@ payload         | {{< highlight shell >}}
       "resources": [
         "events"
       ],
-      "resourceNames": [
+      "resource_names": [
         ""
       ]
     }

--- a/content/sensu-go/5.1/reference/checks.md
+++ b/content/sensu-go/5.1/reference/checks.md
@@ -399,7 +399,7 @@ description  | Sensu entity attributes to match entities in the registry, using 
 required     | false
 type         | Array
 default      | current namespace value configured for `sensuctl` (ie `default`)
-example      | {{< highlight shell >}}"entity_attributes": ["entity.EntityClass == 'proxy'"]{{< /highlight >}}
+example      | {{< highlight shell >}}"entity_attributes": ["entity.entity_class == 'proxy'"]{{< /highlight >}}
 
 |splay       |      |
 -------------|------

--- a/content/sensu-go/5.1/reference/entities.md
+++ b/content/sensu-go/5.1/reference/entities.md
@@ -298,14 +298,6 @@ example      | {{< highlight json >}}
   }
 }{{< /highlight >}}
 
-keepalive_timeout  | 
--------------|------ 
-description  | The time in seconds until an entity keepalive is considered stale. 
-required     | false 
-type         | integer 
-default      | 120
-example      | {{< highlight shell >}}"keepalive_timeout": 120 {{< /highlight >}}
-
 redact       | 
 -------------|------ 
 description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.

--- a/content/sensu-go/5.1/reference/mutators.md
+++ b/content/sensu-go/5.1/reference/mutators.md
@@ -106,6 +106,13 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"command": "/etc/sensu/plugins/mutated.go"{{</highlight>}}
 
+env_vars      | 
+-------------|------
+description  | An array of environment variables to use with command execution.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"env_vars": ["RUBY_VERSION=2.5.0"]{{< /highlight >}}
+
 timeout      | 
 -------------|------ 
 description  | The mutator execution duration timeout in seconds (hard stop). 

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -444,7 +444,7 @@ example      | {{< highlight shell >}}"rules": [
   {
     "verbs": ["get", "list"],
     "resources": ["checks"],
-    "resourceNames": [""]
+    "resource_names": [""]
   }
 ]{{< /highlight >}}
 
@@ -465,12 +465,12 @@ required     | true
 type         | Array
 example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
-resourceNames    | 
+resource_names    | 
 -------------|------ 
 description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
 required     | false
 type         | Array
-example      | {{< highlight shell >}}"resourceNames": ["check-cpu"]{{< /highlight >}}
+example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}
 
 ### Role examples
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Removes the `keepalive_timeout` attribute from the entity spec. Closes #1063 (Reference: https://github.com/sensu/sensu-go/pull/2045)
- Adds the `env_vars` attribute to the mutator spec. Closes #1064
- Fixes the example for `entity_attributes` to use snake case. Closes #1057
- Uses snake case for all references to role `resource_names`. Closes #1062 