### PR TITLE
Add missing subscriptions payload parameter

### DIFF
--- a/content/sensu-go/5.0/api/checks.md
+++ b/content/sensu-go/5.0/api/checks.md
@@ -320,6 +320,8 @@ HTTP/1.1 202 Accepted
 {"issued":1543861798}
 {{< /highlight >}}
 
+_PRO TIP: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition. This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand._
+
 #### API Specification {#checkscheckexecute-post-specification}
 
 /checks/:check/execute (POST) | 
@@ -334,7 +336,7 @@ payload         | {{< highlight shell >}}
   ]
 }
 {{< /highlight >}}
-payload parameters | `check` (required): the name of the check to execute, and `subscriptions` (optional): an array of subscriptions to publish the check request to.
+payload parameters | `check` (required): the name of the check to execute, and `subscriptions` (optional): an array of subscriptions to publish the check request to. When provided with the request, the `subscriptions` attribute overrides any subscriptions configured in the check definition.
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/checks/:check/hooks/:type` API endpoint {#the-checkscheckhooks-api-endpoint}

--- a/content/sensu-go/5.0/api/checks.md
+++ b/content/sensu-go/5.0/api/checks.md
@@ -326,8 +326,15 @@ HTTP/1.1 202 Accepted
 ----------------|------
 description     | Creates an adhoc request to execute a check given the check name.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/checks/check-sensu-site/execute
-payload         | {{< highlight shell >}}{"check": "check-sensu-site"}{{< /highlight >}}
-payload parameters | `check` (required): the name of the check to execute
+payload         | {{< highlight shell >}}
+{
+  "check": "check-sensu-site",
+  "subscriptions": [
+    "entity:i-424242"
+  ]
+}
+{{< /highlight >}}
+payload parameters | `check` (required): the name of the check to execute, and `subscriptions` (optional): an array of subscriptions to publish the check request to.
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/checks/:check/hooks/:type` API endpoint {#the-checkscheckhooks-api-endpoint}

--- a/content/sensu-go/5.1/api/checks.md
+++ b/content/sensu-go/5.1/api/checks.md
@@ -320,14 +320,23 @@ HTTP/1.1 202 Accepted
 {"issued":1543861798}
 {{< /highlight >}}
 
+_PRO TIP: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition. This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand._
+
 #### API Specification {#checkscheckexecute-post-specification}
 
 /checks/:check/execute (POST) | 
 ----------------|------
 description     | Creates an adhoc request to execute a check given the check name.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/checks/check-sensu-site/execute
-payload         | {{< highlight shell >}}{"check": "check-sensu-site"}{{< /highlight >}}
-payload parameters | `check` (required): the name of the check to execute
+payload         | {{< highlight shell >}}
+{
+  "check": "check-sensu-site",
+  "subscriptions": [
+    "entity:i-424242"
+  ]
+}
+{{< /highlight >}}
+payload parameters | `check` (required): the name of the check to execute, and `subscriptions` (optional): an array of subscriptions to publish the check request to. When provided with the request, the `subscriptions` attribute overrides any subscriptions configured in the check definition.
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/checks/:check/hooks/:type` API endpoint {#the-checkscheckhooks-api-endpoint}


### PR DESCRIPTION
Add missing `subscriptions` payload parameter to the `POST /checks/:check/execute` API docs.

## Description

The `POST /checks/:check/execute` API docs are missing the supported "subscriptions" payload parameter; see: https://github.com/sensu/sensu-go/blob/master/api/core/v2/adhoc.pb.go#L26-L28 

## Motivation and Context

Requesting adhoc executions of checks (against arbitrary subscriptions) is needed for various Sensu workflows including "automated remediation" and "self-healing" workflows. The most common use case is to target an entity subscription (i.e. a service check fails on one particular node; a remediation handler requests an action to be executed against that same node, where the "action" is a check execution configured with `"publish": false`, and the command is some remediation action such as starting or restarting a service).  

## Review Instructions

Test my changes and make sure they work? 😄 
