### PR TITLE
Document built-in deregistration extension

### DIFF
--- a/content/sensu-core/0.29/reference/clients.md
+++ b/content/sensu-core/0.29/reference/clients.md
@@ -822,7 +822,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1232,3 +1232,7 @@ information for operations teams can be extremely valuable._
 [48]: #deregistration-attributes
 [49]: ../../api/checks#the-request-api-endpoint
 [50]: #http-socket-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/0.29/reference/server.md
+++ b/content/sensu-core/0.29/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.0/reference/clients.md
+++ b/content/sensu-core/1.0/reference/clients.md
@@ -822,7 +822,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1232,3 +1232,7 @@ information for operations teams can be extremely valuable._
 [48]: #deregistration-attributes
 [49]: ../../api/checks#the-request-api-endpoint
 [50]: #http-socket-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.0/reference/server.md
+++ b/content/sensu-core/1.0/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.1/reference/clients.md
+++ b/content/sensu-core/1.1/reference/clients.md
@@ -830,7 +830,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1240,3 +1240,7 @@ information for operations teams can be extremely valuable._
 [48]: #deregistration-attributes
 [49]: ../../api/checks#the-request-api-endpoint
 [50]: #http-socket-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.1/reference/server.md
+++ b/content/sensu-core/1.1/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.2/reference/clients.md
+++ b/content/sensu-core/1.2/reference/clients.md
@@ -830,7 +830,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1240,3 +1240,7 @@ information for operations teams can be extremely valuable._
 [48]: #deregistration-attributes
 [49]: ../../api/checks#the-request-api-endpoint
 [50]: #http-socket-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.2/reference/server.md
+++ b/content/sensu-core/1.2/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.3/reference/clients.md
+++ b/content/sensu-core/1.3/reference/clients.md
@@ -838,7 +838,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1248,3 +1248,7 @@ information for operations teams can be extremely valuable._
 [48]: #deregistration-attributes
 [49]: ../../api/checks#the-request-api-endpoint
 [50]: #http-socket-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.3/reference/server.md
+++ b/content/sensu-core/1.3/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.4/reference/clients.md
+++ b/content/sensu-core/1.4/reference/clients.md
@@ -838,7 +838,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1248,3 +1248,7 @@ information for operations teams can be extremely valuable._
 [48]: #deregistration-attributes
 [49]: ../../api/checks#the-request-api-endpoint
 [50]: #http-socket-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.4/reference/server.md
+++ b/content/sensu-core/1.4/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.5/reference/clients.md
+++ b/content/sensu-core/1.5/reference/clients.md
@@ -854,7 +854,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1340,3 +1340,7 @@ information for operations teams can be extremely valuable._
 [63]: #opsgenie-attributes
 [64]: /sensu-enterprise/latest/integrations/opsgenie
 [65]: ../checks#influxdb-attributes
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.5/reference/server.md
+++ b/content/sensu-core/1.5/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.6/reference/clients.md
+++ b/content/sensu-core/1.6/reference/clients.md
@@ -867,7 +867,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. To add a deregistration handler to Sensu, install [Sensu Plugins Sensu][68] to use the [`handler-sensu-deregister.rb` handler][69] or [upgrade][70] to Sensu Core [1.7 or later][71] to use the built-in deregistration extension.
 required     | false
 type         | String
 default      | `deregistration`
@@ -1355,3 +1355,7 @@ information for operations teams can be extremely valuable._
 [65]: ../checks#influxdb-attributes
 [66]: ../../api/clients/#clientsclient-delete
 [67]: ../../platforms
+[68]: https://github.com/sensu-plugins/sensu-plugins-sensu
+[69]: https://github.com/sensu-plugins/sensu-plugins-sensu/blob/master/bin/handler-sensu-deregister.rb
+[70]: /sensu-core/1.7/installation/upgrading/#upgrading-the-sensu-package
+[71]: /sensu-core/1.7/changelog/#core-v1-7-0

--- a/content/sensu-core/1.6/reference/server.md
+++ b/content/sensu-core/1.6/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu

--- a/content/sensu-core/1.7/reference/clients.md
+++ b/content/sensu-core/1.7/reference/clients.md
@@ -112,7 +112,8 @@ registration events are logged in the [Sensu server][5] log._
 
 Similarly to registration events, Sensu can create and process a deregistration event when the Sensu client process stops.
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
-To enable deregistration events, set the `deregister` flag to `true` and specify the event handler using the [`deregistration` definition scope][48].
+By default, registration events trigger the built-in deregistration extension.
+To enable deregistration events, set the client `deregister` flag to `true` and specify the event handler using the client [`deregistration` definition scope][48].
 
 #### Proxy clients
 
@@ -873,7 +874,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event. By default, Sensu uses the built-in deregistration extension to remove clients from Sensu when a client process stops.
+description  | The deregistration handler that should process the client deregistration event. By default, Sensu uses the built-in deregistration extension to remove clients from Sensu when a client process stops. To configure the host and port used by the deregistration extension, see the [configuration reference][68].
 required     | false
 type         | String
 default      | `deregistration`
@@ -1361,3 +1362,4 @@ information for operations teams can be extremely valuable._
 [65]: ../checks#influxdb-attributes
 [66]: ../../api/clients/#clientsclient-delete
 [67]: ../../platforms
+[68]: ../configuration

--- a/content/sensu-core/1.7/reference/clients.md
+++ b/content/sensu-core/1.7/reference/clients.md
@@ -15,7 +15,7 @@ menu:
 - [Client keepalives](#client-keepalives)
   - [What is a client keepalive?](#what-is-a-client-keepalive)
   - [Client registration & the client registry](#registration-and-registry)
-    - [Registration events](#registration-events)
+    - [Registration and deregistration events](#registration-events)
     - [Proxy clients](#proxy-clients)
   - [How are keepalive events created?](#keepalive-events)
   - [Client keepalive configuration](#client-keepalive-configuration)
@@ -107,6 +107,12 @@ attributes][31], below.
 _WARNING: registration events are not stored in the event registry (in the Sensu
 [data store][8]), so they are not accessible via the Sensu API; however, all
 registration events are logged in the [Sensu server][5] log._
+
+#### Deregistration events
+
+Similarly to registration events, Sensu can create and process a deregistration event when the Sensu client process stops.
+You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
+To enable deregistration events, set the `deregister` flag to `true` and specify the event handler using the [`deregistration` definition scope][48].
 
 #### Proxy clients
 
@@ -867,7 +873,7 @@ provided as recommendations for controlling client deregistration behavior._
 
 handler      | 
 -------------|------
-description  | The deregistration handler that should process the client deregistration event.
+description  | The deregistration handler that should process the client deregistration event. By default, Sensu uses the built-in deregistration extension to remove clients from Sensu when a client process stops.
 required     | false
 type         | String
 default      | `deregistration`

--- a/content/sensu-core/1.7/reference/configuration.md
+++ b/content/sensu-core/1.7/reference/configuration.md
@@ -745,6 +745,19 @@ example      | {{< highlight json >}}{
 }
 {{< /highlight >}}
 
+deregistration | 
+-------------|------
+description  | Host and port configuration for the built-in deregistration extension. By default, the deregistration extension communicates with the Sensu API running on 127.0.0.1 port 4567.
+required     | false
+type         | Hash
+example      | {{< highlight json >}}{
+  "deregistration": {
+    "host": "10.0.0.1",
+    "port": 14567
+  }
+}
+{{< /highlight >}}
+
 ## Sensu definition specification
 
 Sensu uses the `"sensu": {}` definition scope.

--- a/content/sensu-core/1.7/reference/server.md
+++ b/content/sensu-core/1.7/reference/server.md
@@ -67,7 +67,7 @@ servers &ndash; check requests for a given check (based on the check name) will
 be published at the <abbr title="typically accurate within 500ms">exact same
 time</abbr>. The also means that in the event of a Sensu server restart and/or
 Sensu server task re-election (i.e. if a new Sensu server is elected
-to become reponsible for check execution scheduling), check execution
+to become responsible for check execution scheduling), check execution
 scheduling intervals will remain consistent.
 
 In fact, because this algorithm is also shared by the Sensu client &ndash; which
@@ -137,7 +137,7 @@ the cluster will force a redistribution of tasks.
   responsible for monitoring check aggregates and pruning stale
   aggregate results.
 
-To observe which Sensu server is currently reponsible for one or more
+To observe which Sensu server is currently responsible for one or more
 tasks, see [API /info][23].
 
 ## Scaling Sensu


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Clarifies install process for deregistration handler in v1.6 and earlier
- Calls out built-in deregistration extension in v1.7

To do:
- [x] Copy to v1.5 and earlier
- [x] Add extensions config
