### PR TITLE
Update error text when Sensu Enterprise 3.1 and prior is given an encrypted private key

### DIFF
--- a/content/sensu-enterprise/2.6/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.6/guides/troubleshooting.md
@@ -89,11 +89,10 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you may see the following error:
+These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info' for #
-An error was encountered while loading an SSL private key.
+Unexpected exception: undefined method `get_private_key_info'
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/2.6/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.6/guides/troubleshooting.md
@@ -89,7 +89,7 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
+These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
 Unexpected exception: undefined method `get_private_key_info'

--- a/content/sensu-enterprise/2.6/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.6/guides/troubleshooting.md
@@ -92,7 +92,7 @@ Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to 
 These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info'
+Unexpected exception: undefined method `get_private_key_info' for #
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/2.7/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.7/guides/troubleshooting.md
@@ -89,11 +89,10 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you may see the following error:
+These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info' for #
-An error was encountered while loading an SSL private key.
+Unexpected exception: undefined method `get_private_key_info'
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/2.7/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.7/guides/troubleshooting.md
@@ -89,7 +89,7 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
+These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
 Unexpected exception: undefined method `get_private_key_info'

--- a/content/sensu-enterprise/2.7/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.7/guides/troubleshooting.md
@@ -92,7 +92,7 @@ Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to 
 These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info'
+Unexpected exception: undefined method `get_private_key_info' for #
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/2.8/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.8/guides/troubleshooting.md
@@ -89,11 +89,10 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you may see the following error:
+These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info' for #
-An error was encountered while loading an SSL private key.
+Unexpected exception: undefined method `get_private_key_info'
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/2.8/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.8/guides/troubleshooting.md
@@ -89,7 +89,7 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
+These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
 Unexpected exception: undefined method `get_private_key_info'

--- a/content/sensu-enterprise/2.8/guides/troubleshooting.md
+++ b/content/sensu-enterprise/2.8/guides/troubleshooting.md
@@ -92,7 +92,7 @@ Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to 
 These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info'
+Unexpected exception: undefined method `get_private_key_info' for #
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/3.0/guides/troubleshooting.md
+++ b/content/sensu-enterprise/3.0/guides/troubleshooting.md
@@ -89,11 +89,10 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you may see the following error:
+These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info' for #
-An error was encountered while loading an SSL private key.
+Unexpected exception: undefined method `get_private_key_info'
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/3.0/guides/troubleshooting.md
+++ b/content/sensu-enterprise/3.0/guides/troubleshooting.md
@@ -89,7 +89,7 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
+These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
 Unexpected exception: undefined method `get_private_key_info'

--- a/content/sensu-enterprise/3.0/guides/troubleshooting.md
+++ b/content/sensu-enterprise/3.0/guides/troubleshooting.md
@@ -92,7 +92,7 @@ Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to 
 These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info'
+Unexpected exception: undefined method `get_private_key_info' for #
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/3.1/guides/troubleshooting.md
+++ b/content/sensu-enterprise/3.1/guides/troubleshooting.md
@@ -89,7 +89,7 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
+These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
 Unexpected exception: undefined method `get_private_key_info'

--- a/content/sensu-enterprise/3.1/guides/troubleshooting.md
+++ b/content/sensu-enterprise/3.1/guides/troubleshooting.md
@@ -92,7 +92,7 @@ Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to 
 These keys must be in a plaintext, unencrypted format, otherwise you may see an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info'
+Unexpected exception: undefined method `get_private_key_info' for #
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.

--- a/content/sensu-enterprise/3.1/guides/troubleshooting.md
+++ b/content/sensu-enterprise/3.1/guides/troubleshooting.md
@@ -89,10 +89,10 @@ If the values of a particular file differ from what you're expecting, then see t
 
 Sensu Enterprise can use PEM-formatted TLS/SSL certificates and private keys to secure communication with Redis and RabbitMQ.
 (See the [securing Sensu guide][3] for more information.)
-These keys must be in a plaintext, unencrypted format, otherwise you may see the following error:
+These keys must be in a plaintext, unencrypted format, otherwise you an error containing the following:
 
 {{< highlight text >}}
-Unexpected exception: undefined method `get_private_key_info' for #
+Unexpected exception: undefined method `get_private_key_info'
 {{< /highlight >}}
 
 If you see the word `ENCRYPTED` in the first few lines of the PEM private key, the key is in an unsupported, encrypted format.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Closes #993 

## Motivation and Context
As the exception thrown by private keys being encrypted wasn't caught until 3.2:

https://github.com/sensu/sensu-enterprise/issues/385

The error seen will be different in SE 3.1 and prior. The text only has a portion of the error as it is a long Ruby stack trace.

## Review Instructions
- Error is based on https://github.com/sensu/sensu-enterprise/issues/385. 
- Ensure language is reads ok.
