### PR TITLE
Add script installation to second section in monitoring external resources guide

### DIFF
--- a/content/sensu-go/5.0/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.0/guides/monitor-external-resources.md
@@ -135,7 +135,7 @@ Before we get started, go ahead and [install the HTTP check script][13] if you h
 
 ### Installing an HTTP check script
 
-First, we'll install a [bash script][4], named `http_check.sh`, to perform an HTTP
+If you haven't already, install a [bash script][4], named `http_check.sh`, to perform an HTTP
 check using **curl**.
 
 {{< highlight shell >}}

--- a/content/sensu-go/5.0/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.0/guides/monitor-external-resources.md
@@ -133,6 +133,21 @@ Now let's say that, instead of monitoring just sensu.io, we want to monitor mult
 In this section of the guide, we'll use the [`proxy_requests` check attribute][3], along with [entity labels][11] and [token substitution][12], to monitor three sites using the same check.
 Before we get started, go ahead and [install the HTTP check script][13] if you haven't already.
 
+### Installing an HTTP check script
+
+First, we'll install a [bash script][4], named `http_check.sh`, to perform an HTTP
+check using **curl**.
+
+{{< highlight shell >}}
+sudo curl https://raw.githubusercontent.com/sensu/sensu-go/5.1.0/examples/checks/http_check.sh \
+-o /usr/local/bin/http_check.sh && \
+sudo chmod +x /usr/local/bin/http_check.sh
+{{< /highlight >}}
+
+_PRO TIP: While this command may be appropriate when running a few agents, you should consider
+using [Sensu assets][5] or a [configuration management][15] tool to provide
+runtime dependencies._
+
 ### Creating proxy entities
 
 Instead of creating a proxy entity using the `proxy_entity_name` check attribute, we'll be using sensuctl to create proxy entities to represent the three sites we want to monitor.

--- a/content/sensu-go/5.1/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.1/guides/monitor-external-resources.md
@@ -133,6 +133,21 @@ Now let's say that, instead of monitoring just sensu.io, we want to monitor mult
 In this section of the guide, we'll use the [`proxy_requests` check attribute][3], along with [entity labels][11] and [token substitution][12], to monitor three sites using the same check.
 Before we get started, go ahead and [install the HTTP check script][13] if you haven't already.
 
+### Installing an HTTP check script
+
+If you haven't already, install a [bash script][4], named `http_check.sh`, to perform an HTTP
+check using **curl**.
+
+{{< highlight shell >}}
+sudo curl https://raw.githubusercontent.com/sensu/sensu-go/5.1.0/examples/checks/http_check.sh \
+-o /usr/local/bin/http_check.sh && \
+sudo chmod +x /usr/local/bin/http_check.sh
+{{< /highlight >}}
+
+_PRO TIP: While this command may be appropriate when running a few agents, you should consider
+using [Sensu assets][5] or a [configuration management][15] tool to provide
+runtime dependencies._
+
 ### Creating proxy entities
 
 Instead of creating a proxy entity using the `proxy_entity_name` check attribute, we'll be using sensuctl to create proxy entities to represent the three sites we want to monitor.

--- a/content/sensu-go/5.2/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.2/guides/monitor-external-resources.md
@@ -133,6 +133,21 @@ Now let's say that, instead of monitoring just sensu.io, we want to monitor mult
 In this section of the guide, we'll use the [`proxy_requests` check attribute][3], along with [entity labels][11] and [token substitution][12], to monitor three sites using the same check.
 Before we get started, go ahead and [install the HTTP check script][13] if you haven't already.
 
+### Installing an HTTP check script
+
+If you haven't already, install a [bash script][4], named `http_check.sh`, to perform an HTTP
+check using **curl**.
+
+{{< highlight shell >}}
+sudo curl https://raw.githubusercontent.com/sensu/sensu-go/5.1.0/examples/checks/http_check.sh \
+-o /usr/local/bin/http_check.sh && \
+sudo chmod +x /usr/local/bin/http_check.sh
+{{< /highlight >}}
+
+_PRO TIP: While this command may be appropriate when running a few agents, you should consider
+using [Sensu assets][5] or a [configuration management][15] tool to provide
+runtime dependencies._
+
 ### Creating proxy entities
 
 Instead of creating a proxy entity using the `proxy_entity_name` check attribute, we'll be using sensuctl to create proxy entities to represent the three sites we want to monitor.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add required script to monitoring multiple proxy entities section.

## Motivation and Context
As it stands, without a user going through each section in order, they will not get the required shell script needed in the second section. This adds those steps to the second section in case a user uses the TOC at the top to skip down.

Another solution would be to use an `asset` here, but that requires something in bonsai for http checking or another store on the internet.

## Review Instructions
Open to any suggestions on how no to repeat the same section on the same page but we might be stuck with this for now.

- [ ] Copy to all versions
