### PR TITLE
remove husky and precommit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "devDependencies": {
     "conzole": "^0.2.0",
     "grunt": "^1.0.1",
-    "husky": "^0.14.3",
     "js-yaml": "^3.9.1",
     "string": "^3.3.3",
     "toml": "^2.3.2",
@@ -16,7 +15,6 @@
   },
   "scripts": {
     "postinstall": "grunt",
-    "precommit": "grunt",
     "server": "grunt server",
     "hugo-version": "grunt hugo-version",
     "test": "bin/test"


### PR DESCRIPTION
## Description

Remove husky dependency and `precommit` script from package.json

## Motivation and Context

Closes #881

Once this change is applied, it may be necessary for folks to run `node ./node_modules/husky/bin/uninstall.js` to remove existing git hooks.
