### PR TITLE
[Sensu 1.x] Add begin attribute to silencing reference

### DIFF
--- a/content/sensu-core/1.2/reference/silencing.md
+++ b/content/sensu-core/1.2/reference/silencing.md
@@ -217,6 +217,13 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+begin        |      |
+-------------|------|
+description  | Time at which the silence entry goes into effect, in UNIX epoch time. You can use the `begin` attribute to schedule a silencing entry for a planned maintenance.
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"begin": 1512512023{{< /highlight >}}
+
 ## Examples
 
 ### Silence all checks on a specific client

--- a/content/sensu-core/1.3/reference/silencing.md
+++ b/content/sensu-core/1.3/reference/silencing.md
@@ -217,6 +217,13 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+begin        |      |
+-------------|------|
+description  | Time at which the silence entry goes into effect, in UNIX epoch time. You can use the `begin` attribute to schedule a silencing entry for a planned maintenance.
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"begin": 1512512023{{< /highlight >}}
+
 ## Examples
 
 ### Silence all checks on a specific client

--- a/content/sensu-core/1.4/reference/silencing.md
+++ b/content/sensu-core/1.4/reference/silencing.md
@@ -217,6 +217,13 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+begin        |      |
+-------------|------|
+description  | Time at which the silence entry goes into effect, in UNIX epoch time. You can use the `begin` attribute to schedule a silencing entry for a planned maintenance.
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"begin": 1512512023{{< /highlight >}}
+
 ## Examples
 
 ### Silence all checks on a specific client

--- a/content/sensu-core/1.5/reference/silencing.md
+++ b/content/sensu-core/1.5/reference/silencing.md
@@ -217,6 +217,13 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+begin        |      |
+-------------|------|
+description  | Time at which the silence entry goes into effect, in UNIX epoch time. You can use the `begin` attribute to schedule a silencing entry for a planned maintenance.
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"begin": 1512512023{{< /highlight >}}
+
 ## Examples
 
 ### Silence all checks on a specific client

--- a/content/sensu-core/1.6/reference/silencing.md
+++ b/content/sensu-core/1.6/reference/silencing.md
@@ -217,6 +217,13 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+begin        |      |
+-------------|------|
+description  | Time at which the silence entry goes into effect, in UNIX epoch time. You can use the `begin` attribute to schedule a silencing entry for a planned maintenance.
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"begin": 1512512023{{< /highlight >}}
+
 ## Examples
 
 ### Silence all checks on a specific client


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Adds the `begin` attribute to allow users to schedule planned maintenance

To do:

- [ ] Copy to versions 1.2-1.6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #654 
