### PR TITLE
Fix TOC link to license instructions

### DIFF
--- a/content/sensu-go/5.2/reference/license.md
+++ b/content/sensu-go/5.2/reference/license.md
@@ -10,7 +10,7 @@ menu:
     parent: reference
 ---
 
-- [Activating your license](#enterprise-features-in-sensu-go)
+- [Activating your license](#activating-your-sensu-enterprise-license)
 - [License expiration](#license-expiration)
 - [License management API](../../api/license)
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fixes a broken link in the TOC in the license reference page.

## Motivation and Context
To be correct!

## Review Instructions
Pull down and ensure link works.
