### PR TITLE
Update `http_proxy` attributes in InfluxDB, Librato, and VictorOps integrations

### DIFF
--- a/content/sensu-enterprise/2.6/integrations/influxdb.md
+++ b/content/sensu-enterprise/2.6/integrations/influxdb.md
@@ -95,6 +95,13 @@ allowed values | `0.8`, `0.9`
 default        | `0.8`
 example        | {{< highlight shell >}}"api_version": "0.9"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 timeout      | 
 -------------|------
 description  | The InfluxDB HTTP API POST timeout (write).

--- a/content/sensu-enterprise/2.6/integrations/librato.md
+++ b/content/sensu-enterprise/2.6/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/2.7/integrations/influxdb.md
+++ b/content/sensu-enterprise/2.7/integrations/influxdb.md
@@ -95,6 +95,13 @@ allowed values | `0.8`, `0.9`
 default        | `0.8`
 example        | {{< highlight shell >}}"api_version": "0.9"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
+
 timeout      | 
 -------------|------
 description  | The InfluxDB HTTP API POST timeout (write).

--- a/content/sensu-enterprise/2.7/integrations/librato.md
+++ b/content/sensu-enterprise/2.7/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/2.8/integrations/influxdb.md
+++ b/content/sensu-enterprise/2.8/integrations/influxdb.md
@@ -110,6 +110,12 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 timeout      | 
 -------------|------

--- a/content/sensu-enterprise/2.8/integrations/librato.md
+++ b/content/sensu-enterprise/2.8/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.0/integrations/influxdb.md
+++ b/content/sensu-enterprise/3.0/integrations/influxdb.md
@@ -110,6 +110,12 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 timeout      | 
 -------------|------

--- a/content/sensu-enterprise/3.0/integrations/librato.md
+++ b/content/sensu-enterprise/3.0/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.0/integrations/victorops.md
+++ b/content/sensu-enterprise/3.0/integrations/victorops.md
@@ -59,13 +59,6 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
-http_proxy   | |
--------------|------
-description  | The URL of a proxy to be used for HTTP requests.
-required     | false
-type         | String
-example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
-
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.1/integrations/influxdb.md
+++ b/content/sensu-enterprise/3.1/integrations/influxdb.md
@@ -110,6 +110,12 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 timeout      | 
 -------------|------

--- a/content/sensu-enterprise/3.1/integrations/librato.md
+++ b/content/sensu-enterprise/3.1/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.1/integrations/victorops.md
+++ b/content/sensu-enterprise/3.1/integrations/victorops.md
@@ -59,13 +59,6 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
-http_proxy   | |
--------------|------
-description  | The URL of a proxy to be used for HTTP requests.
-required     | false
-type         | String
-example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
-
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.2/integrations/influxdb.md
+++ b/content/sensu-enterprise/3.2/integrations/influxdb.md
@@ -110,6 +110,12 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 timeout      | 
 -------------|------

--- a/content/sensu-enterprise/3.2/integrations/librato.md
+++ b/content/sensu-enterprise/3.2/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.2/integrations/victorops.md
+++ b/content/sensu-enterprise/3.2/integrations/victorops.md
@@ -59,13 +59,6 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
-http_proxy   | |
--------------|------
-description  | The URL of a proxy to be used for HTTP requests.
-required     | false
-type         | String
-example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
-
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.

--- a/content/sensu-enterprise/3.3/integrations/influxdb.md
+++ b/content/sensu-enterprise/3.3/integrations/influxdb.md
@@ -110,6 +110,12 @@ example        | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 timeout      | 
 -------------|------

--- a/content/sensu-enterprise/3.3/integrations/librato.md
+++ b/content/sensu-enterprise/3.3/integrations/librato.md
@@ -58,6 +58,12 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"api_key": "90SHpjPOFqd2YJFIX9rzDq7ik6CiDmqu2AvqcXJAX3buIwcOGqIOgNilwKMjpStO"{{< /highlight >}}
 
+http_proxy   | |
+-------------|------
+description  | The URL of a proxy to be used for HTTP requests.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
 
 [?]:  #
 [1]:  /sensu-enterprise

--- a/content/sensu-enterprise/3.3/integrations/victorops.md
+++ b/content/sensu-enterprise/3.3/integrations/victorops.md
@@ -59,13 +59,6 @@ type         | String
 default      | `everyone`
 example      | {{< highlight shell >}}"routing_key": "ops"{{< /highlight >}}
 
-http_proxy   | |
--------------|------
-description  | The URL of a proxy to be used for HTTP requests.
-required     | false
-type         | String
-example      | {{< highlight shell >}}"http_proxy": "http://192.168.250.11:3128"{{< /highlight >}}
-
 filters        | 
 ---------------|------
 description    | An array of Sensu event filters (names) to use when filtering events for the handler. Each array item must be a string. Specified filters are merged with default values.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Adds http_proxy attribute to influx and librato integrations
- Removes http_proxy from victorops integration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Follow up to #1090 
