### PR TITLE
Add env_vars to Slack and Influx handler examples

### DIFF
--- a/content/sensu-go/5.0/api/handlers.md
+++ b/content/sensu-go/5.0/api/handlers.md
@@ -37,13 +37,18 @@ curl -s http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers -H "Author
       "labels": null,
       "annotations": null
     },
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
     "timeout": 0,
-    "handlers": null,
-    "filters": null,
-    "env_vars": null,
-    "runtime_assets": null
+    "type": "pipe"
   }
 ]
 {{< /highlight >}}
@@ -65,13 +70,18 @@ output         | {{< highlight shell >}}
       "labels": null,
       "annotations": null
     },
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
     "timeout": 0,
-    "handlers": null,
-    "filters": null,
-    "env_vars": null,
-    "runtime_assets": null
+    "type": "pipe"
   },
   {
     "metadata": {
@@ -80,13 +90,17 @@ output         | {{< highlight shell >}}
       "labels": null,
       "annotations": null
     },
-    "type": "pipe",
-    "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'sensu' --username 'sensu' --password 'password'",
+    "command": "sensu-influxdb-handler -d sensu",
+    "env_vars": [
+      "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+      "INFLUX_USER=sensu",
+      "INFLUX_PASSWORD=password"
+    ],
+    "filters": [],
+    "handlers": [],
+    "runtime_assets": [],
     "timeout": 0,
-    "handlers": null,
-    "filters": null,
-    "env_vars": null,
-    "runtime_assets": null
+    "type": "pipe"
   }
 ]
 {{< /highlight >}}
@@ -105,13 +119,17 @@ payload         | {{< highlight shell >}}
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'sensu' --username 'sensu' --password 'password'",
+  "command": "sensu-influxdb-handler -d sensu",
+  "env_vars": [
+    "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+    "INFLUX_USER=sensu",
+    "INFLUX_PASSWORD=password"
+  ],
+  "filters": [],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -137,13 +155,18 @@ curl -s http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack -H "
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+  "command": "sensu-slack-handler --channel '#monitoring'",
+  "env_vars": [
+    "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  ],
+  "filters": [
+    "is_incident",
+    "not_silenced"
+  ],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 
@@ -163,13 +186,18 @@ output               | {{< highlight json >}}
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+  "command": "sensu-slack-handler --channel '#monitoring'",
+  "env_vars": [
+    "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  ],
+  "filters": [
+    "is_incident",
+    "not_silenced"
+  ],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 
@@ -189,13 +217,17 @@ payload         | {{< highlight shell >}}
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'sensu' --username 'sensu' --password 'password'",
+  "command": "sensu-influxdb-handler -d sensu",
+  "env_vars": [
+    "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+    "INFLUX_USER=sensu",
+    "INFLUX_PASSWORD=password"
+  ],
+  "filters": [],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/5.0/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.0/guides/influx-db-metric-handler.md
@@ -38,15 +38,13 @@ handler that we will call `influx-db`, which is a **pipe** handler that pipes
 event data into our previous script named `sensu-influxdb-handler`. We will also
 pass the database name, address, username, and password of the InfluxDB you wish
 to populate.
+We'll use environment variables (`env-vars`) to pass the InfluxDB address, username, and password to the handler.
 
 {{< highlight shell >}}
 sensuctl handler create influx-db \
 --type pipe \
---command "sensu-influxdb-handler \
---addr 'http://123.4.5.6:8086' \
---db-name 'myDB' \
---username 'foo' \
---password 'bar'"
+--command "sensu-influxdb-handler -d sensu" \
+--env-vars "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086, INFLUX_USER=sensu, INFLUX_PASSWORD=password"
 {{< /highlight >}}
 
 ### Assigning the handler to an event

--- a/content/sensu-go/5.0/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.0/guides/install-check-executables-with-assets.md
@@ -99,8 +99,10 @@ sensu-agent    check_website      CheckHttpResponseTime OK: 345      0       fal
 
 {{< highlight shell >}}
 sensuctl handler create influx-db \
---command "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --username 'foo' --password 'bar' --db-name 'myDB'" \
---runtime-assets sensu-influxdb-handler
+--type pipe \
+--runtime-assets sensu-influxdb-handler \
+--command "sensu-influxdb-handler -d sensu" \
+--env-vars "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086, INFLUX_USER=sensu, INFLUX_PASSWORD=password"
 {{< /highlight >}}
 
 ### Validating the handler asset

--- a/content/sensu-go/5.0/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.0/guides/send-slack-alerts.md
@@ -56,8 +56,8 @@ After saving, you'll see your webhook URL under Integration Settings.
 
 Now that our handler command is installed, the second step is to create a
 handler that we will call `slack`, which is a **pipe** handler that pipes event
-data into our previous script named `slack-handler`. We will also pass the
-[Slack webhook URL][6] and the Slack channel name to this script. Finally, in
+data into our previous script named `slack-handler`. We'll also use environment variables
+to pass the [Slack webhook URL][6] to this script. Finally, in
 order to avoid silenced events from being sent to Slack, we will use the
 `not_silenced` built-in filter, in addition to the `is_incident` built-in filter
 so zero status events are also discarded.
@@ -65,9 +65,8 @@ so zero status events are also discarded.
 {{< highlight shell >}}
 sensuctl handler create slack \
 --type pipe \
---command 'slack-handler \
-  --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX \
-  --channel monitoring' \
+--env-vars "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX" \
+--command "sensu-slack-handler --channel '#monitoring'" \
 --filters is_incident,not_silenced
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/reference/filters.md
+++ b/content/sensu-go/5.0/reference/filters.md
@@ -107,11 +107,17 @@ To use the incidents filter, include the `is_incident` filter in the handler con
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
     "filters": [
       "is_incident"
-    ]
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}
@@ -141,12 +147,18 @@ To allow silencing for an event handler, add the `not_silenced` filter to the ha
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
     "filters": [
       "is_incident",
       "not_silenced"
-    ]
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}
@@ -166,15 +178,23 @@ To use the metrics filter, include the `has_metrics` filter in the handler confi
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
+    "name": "influx-db",
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'myDB' --username 'foo' --password 'bar'",
+    "command": "sensu-influxdb-handler -d sensu",
+    "env_vars": [
+      "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+      "INFLUX_USER=sensu",
+      "INFLUX_PASSWORD=password"
+    ],
     "filters": [
       "has_metrics"
-    ]
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -281,13 +281,23 @@ configured webhook URL, using the `handler-slack` executable command.
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "slack",
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring"
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.0/sensuctl/reference.md
+++ b/content/sensu-go/5.0/sensuctl/reference.md
@@ -179,13 +179,24 @@ For example, the following file `my-resources.json` specifies two resources: a `
 }
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack",
+    "namespace": "default"
+  },
   "spec": {
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
-    "metadata" : {
-      "name": "slack",
-      "namespace": "default"
-    }
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.1/api/handlers.md
+++ b/content/sensu-go/5.1/api/handlers.md
@@ -37,13 +37,18 @@ curl -s http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers -H "Author
       "labels": null,
       "annotations": null
     },
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
     "timeout": 0,
-    "handlers": null,
-    "filters": null,
-    "env_vars": null,
-    "runtime_assets": null
+    "type": "pipe"
   }
 ]
 {{< /highlight >}}
@@ -65,13 +70,18 @@ output         | {{< highlight shell >}}
       "labels": null,
       "annotations": null
     },
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
     "timeout": 0,
-    "handlers": null,
-    "filters": null,
-    "env_vars": null,
-    "runtime_assets": null
+    "type": "pipe"
   },
   {
     "metadata": {
@@ -80,13 +90,17 @@ output         | {{< highlight shell >}}
       "labels": null,
       "annotations": null
     },
-    "type": "pipe",
-    "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'sensu' --username 'sensu' --password 'password'",
+    "command": "sensu-influxdb-handler -d sensu",
+    "env_vars": [
+      "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+      "INFLUX_USER=sensu",
+      "INFLUX_PASSWORD=password"
+    ],
+    "filters": [],
+    "handlers": [],
+    "runtime_assets": [],
     "timeout": 0,
-    "handlers": null,
-    "filters": null,
-    "env_vars": null,
-    "runtime_assets": null
+    "type": "pipe"
   }
 ]
 {{< /highlight >}}
@@ -105,13 +119,17 @@ payload         | {{< highlight shell >}}
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'sensu' --username 'sensu' --password 'password'",
+  "command": "sensu-influxdb-handler -d sensu",
+  "env_vars": [
+    "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+    "INFLUX_USER=sensu",
+    "INFLUX_PASSWORD=password"
+  ],
+  "filters": [],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -137,13 +155,18 @@ curl -s http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack -H "
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+  "command": "sensu-slack-handler --channel '#monitoring'",
+  "env_vars": [
+    "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  ],
+  "filters": [
+    "is_incident",
+    "not_silenced"
+  ],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 
@@ -163,13 +186,18 @@ output               | {{< highlight json >}}
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+  "command": "sensu-slack-handler --channel '#monitoring'",
+  "env_vars": [
+    "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  ],
+  "filters": [
+    "is_incident",
+    "not_silenced"
+  ],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 
@@ -189,13 +217,17 @@ payload         | {{< highlight shell >}}
     "labels": null,
     "annotations": null
   },
-  "type": "pipe",
-  "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'sensu' --username 'sensu' --password 'password'",
+  "command": "sensu-influxdb-handler -d sensu",
+  "env_vars": [
+    "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+    "INFLUX_USER=sensu",
+    "INFLUX_PASSWORD=password"
+  ],
+  "filters": [],
+  "handlers": [],
+  "runtime_assets": [],
   "timeout": 0,
-  "handlers": null,
-  "filters": null,
-  "env_vars": null,
-  "runtime_assets": null
+  "type": "pipe"
 }
 {{< /highlight >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/5.1/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.1/guides/influx-db-metric-handler.md
@@ -38,15 +38,13 @@ handler that we will call `influx-db`, which is a **pipe** handler that pipes
 event data into our previous script named `sensu-influxdb-handler`. We will also
 pass the database name, address, username, and password of the InfluxDB you wish
 to populate.
+We'll use environment variables (`env-vars`) to pass the InfluxDB address, username, and password to the handler.
 
 {{< highlight shell >}}
 sensuctl handler create influx-db \
 --type pipe \
---command "sensu-influxdb-handler \
---addr 'http://123.4.5.6:8086' \
---db-name 'myDB' \
---username 'foo' \
---password 'bar'"
+--command "sensu-influxdb-handler -d sensu" \
+--env-vars "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086, INFLUX_USER=sensu, INFLUX_PASSWORD=password"
 {{< /highlight >}}
 
 ### Assigning the handler to an event

--- a/content/sensu-go/5.1/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.1/guides/install-check-executables-with-assets.md
@@ -99,8 +99,10 @@ sensu-agent    check_website      CheckHttpResponseTime OK: 345      0       fal
 
 {{< highlight shell >}}
 sensuctl handler create influx-db \
---command "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --username 'foo' --password 'bar' --db-name 'myDB'" \
---runtime-assets sensu-influxdb-handler
+--type pipe \
+--runtime-assets sensu-influxdb-handler \
+--command "sensu-influxdb-handler -d sensu" \
+--env-vars "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086, INFLUX_USER=sensu, INFLUX_PASSWORD=password"
 {{< /highlight >}}
 
 ### Validating the handler asset

--- a/content/sensu-go/5.1/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.1/guides/send-slack-alerts.md
@@ -56,8 +56,8 @@ After saving, you'll see your webhook URL under Integration Settings.
 
 Now that our handler command is installed, the second step is to create a
 handler that we will call `slack`, which is a **pipe** handler that pipes event
-data into our previous script named `slack-handler`. We will also pass the
-[Slack webhook URL][6] and the Slack channel name to this script. Finally, in
+data into our previous script named `slack-handler`. We'll also use environment variables
+to pass the [Slack webhook URL][6] to this script. Finally, in
 order to avoid silenced events from being sent to Slack, we will use the
 `not_silenced` built-in filter, in addition to the `is_incident` built-in filter
 so zero status events are also discarded.
@@ -65,9 +65,8 @@ so zero status events are also discarded.
 {{< highlight shell >}}
 sensuctl handler create slack \
 --type pipe \
---command 'slack-handler \
-  --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX \
-  --channel monitoring' \
+--env-vars "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX" \
+--command "sensu-slack-handler --channel '#monitoring'" \
 --filters is_incident,not_silenced
 {{< /highlight >}}
 

--- a/content/sensu-go/5.1/reference/filters.md
+++ b/content/sensu-go/5.1/reference/filters.md
@@ -107,11 +107,17 @@ To use the incidents filter, include the `is_incident` filter in the handler con
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
     "filters": [
       "is_incident"
-    ]
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}
@@ -141,12 +147,18 @@ To allow silencing for an event handler, add the `not_silenced` filter to the ha
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "slack-handler --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
     "filters": [
       "is_incident",
       "not_silenced"
-    ]
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}
@@ -166,15 +178,23 @@ To use the metrics filter, include the `has_metrics` filter in the handler confi
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
+    "name": "influx-db",
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --db-name 'myDB' --username 'foo' --password 'bar'",
+    "command": "sensu-influxdb-handler -d sensu",
+    "env_vars": [
+      "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+      "INFLUX_USER=sensu",
+      "INFLUX_PASSWORD=password"
+    ],
     "filters": [
       "has_metrics"
-    ]
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.1/reference/handlers.md
+++ b/content/sensu-go/5.1/reference/handlers.md
@@ -281,13 +281,23 @@ configured webhook URL, using the `handler-slack` executable command.
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "slack",
     "namespace": "default"
   },
   "spec": {
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring"
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.1/sensuctl/reference.md
+++ b/content/sensu-go/5.1/sensuctl/reference.md
@@ -176,13 +176,24 @@ For example, the following file `my-resources.json` specifies two resources: a `
 }
 {
   "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack",
+    "namespace": "default"
+  },
   "spec": {
-    "type": "pipe",
-    "command": "handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring",
-    "metadata" : {
-      "name": "slack",
-      "namespace": "default"
-    }
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced"
+    ],
+    "handlers": [],
+    "runtime_assets": [],
+    "timeout": 0,
+    "type": "pipe"
   }
 }
 {{< /highlight >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Updates Slack and InfluxDB handler examples to pass in secrets using environment variables to match the latest version of those plugins. Slack commands tested using CentOS and Vagrant.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1068
