### PR TITLE
Fix example metric output_format configuration 

### DIFF
--- a/content/sensu-enterprise/2.6/built-in-mutators.md
+++ b/content/sensu-enterprise/2.6/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"

--- a/content/sensu-enterprise/2.7/built-in-mutators.md
+++ b/content/sensu-enterprise/2.7/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"

--- a/content/sensu-enterprise/2.8/built-in-mutators.md
+++ b/content/sensu-enterprise/2.8/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"

--- a/content/sensu-enterprise/3.0/built-in-mutators.md
+++ b/content/sensu-enterprise/3.0/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"

--- a/content/sensu-enterprise/3.1/built-in-mutators.md
+++ b/content/sensu-enterprise/3.1/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"

--- a/content/sensu-enterprise/3.2/built-in-mutators.md
+++ b/content/sensu-enterprise/3.2/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"

--- a/content/sensu-enterprise/3.3/built-in-mutators.md
+++ b/content/sensu-enterprise/3.3/built-in-mutators.md
@@ -49,6 +49,7 @@ handlers: one for notifications (`pagerduty`), another for metric storage
 {
   "checks": {
     "ntp": {
+      "type": "metric",
       "command": "/usr/lib/nagios/plugins/check_ntp -H time.nrc.ca",
       "subscribers": [
         "production"


### PR DESCRIPTION
For this example config to work, the `"type": "metric"` attribute would need to be set.

## Description
Added '"type": "metric"` to the example configuration snippet. 

## Motivation and Context
To help make it more obvious that `"type": "metric"` is required. 

## Review Instructions
It's a one-liner. :) 
