### PR TITLE
Remove link to deprecated Uchiwa docs

### DIFF
--- a/layouts/partials/productVersionDrawer.html
+++ b/layouts/partials/productVersionDrawer.html
@@ -36,11 +36,7 @@
       <ul class="hiddenItems">
         {{ range sort .Site.Params.Products "weight" }} 
           {{ $.Scratch.Set "url" "" }}
-          {{ if eq .identifier "uchiwa" }}
-            {{ $.Scratch.Set "url" "https://docs.uchiwa.io/" }}
-          {{ else }}
             {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
-          {{ end }}
           {{ $url := $.Scratch.Get "url" }}
           <li class="hiddenItem"><a href="{{ $url }}">{{ .name }}</a></li>
         {{ end }}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
This PR removes a link to the deprecated Uchiwa docs site from the product drawer partial.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1249 

## Review instructions
Run locally and decrease window width until the sidebar collapses, then switch to the Uchiwa docs.