### PR TITLE
Use default namespace in entity reference examples

### DIFF
--- a/content/sensu-go/5.0/reference/entities.md
+++ b/content/sensu-go/5.0/reference/entities.md
@@ -49,7 +49,7 @@ For example, to create a proxy entity with a `url` label using sensuctl `create`
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "web",
+    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }
@@ -90,7 +90,7 @@ And update the `metadata` scope to include `labels`.
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "web",
+    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }

--- a/content/sensu-go/5.1/reference/entities.md
+++ b/content/sensu-go/5.1/reference/entities.md
@@ -49,7 +49,7 @@ For example, to create a proxy entity with a `url` label using sensuctl `create`
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "web",
+    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }
@@ -90,7 +90,7 @@ And update the `metadata` scope to include `labels`.
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "web",
+    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }

--- a/content/sensu-go/5.2/reference/entities.md
+++ b/content/sensu-go/5.2/reference/entities.md
@@ -49,7 +49,7 @@ For example, to create a proxy entity with a `url` label using sensuctl `create`
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "web",
+    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }
@@ -90,7 +90,7 @@ And update the `metadata` scope to include `labels`.
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "web",
+    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Closes #1214 

## Motivation and Context
While #1214 was opened and appears to be a bug in Sensu Go (https://github.com/sensu/sensu-go/issues/2739), this PR will remove the need for a `web` namespace in the entity reference as the concept described there doesn't need a 2nd one; the default namespace will work too.

## Review Instructions
<!--- Optional -->
