### PR TITLE
Correct sensuctl OSX install instructions

### DIFF
--- a/content/sensu-go/5.0/installation/install-sensu.md
+++ b/content/sensu-go/5.0/installation/install-sensu.md
@@ -311,7 +311,7 @@ tar -xvf sensu-go-5.0.1-darwin-amd64.tar.gz
 Copy the executable into your PATH.
 
 {{< highlight shell >}}
-sudo cp sensuctl /usr/local/bin/
+sudo cp bin/sensuctl /usr/local/bin/
 {{< /highlight >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/5.0/installation/install-sensu.md
+++ b/content/sensu-go/5.0/installation/install-sensu.md
@@ -311,7 +311,7 @@ tar -xvf sensu-go-5.0.1-darwin-amd64.tar.gz
 Copy the executable into your PATH.
 
 {{< highlight shell >}}
-sudo cp bin/sensuctl /usr/local/bin/
+sudo cp sensuctl /usr/local/bin/
 {{< /highlight >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/5.2/installation/install-sensu.md
+++ b/content/sensu-go/5.2/installation/install-sensu.md
@@ -324,7 +324,7 @@ tar -xvf sensu-enterprise-go_5.2.1_darwin_amd64.tar.gz
 Copy the executable into your PATH.
 
 {{< highlight shell >}}
-sudo cp bin/sensuctl /usr/local/bin/
+sudo cp sensuctl /usr/local/bin/
 {{< /highlight >}}
 
 {{< platformBlockClose >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Directory structure inside binary-only distributions changed in 5.2.

## Motivation and Context
Corrects the installation process for sensuctl on OSX.

## Review Instructions
None. QA:
```
~ $ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.2.1/sensu-enterprise-go_5.2.1_darwin_amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12.7M  100 12.7M    0     0  7462k      0  0:00:01  0:00:01 --:--:-- 7462k
~ $ tar -xvf sensu-enterprise-go_5.2.1_darwin_amd64.tar.gz
x CHANGELOG.md
x LICENSE
x README.md
x sensu-agent
x sensuctl
```
Notice no `bin` directory and `sensuctl` exists so any `sudo cp sensuctl dest` command should work.

