### PR TITLE
Add trusted ca to securing guide

### DIFF
--- a/content/sensu-go/5.0/guides/securing-sensu.md
+++ b/content/sensu-go/5.0/guides/securing-sensu.md
@@ -98,7 +98,7 @@ The agent will then connect Sensu servers over wss. Do note that by changing the
 
 It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.
 
-You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
+You may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
 
 {{< highlight yaml>}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"

--- a/content/sensu-go/5.0/guides/securing-sensu.md
+++ b/content/sensu-go/5.0/guides/securing-sensu.md
@@ -96,6 +96,14 @@ backend-url:
 
 The agent will then connect Sensu servers over wss. Do note that by changing the configuration to wss, plaintext communication will not be possible.
 
+It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.
+
+You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
+
+{{< highlight yaml>}}
+trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
+{{< /highlight >}}
+
 _NOTE: If creating a Sensu cluster, every cluster member needs to be present in the configuration. See the [Sensu Go clustering guide][2] for more information on how to configure agents for a clustered configuration._
 
 

--- a/content/sensu-go/5.1/guides/securing-sensu.md
+++ b/content/sensu-go/5.1/guides/securing-sensu.md
@@ -98,7 +98,7 @@ The agent will then connect Sensu servers over wss. Do note that by changing the
 
 It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.
 
-You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
+You may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
 
 {{< highlight yaml>}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"

--- a/content/sensu-go/5.1/guides/securing-sensu.md
+++ b/content/sensu-go/5.1/guides/securing-sensu.md
@@ -96,6 +96,14 @@ backend-url:
 
 The agent will then connect Sensu servers over wss. Do note that by changing the configuration to wss, plaintext communication will not be possible.
 
+It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.
+
+You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
+
+{{< highlight yaml>}}
+trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
+{{< /highlight >}}
+
 _NOTE: If creating a Sensu cluster, every cluster member needs to be present in the configuration. See the [Sensu Go clustering guide][2] for more information on how to configure agents for a clustered configuration._
 
 

--- a/content/sensu-go/5.2/guides/securing-sensu.md
+++ b/content/sensu-go/5.2/guides/securing-sensu.md
@@ -98,7 +98,7 @@ The agent will then connect Sensu servers over wss. Do note that by changing the
 
 It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.
 
-You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
+You may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
 
 {{< highlight yaml>}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"

--- a/content/sensu-go/5.2/guides/securing-sensu.md
+++ b/content/sensu-go/5.2/guides/securing-sensu.md
@@ -96,6 +96,14 @@ backend-url:
 
 The agent will then connect Sensu servers over wss. Do note that by changing the configuration to wss, plaintext communication will not be possible.
 
+It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.
+
+You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 
+
+{{< highlight yaml>}}
+trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
+{{< /highlight >}}
+
 _NOTE: If creating a Sensu cluster, every cluster member needs to be present in the configuration. See the [Sensu Go clustering guide][2] for more information on how to configure agents for a clustered configuration._
 
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Closes #1097 by adding the following copy:
```
It is also possible to provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if starting the agent via `sensu-agent start`.

You you may include it as part of the agent configuration in `/etc/sensu/agent.yml` as: 

{{< highlight yaml>}}
trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
{{< /highlight >}}
```
