### PR TITLE
Fix enterprise command in install guide

### DIFF
--- a/content/sensu-go/5.2/installation/install-sensu.md
+++ b/content/sensu-go/5.2/installation/install-sensu.md
@@ -372,7 +372,7 @@ To learn more about enterprise features in Sensu Go, [contact the Sensu sales te
 If you already have an enterprise license, [log in to your Sensu account](https://account.sensu.io/) and download your license file, then activate your license using sensuctl.
 
 {{< highlight shell >}}
-sensuctl license install --file license.json
+sensuctl create --file license.json
 {{< /highlight >}}
 
 You can use sensuctl to view your license details at any time.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Remove reference to `sensuctl license install`