### PR TITLE
Adjust font sizes in sidebar menu

### DIFF
--- a/static/stylesheets/docs-overrides.css
+++ b/static/stylesheets/docs-overrides.css
@@ -1060,7 +1060,7 @@ code {
 .drawer .toc li .panel > li a {
   font-family: 'Work Sans';
   font-weight: 400;
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1.375;
   color: #2C3458;
   padding: 0;
@@ -1071,7 +1071,7 @@ code {
 .drawer .toc li .panel > li a.current {
   font-family: 'Work Sans';
   font-weight: 600;
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1.375;
   color: #89C967;
 }

--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -562,11 +562,11 @@ button.accordion.active, button.accordion:hover {
   }
 
   .drawer .toc li a.menu-title {
-    font-size: 18px;
+    font-size: 16px;
   }
 
   .drawer .toc li a.menu-child {
-    font-size: 16px;
+    font-size: 15px;
   }  
 }
 
@@ -586,7 +586,7 @@ button.accordion.active, button.accordion:hover {
   }
 
   .drawer .toc li a.menu-child {
-    font-size: 14px;
+    font-size: 15px;
   }
 
   .banner .name strong {


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Makes menu titles 16px at all widths for which the sidebar is expanded
- Decreases size of submenu items to 15px

Before on the right, after on the left

Large screen:
![screen shot 2019-01-23 at 9 02 43 am](https://user-images.githubusercontent.com/11339965/51623711-2a2aab80-1eee-11e9-8ce7-2e7a3864a45b.png)

Mid size screen:
![screen shot 2019-01-23 at 9 03 53 am](https://user-images.githubusercontent.com/11339965/51623720-2dbe3280-1eee-11e9-9fc5-eb9771519bf8.png)

Small screen:
![screen shot 2019-01-23 at 9 04 14 am](https://user-images.githubusercontent.com/11339965/51623730-30208c80-1eee-11e9-81b0-9c8bb2124137.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Makes submenus more readable while we wait for improved search functionality