### PR TITLE
remove repeated metadata scope

### DIFF
--- a/content/sensu-go/5.0/reference/handlers.md
+++ b/content/sensu-go/5.0/reference/handlers.md
@@ -320,10 +320,6 @@ will timeout if an acknowledgement (`ACK`) is not received within 30 seconds.
     "socket": {
       "host": "10.0.1.99",
       "port": 4444
-    },
-    "metadata" : {
-      "name": "tcp_handler",
-      "namespace": "default"
     }
   }
 }

--- a/content/sensu-go/5.1/reference/handlers.md
+++ b/content/sensu-go/5.1/reference/handlers.md
@@ -320,10 +320,6 @@ will timeout if an acknowledgement (`ACK`) is not received within 30 seconds.
     "socket": {
       "host": "10.0.1.99",
       "port": 4444
-    },
-    "metadata" : {
-      "name": "tcp_handler",
-      "namespace": "default"
     }
   }
 }

--- a/content/sensu-go/5.2/reference/handlers.md
+++ b/content/sensu-go/5.2/reference/handlers.md
@@ -320,10 +320,6 @@ will timeout if an acknowledgement (`ACK`) is not received within 30 seconds.
     "socket": {
       "host": "10.0.1.99",
       "port": 4444
-    },
-    "metadata" : {
-      "name": "tcp_handler",
-      "namespace": "default"
     }
   }
 }


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Remove un-needed `metadata` hash from `spec` scope in TCP handler example.

Sensu appears to actually take this data and make a valid handler, but nowhere to be seen is the `metadata` has in the `spec` scope when printing the handler using `sensuctl`:

```
sensuctl handler info tcp_handler --format wrapped-json
{
  "type": "Handler",
  "api_version": "core/v2",
  "metadata": {
    "name": "tcp_handler",
    "namespace": "default"
  },
  "spec": {
    "env_vars": null,
    "filters": null,
    "handlers": null,
    "runtime_assets": null,
    "socket": {
      "host": "10.0.1.99",
      "port": 4444
    },
    "timeout": 0,
    "type": "tcp"
  }
}
```

## Motivation and Context
To be correct.

## Review Instructions
Ensure that the change is actually valid and no other meaning is behind `metadata` being in the `spec` scope.
