### PR TITLE
Update client-to-server transport documentation

### DIFF
--- a/content/sensu-go/5.0/guides/clustering.md
+++ b/content/sensu-go/5.0/guides/clustering.md
@@ -256,13 +256,33 @@ client.pem
 
 ### Client-to-server transport security with HTTPS {#client-to-server-with-https}
 
-Below are example configuration snippets from `/etc/sensu/backend.yml` that will be the same for `backend-1`, `backend-2` and `backend-3`.
+Below are example configuration snippets from `/etc/sensu/backend.yml` on three Sensu backends named `backend-1`, `backend-2` and `backend-3` with IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.
 This configuration assumes that your client certificates are in `/etc/sensu/certs/` and your CA certificate is in `/usr/local/share/ca-certificates/sensu/`.
 
 {{< highlight shell >}}
-etcd-cert-file: "/etc/sensu/certs/backend-1.pem"
-etcd-key-file: "/etc/sensu/certs/backend-1-key.pem"
-etcd-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+##
+# etcd peer ssl configuration for backend-1/10.0.0.1
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-1.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-1-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+
+##
+# etcd peer ssl configuration for backend-2/10.0.0.2
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-2.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-2-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+
+##
+# etcd peer ssl configuration for backend-3/10.0.0.3
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-3.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-3-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
 {{< /highlight >}}
 
 Validating with curl:
@@ -274,13 +294,35 @@ https://127.0.0.1:2379/v2/keys/foo -XPUT -d value=bar
 
 ### Client-to-server authentication with HTTPS client certificates {#client-to-server-auth-with-https}
 
-Below are example configuration snippets from `/etc/sensu/backend.yml` that will be the same for `backend-1`, `backend-2` and `backend-3`.
+Below are example configuration snippets from `/etc/sensu/backend.yml` on three Sensu backends named `backend-1`, `backend-2` and `backend-3` with IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.
 This configuration assumes your client certificates are in `/etc/sensu/certs/` and your CA certificate is in `/usr/local/share/ca-certificates/sensu/`.
 
 {{< highlight shell >}}
-etcd-cert-file: "/etc/sensu/certs/client.pem"
-etcd-key-file: "/etc/sensu/certs/client-key.pem"
-etcd-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+##
+# etcd peer ssl configuration for backend-1/10.0.0.1
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-1.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-1-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+etcd-client-cert-auth: true
+
+##
+# etcd peer ssl configuration for backend-2/10.0.0.2
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-2.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-2-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+etcd-client-cert-auth: true
+
+##
+# etcd peer ssl configuration for backend-3/10.0.0.3
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-3.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-3-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
 etcd-client-cert-auth: true
 {{< /highlight >}}
 

--- a/content/sensu-go/5.0/guides/clustering.md
+++ b/content/sensu-go/5.0/guides/clustering.md
@@ -260,8 +260,8 @@ Below are example configuration snippets from `/etc/sensu/backend.yml` that will
 This configuration assumes that your client certificates are in `/etc/sensu/certs/` and your CA certificate is in `/usr/local/share/ca-certificates/sensu/`.
 
 {{< highlight shell >}}
-etcd-cert-file: "/etc/sensu/certs/client.pem"
-etcd-key-file: "/etc/sensu/certs/client-key.pem"
+etcd-cert-file: "/etc/sensu/certs/backend-1.pem"
+etcd-key-file: "/etc/sensu/certs/backend-1-key.pem"
 etcd-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
 {{< /highlight >}}
 

--- a/content/sensu-go/5.1/guides/clustering.md
+++ b/content/sensu-go/5.1/guides/clustering.md
@@ -260,8 +260,8 @@ Below are example configuration snippets from `/etc/sensu/backend.yml` that will
 This configuration assumes that your client certificates are in `/etc/sensu/certs/` and your CA certificate is in `/usr/local/share/ca-certificates/sensu/`.
 
 {{< highlight shell >}}
-etcd-cert-file: "/etc/sensu/certs/client.pem"
-etcd-key-file: "/etc/sensu/certs/client-key.pem"
+etcd-cert-file: "/etc/sensu/certs/backend-1.pem"
+etcd-key-file: "/etc/sensu/certs/backend-1-key.pem"
 etcd-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
 {{< /highlight >}}
 

--- a/content/sensu-go/5.1/guides/clustering.md
+++ b/content/sensu-go/5.1/guides/clustering.md
@@ -64,7 +64,7 @@ _NOTE: This backend configuration assumes you have set up and installed the sens
 ##
 # store configuration for backend-1/10.0.0.1
 ##
-etcd-advertise-client-urls: "http://10.0.0.1:2379"
+ etcd-advertise-client-urls: "http://10.0.0.1:2379"
 etcd-listen-client-urls: "http://10.0.0.1:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
@@ -256,13 +256,33 @@ client.pem
 
 ### Client-to-server transport security with HTTPS {#client-to-server-with-https}
 
-Below are example configuration snippets from `/etc/sensu/backend.yml` that will be the same for `backend-1`, `backend-2` and `backend-3`.
+Below are example configuration snippets from `/etc/sensu/backend.yml` on three Sensu backends named `backend-1`, `backend-2` and `backend-3` with IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.
 This configuration assumes that your client certificates are in `/etc/sensu/certs/` and your CA certificate is in `/usr/local/share/ca-certificates/sensu/`.
 
 {{< highlight shell >}}
-etcd-cert-file: "/etc/sensu/certs/backend-1.pem"
-etcd-key-file: "/etc/sensu/certs/backend-1-key.pem"
-etcd-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+##
+# etcd peer ssl configuration for backend-1/10.0.0.1
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-1.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-1-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+
+##
+# etcd peer ssl configuration for backend-2/10.0.0.2
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-2.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-2-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+
+##
+# etcd peer ssl configuration for backend-3/10.0.0.3
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-3.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-3-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
 {{< /highlight >}}
 
 Validating with curl:
@@ -274,13 +294,35 @@ https://127.0.0.1:2379/v2/keys/foo -XPUT -d value=bar
 
 ### Client-to-server authentication with HTTPS client certificates {#client-to-server-auth-with-https}
 
-Below are example configuration snippets from `/etc/sensu/backend.yml` that will be the same for `backend-1`, `backend-2` and `backend-3`.
+Below are example configuration snippets from `/etc/sensu/backend.yml` on three Sensu backends named `backend-1`, `backend-2` and `backend-3` with IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.
 This configuration assumes your client certificates are in `/etc/sensu/certs/` and your CA certificate is in `/usr/local/share/ca-certificates/sensu/`.
 
 {{< highlight shell >}}
-etcd-cert-file: "/etc/sensu/certs/client.pem"
-etcd-key-file: "/etc/sensu/certs/client-key.pem"
-etcd-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+##
+# etcd peer ssl configuration for backend-1/10.0.0.1
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-1.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-1-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+etcd-client-cert-auth: true
+
+##
+# etcd peer ssl configuration for backend-2/10.0.0.2
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-2.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-2-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
+etcd-client-cert-auth: true
+
+##
+# etcd peer ssl configuration for backend-3/10.0.0.3
+##
+
+etcd-peer-cert-file: "/etc/sensu/certs/backend-3.pem"
+etcd-peer-key-file: "/etc/sensu/certs/backend-3-key.pem"
+etcd-peer-trusted-ca-file: "/usr/local/share/ca-certificates/sensu/ca.pem"
 etcd-client-cert-auth: true
 {{< /highlight >}}
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
The example yaml file under the *Client-to-server transport security with HTTPS* section in the clustering guide says to use the client.pem and client-key.pem files. However, this fails to work and are not the correct certs and keys to use in this location. Instead, you should use the specific backend cert and keys you generated in the previous step.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because currently the provided solution in the documentation leads users down a path that will fail. The change provided in this PR should direct users to utilize the correct certs and keys.
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->

## Review Instructions
<!--- Optional -->
