### PR TITLE
link to the Sensu License from Sensu Go installation doc

### DIFF
--- a/content/sensu-go/5.0/installation/install-sensu.md
+++ b/content/sensu-go/5.0/installation/install-sensu.md
@@ -18,6 +18,9 @@ Select a platform from the dropdown above.
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), and Docker.
 See the list of [supported platforms][5] for more information.
 
+Official Sensu Go builds described here are provided under the terms of the
+[Sensu License][13].
+
 {{< platformBlock "Ubuntu RHEL/CentOS" >}}
 
 ## Install the Sensu backend
@@ -412,3 +415,4 @@ While it can be run from the docker container, doing so may be problematic.
 [10]: ../../guides/send-slack-alerts
 [11]: https://github.com/sensu/sensu-go/blob/master/packaging/files/backend.yml.example
 [12]: ../verify
+[13]: https://sensu.io/sensu-license

--- a/content/sensu-go/5.0/installation/install-sensu.md
+++ b/content/sensu-go/5.0/installation/install-sensu.md
@@ -17,9 +17,7 @@ aliases:
 Select a platform from the dropdown above.
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), and Docker.
 See the list of [supported platforms][5] for more information.
-
-Official Sensu Go builds described here are provided under the terms of the
-[Sensu License][13].
+Sensu downloads are provided under the [Sensu License][13].
 
 {{< platformBlock "Ubuntu RHEL/CentOS" >}}
 

--- a/content/sensu-go/5.1/installation/install-sensu.md
+++ b/content/sensu-go/5.1/installation/install-sensu.md
@@ -15,9 +15,7 @@ menu:
 Select a platform from the dropdown above.
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), and Docker.
 See the list of [supported platforms][5] for more information.
-
-Official Sensu Go builds described here are provided under the terms of the
-[Sensu License][13].
+Sensu downloads are provided under the [Sensu License][13].
 
 {{< platformBlock "Ubuntu RHEL/CentOS" >}}
 

--- a/content/sensu-go/5.1/installation/install-sensu.md
+++ b/content/sensu-go/5.1/installation/install-sensu.md
@@ -16,6 +16,9 @@ Select a platform from the dropdown above.
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), and Docker.
 See the list of [supported platforms][5] for more information.
 
+Official Sensu Go builds described here are provided under the terms of the
+[Sensu License][13].
+
 {{< platformBlock "Ubuntu RHEL/CentOS" >}}
 
 ## Install the Sensu backend
@@ -422,3 +425,4 @@ While it can be run from the docker container, doing so may be problematic.
 [10]: ../../guides/send-slack-alerts
 [11]: https://github.com/sensu/sensu-go/blob/master/packaging/files/backend.yml.example
 [12]: ../verify
+[13]: https://sensu.io/sensu-license

--- a/content/sensu-go/5.2/installation/install-sensu.md
+++ b/content/sensu-go/5.2/installation/install-sensu.md
@@ -15,9 +15,7 @@ menu:
 Select a platform from the dropdown above.
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), and Docker.
 See the list of [supported platforms][5] for more information.
-
-Official Sensu Go builds described here are provided under the terms of the
-[Sensu License][13].
+Sensu downloads are provided under the [Sensu License][13].
 
 {{< platformBlock "Ubuntu RHEL/CentOS" >}}
 

--- a/content/sensu-go/5.2/installation/install-sensu.md
+++ b/content/sensu-go/5.2/installation/install-sensu.md
@@ -16,6 +16,9 @@ Select a platform from the dropdown above.
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), and Docker.
 See the list of [supported platforms][5] for more information.
 
+Official Sensu Go builds described here are provided under the terms of the
+[Sensu License][13].
+
 {{< platformBlock "Ubuntu RHEL/CentOS" >}}
 
 ## Install the Sensu backend
@@ -422,3 +425,4 @@ While it can be run from the docker container, doing so may be problematic.
 [10]: ../../guides/send-slack-alerts
 [11]: https://github.com/sensu/sensu-go/blob/master/packaging/files/backend.yml.example
 [12]: ../verify
+[13]: https://sensu.io/sensu-license


### PR DESCRIPTION
## Description

Adds a reference to the Sensu License on each iteration of the Sensu Go installation doc

## Motivation and Context

Closes #1155 