### PR TITLE
Add link for sensu core/sensu client on SE installation page

### DIFF
--- a/content/sensu-enterprise/2.6/installation/overview.md
+++ b/content/sensu-enterprise/2.6/installation/overview.md
@@ -61,7 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
-4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/2.6/installation/overview.md
+++ b/content/sensu-enterprise/2.6/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/2.7/installation/overview.md
+++ b/content/sensu-enterprise/2.7/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/2.8/installation/overview.md
+++ b/content/sensu-enterprise/2.8/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/3.0/installation/overview.md
+++ b/content/sensu-enterprise/3.0/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/3.1/installation/overview.md
+++ b/content/sensu-enterprise/3.1/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/3.2/installation/overview.md
+++ b/content/sensu-enterprise/3.2/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-enterprise/3.3/installation/overview.md
+++ b/content/sensu-enterprise/3.3/installation/overview.md
@@ -46,6 +46,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-rhel-centos)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-rhel-centos)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-rhel-centos/#sensu-core)
 
 {{< platformBlockClose >}}
 
@@ -60,6 +61,7 @@ please complete the following sections of the Sensu installation guide:
 1. [Install and Configure Redis](/sensu-core/latest/installation/install-redis-on-ubuntu-debian)
 2. [Install and Configure RabbitMQ](/sensu-core/latest/installation/install-rabbitmq-on-ubuntu-debian)
 3. [Install Sensu Enterprise](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
+4. [Install Sensu Core (to get Sensu Client)](/sensu-core/latest/platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 {{< platformBlockClose >}}
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Adds a link to say that Sensu Core is required as it provides the Sensu Client.

## Motivation and Context
Closes #1228

## Review Instructions
- [x] Copy to all versions
