### PR TITLE
[WIP] Document test credentials API and command

### DIFF
--- a/content/sensu-go/5.1/api/auth.md
+++ b/content/sensu-go/5.1/api/auth.md
@@ -1,0 +1,36 @@
+---
+title: "Authorization API"
+description: "Sensu Go authorization API reference documentation"
+version: "5.1"
+product: "Sensu Go"
+menu:
+  sensu-go-5.1:
+    parent: api
+---
+
+- [The `/auth/test` API endpoint](#the-authtest-api-endpoint)
+  - [`/auth/test` (GET)](#authtest-get)
+
+## The `/auth/test` API endpoint {#the-authtest-api-endpoint}
+
+### `/auth/test` (GET) {#authtest-get}
+
+The `/auth/test` API endpoint provides HTTP GET access to test user credentials.
+
+#### EXAMPLE {#authtest-get-example}
+
+In the following example, querying the `/auth/test` API with a given username and password returns a 200 OK response, indicating that the credentials are valid.
+
+{{< highlight shell >}}
+curl -u myusername:mypassword http://127.0.0.1:8080/auth/test 
+
+HTTP/1.1 200 OK
+{{< /highlight >}}
+
+#### API Specification {#authtest-get-specification}
+
+/auth/test (GET)     |     |
+---------------------|------
+description          | Tests a given username and password.
+example url          | http://hostname:8080/api/core/v2/auth/test
+response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/5.1/api/users.md
+++ b/content/sensu-go/5.1/api/users.md
@@ -25,6 +25,8 @@ menu:
 - [The `/users/:user/groups/:group` API endpoints](#the-usersusergroupsgroup-api-endpoints)
   - [`/users/:user/groups/:group` (PUT)](#usersusergroupsgroup-put)
   - [`/users/:user/groups/:group` (DELETE)](#usersusergroupsgroup-delete)
+- [The `/users/auth/test` API endpoint](#the-usersauthtest-api-endpoint)
+  - [`/users/auth/test` (GET)](#usersauthtest-get)
 
 ## Authentication
 
@@ -400,5 +402,34 @@ description               | Removes a user from a group.
 example url               | http://hostname:8080/api/core/v2/users/alice/groups/ops
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-[1]: ../../reference/rbac#user-specification
+## The `/users/auth/test` API endpoint {#the-usersauthtest-api-endpoint}
 
+### `/users/auth/test` (GET) {#usersauthtest-get}
+
+The `/users/auth/test` API endpoint provides HTTP GET access to test user credentials.
+
+#### EXAMPLE {#usersauthtest-get-example}
+
+In the following example, querying the `/users/auth/test` API for a given username and password returns a... indicating that the credentials are valid.
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer TOKEN" \
+http://127.0.0.1:8080/api/core/v2/users/auth/test
+
+HTTP/1.1 
+
+{{< /highlight >}}
+
+#### API Specification {#usersuser-get-specification}
+
+/users/auth/test (GET) | 
+---------------------|------
+description          | Tests a given username and password.
+example url          | http://hostname:8080/api/core/v2/users/auth/test
+response type        | 
+response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output               | {{< highlight json >}}
+
+{{< /highlight >}}
+
+[1]: ../../reference/rbac#user-specification

--- a/content/sensu-go/5.1/api/users.md
+++ b/content/sensu-go/5.1/api/users.md
@@ -25,8 +25,6 @@ menu:
 - [The `/users/:user/groups/:group` API endpoints](#the-usersusergroupsgroup-api-endpoints)
   - [`/users/:user/groups/:group` (PUT)](#usersusergroupsgroup-put)
   - [`/users/:user/groups/:group` (DELETE)](#usersusergroupsgroup-delete)
-- [The `/users/auth/test` API endpoint](#the-usersauthtest-api-endpoint)
-  - [`/users/auth/test` (GET)](#usersauthtest-get)
 
 ## Authentication
 
@@ -401,35 +399,5 @@ HTTP/1.1 204 No Content
 description               | Removes a user from a group.
 example url               | http://hostname:8080/api/core/v2/users/alice/groups/ops
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-
-## The `/users/auth/test` API endpoint {#the-usersauthtest-api-endpoint}
-
-### `/users/auth/test` (GET) {#usersauthtest-get}
-
-The `/users/auth/test` API endpoint provides HTTP GET access to test user credentials.
-
-#### EXAMPLE {#usersauthtest-get-example}
-
-In the following example, querying the `/users/auth/test` API for a given username and password returns a... indicating that the credentials are valid.
-
-{{< highlight shell >}}
-curl -H "Authorization: Bearer TOKEN" \
-http://127.0.0.1:8080/api/core/v2/users/auth/test
-
-HTTP/1.1 
-
-{{< /highlight >}}
-
-#### API Specification {#usersuser-get-specification}
-
-/users/auth/test (GET) | 
----------------------|------
-description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/users/auth/test
-response type        | 
-response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-output               | {{< highlight json >}}
-
-{{< /highlight >}}
 
 [1]: ../../reference/rbac#user-specification

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -230,22 +230,28 @@ To assign permissions to a user:
 
 You can use [sensuctl][2] to view, create, and manage users.
 
+To test the password for a user:
+
+{{< highlight shell >}}
+sensuctl user test-creds USERNAME --password 'password'
+{{< /highlight >}}
+
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password [USERNAME]
+sensuctl user change-password USERNAME
 {{< /highlight >}}
 
 To disable a user:
 
 {{< highlight shell >}}
-sensuctl user disable [USERNAME]
+sensuctl user disable USERNAME
 {{< /highlight >}}
 
 To re-enable a disabled user:
 
 {{< highlight shell >}}
-sensuctl user reinstate [USERNAME]
+sensuctl user reinstate USERNAME
 {{< /highlight >}}
 
 ### User specification

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -236,22 +236,24 @@ To test the password for a user:
 sensuctl user test-creds USERNAME --password 'password'
 {{< /highlight >}}
 
+An empty response indicates valid credentials; a request-unauthorized response indicates invalid credentials.
+
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password [USERNAME]
 {{< /highlight >}}
 
 To disable a user:
 
 {{< highlight shell >}}
-sensuctl user disable USERNAME
+sensuctl user disable [USERNAME]
 {{< /highlight >}}
 
 To re-enable a disabled user:
 
 {{< highlight shell >}}
-sensuctl user reinstate USERNAME
+sensuctl user reinstate [USERNAME]
 {{< /highlight >}}
 
 ### User specification


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
To be merged immediately following the Sensu Go 5.1.1 release.

- Adds the sensuctl command to the RBAC reference
- Adds the auth/test endpoint to the API docs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1127 
