### PR TITLE
Enable HTTPS for Sensu Enterprise repo URLs

### DIFF
--- a/content/sensu-core/0.29/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/0.29/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/0.29/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/0.29/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/0.29/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/0.29/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.0/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.0/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.0/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.0/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.0/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.0/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.1/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.1/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.1/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.1/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.1/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.1/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.2/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.2/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.2/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.2/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.2/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.2/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.3/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.3/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.3/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.3/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.3/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.3/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.4/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.4/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.4/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.4/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.4/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.4/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.5/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.5/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.5/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.5/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.5/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.5/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.6/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.6/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.6/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.6/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.6/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.6/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-core/1.7/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.7/platforms/sensu-on-rhel-centos.md
@@ -128,7 +128,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -162,7 +162,7 @@ $ echo $SE_USER:$SE_PASS
    {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-core/1.7/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.7/platforms/sensu-on-ubuntu-debian.md
@@ -126,23 +126,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise:
+6. Install Sensu Enterprise:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise{{< /highlight >}}
 
-6. Configure Sensu Enterprise. **No "default" configuration is provided with
+7. Configure Sensu Enterprise. **No "default" configuration is provided with
    Sensu Enterprise**, so Sensu Enterprise will run without the corresponding
    configuration. Please refer to the ["Configure Sensu" section][11] (below)
    for more information on configuring Sensu Enterprise.
@@ -162,23 +167,28 @@ SE_PASS=PASSWORD{{< /highlight >}}
 $ echo $SE_USER:$SE_PASS
 1234567890:PASSWORD{{< /highlight >}}
 
-2. Install the GPG public key:
+2. Install the `apt-transport-https` package:
+{{< highlight shell >}}
+sudo apt-get install apt-transport-https
+{{< /highlight >}}
+
+3. Install the GPG public key:
    {{< highlight shell >}}
 wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
-3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
+4. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
 echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
-4. Update APT:
+5. Update APT:
    {{< highlight shell >}}
 sudo apt-get update{{< /highlight >}}
 
-5. Install Sensu Enterprise Dashboard:
+6. Install Sensu Enterprise Dashboard:
    {{< highlight shell >}}
 sudo apt-get install sensu-enterprise-dashboard{{< /highlight >}}
 
-6. Configure Sensu Enterprise Dashboard. **The default configuration
+7. Configure Sensu Enterprise Dashboard. **The default configuration
    will not work without modification** Please refer to the
    ["Example Sensu Enterprise Dashboard configurations" section][18] (below) for more information on
    configuring Sensu Enterprise Dashboard.

--- a/content/sensu-core/1.7/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.7/platforms/sensu-on-ubuntu-debian.md
@@ -128,11 +128,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}
@@ -164,11 +164,11 @@ $ echo $SE_USER:$SE_PASS
 
 2. Install the GPG public key:
    {{< highlight shell >}}
-wget -q http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
+wget -q https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt/pubkey.gpg -O- | sudo apt-key add -{{< /highlight >}}
 
 3. Create an APT configuration file at `/etc/apt/sources.list.d/sensu-enterprise.list`:
    {{< highlight shell >}}
-echo "deb     http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
+echo "deb     https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/apt sensu-enterprise main" | sudo tee /etc/apt/sources.list.d/sensu-enterprise.list{{< /highlight >}}
 
 4. Update APT:
    {{< highlight shell >}}

--- a/content/sensu-enterprise/2.6/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/2.6/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-enterprise/2.7/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/2.7/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-enterprise/2.8/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/2.8/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-enterprise/3.0/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/3.0/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-enterprise/3.1/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/3.1/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-enterprise/3.2/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/3.2/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}

--- a/content/sensu-enterprise/3.3/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/3.3/quick-start/five-minute-install.md
@@ -66,7 +66,7 @@ Add the Sensu Enterprise repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise]
 name=sensu-enterprise
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/noarch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise.repo{{< /highlight >}}
@@ -76,7 +76,7 @@ Add the Sensu Enterprise Dashboard repository:
 {{< highlight shell >}}
 echo "[sensu-enterprise-dashboard]
 name=sensu-enterprise-dashboard
-baseurl=http://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
+baseurl=https://$SE_USER:$SE_PASS@enterprise.sensuapp.com/yum/\$basearch/
 gpgkey=https://repositories.sensuapp.org/yum/pubkey.gpg
 gpgcheck=1
 enabled=1" | sudo tee /etc/yum.repos.d/sensu-enterprise-dashboard.repo{{< /highlight >}}


### PR DESCRIPTION
## Description

Replace all plaintext HTTP links to `enterprise.sensuapp.com` with corresponding HTTPS links.

## Motivation and Context

HTTPS is superior to plaintext HTTP.
