### PR TITLE
Style text within tables

### DIFF
--- a/static/stylesheets/docs-overrides.css
+++ b/static/stylesheets/docs-overrides.css
@@ -888,7 +888,8 @@ code {
 }
 
 .article p,
-.drawer p {
+.drawer p,
+.article td {
   font-family: 'Work Sans';
   font-weight: 400;
   font-size: 16px;


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Styles text within tables with the same base style as standard paragraph text

Before:
![screen shot 2019-01-14 at 12 06 39 pm](https://user-images.githubusercontent.com/11339965/51138025-ebfa0180-17f4-11e9-85cd-5d82218073f7.png)

After:
![screen shot 2019-01-14 at 12 06 45 pm](https://user-images.githubusercontent.com/11339965/51138022-e997a780-17f4-11e9-9cc0-71314cdbd6ad.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #894

## Review Instructions
<!--- Optional -->
Run locally and try to find anything that looks incorrectly styled
