### PR TITLE
Add response for health API

### DIFF
--- a/content/sensu-core/1.7/api/health-and-info.md
+++ b/content/sensu-core/1.7/api/health-and-info.md
@@ -90,8 +90,14 @@ Sensu servers which may be registered and processing check results._
 description    | Returns health information on transport & Redis connections.
 example url    | http://hostname:4567/health
 parameters     | <ul><li>`consumers`:<ul><li>**required**: true</li><li>**type**: Integer</li><li>**description**: The minimum number of transport consumers to be considered healthy</li><li>**notes**: not supported for Sensu installations using Redis as the transport</li></ul></li><li>`messages`:<ul><li>**required**: true</li><li>**type**: Integer</li><li>**description**: The maximum amount of transport queued messages to be considered healthy</li></ul></li></ul>
-response type  | [HTTP-header][11] only (no content)
+response type  | [HTTP-header][11] only (no content) or array
 response codes | <ul><li>**Success**: 204 (No Content)</li><li>**Error**: 412 (Precondition Failed)</li></ul>
+response body | {{< highlight json >}}
+[
+  "keepalive consumers (0) less than min_consumers (1000)",
+  "result consumers (0) less than min_consumers (1000)"
+]
+{{< /highlight >}}
 output         | {{< highlight shell >}}HTTP/1.1 412 Precondition Failed
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS

--- a/content/sensu-core/1.7/api/health-and-info.md
+++ b/content/sensu-core/1.7/api/health-and-info.md
@@ -92,7 +92,8 @@ example url    | http://hostname:4567/health
 parameters     | <ul><li>`consumers`:<ul><li>**required**: true</li><li>**type**: Integer</li><li>**description**: The minimum number of transport consumers to be considered healthy</li><li>**notes**: not supported for Sensu installations using Redis as the transport</li></ul></li><li>`messages`:<ul><li>**required**: true</li><li>**type**: Integer</li><li>**description**: The maximum amount of transport queued messages to be considered healthy</li></ul></li></ul>
 response type  | [HTTP-header][11] only (no content) or array
 response codes | <ul><li>**Success**: 204 (No Content)</li><li>**Error**: 412 (Precondition Failed)</li></ul>
-response body | {{< highlight json >}}
+response body  | If applicable, the health API includes a response body containing information about the unhealthy Sensu instance. For example:<ul><li>`not connected to redis`</li><li>`not connected to transport`</li><li>`keepalive messages (x) greater than max_messages (x)`</li><li>`result messages (x) greater than max_messages (x)`</li><li>`keepalive consumers (x) less than min_consumers (x)`</li><li>`result consumers (x) less than min_consumers (x)`</li></ul> See the Sensu reference docs to configure [Redis][12] and the [RabbitMQ transport][13], and visit the [RabbitMQ docs][14] for more information about messages and consumers. To detect unhealthy states and monitor RabbitMQ metrics, see the [guide to monitoring Sensu][15].
+response example | {{< highlight json >}}
 [
   "keepalive consumers (0) less than min_consumers (1000)",
   "result consumers (0) less than min_consumers (1000)"
@@ -240,3 +241,7 @@ output         | {{< highlight json >}}{
 [9]:  https://www.rabbitmq.com/
 [10]: http://redis.io/
 [11]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+[12]: ../../reference/redis
+[13]: ../../reference/rabbitmq
+[14]: https://www.rabbitmq.com/documentation.html
+[15]: ../../guides/monitor-the-monitor


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Documents new response body for the health API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Reference: https://github.com/sensu/sensu/pull/1934

## Review Instructions
<!--- Optional -->
- [x] Can we add instructions for each of the responses listed above? For example: If you get this response, go look at this doc.

Available responses:
- `not connected to redis`
  - https://docs.sensu.io/sensu-core/1.6/reference/redis/
- `not connected to transport`
  - https://docs.sensu.io/sensu-core/1.6/reference/rabbitmq/
- `keepalive messages (x) greater than max_messages (x)`
- `result messages (x) greater than max_messages (x)`
- `keepalive consumers (x) less than min_consumers (x)`
- `result consumers (x) less than min_consumers (x)`
