### PR TITLE
Agents are namespaced copy to all versions

### DIFF
--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -19,7 +19,7 @@ menu:
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
-- **Namespaces** partition resources within Sensu. Sensu checks, handlers, and other [namespaced resources][17] belong to a single namespace.
+- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (get, delete, etc.) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace; **cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.

--- a/content/sensu-go/5.1/reference/agent.md
+++ b/content/sensu-go/5.1/reference/agent.md
@@ -673,7 +673,7 @@ keepalive-timeout: 300{{< /highlight >}}
 
 | namespace |      |
 ---------------|------
-description    | Agent namespace
+description    | Agent namespace _NOTE: Agents are represented in the backend as a class of entity. Entities can only belong to a [single namespace][41]._
 type           | String
 default        | `default`
 example        | {{< highlight shell >}}# Command line example
@@ -879,3 +879,4 @@ statsd-metrics-port: 6125{{< /highlight >}}
 [38]: #name
 [39]: ../checks#check-result-specification
 [40]: ../../guides/send-slack-alerts
+[41]: ../rbac/#namespaced-resource-types

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -19,7 +19,7 @@ menu:
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
-- **Namespaces** partition resources within Sensu. Sensu checks, handlers, and other [namespaced resources][17] belong to a single namespace.
+- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (get, delete, etc.) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace; **cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
@@ -27,7 +27,7 @@ RBAC allows management and access of users and resources based on **namespaces**
 Sensu access controls apply to [sensuctl][2], the Sensu [API][19], and the Sensu [dashboard][3].
 
 ## Namespaces
-Namespaces help teams use different resources (checks, handlers, etc.) within Sensu and impose their own controls on those resources.
+Namespaces help teams use different resources (entities, checks, handlers, etc.) within Sensu and impose their own controls on those resources.
 A Sensu instance can have multiple namespaces, each with their own set of managed resources.
 Resource names need to be unique within a namespace, but not across namespaces.
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
- Add to all versions from #1108 
- Have `entities` listed above Namespace heading.

## Motivation and Context
Trigger happy.

## Review Instructions
<!--- Optional -->
