### PR TITLE
Document http_proxy parameter for integrations which support it

### DIFF
--- a/content/sensu-enterprise/2.6/integrations/jira.md
+++ b/content/sensu-enterprise/2.6/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.6/integrations/puppet.md
+++ b/content/sensu-enterprise/2.6/integrations/puppet.md
@@ -171,7 +171,7 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
-timeout      | 
+timeout      | |
 -------------|------
 description  | The handler execution duration timeout in seconds (hard stop).
 required     | false

--- a/content/sensu-enterprise/2.6/integrations/puppet.md
+++ b/content/sensu-enterprise/2.6/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | 
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/2.6/integrations/rollbar.md
+++ b/content/sensu-enterprise/2.6/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.6/integrations/servicenow.md
+++ b/content/sensu-enterprise/2.6/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.7/integrations/jira.md
+++ b/content/sensu-enterprise/2.7/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.7/integrations/puppet.md
+++ b/content/sensu-enterprise/2.7/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | |
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/2.7/integrations/rollbar.md
+++ b/content/sensu-enterprise/2.7/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.7/integrations/servicenow.md
+++ b/content/sensu-enterprise/2.7/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.8/integrations/jira.md
+++ b/content/sensu-enterprise/2.8/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.8/integrations/puppet.md
+++ b/content/sensu-enterprise/2.8/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | |
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/2.8/integrations/rollbar.md
+++ b/content/sensu-enterprise/2.8/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/2.8/integrations/servicenow.md
+++ b/content/sensu-enterprise/2.8/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.0/integrations/jira.md
+++ b/content/sensu-enterprise/3.0/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.0/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.0/integrations/opsgenie.md
@@ -155,6 +155,13 @@ type                   | Boolean
 default                | `false`
 example                | {{< highlight shell >}}"overwrite_quiet_hours": true{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.0/integrations/puppet.md
+++ b/content/sensu-enterprise/3.0/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | |
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.0/integrations/rollbar.md
+++ b/content/sensu-enterprise/3.0/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.0/integrations/servicenow.md
+++ b/content/sensu-enterprise/3.0/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.0/integrations/victorops.md
+++ b/content/sensu-enterprise/3.0/integrations/victorops.md
@@ -59,6 +59,13 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.1/integrations/jira.md
+++ b/content/sensu-enterprise/3.1/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.1/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.1/integrations/opsgenie.md
@@ -155,6 +155,13 @@ type                   | Boolean
 default                | `false`
 example                | {{< highlight shell >}}"overwrite_quiet_hours": true{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.1/integrations/puppet.md
+++ b/content/sensu-enterprise/3.1/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | |
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.1/integrations/rollbar.md
+++ b/content/sensu-enterprise/3.1/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.1/integrations/servicenow.md
+++ b/content/sensu-enterprise/3.1/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.1/integrations/victorops.md
+++ b/content/sensu-enterprise/3.1/integrations/victorops.md
@@ -59,6 +59,13 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.2/integrations/jira.md
+++ b/content/sensu-enterprise/3.2/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.2/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.2/integrations/opsgenie.md
@@ -155,6 +155,13 @@ type                   | Boolean
 default                | `false`
 example                | {{< highlight shell >}}"overwrite_quiet_hours": true{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.2/integrations/puppet.md
+++ b/content/sensu-enterprise/3.2/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | |
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.2/integrations/rollbar.md
+++ b/content/sensu-enterprise/3.2/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.2/integrations/servicenow.md
+++ b/content/sensu-enterprise/3.2/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.2/integrations/victorops.md
+++ b/content/sensu-enterprise/3.2/integrations/victorops.md
@@ -59,6 +59,13 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.3/integrations/jira.md
+++ b/content/sensu-enterprise/3.3/integrations/jira.md
@@ -97,6 +97,13 @@ required     | false
 type         | String
 example      | {{< highlight shell >}}"root_url": "https://services.example.com/proxy/jira"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.3/integrations/opsgenie.md
+++ b/content/sensu-enterprise/3.3/integrations/opsgenie.md
@@ -163,6 +163,13 @@ type                   | Boolean
 default                | `false`
 example                | {{< highlight shell >}}"overwrite_quiet_hours": true{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.3/integrations/puppet.md
+++ b/content/sensu-enterprise/3.3/integrations/puppet.md
@@ -164,6 +164,21 @@ required            | true
 type                | String
 example             | {{< highlight shell >}}"truststore_password": "secret"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
+timeout      | |
+-------------|------
+description  | The handler execution duration timeout in seconds (hard stop).
+required     | false
+type         | Integer
+default      | `10`
+example      | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
+
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.3/integrations/rollbar.md
+++ b/content/sensu-enterprise/3.3/integrations/rollbar.md
@@ -66,6 +66,13 @@ required           | true
 type               | String
 example            | {{< highlight shell >}}"access_token_patch": "f34948101a714661a83dcd8dbe6a167a"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.3/integrations/servicenow.md
+++ b/content/sensu-enterprise/3.3/integrations/servicenow.md
@@ -153,6 +153,13 @@ type         | String
 default      | `em_event`
 example      | {{< highlight shell >}}"event_table": "em_event"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.3/integrations/victorops.md
+++ b/content/sensu-enterprise/3.3/integrations/victorops.md
@@ -59,6 +59,13 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.


### PR DESCRIPTION
## Description

Add documentation of the `http_proxy` attribute for Enterprise integrations which support it.

## Motivation and Context

Any Enterprise integration making use of our proprietary HTTPClient library is expected to honor the `http_proxy` attribute. Documentation for each integration using this library should indicate support for this attribute.

Currently the applicable integrations are:

- [x] ServiceNow
- [x] Puppet
- [x] Rollbar
- [x] Jira
- [x] OpsGenie
- [x] VictorOps (from 3.0 on)

Relates to https://github.com/sensu/sensu-docs/issues/865