### PR TITLE
Update event API and reference docs

### DIFF
--- a/content/sensu-go/5.0/api/events.md
+++ b/content/sensu-go/5.0/api/events.md
@@ -171,72 +171,73 @@ output         | {{< highlight shell >}}
 
 ### `/events` (POST)
 
-/events (POST) | 
-----------------|------
-description     | Create a Sensu event.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
-payload         | {{< highlight shell >}}
-{
-  "timestamp": 1542667666,
+The `/events` API endpoint provides HTTP POST access to create an event and send it to the Sensu pipeline.
+
+#### EXAMPLE {#events-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/events` API to create an event.
+The request includes information about the check and entity represented by the event and returns a successful HTTP 200 OK response and the event definition.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
   "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "...": "...",
-      "arch": "amd64"
-    },
-    "subscriptions": [
-      "testing",
-      "entity:webserver01"
-    ],
+    "entity_class": "proxy",
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server1",
+      "namespace": "default"
     }
   },
   "check": {
-    "check_hooks": null,
-    "duration": 2.033888684,
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
-    "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "output": "",
+    "output": "Server error",
     "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events
+
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+#### API Specification {#events-post-specification}
+
+/events (POST) | 
+----------------|------
+description     | Create a Sensu event for a new entity and check combination. To create an event for an existing entity and check combination or to update an existing event, use the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
+payload         | {{< highlight shell >}}
+{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "state": "failing",
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section for the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Conflict**: 409 (Event already exists for the entity and check)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/events/:entity` API endpoint {#the-eventsentity-api-endpoint}
 
@@ -464,64 +465,209 @@ output               | {{< highlight json >}}
 
 ### `/events/:entity/:check` (PUT) {#eventsentitycheck-put}
 
+The `/events/:entity/:check` API endpoint provides HTTP PUT access to create or update an event and send it to the Sensu pipeline.
+
 #### EXAMPLE {#eventsentitycheck-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `sensu-go-entity` entity and the `check-cpu` check, resulting in a 200 (OK) HTTP response code.
+In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `server1` entity and the `server-health` check and process it using the `slack` event handler.
+The event includes a status code of `1`, indicating a warning, and an output message of "Server error".
 
 {{< highlight shell >}}
 curl -X PUT \
 -H "Authorization: Bearer TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
-
-HTTP/1.1 200 OK
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
 
+The request returns a 200 (OK) HTTP response code and the resulting event definition.
+
+{{< highlight shell >}}
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+You can use sensuctl or the [Sensu dashboard](../../dashboard/overview) to see the event.
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+You should see the event with the status and output specified in the request.
+
+{{< highlight shell >}}
+    Entity        Check                   Output                 Status   Silenced             Timestamp            
+────────────── ──────────── ─────────────────────────────────── ──────── ────────── ─────────────────────────────── 
+    server1      server-health   Server error             1      false      2019-03-14 16:56:09 +0000 UTC 
+{{< /highlight >}}
 
 #### API Specification {#eventsentitycheck-put-specification}
 
 /events/:entity/:check (PUT) | 
 ----------------|------
 description     | Creates an event for a given entity and check.
-example url     | http://hostname:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
+example url     | http://hostname:8080/api/core/v2/namespaces/default/events/server1/server-health
 payload         | {{< highlight shell >}}
 {
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}
+{{< /highlight >}}
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section below.
+response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+#### Payload parameters {#eventsentitycheck-put-parameters}
+
+The `/events/:entity/:check` PUT endpoint requires a request payload containing an `entity` scope and a `check` scope.
+The `entity` scope contains information about the component of your infrastructure represented by the event.
+At a minimum, Sensu requires the `entity` scope to contain the `entity_class` (`agent` or `proxy`) and the entity `name` and `namespace` within a `metadata` scope.
+For more information about entity attributes, see the [entity specification](../../reference/entities#specification).
+
+The `check` scope contains information about the event status and how the event was created.
+At a minimum, Sensu requires the `check` scope to contain a `name` within a `metadata` scope and either an `interval` or `cron` attribute.
+For more information about check attributes, see the [check specification](../../reference/checks#specification).
+
+**Example request with minimum required event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
   }
-}
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
-payload parameters | <ul><li>`timestamp` (required, integer): Unix timestamp for the event, for example `1542667666`</li><li>`entity` scope containing the `entity_class` and a `metadata` scope containing `name` (string) and `namespace` (string)</li><li>`check` scope containing `interval` (integer) or `cron` (string), and a `metadata` scope containing `name` (string) and `namespace` (string)</li>
-response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+The minimum required attributes shown above let you create an event using the `/events/:entity/:check` PUT endpoint, however the request can include any attributes defined in the [event specification](../../reference/events).
+To create useful, actionable events, we recommend adding check attributes such as the event `status` (`0` for OK, `1` for warning, `2` for critical), an `output` message, and one or more event `handlers`.
+For more information about these attributes and their available values, see the [event specification](../../reference/events).
+
+While a `timestamp` is not required to create an event, Sensu assigns a timestamp of `0` (January 1, 1970) to events without a specified timestamp, so we recommend adding a Unix timestamp when creating events.
+
+**Example request with minimum recommended event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
+{{< /highlight >}}
+
+#### Creating metric events
+
+In addition to the `entity` and `check` scopes, Sensu events can include a `metrics` scope containing metrics in Sensu metric format.
+See the [events reference](../../reference/events#metrics) and for more information about Sensu metric format.
+
+**Example request including metrics**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "status": 0,
+    "output_metric_handlers": ["influxdb"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-metrics"
+    }
+  },
+  "metrics": {
+    "handlers": [
+      "influxdb"
+    ],
+    "points": [
+      {
+        "name": "server1.server-metrics.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "server1.server-metrics.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-metrics
+{{< /highlight >}}
 
 ### `/events/:entity/:check` (DELETE) {#eventsentitycheck-delete}
 

--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -10,10 +10,22 @@ menu:
     parent: reference
 ---
 
-- [Specification](#events-specification)
-- [Examples](#example-check-only-event-data)
+- [How do events work?](#how-do-events-work)
+- [Creating events using the Sensu agent](#creating-events-using-the-sensu-agent)
+- [Creating events using the events API](#creating-events-using-the-events-api)
+- [Managing events](#managing-events)
+  - [Deleting events](#deleting-events)
+  - [Resolving events](#resolving-events)
+- [Event format](#event-format)
+- [Using event data](#using-event-data)
+- [Events specification](#events-specification)
+	- [Top-level attributes](#top-level-attributes)
+	- [Spec attributes](#spec-attributes)
+	- [Check attributes](#check-attributes)
+	- [Metric attributes](#metric-attributes)
+- [Examples](#examples)
 
-## How do Events work?
+## How do events work?
 
 An event is a generic container used by Sensu to provide context to checks
 and/or metrics. The context, called "event data," contains information about the
@@ -23,7 +35,7 @@ These generic containers allow Sensu to handle different types of events in the
 pipeline. Since events are polymorphic in nature, it is important to never
 assume their contents, or lack-thereof.
 
-## Check-only events
+### Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu
 server, regardless of the status indicated by the check result. An event is
@@ -33,7 +45,7 @@ forwarded to the Sensu backend for processing. Potentially noteworthy events may
 be processed by one or more event handlers to do things such as send an email or
 invoke an automated action.
 
-## Metric-only events
+### Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the
 [Statsd listener][5]. The agent will translate the statsd metrics to Sensu
@@ -41,7 +53,7 @@ Metric Format, and place them inside an event. These events, since they do not
 contain checks, bypass the store, and are sent off to the event pipeline and
 corresponding event handlers.
 
-## Check and metric events
+### Check and metric events
 
 Events that contain _both_ a check and metrics, most likely originated from
 [check output metric extraction][6]. If a check is configured for metric
@@ -50,186 +62,195 @@ Metric Format. Both the check results, and resulting (extracted) metrics are
 stored inside the event. Event handlers from `event.Check.Handlers` and
 `event.Metrics.Handlers` will be invoked.
 
+## Creating events using the Sensu agent
+
+The Sensu agent is a powerful event producer and monitoring automation tool.
+You can use Sensu agents to produce events automatically using service checks and metric checks.
+Sensu agents can also act as a collector for metrics throughout your infrastructure.
+
+- [Creating events using service checks](../agent#creating-monitoring-events-using-service-checks)
+- [Creating events using metric checks](../../guides/extract-metrics-with-checks)
+- [Creating events using the agent API](../agent#creating-monitoring-events-using-the-agent-api)
+- [Creating events using the agent TCP and UDP sockets](../agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets)
+- [Creating events using the StatsD listener](../agent#creating-monitoring-events-using-the-statsd-listener)
+
+## Creating events using the events API
+
+You can send events directly to the Sensu pipeline using the events API.
+To create an event, send a JSON event definition to the [events API PUT endpoint](../../api/events#eventsentitycheck-put).
+
+## Managing events
+
+You can manage event using the [Sensu dashboard](../../dashboard/overview), [events API](../../api/events), and the [sensuctl](../../sensuctl/reference) command line tool.
+
+### Viewing events
+
+To list all events:
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+To show event details in the default [output format](../../sensuctl/reference/#preferred-output-format):
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name
+{{< /highlight >}}
+
+With both the `list` and `info` commands, you can specify an [output format](../../sensuctl/reference/#preferred-output-format) using the `--format` flag:
+
+- `yaml` or `wrapped-json` formats for use with [`sensuctl create`][sc]
+- `json` format for use with the [events API](../../api/events)
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name --format yaml
+{{< /highlight >}}
+
+### Deleting events
+
+To delete an event:
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name
+{{< /highlight >}}
+
+You can use the `--skip-confirm` flag to skip the confirmation step.
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name --skip-confirm
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Deleted
+{{< /highlight >}}
+
+### Resolving events
+
+You can use sensuctl to change the status of an event to `0` (OK).
+Events resolved by sensuctl include the output message: "Resolved manually by sensuctl".
+
+{{< highlight shell >}}
+sensuctl event resolve entity-name check-name
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Resolved
+{{< /highlight >}}
+
+## Event format
+
+Sensu events contain:
+
+- `entity` scope (required)
+  - Information about the source of the event, including any attributes defined in the [entity specification](../entities#entities-specification)
+- `check` scope (optional if the `metrics` scope is present)
+  - Information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification)
+  - Information about the event and its history, including any check attributes defined in the [event specification on this page](#check-attributes)
+- `metrics` scope (optional if the `check` scope is present)
+  - Metric points in [Sensu metric format](#metrics)
+- `timestamp`
+  - Time that the event occurred in seconds since the Unix epoch
+
+## Using event data
+
+Event data is powerful tool for automating monitoring workflows.
+For example, see [the guide to reducing alert fatigue](guides/reduce-alert-fatigue/) by filtering events based on the event `occurrences` attribute.
+
 ## Events specification
 
-### Attributes
-|timestamp   |      |
--------------|------
-description  | The time of the Event occurrence in epoch time.
-type         | integer
-example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+### Top-level attributes
 
-|silenced (deprecated)    |      |
+type         | 
 -------------|------
-description  | If the event is to be silenced.
-type         | boolean
-example      | {{< highlight shell >}}"silenced": false{{< /highlight >}}
-_NOTE: Silenced has been deprecated from Event. Please see [check specification][7]._
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Events should always be of type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Event"{{< /highlight >}}
 
-|check       |      |
+api_version  | 
 -------------|------
-description  | The [check attributes][1] used to obtain the check result.
-type         | Check
+description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.0, this attribute should always be `core/v2`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level scope containing the event `namespace`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference](#metadata-attributes) for details.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "namespace": "default"
+}{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the event [spec attributes][sp].
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
 example      | {{< highlight shell >}}
-{
+"spec": {
   "check": {
     "check_hooks": null,
-    "duration": 1.903135228,
-    "executed": 1522100915,
+    "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
     "high_flap_threshold": 0,
     "history": [
       {
-        "executed": 1522100315
+        "executed": 1552505833,
+        "status": 0
       },
       {
-        "executed": 1522100915
+        "executed": 1552505843,
+        "status": 0
       }
     ],
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
+    "interval": 10,
+    "issued": 1552506033,
+    "last_ok": 1552506033,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "executed": 1542667666,
-    "history": [
-      {
-        "status": 1,
-        "executed": 1542667666
-      }
-    ],
-    "issued": 1542667666,
-    "output": "",
-    "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
     "occurrences": 1,
     "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
-    "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
-}
-{{< /highlight >}}
-
-<a name="metrics">
-
-|metrics     |      |
--------------|------
-description  | The metrics collected by the entity.
-type         | Metrics
-example      | {{< highlight json >}}
-{
-  "metrics": {
-    "handlers": [
+    "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+    "output_metric_format": "graphite_plaintext",
+    "output_metric_handlers": [
       "influx-db"
     ],
-    "points": [
-      {
-        "name": "weather.temperature",
-        "value": 82,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      },
-      {
-        "name": "weather.humidity",
-        "value": 30,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      }
-    ]
-  }
-}
-{{< /highlight >}}
-
-|entity      |      |
--------------|------
-description  | The [entity attributes][2] from the originating entity (agent or proxy).
-type         | Entity
-example      | {{< highlight json >}}
-{
-  "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "os": "linux",
-      "platform": "centos",
-      "platform_family": "rhel",
-      "platform_version": "7.4.1708",
-      "network": {
-        "interfaces": [
-          {
-            "name": "lo",
-            "addresses": [
-              "127.0.0.1/8",
-              "::1/128"
-            ]
-          },
-          {
-            "name": "enp0s3",
-            "mac": "08:00:27:11:ad:d2",
-            "addresses": [
-              "10.0.2.15/24",
-              "fe80::26a5:54ec:cf0d:9704/64"
-            ]
-          },
-          {
-            "name": "enp0s8",
-            "mac": "08:00:27:bc:be:60",
-            "addresses": [
-              "172.28.128.3/24",
-              "fe80::a00:27ff:febc:be60/64"
-            ]
-          }
-        ]
-      },
-      "arch": "amd64"
-    },
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "testing",
-      "entity:webserver01"
+      "entity:sensu-go-sandbox"
     ],
-    "last_seen": 1542667635,
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  },
+  "entity": {
     "deregister": false,
     "deregistration": {},
-    "user": "agent",
+    "entity_class": "agent",
+    "last_seen": 1552495139,
+    "metadata": {
+      "name": "sensu-go-sandbox",
+      "namespace": "default"
+    },
     "redact": [
       "password",
       "passwd",
@@ -241,75 +262,464 @@ example      | {{< highlight json >}}
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
+    "subscriptions": [
+      "entity:sensu-go-sandbox"
+    ],
+    "system": {
+      "arch": "amd64",
+      "hostname": "sensu-go-sandbox",
+      "network": {
+        "interfaces": [
+          {
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ],
+            "name": "lo"
+          },
+          {
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::5a94:f67a:1bfc:a579/64"
+            ],
+            "mac": "08:00:27:8b:c9:3f",
+            "name": "eth0"
+          }
+        ]
+      },
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804"
+    },
+    "user": "agent"
+  },
+  "metrics": {
+    "handlers": [
+      "influx-db"
+    ],
+    "points": [
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552506033
 }
 {{< /highlight >}}
 
-## Example check-only event data
+### Metadata attributes
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][26] that this event belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+### Spec attributes
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred in seconds since the Unix epoch
+required     | false
+type         | Integer
+default      | `0`
+example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+
+|entity      |      |
+-------------|------
+description  | The [entity attributes][2] from the originating entity (agent or proxy).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"entity": {
+  "deregister": false,
+  "deregistration": {},
+  "entity_class": "agent",
+  "last_seen": 1552495139,
+  "metadata": {
+    "name": "sensu-go-sandbox",
+    "namespace": "default"
+  },
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "system": {
+    "arch": "amd64",
+    "hostname": "sensu-go-sandbox",
+    "network": {
+      "interfaces": [
+        {
+          "addresses": [
+            "127.0.0.1/8",
+            "::1/128"
+          ],
+          "name": "lo"
+        },
+        {
+          "addresses": [
+            "10.0.2.15/24",
+            "fe80::5a94:f67a:1bfc:a579/64"
+          ],
+          "mac": "08:00:27:8b:c9:3f",
+          "name": "eth0"
+        }
+      ]
+    },
+    "os": "linux",
+    "platform": "centos",
+    "platform_family": "rhel",
+    "platform_version": "7.5.1804"
+  },
+  "user": "agent"
+}
+{{< /highlight >}}
+
+|check       |      |
+-------------|------
+description  | The [check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification](#check-attributes) and the [check specification](../checks#check-specification).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"check": {
+  "check_hooks": null,
+  "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+  "duration": 0.060790838,
+  "env_vars": null,
+  "executed": 1552506033,
+  "handlers": [],
+  "high_flap_threshold": 0,
+  "history": [
+    {
+      "executed": 1552505833,
+      "status": 0
+    },
+    {
+      "executed": 1552505843,
+      "status": 0
+    }
+  ],
+  "interval": 10,
+  "issued": 1552506033,
+  "last_ok": 1552506033,
+  "low_flap_threshold": 0,
+  "metadata": {
+    "name": "curl_timings",
+    "namespace": "default"
+  },
+  "occurrences": 1,
+  "occurrences_watermark": 1,
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005",
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+  "proxy_entity_name": "",
+  "publish": true,
+  "round_robin": false,
+  "runtime_assets": [],
+  "state": "passing",
+  "status": 0,
+  "stdin": false,
+  "subdue": null,
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "timeout": 0,
+  "total_state_change": 0,
+  "ttl": 0
+}
+{{< /highlight >}}
+
+<a name="metrics"></a>
+
+|metrics     |      |
+-------------|------
+description  | The metrics collected by the entity in Sensu metric format. See the [metrics attributes](#metric-attributes).
+type         | Map
+required     | false
+example      | {{< highlight shell >}}
+"metrics": {
+  "handlers": [
+    "influx-db"
+  ],
+  "points": [
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_total",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.005
+    },
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.004
+    }
+  ]
+}
+{{< /highlight >}}
+
+### Check attributes
+
+Sensu events include a `check` scope containing information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification), and information about the event and its history, including the attributes defined below.
+
+duration     |      |
+-------------|------
+description  | Command execution time in seconds
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
+
+executed     |      |
+-------------|------
+description  | Time that the check request was executed
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+history      |      |
+-------------|------
+description  | Check status history for the last 21 check executions. See the [history attributes](#history-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"history": [
+  {
+    "executed": 1552505983,
+    "status": 0
+  },
+  {
+    "executed": 1552505993,
+    "status": 0
+  }
+]
+{{< /highlight >}}
+
+issued       |      |
+-------------|------
+description  | Time that the check request was issued in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"issued": 1552506033{{< /highlight >}}
+
+last_ok      |      |
+-------------|------
+description  | The last time that the check returned an OK `status` (`0`) in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"last_ok": 1552506033{{< /highlight >}}
+
+occurrences  |      |
+-------------|------
+description  | The number of times an event with the same status has occurred for the given entity and check
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"occurrences": 1{{< /highlight >}}
+
+occurrences_watermark | |
+-------------|------
+description  | The highest number of occurrences for the given entity and check at the current status
+required     | false 
+type         | Integer
+example      | {{< highlight shell >}}"occurrences_watermark": 1{{< /highlight >}}\
+
+output       |      |
+-------------|------
+description  | The output from the execution of the check command
+required     | false
+type         | String
+example      | {{< highlight shell >}}
+"output": "sensu-go-sandbox.curl_timings.time_total 0.005"
+{{< /highlight >}}
+
+state         |      |
+-------------|------
+description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+total_state_change | |
+-------------|------
+description  | The total state change percentage for the check's history
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"total_state_change": 0{{< /highlight >}}
+
+#### History attributes
+
+executed     |      |
+-------------|------
+description  |Time that the check request was executed in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+### Metric attributes
+
+handlers     |      |
+-------------|------
+description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"handlers": [
+  "influx-db"
+]
+{{< /highlight >}}
+
+points       |      |
+-------------|------
+description  | Metric data points including a name, timestamp, value, and tags. See the [points attributes](#points-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"points": [
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_total",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.005
+  },
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.004
+  }
+]
+{{< /highlight >}}
+
+#### Points attributes
+
+name         |      |
+-------------|------
+description  | The metric name in the format `$entity.$check.$metric` where `$entity` is the entity name, `$check` is the check name, and `$metric` is the metric name.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"name": "sensu-go-sandbox.curl_timings.time_total"{{< /highlight >}}
+
+tags         |      |
+-------------|------
+description  | Optional tags to include with the metric
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"tags": []{{< /highlight >}}
+
+timestamp    |      |
+-------------|------
+description  | Time that the metric was collected in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"timestamp": 1552506033{{< /highlight >}}
+
+value        |      |
+-------------|------
+description  | The metric value
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"value": 0.005{{< /highlight >}}
+
+## Examples
+
+### Example check-only event data
 
 {{< highlight json >}}
 {
   "type": "Event",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "namespace": "default"
   },
   "spec": {
-    "timestamp": 1542667666,
-    "entity": {
-      "entity_class": "agent",
-      "system": {
-        "hostname": "webserver01",
-        "os": "linux",
-        "platform": "centos",
-        "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "network": {
-          "interfaces": [
-            {
-              "name": "lo",
-              "addresses": [
-                "127.0.0.1/8",
-                "::1/128"
-              ]
-            },
-            {
-              "name": "enp0s3",
-              "mac": "08:00:27:11:ad:d2",
-              "addresses": [
-                "10.0.2.15/24",
-                "fe80::26a5:54ec:cf0d:9704/64"
-              ]
-            },
-            {
-              "name": "enp0s8",
-              "mac": "08:00:27:bc:be:60",
-              "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:febc:be60/64"
-              ]
-            }
-          ]
-        },
-        "arch": "amd64"
-      },
-      "subscriptions": [
-        "testing",
-        "entity:webserver01"
+    "check": {
+      "check_hooks": null,
+      "command": "check-cpu.sh -w 75 -c 90",
+      "duration": 1.07055808,
+      "env_vars": null,
+      "executed": 1552594757,
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "history": [
+        {
+          "executed": 1552594757,
+          "status": 0
+        }
       ],
-      "last_seen": 1542667635,
+      "interval": 60,
+      "issued": 1552594757,
+      "last_ok": 1552594758,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "check-cpu",
+        "namespace": "default"
+      },
+      "occurrences": 1,
+      "occurrences_watermark": 1,
+      "output": "CPU OK - Usage:3.96\n",
+      "output_metric_format": "",
+      "output_metric_handlers": [],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "linux"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
       "deregister": false,
       "deregistration": {},
-      "user": "agent",
+      "entity_class": "agent",
+      "last_seen": 1552594641,
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default"
+      },
       "redact": [
         "password",
         "passwd",
@@ -320,55 +730,269 @@ example      | {{< highlight json >}}
         "secret_key",
         "private_key",
         "secret"
-      ]
+      ],
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-centos",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::9688:67ca:3d78:ced9/64"
+              ],
+              "mac": "08:00:27:11:ad:d2",
+              "name": "enp0s3"
+            },
+            {
+              "addresses": [
+                "172.28.128.3/24",
+                "fe80::a00:27ff:fe6b:c1e9/64"
+              ],
+              "mac": "08:00:27:6b:c1:e9",
+              "name": "enp0s8"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.4.1708"
+      },
+      "user": "agent"
     },
+    "timestamp": 1552594758
+  }
+}
+{{< /highlight >}}
+
+### Example event with check and metric data
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
     "check": {
       "check_hooks": null,
-      "duration": 2.033888684,
-      "executed": 1522170513,
-      "command": "http_check.sh http://localhost:80",
-      "handlers": [
-        "slack"
-      ],
+      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "duration": 0.060790838,
+      "env_vars": null,
+      "executed": 1552506033,
+      "handlers": [],
       "high_flap_threshold": 0,
-      "interval": 20,
-      "low_flap_threshold": 0,
-      "publish": true,
-      "runtime_assets": [],
-      "subscriptions": [
-        "testing"
-      ],
-      "proxy_entity_name": "",
-      "check_hooks": null,
-      "stdin": false,
-      "ttl": 0,
-      "timeout": 0,
-      "duration": 0.010849143,
-      "executed": 1542667666,
       "history": [
         {
-          "status": 1,
-          "executed": 1542667666
+          "executed": 1552505833,
+          "status": 0
+        },
+        {
+          "executed": 1552505843,
+          "status": 0
         }
       ],
-      "issued": 1542667666,
-      "output": "",
-      "state": "failing",
-      "status": 1,
-      "total_state_change": 0,
-      "last_ok": 0,
+      "interval": 10,
+      "issued": 1552506033,
+      "last_ok": 1552506033,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "curl_timings",
+        "namespace": "default"
+      },
       "occurrences": 1,
       "occurrences_watermark": 1,
-      "output_metric_format": "",
-      "output_metric_handlers": [],
-      "env_vars": null,
+      "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+      "output_metric_format": "graphite_plaintext",
+      "output_metric_handlers": [
+        "influx-db"
+      ],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
       "metadata": {
-        "name": "check-nginx",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
-    }
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
+  }
+}
+{{< /highlight >}}
+
+### Example metric-only event
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
+      "metadata": {
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
   }
 }
 {{< /highlight >}}
@@ -380,3 +1004,6 @@ example      | {{< highlight json >}}
 [5]: ../../guides/aggregate-metrics-statsd/
 [6]: ../../guides/extract-metrics-with-checks
 [7]: ../checks/#check-specification
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes
+[26]: ../rbac#namespaces

--- a/content/sensu-go/5.0/reference/events.md
+++ b/content/sensu-go/5.0/reference/events.md
@@ -557,7 +557,7 @@ example      | {{< highlight shell >}}
 
 state         |      |
 -------------|------
-description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+description  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}

--- a/content/sensu-go/5.1/api/events.md
+++ b/content/sensu-go/5.1/api/events.md
@@ -171,72 +171,73 @@ output         | {{< highlight shell >}}
 
 ### `/events` (POST)
 
-/events (POST) | 
-----------------|------
-description     | Create a Sensu event.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
-payload         | {{< highlight shell >}}
-{
-  "timestamp": 1542667666,
+The `/events` API endpoint provides HTTP POST access to create an event and send it to the Sensu pipeline.
+
+#### EXAMPLE {#events-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/events` API to create an event.
+The request includes information about the check and entity represented by the event and returns a successful HTTP 200 OK response and the event definition.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
   "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "...": "...",
-      "arch": "amd64"
-    },
-    "subscriptions": [
-      "testing",
-      "entity:webserver01"
-    ],
+    "entity_class": "proxy",
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server1",
+      "namespace": "default"
     }
   },
   "check": {
-    "check_hooks": null,
-    "duration": 2.033888684,
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
-    "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "output": "",
+    "output": "Server error",
     "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events
+
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+#### API Specification {#events-post-specification}
+
+/events (POST) | 
+----------------|------
+description     | Create a Sensu event for a new entity and check combination. To create an event for an existing entity and check combination or to update an existing event, use the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
+payload         | {{< highlight shell >}}
+{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "state": "failing",
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section for the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Conflict**: 409 (Event already exists for the entity and check)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/events/:entity` API endpoint {#the-eventsentity-api-endpoint}
 
@@ -464,64 +465,209 @@ output               | {{< highlight json >}}
 
 ### `/events/:entity/:check` (PUT) {#eventsentitycheck-put}
 
+The `/events/:entity/:check` API endpoint provides HTTP PUT access to create or update an event and send it to the Sensu pipeline.
+
 #### EXAMPLE {#eventsentitycheck-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `sensu-go-entity` entity and the `check-cpu` check, resulting in a 200 (OK) HTTP response code.
+In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `server1` entity and the `server-health` check and process it using the `slack` event handler.
+The event includes a status code of `1`, indicating a warning, and an output message of "Server error".
 
 {{< highlight shell >}}
 curl -X PUT \
 -H "Authorization: Bearer TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
-
-HTTP/1.1 200 OK
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
 
+The request returns a 200 (OK) HTTP response code and the resulting event definition.
+
+{{< highlight shell >}}
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+You can use sensuctl or the [Sensu dashboard](../../dashboard/overview) to see the event.
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+You should see the event with the status and output specified in the request.
+
+{{< highlight shell >}}
+    Entity        Check                   Output                 Status   Silenced             Timestamp            
+────────────── ──────────── ─────────────────────────────────── ──────── ────────── ─────────────────────────────── 
+    server1      server-health   Server error             1      false      2019-03-14 16:56:09 +0000 UTC 
+{{< /highlight >}}
 
 #### API Specification {#eventsentitycheck-put-specification}
 
 /events/:entity/:check (PUT) | 
 ----------------|------
 description     | Creates an event for a given entity and check.
-example url     | http://hostname:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
+example url     | http://hostname:8080/api/core/v2/namespaces/default/events/server1/server-health
 payload         | {{< highlight shell >}}
 {
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}
+{{< /highlight >}}
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section below.
+response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+#### Payload parameters {#eventsentitycheck-put-parameters}
+
+The `/events/:entity/:check` PUT endpoint requires a request payload containing an `entity` scope and a `check` scope.
+The `entity` scope contains information about the component of your infrastructure represented by the event.
+At a minimum, Sensu requires the `entity` scope to contain the `entity_class` (`agent` or `proxy`) and the entity `name` and `namespace` within a `metadata` scope.
+For more information about entity attributes, see the [entity specification](../../reference/entities#specification).
+
+The `check` scope contains information about the event status and how the event was created.
+At a minimum, Sensu requires the `check` scope to contain a `name` within a `metadata` scope and either an `interval` or `cron` attribute.
+For more information about check attributes, see the [check specification](../../reference/checks#specification).
+
+**Example request with minimum required event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
   }
-}
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
-payload parameters | <ul><li>`timestamp` (required, integer): Unix timestamp for the event, for example `1542667666`</li><li>`entity` scope containing the `entity_class` and a `metadata` scope containing `name` (string) and `namespace` (string)</li><li>`check` scope containing `interval` (integer) or `cron` (string), and a `metadata` scope containing `name` (string) and `namespace` (string)</li>
-response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+The minimum required attributes shown above let you create an event using the `/events/:entity/:check` PUT endpoint, however the request can include any attributes defined in the [event specification](../../reference/events).
+To create useful, actionable events, we recommend adding check attributes such as the event `status` (`0` for OK, `1` for warning, `2` for critical), an `output` message, and one or more event `handlers`.
+For more information about these attributes and their available values, see the [event specification](../../reference/events).
+
+While a `timestamp` is not required to create an event, Sensu assigns a timestamp of `0` (January 1, 1970) to events without a specified timestamp, so we recommend adding a Unix timestamp when creating events.
+
+**Example request with minimum recommended event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
+{{< /highlight >}}
+
+#### Creating metric events
+
+In addition to the `entity` and `check` scopes, Sensu events can include a `metrics` scope containing metrics in Sensu metric format.
+See the [events reference](../../reference/events#metrics) and for more information about Sensu metric format.
+
+**Example request including metrics**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "status": 0,
+    "output_metric_handlers": ["influxdb"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-metrics"
+    }
+  },
+  "metrics": {
+    "handlers": [
+      "influxdb"
+    ],
+    "points": [
+      {
+        "name": "server1.server-metrics.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "server1.server-metrics.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-metrics
+{{< /highlight >}}
 
 ### `/events/:entity/:check` (DELETE) {#eventsentitycheck-delete}
 

--- a/content/sensu-go/5.1/reference/events.md
+++ b/content/sensu-go/5.1/reference/events.md
@@ -10,10 +10,22 @@ menu:
     parent: reference
 ---
 
-- [Specification](#events-specification)
-- [Examples](#example-check-only-event-data)
+- [How do events work?](#how-do-events-work)
+- [Creating events using the Sensu agent](#creating-events-using-the-sensu-agent)
+- [Creating events using the events API](#creating-events-using-the-events-api)
+- [Managing events](#managing-events)
+  - [Deleting events](#deleting-events)
+  - [Resolving events](#resolving-events)
+- [Event format](#event-format)
+- [Using event data](#using-event-data)
+- [Events specification](#events-specification)
+	- [Top-level attributes](#top-level-attributes)
+	- [Spec attributes](#spec-attributes)
+	- [Check attributes](#check-attributes)
+	- [Metric attributes](#metric-attributes)
+- [Examples](#examples)
 
-## How do Events work?
+## How do events work?
 
 An event is a generic container used by Sensu to provide context to checks
 and/or metrics. The context, called "event data," contains information about the
@@ -23,7 +35,7 @@ These generic containers allow Sensu to handle different types of events in the
 pipeline. Since events are polymorphic in nature, it is important to never
 assume their contents, or lack-thereof.
 
-## Check-only events
+### Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu
 server, regardless of the status indicated by the check result. An event is
@@ -33,7 +45,7 @@ forwarded to the Sensu backend for processing. Potentially noteworthy events may
 be processed by one or more event handlers to do things such as send an email or
 invoke an automated action.
 
-## Metric-only events
+### Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the
 [Statsd listener][5]. The agent will translate the statsd metrics to Sensu
@@ -41,7 +53,7 @@ Metric Format, and place them inside an event. These events, since they do not
 contain checks, bypass the store, and are sent off to the event pipeline and
 corresponding event handlers.
 
-## Check and metric events
+### Check and metric events
 
 Events that contain _both_ a check and metrics, most likely originated from
 [check output metric extraction][6]. If a check is configured for metric
@@ -50,186 +62,195 @@ Metric Format. Both the check results, and resulting (extracted) metrics are
 stored inside the event. Event handlers from `event.Check.Handlers` and
 `event.Metrics.Handlers` will be invoked.
 
+## Creating events using the Sensu agent
+
+The Sensu agent is a powerful event producer and monitoring automation tool.
+You can use Sensu agents to produce events automatically using service checks and metric checks.
+Sensu agents can also act as a collector for metrics throughout your infrastructure.
+
+- [Creating events using service checks](../agent#creating-monitoring-events-using-service-checks)
+- [Creating events using metric checks](../../guides/extract-metrics-with-checks)
+- [Creating events using the agent API](../agent#creating-monitoring-events-using-the-agent-api)
+- [Creating events using the agent TCP and UDP sockets](../agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets)
+- [Creating events using the StatsD listener](../agent#creating-monitoring-events-using-the-statsd-listener)
+
+## Creating events using the events API
+
+You can send events directly to the Sensu pipeline using the events API.
+To create an event, send a JSON event definition to the [events API PUT endpoint](../../api/events#eventsentitycheck-put).
+
+## Managing events
+
+You can manage event using the [Sensu dashboard](../../dashboard/overview), [events API](../../api/events), and the [sensuctl](../../sensuctl/reference) command line tool.
+
+### Viewing events
+
+To list all events:
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+To show event details in the default [output format](../../sensuctl/reference/#preferred-output-format):
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name
+{{< /highlight >}}
+
+With both the `list` and `info` commands, you can specify an [output format](../../sensuctl/reference/#preferred-output-format) using the `--format` flag:
+
+- `yaml` or `wrapped-json` formats for use with [`sensuctl create`][sc]
+- `json` format for use with the [events API](../../api/events)
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name --format yaml
+{{< /highlight >}}
+
+### Deleting events
+
+To delete an event:
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name
+{{< /highlight >}}
+
+You can use the `--skip-confirm` flag to skip the confirmation step.
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name --skip-confirm
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Deleted
+{{< /highlight >}}
+
+### Resolving events
+
+You can use sensuctl to change the status of an event to `0` (OK).
+Events resolved by sensuctl include the output message: "Resolved manually by sensuctl".
+
+{{< highlight shell >}}
+sensuctl event resolve entity-name check-name
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Resolved
+{{< /highlight >}}
+
+## Event format
+
+Sensu events contain:
+
+- `entity` scope (required)
+  - Information about the source of the event, including any attributes defined in the [entity specification](../entities#entities-specification)
+- `check` scope (optional if the `metrics` scope is present)
+  - Information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification)
+  - Information about the event and its history, including any check attributes defined in the [event specification on this page](#check-attributes)
+- `metrics` scope (optional if the `check` scope is present)
+  - Metric points in [Sensu metric format](#metrics)
+- `timestamp`
+  - Time that the event occurred in seconds since the Unix epoch
+
+## Using event data
+
+Event data is powerful tool for automating monitoring workflows.
+For example, see [the guide to reducing alert fatigue](guides/reduce-alert-fatigue/) by filtering events based on the event `occurrences` attribute.
+
 ## Events specification
 
-### Attributes
-|timestamp   |      |
--------------|------
-description  | The time of the Event occurrence in epoch time.
-type         | integer
-example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+### Top-level attributes
 
-|silenced (deprecated)    |      |
+type         | 
 -------------|------
-description  | If the event is to be silenced.
-type         | boolean
-example      | {{< highlight shell >}}"silenced": false{{< /highlight >}}
-_NOTE: Silenced has been deprecated from Event. Please see [check specification][7]._
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Events should always be of type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Event"{{< /highlight >}}
 
-|check       |      |
+api_version  | 
 -------------|------
-description  | The [check attributes][1] used to obtain the check result.
-type         | Check
+description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.1, this attribute should always be `core/v2`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level scope containing the event `namespace`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference](#metadata-attributes) for details.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "namespace": "default"
+}{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the event [spec attributes][sp].
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
 example      | {{< highlight shell >}}
-{
+"spec": {
   "check": {
     "check_hooks": null,
-    "duration": 1.903135228,
-    "executed": 1522100915,
+    "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
     "high_flap_threshold": 0,
     "history": [
       {
-        "executed": 1522100315
+        "executed": 1552505833,
+        "status": 0
       },
       {
-        "executed": 1522100915
+        "executed": 1552505843,
+        "status": 0
       }
     ],
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
+    "interval": 10,
+    "issued": 1552506033,
+    "last_ok": 1552506033,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "executed": 1542667666,
-    "history": [
-      {
-        "status": 1,
-        "executed": 1542667666
-      }
-    ],
-    "issued": 1542667666,
-    "output": "",
-    "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
     "occurrences": 1,
     "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
-    "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
-}
-{{< /highlight >}}
-
-<a name="metrics">
-
-|metrics     |      |
--------------|------
-description  | The metrics collected by the entity.
-type         | Metrics
-example      | {{< highlight json >}}
-{
-  "metrics": {
-    "handlers": [
+    "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+    "output_metric_format": "graphite_plaintext",
+    "output_metric_handlers": [
       "influx-db"
     ],
-    "points": [
-      {
-        "name": "weather.temperature",
-        "value": 82,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      },
-      {
-        "name": "weather.humidity",
-        "value": 30,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      }
-    ]
-  }
-}
-{{< /highlight >}}
-
-|entity      |      |
--------------|------
-description  | The [entity attributes][2] from the originating entity (agent or proxy).
-type         | Entity
-example      | {{< highlight json >}}
-{
-  "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "os": "linux",
-      "platform": "centos",
-      "platform_family": "rhel",
-      "platform_version": "7.4.1708",
-      "network": {
-        "interfaces": [
-          {
-            "name": "lo",
-            "addresses": [
-              "127.0.0.1/8",
-              "::1/128"
-            ]
-          },
-          {
-            "name": "enp0s3",
-            "mac": "08:00:27:11:ad:d2",
-            "addresses": [
-              "10.0.2.15/24",
-              "fe80::26a5:54ec:cf0d:9704/64"
-            ]
-          },
-          {
-            "name": "enp0s8",
-            "mac": "08:00:27:bc:be:60",
-            "addresses": [
-              "172.28.128.3/24",
-              "fe80::a00:27ff:febc:be60/64"
-            ]
-          }
-        ]
-      },
-      "arch": "amd64"
-    },
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "testing",
-      "entity:webserver01"
+      "entity:sensu-go-sandbox"
     ],
-    "last_seen": 1542667635,
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  },
+  "entity": {
     "deregister": false,
     "deregistration": {},
-    "user": "agent",
+    "entity_class": "agent",
+    "last_seen": 1552495139,
+    "metadata": {
+      "name": "sensu-go-sandbox",
+      "namespace": "default"
+    },
     "redact": [
       "password",
       "passwd",
@@ -241,75 +262,464 @@ example      | {{< highlight json >}}
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
+    "subscriptions": [
+      "entity:sensu-go-sandbox"
+    ],
+    "system": {
+      "arch": "amd64",
+      "hostname": "sensu-go-sandbox",
+      "network": {
+        "interfaces": [
+          {
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ],
+            "name": "lo"
+          },
+          {
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::5a94:f67a:1bfc:a579/64"
+            ],
+            "mac": "08:00:27:8b:c9:3f",
+            "name": "eth0"
+          }
+        ]
+      },
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804"
+    },
+    "user": "agent"
+  },
+  "metrics": {
+    "handlers": [
+      "influx-db"
+    ],
+    "points": [
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552506033
 }
 {{< /highlight >}}
 
-## Example check-only event data
+### Metadata attributes
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][26] that this event belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+### Spec attributes
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred in seconds since the Unix epoch
+required     | false
+type         | Integer
+default      | `0`
+example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+
+|entity      |      |
+-------------|------
+description  | The [entity attributes][2] from the originating entity (agent or proxy).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"entity": {
+  "deregister": false,
+  "deregistration": {},
+  "entity_class": "agent",
+  "last_seen": 1552495139,
+  "metadata": {
+    "name": "sensu-go-sandbox",
+    "namespace": "default"
+  },
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "system": {
+    "arch": "amd64",
+    "hostname": "sensu-go-sandbox",
+    "network": {
+      "interfaces": [
+        {
+          "addresses": [
+            "127.0.0.1/8",
+            "::1/128"
+          ],
+          "name": "lo"
+        },
+        {
+          "addresses": [
+            "10.0.2.15/24",
+            "fe80::5a94:f67a:1bfc:a579/64"
+          ],
+          "mac": "08:00:27:8b:c9:3f",
+          "name": "eth0"
+        }
+      ]
+    },
+    "os": "linux",
+    "platform": "centos",
+    "platform_family": "rhel",
+    "platform_version": "7.5.1804"
+  },
+  "user": "agent"
+}
+{{< /highlight >}}
+
+|check       |      |
+-------------|------
+description  | The [check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification](#check-attributes) and the [check specification](../checks#check-specification).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"check": {
+  "check_hooks": null,
+  "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+  "duration": 0.060790838,
+  "env_vars": null,
+  "executed": 1552506033,
+  "handlers": [],
+  "high_flap_threshold": 0,
+  "history": [
+    {
+      "executed": 1552505833,
+      "status": 0
+    },
+    {
+      "executed": 1552505843,
+      "status": 0
+    }
+  ],
+  "interval": 10,
+  "issued": 1552506033,
+  "last_ok": 1552506033,
+  "low_flap_threshold": 0,
+  "metadata": {
+    "name": "curl_timings",
+    "namespace": "default"
+  },
+  "occurrences": 1,
+  "occurrences_watermark": 1,
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005",
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+  "proxy_entity_name": "",
+  "publish": true,
+  "round_robin": false,
+  "runtime_assets": [],
+  "state": "passing",
+  "status": 0,
+  "stdin": false,
+  "subdue": null,
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "timeout": 0,
+  "total_state_change": 0,
+  "ttl": 0
+}
+{{< /highlight >}}
+
+<a name="metrics"></a>
+
+|metrics     |      |
+-------------|------
+description  | The metrics collected by the entity in Sensu metric format. See the [metrics attributes](#metric-attributes).
+type         | Map
+required     | false
+example      | {{< highlight shell >}}
+"metrics": {
+  "handlers": [
+    "influx-db"
+  ],
+  "points": [
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_total",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.005
+    },
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.004
+    }
+  ]
+}
+{{< /highlight >}}
+
+### Check attributes
+
+Sensu events include a `check` scope containing information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification), and information about the event and its history, including the attributes defined below.
+
+duration     |      |
+-------------|------
+description  | Command execution time in seconds
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
+
+executed     |      |
+-------------|------
+description  | Time that the check request was executed
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+history      |      |
+-------------|------
+description  | Check status history for the last 21 check executions. See the [history attributes](#history-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"history": [
+  {
+    "executed": 1552505983,
+    "status": 0
+  },
+  {
+    "executed": 1552505993,
+    "status": 0
+  }
+]
+{{< /highlight >}}
+
+issued       |      |
+-------------|------
+description  | Time that the check request was issued in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"issued": 1552506033{{< /highlight >}}
+
+last_ok      |      |
+-------------|------
+description  | The last time that the check returned an OK `status` (`0`) in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"last_ok": 1552506033{{< /highlight >}}
+
+occurrences  |      |
+-------------|------
+description  | The number of times an event with the same status has occurred for the given entity and check
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"occurrences": 1{{< /highlight >}}
+
+occurrences_watermark | |
+-------------|------
+description  | The highest number of occurrences for the given entity and check at the current status
+required     | false 
+type         | Integer
+example      | {{< highlight shell >}}"occurrences_watermark": 1{{< /highlight >}}\
+
+output       |      |
+-------------|------
+description  | The output from the execution of the check command
+required     | false
+type         | String
+example      | {{< highlight shell >}}
+"output": "sensu-go-sandbox.curl_timings.time_total 0.005"
+{{< /highlight >}}
+
+state         |      |
+-------------|------
+description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+total_state_change | |
+-------------|------
+description  | The total state change percentage for the check's history
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"total_state_change": 0{{< /highlight >}}
+
+#### History attributes
+
+executed     |      |
+-------------|------
+description  |Time that the check request was executed in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+### Metric attributes
+
+handlers     |      |
+-------------|------
+description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"handlers": [
+  "influx-db"
+]
+{{< /highlight >}}
+
+points       |      |
+-------------|------
+description  | Metric data points including a name, timestamp, value, and tags. See the [points attributes](#points-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"points": [
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_total",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.005
+  },
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.004
+  }
+]
+{{< /highlight >}}
+
+#### Points attributes
+
+name         |      |
+-------------|------
+description  | The metric name in the format `$entity.$check.$metric` where `$entity` is the entity name, `$check` is the check name, and `$metric` is the metric name.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"name": "sensu-go-sandbox.curl_timings.time_total"{{< /highlight >}}
+
+tags         |      |
+-------------|------
+description  | Optional tags to include with the metric
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"tags": []{{< /highlight >}}
+
+timestamp    |      |
+-------------|------
+description  | Time that the metric was collected in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"timestamp": 1552506033{{< /highlight >}}
+
+value        |      |
+-------------|------
+description  | The metric value
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"value": 0.005{{< /highlight >}}
+
+## Examples
+
+### Example check-only event data
 
 {{< highlight json >}}
 {
   "type": "Event",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "namespace": "default"
   },
   "spec": {
-    "timestamp": 1542667666,
-    "entity": {
-      "entity_class": "agent",
-      "system": {
-        "hostname": "webserver01",
-        "os": "linux",
-        "platform": "centos",
-        "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "network": {
-          "interfaces": [
-            {
-              "name": "lo",
-              "addresses": [
-                "127.0.0.1/8",
-                "::1/128"
-              ]
-            },
-            {
-              "name": "enp0s3",
-              "mac": "08:00:27:11:ad:d2",
-              "addresses": [
-                "10.0.2.15/24",
-                "fe80::26a5:54ec:cf0d:9704/64"
-              ]
-            },
-            {
-              "name": "enp0s8",
-              "mac": "08:00:27:bc:be:60",
-              "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:febc:be60/64"
-              ]
-            }
-          ]
-        },
-        "arch": "amd64"
-      },
-      "subscriptions": [
-        "testing",
-        "entity:webserver01"
+    "check": {
+      "check_hooks": null,
+      "command": "check-cpu.sh -w 75 -c 90",
+      "duration": 1.07055808,
+      "env_vars": null,
+      "executed": 1552594757,
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "history": [
+        {
+          "executed": 1552594757,
+          "status": 0
+        }
       ],
-      "last_seen": 1542667635,
+      "interval": 60,
+      "issued": 1552594757,
+      "last_ok": 1552594758,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "check-cpu",
+        "namespace": "default"
+      },
+      "occurrences": 1,
+      "occurrences_watermark": 1,
+      "output": "CPU OK - Usage:3.96\n",
+      "output_metric_format": "",
+      "output_metric_handlers": [],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "linux"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
       "deregister": false,
       "deregistration": {},
-      "user": "agent",
+      "entity_class": "agent",
+      "last_seen": 1552594641,
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default"
+      },
       "redact": [
         "password",
         "passwd",
@@ -320,55 +730,269 @@ example      | {{< highlight json >}}
         "secret_key",
         "private_key",
         "secret"
-      ]
+      ],
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-centos",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::9688:67ca:3d78:ced9/64"
+              ],
+              "mac": "08:00:27:11:ad:d2",
+              "name": "enp0s3"
+            },
+            {
+              "addresses": [
+                "172.28.128.3/24",
+                "fe80::a00:27ff:fe6b:c1e9/64"
+              ],
+              "mac": "08:00:27:6b:c1:e9",
+              "name": "enp0s8"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.4.1708"
+      },
+      "user": "agent"
     },
+    "timestamp": 1552594758
+  }
+}
+{{< /highlight >}}
+
+### Example event with check and metric data
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
     "check": {
       "check_hooks": null,
-      "duration": 2.033888684,
-      "executed": 1522170513,
-      "command": "http_check.sh http://localhost:80",
-      "handlers": [
-        "slack"
-      ],
+      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "duration": 0.060790838,
+      "env_vars": null,
+      "executed": 1552506033,
+      "handlers": [],
       "high_flap_threshold": 0,
-      "interval": 20,
-      "low_flap_threshold": 0,
-      "publish": true,
-      "runtime_assets": [],
-      "subscriptions": [
-        "testing"
-      ],
-      "proxy_entity_name": "",
-      "check_hooks": null,
-      "stdin": false,
-      "ttl": 0,
-      "timeout": 0,
-      "duration": 0.010849143,
-      "executed": 1542667666,
       "history": [
         {
-          "status": 1,
-          "executed": 1542667666
+          "executed": 1552505833,
+          "status": 0
+        },
+        {
+          "executed": 1552505843,
+          "status": 0
         }
       ],
-      "issued": 1542667666,
-      "output": "",
-      "state": "failing",
-      "status": 1,
-      "total_state_change": 0,
-      "last_ok": 0,
+      "interval": 10,
+      "issued": 1552506033,
+      "last_ok": 1552506033,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "curl_timings",
+        "namespace": "default"
+      },
       "occurrences": 1,
       "occurrences_watermark": 1,
-      "output_metric_format": "",
-      "output_metric_handlers": [],
-      "env_vars": null,
+      "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+      "output_metric_format": "graphite_plaintext",
+      "output_metric_handlers": [
+        "influx-db"
+      ],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
       "metadata": {
-        "name": "check-nginx",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
-    }
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
+  }
+}
+{{< /highlight >}}
+
+### Example metric-only event
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
+      "metadata": {
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
   }
 }
 {{< /highlight >}}
@@ -380,3 +1004,6 @@ example      | {{< highlight json >}}
 [5]: ../../guides/aggregate-metrics-statsd/
 [6]: ../../guides/extract-metrics-with-checks
 [7]: ../checks/#check-specification
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes
+[26]: ../rbac#namespaces

--- a/content/sensu-go/5.1/reference/events.md
+++ b/content/sensu-go/5.1/reference/events.md
@@ -557,7 +557,7 @@ example      | {{< highlight shell >}}
 
 state         |      |
 -------------|------
-description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+description  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}

--- a/content/sensu-go/5.2/api/events.md
+++ b/content/sensu-go/5.2/api/events.md
@@ -171,72 +171,73 @@ output         | {{< highlight shell >}}
 
 ### `/events` (POST)
 
-/events (POST) | 
-----------------|------
-description     | Create a Sensu event.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
-payload         | {{< highlight shell >}}
-{
-  "timestamp": 1542667666,
+The `/events` API endpoint provides HTTP POST access to create an event and send it to the Sensu pipeline.
+
+#### EXAMPLE {#events-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/events` API to create an event.
+The request includes information about the check and entity represented by the event and returns a successful HTTP 200 OK response and the event definition.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
   "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "...": "...",
-      "arch": "amd64"
-    },
-    "subscriptions": [
-      "testing",
-      "entity:webserver01"
-    ],
+    "entity_class": "proxy",
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server1",
+      "namespace": "default"
     }
   },
   "check": {
-    "check_hooks": null,
-    "duration": 2.033888684,
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
-    "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "output": "",
+    "output": "Server error",
     "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events
+
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+#### API Specification {#events-post-specification}
+
+/events (POST) | 
+----------------|------
+description     | Create a Sensu event for a new entity and check combination. To create an event for an existing entity and check combination or to update an existing event, use the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
+payload         | {{< highlight shell >}}
+{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "state": "failing",
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section for the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Conflict**: 409 (Event already exists for the entity and check)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/events/:entity` API endpoint {#the-eventsentity-api-endpoint}
 
@@ -464,64 +465,209 @@ output               | {{< highlight json >}}
 
 ### `/events/:entity/:check` (PUT) {#eventsentitycheck-put}
 
+The `/events/:entity/:check` API endpoint provides HTTP PUT access to create or update an event and send it to the Sensu pipeline.
+
 #### EXAMPLE {#eventsentitycheck-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `sensu-go-entity` entity and the `check-cpu` check, resulting in a 200 (OK) HTTP response code.
+In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `server1` entity and the `server-health` check and process it using the `slack` event handler.
+The event includes a status code of `1`, indicating a warning, and an output message of "Server error".
 
 {{< highlight shell >}}
 curl -X PUT \
 -H "Authorization: Bearer TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
-
-HTTP/1.1 200 OK
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
 
+The request returns a 200 (OK) HTTP response code and the resulting event definition.
+
+{{< highlight shell >}}
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+You can use sensuctl or the [Sensu dashboard](../../dashboard/overview) to see the event.
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+You should see the event with the status and output specified in the request.
+
+{{< highlight shell >}}
+    Entity        Check                   Output                 Status   Silenced             Timestamp            
+────────────── ──────────── ─────────────────────────────────── ──────── ────────── ─────────────────────────────── 
+    server1      server-health   Server error             1      false      2019-03-14 16:56:09 +0000 UTC 
+{{< /highlight >}}
 
 #### API Specification {#eventsentitycheck-put-specification}
 
 /events/:entity/:check (PUT) | 
 ----------------|------
 description     | Creates an event for a given entity and check.
-example url     | http://hostname:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
+example url     | http://hostname:8080/api/core/v2/namespaces/default/events/server1/server-health
 payload         | {{< highlight shell >}}
 {
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}
+{{< /highlight >}}
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section below.
+response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+#### Payload parameters {#eventsentitycheck-put-parameters}
+
+The `/events/:entity/:check` PUT endpoint requires a request payload containing an `entity` scope and a `check` scope.
+The `entity` scope contains information about the component of your infrastructure represented by the event.
+At a minimum, Sensu requires the `entity` scope to contain the `entity_class` (`agent` or `proxy`) and the entity `name` and `namespace` within a `metadata` scope.
+For more information about entity attributes, see the [entity specification](../../reference/entities#specification).
+
+The `check` scope contains information about the event status and how the event was created.
+At a minimum, Sensu requires the `check` scope to contain a `name` within a `metadata` scope and either an `interval` or `cron` attribute.
+For more information about check attributes, see the [check specification](../../reference/checks#specification).
+
+**Example request with minimum required event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
   }
-}
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
-payload parameters | <ul><li>`timestamp` (required, integer): Unix timestamp for the event, for example `1542667666`</li><li>`entity` scope containing the `entity_class` and a `metadata` scope containing `name` (string) and `namespace` (string)</li><li>`check` scope containing `interval` (integer) or `cron` (string), and a `metadata` scope containing `name` (string) and `namespace` (string)</li>
-response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+The minimum required attributes shown above let you create an event using the `/events/:entity/:check` PUT endpoint, however the request can include any attributes defined in the [event specification](../../reference/events).
+To create useful, actionable events, we recommend adding check attributes such as the event `status` (`0` for OK, `1` for warning, `2` for critical), an `output` message, and one or more event `handlers`.
+For more information about these attributes and their available values, see the [event specification](../../reference/events).
+
+While a `timestamp` is not required to create an event, Sensu assigns a timestamp of `0` (January 1, 1970) to events without a specified timestamp, so we recommend adding a Unix timestamp when creating events.
+
+**Example request with minimum recommended event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
+{{< /highlight >}}
+
+#### Creating metric events
+
+In addition to the `entity` and `check` scopes, Sensu events can include a `metrics` scope containing metrics in Sensu metric format.
+See the [events reference](../../reference/events#metrics) and for more information about Sensu metric format.
+
+**Example request including metrics**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "status": 0,
+    "output_metric_handlers": ["influxdb"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-metrics"
+    }
+  },
+  "metrics": {
+    "handlers": [
+      "influxdb"
+    ],
+    "points": [
+      {
+        "name": "server1.server-metrics.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "server1.server-metrics.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-metrics
+{{< /highlight >}}
 
 ### `/events/:entity/:check` (DELETE) {#eventsentitycheck-delete}
 

--- a/content/sensu-go/5.2/reference/events.md
+++ b/content/sensu-go/5.2/reference/events.md
@@ -10,10 +10,22 @@ menu:
     parent: reference
 ---
 
-- [Specification](#events-specification)
-- [Examples](#example-check-only-event-data)
+- [How do events work?](#how-do-events-work)
+- [Creating events using the Sensu agent](#creating-events-using-the-sensu-agent)
+- [Creating events using the events API](#creating-events-using-the-events-api)
+- [Managing events](#managing-events)
+  - [Deleting events](#deleting-events)
+  - [Resolving events](#resolving-events)
+- [Event format](#event-format)
+- [Using event data](#using-event-data)
+- [Events specification](#events-specification)
+	- [Top-level attributes](#top-level-attributes)
+	- [Spec attributes](#spec-attributes)
+	- [Check attributes](#check-attributes)
+	- [Metric attributes](#metric-attributes)
+- [Examples](#examples)
 
-## How do Events work?
+## How do events work?
 
 An event is a generic container used by Sensu to provide context to checks
 and/or metrics. The context, called "event data," contains information about the
@@ -23,7 +35,7 @@ These generic containers allow Sensu to handle different types of events in the
 pipeline. Since events are polymorphic in nature, it is important to never
 assume their contents, or lack-thereof.
 
-## Check-only events
+### Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu
 server, regardless of the status indicated by the check result. An event is
@@ -33,7 +45,7 @@ forwarded to the Sensu backend for processing. Potentially noteworthy events may
 be processed by one or more event handlers to do things such as send an email or
 invoke an automated action.
 
-## Metric-only events
+### Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the
 [Statsd listener][5]. The agent will translate the statsd metrics to Sensu
@@ -41,7 +53,7 @@ Metric Format, and place them inside an event. These events, since they do not
 contain checks, bypass the store, and are sent off to the event pipeline and
 corresponding event handlers.
 
-## Check and metric events
+### Check and metric events
 
 Events that contain _both_ a check and metrics, most likely originated from
 [check output metric extraction][6]. If a check is configured for metric
@@ -50,186 +62,195 @@ Metric Format. Both the check results, and resulting (extracted) metrics are
 stored inside the event. Event handlers from `event.Check.Handlers` and
 `event.Metrics.Handlers` will be invoked.
 
+## Creating events using the Sensu agent
+
+The Sensu agent is a powerful event producer and monitoring automation tool.
+You can use Sensu agents to produce events automatically using service checks and metric checks.
+Sensu agents can also act as a collector for metrics throughout your infrastructure.
+
+- [Creating events using service checks](../agent#creating-monitoring-events-using-service-checks)
+- [Creating events using metric checks](../../guides/extract-metrics-with-checks)
+- [Creating events using the agent API](../agent#creating-monitoring-events-using-the-agent-api)
+- [Creating events using the agent TCP and UDP sockets](../agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets)
+- [Creating events using the StatsD listener](../agent#creating-monitoring-events-using-the-statsd-listener)
+
+## Creating events using the events API
+
+You can send events directly to the Sensu pipeline using the events API.
+To create an event, send a JSON event definition to the [events API PUT endpoint](../../api/events#eventsentitycheck-put).
+
+## Managing events
+
+You can manage event using the [Sensu dashboard](../../dashboard/overview), [events API](../../api/events), and the [sensuctl](../../sensuctl/reference) command line tool.
+
+### Viewing events
+
+To list all events:
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+To show event details in the default [output format](../../sensuctl/reference/#preferred-output-format):
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name
+{{< /highlight >}}
+
+With both the `list` and `info` commands, you can specify an [output format](../../sensuctl/reference/#preferred-output-format) using the `--format` flag:
+
+- `yaml` or `wrapped-json` formats for use with [`sensuctl create`][sc]
+- `json` format for use with the [events API](../../api/events)
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name --format yaml
+{{< /highlight >}}
+
+### Deleting events
+
+To delete an event:
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name
+{{< /highlight >}}
+
+You can use the `--skip-confirm` flag to skip the confirmation step.
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name --skip-confirm
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Deleted
+{{< /highlight >}}
+
+### Resolving events
+
+You can use sensuctl to change the status of an event to `0` (OK).
+Events resolved by sensuctl include the output message: "Resolved manually by sensuctl".
+
+{{< highlight shell >}}
+sensuctl event resolve entity-name check-name
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Resolved
+{{< /highlight >}}
+
+## Event format
+
+Sensu events contain:
+
+- `entity` scope (required)
+  - Information about the source of the event, including any attributes defined in the [entity specification](../entities#entities-specification)
+- `check` scope (optional if the `metrics` scope is present)
+  - Information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification)
+  - Information about the event and its history, including any check attributes defined in the [event specification on this page](#check-attributes)
+- `metrics` scope (optional if the `check` scope is present)
+  - Metric points in [Sensu metric format](#metrics)
+- `timestamp`
+  - Time that the event occurred in seconds since the Unix epoch
+
+## Using event data
+
+Event data is powerful tool for automating monitoring workflows.
+For example, see [the guide to reducing alert fatigue](guides/reduce-alert-fatigue/) by filtering events based on the event `occurrences` attribute.
+
 ## Events specification
 
-### Attributes
-|timestamp   |      |
--------------|------
-description  | The time of the Event occurrence in epoch time.
-type         | integer
-example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+### Top-level attributes
 
-|silenced (deprecated)    |      |
+type         | 
 -------------|------
-description  | If the event is to be silenced.
-type         | boolean
-example      | {{< highlight shell >}}"silenced": false{{< /highlight >}}
-_NOTE: Silenced has been deprecated from Event. Please see [check specification][7]._
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Events should always be of type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Event"{{< /highlight >}}
 
-|check       |      |
+api_version  | 
 -------------|------
-description  | The [check attributes][1] used to obtain the check result.
-type         | Check
+description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.2, this attribute should always be `core/v2`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level scope containing the event `namespace`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference](#metadata-attributes) for details.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "namespace": "default"
+}{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the event [spec attributes][sp].
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
 example      | {{< highlight shell >}}
-{
+"spec": {
   "check": {
     "check_hooks": null,
-    "duration": 1.903135228,
-    "executed": 1522100915,
+    "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
     "high_flap_threshold": 0,
     "history": [
       {
-        "executed": 1522100315
+        "executed": 1552505833,
+        "status": 0
       },
       {
-        "executed": 1522100915
+        "executed": 1552505843,
+        "status": 0
       }
     ],
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
+    "interval": 10,
+    "issued": 1552506033,
+    "last_ok": 1552506033,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "executed": 1542667666,
-    "history": [
-      {
-        "status": 1,
-        "executed": 1542667666
-      }
-    ],
-    "issued": 1542667666,
-    "output": "",
-    "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
     "occurrences": 1,
     "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
-    "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
-}
-{{< /highlight >}}
-
-<a name="metrics">
-
-|metrics     |      |
--------------|------
-description  | The metrics collected by the entity.
-type         | Metrics
-example      | {{< highlight json >}}
-{
-  "metrics": {
-    "handlers": [
+    "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+    "output_metric_format": "graphite_plaintext",
+    "output_metric_handlers": [
       "influx-db"
     ],
-    "points": [
-      {
-        "name": "weather.temperature",
-        "value": 82,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      },
-      {
-        "name": "weather.humidity",
-        "value": 30,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      }
-    ]
-  }
-}
-{{< /highlight >}}
-
-|entity      |      |
--------------|------
-description  | The [entity attributes][2] from the originating entity (agent or proxy).
-type         | Entity
-example      | {{< highlight json >}}
-{
-  "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "os": "linux",
-      "platform": "centos",
-      "platform_family": "rhel",
-      "platform_version": "7.4.1708",
-      "network": {
-        "interfaces": [
-          {
-            "name": "lo",
-            "addresses": [
-              "127.0.0.1/8",
-              "::1/128"
-            ]
-          },
-          {
-            "name": "enp0s3",
-            "mac": "08:00:27:11:ad:d2",
-            "addresses": [
-              "10.0.2.15/24",
-              "fe80::26a5:54ec:cf0d:9704/64"
-            ]
-          },
-          {
-            "name": "enp0s8",
-            "mac": "08:00:27:bc:be:60",
-            "addresses": [
-              "172.28.128.3/24",
-              "fe80::a00:27ff:febc:be60/64"
-            ]
-          }
-        ]
-      },
-      "arch": "amd64"
-    },
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "testing",
-      "entity:webserver01"
+      "entity:sensu-go-sandbox"
     ],
-    "last_seen": 1542667635,
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  },
+  "entity": {
     "deregister": false,
     "deregistration": {},
-    "user": "agent",
+    "entity_class": "agent",
+    "last_seen": 1552495139,
+    "metadata": {
+      "name": "sensu-go-sandbox",
+      "namespace": "default"
+    },
     "redact": [
       "password",
       "passwd",
@@ -241,75 +262,464 @@ example      | {{< highlight json >}}
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
+    "subscriptions": [
+      "entity:sensu-go-sandbox"
+    ],
+    "system": {
+      "arch": "amd64",
+      "hostname": "sensu-go-sandbox",
+      "network": {
+        "interfaces": [
+          {
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ],
+            "name": "lo"
+          },
+          {
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::5a94:f67a:1bfc:a579/64"
+            ],
+            "mac": "08:00:27:8b:c9:3f",
+            "name": "eth0"
+          }
+        ]
+      },
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804"
+    },
+    "user": "agent"
+  },
+  "metrics": {
+    "handlers": [
+      "influx-db"
+    ],
+    "points": [
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552506033
 }
 {{< /highlight >}}
 
-## Example check-only event data
+### Metadata attributes
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][26] that this event belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+### Spec attributes
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred in seconds since the Unix epoch
+required     | false
+type         | Integer
+default      | `0`
+example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+
+|entity      |      |
+-------------|------
+description  | The [entity attributes][2] from the originating entity (agent or proxy).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"entity": {
+  "deregister": false,
+  "deregistration": {},
+  "entity_class": "agent",
+  "last_seen": 1552495139,
+  "metadata": {
+    "name": "sensu-go-sandbox",
+    "namespace": "default"
+  },
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "system": {
+    "arch": "amd64",
+    "hostname": "sensu-go-sandbox",
+    "network": {
+      "interfaces": [
+        {
+          "addresses": [
+            "127.0.0.1/8",
+            "::1/128"
+          ],
+          "name": "lo"
+        },
+        {
+          "addresses": [
+            "10.0.2.15/24",
+            "fe80::5a94:f67a:1bfc:a579/64"
+          ],
+          "mac": "08:00:27:8b:c9:3f",
+          "name": "eth0"
+        }
+      ]
+    },
+    "os": "linux",
+    "platform": "centos",
+    "platform_family": "rhel",
+    "platform_version": "7.5.1804"
+  },
+  "user": "agent"
+}
+{{< /highlight >}}
+
+|check       |      |
+-------------|------
+description  | The [check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification](#check-attributes) and the [check specification](../checks#check-specification).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"check": {
+  "check_hooks": null,
+  "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+  "duration": 0.060790838,
+  "env_vars": null,
+  "executed": 1552506033,
+  "handlers": [],
+  "high_flap_threshold": 0,
+  "history": [
+    {
+      "executed": 1552505833,
+      "status": 0
+    },
+    {
+      "executed": 1552505843,
+      "status": 0
+    }
+  ],
+  "interval": 10,
+  "issued": 1552506033,
+  "last_ok": 1552506033,
+  "low_flap_threshold": 0,
+  "metadata": {
+    "name": "curl_timings",
+    "namespace": "default"
+  },
+  "occurrences": 1,
+  "occurrences_watermark": 1,
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005",
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+  "proxy_entity_name": "",
+  "publish": true,
+  "round_robin": false,
+  "runtime_assets": [],
+  "state": "passing",
+  "status": 0,
+  "stdin": false,
+  "subdue": null,
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "timeout": 0,
+  "total_state_change": 0,
+  "ttl": 0
+}
+{{< /highlight >}}
+
+<a name="metrics"></a>
+
+|metrics     |      |
+-------------|------
+description  | The metrics collected by the entity in Sensu metric format. See the [metrics attributes](#metric-attributes).
+type         | Map
+required     | false
+example      | {{< highlight shell >}}
+"metrics": {
+  "handlers": [
+    "influx-db"
+  ],
+  "points": [
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_total",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.005
+    },
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.004
+    }
+  ]
+}
+{{< /highlight >}}
+
+### Check attributes
+
+Sensu events include a `check` scope containing information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification), and information about the event and its history, including the attributes defined below.
+
+duration     |      |
+-------------|------
+description  | Command execution time in seconds
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
+
+executed     |      |
+-------------|------
+description  | Time that the check request was executed
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+history      |      |
+-------------|------
+description  | Check status history for the last 21 check executions. See the [history attributes](#history-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"history": [
+  {
+    "executed": 1552505983,
+    "status": 0
+  },
+  {
+    "executed": 1552505993,
+    "status": 0
+  }
+]
+{{< /highlight >}}
+
+issued       |      |
+-------------|------
+description  | Time that the check request was issued in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"issued": 1552506033{{< /highlight >}}
+
+last_ok      |      |
+-------------|------
+description  | The last time that the check returned an OK `status` (`0`) in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"last_ok": 1552506033{{< /highlight >}}
+
+occurrences  |      |
+-------------|------
+description  | The number of times an event with the same status has occurred for the given entity and check
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"occurrences": 1{{< /highlight >}}
+
+occurrences_watermark | |
+-------------|------
+description  | The highest number of occurrences for the given entity and check at the current status
+required     | false 
+type         | Integer
+example      | {{< highlight shell >}}"occurrences_watermark": 1{{< /highlight >}}\
+
+output       |      |
+-------------|------
+description  | The output from the execution of the check command
+required     | false
+type         | String
+example      | {{< highlight shell >}}
+"output": "sensu-go-sandbox.curl_timings.time_total 0.005"
+{{< /highlight >}}
+
+state         |      |
+-------------|------
+description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+total_state_change | |
+-------------|------
+description  | The total state change percentage for the check's history
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"total_state_change": 0{{< /highlight >}}
+
+#### History attributes
+
+executed     |      |
+-------------|------
+description  |Time that the check request was executed in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+### Metric attributes
+
+handlers     |      |
+-------------|------
+description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"handlers": [
+  "influx-db"
+]
+{{< /highlight >}}
+
+points       |      |
+-------------|------
+description  | Metric data points including a name, timestamp, value, and tags. See the [points attributes](#points-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"points": [
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_total",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.005
+  },
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.004
+  }
+]
+{{< /highlight >}}
+
+#### Points attributes
+
+name         |      |
+-------------|------
+description  | The metric name in the format `$entity.$check.$metric` where `$entity` is the entity name, `$check` is the check name, and `$metric` is the metric name.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"name": "sensu-go-sandbox.curl_timings.time_total"{{< /highlight >}}
+
+tags         |      |
+-------------|------
+description  | Optional tags to include with the metric
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"tags": []{{< /highlight >}}
+
+timestamp    |      |
+-------------|------
+description  | Time that the metric was collected in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"timestamp": 1552506033{{< /highlight >}}
+
+value        |      |
+-------------|------
+description  | The metric value
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"value": 0.005{{< /highlight >}}
+
+## Examples
+
+### Example check-only event data
 
 {{< highlight json >}}
 {
   "type": "Event",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "namespace": "default"
   },
   "spec": {
-    "timestamp": 1542667666,
-    "entity": {
-      "entity_class": "agent",
-      "system": {
-        "hostname": "webserver01",
-        "os": "linux",
-        "platform": "centos",
-        "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "network": {
-          "interfaces": [
-            {
-              "name": "lo",
-              "addresses": [
-                "127.0.0.1/8",
-                "::1/128"
-              ]
-            },
-            {
-              "name": "enp0s3",
-              "mac": "08:00:27:11:ad:d2",
-              "addresses": [
-                "10.0.2.15/24",
-                "fe80::26a5:54ec:cf0d:9704/64"
-              ]
-            },
-            {
-              "name": "enp0s8",
-              "mac": "08:00:27:bc:be:60",
-              "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:febc:be60/64"
-              ]
-            }
-          ]
-        },
-        "arch": "amd64"
-      },
-      "subscriptions": [
-        "testing",
-        "entity:webserver01"
+    "check": {
+      "check_hooks": null,
+      "command": "check-cpu.sh -w 75 -c 90",
+      "duration": 1.07055808,
+      "env_vars": null,
+      "executed": 1552594757,
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "history": [
+        {
+          "executed": 1552594757,
+          "status": 0
+        }
       ],
-      "last_seen": 1542667635,
+      "interval": 60,
+      "issued": 1552594757,
+      "last_ok": 1552594758,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "check-cpu",
+        "namespace": "default"
+      },
+      "occurrences": 1,
+      "occurrences_watermark": 1,
+      "output": "CPU OK - Usage:3.96\n",
+      "output_metric_format": "",
+      "output_metric_handlers": [],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "linux"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
       "deregister": false,
       "deregistration": {},
-      "user": "agent",
+      "entity_class": "agent",
+      "last_seen": 1552594641,
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default"
+      },
       "redact": [
         "password",
         "passwd",
@@ -320,55 +730,269 @@ example      | {{< highlight json >}}
         "secret_key",
         "private_key",
         "secret"
-      ]
+      ],
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-centos",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::9688:67ca:3d78:ced9/64"
+              ],
+              "mac": "08:00:27:11:ad:d2",
+              "name": "enp0s3"
+            },
+            {
+              "addresses": [
+                "172.28.128.3/24",
+                "fe80::a00:27ff:fe6b:c1e9/64"
+              ],
+              "mac": "08:00:27:6b:c1:e9",
+              "name": "enp0s8"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.4.1708"
+      },
+      "user": "agent"
     },
+    "timestamp": 1552594758
+  }
+}
+{{< /highlight >}}
+
+### Example event with check and metric data
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
     "check": {
       "check_hooks": null,
-      "duration": 2.033888684,
-      "executed": 1522170513,
-      "command": "http_check.sh http://localhost:80",
-      "handlers": [
-        "slack"
-      ],
+      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "duration": 0.060790838,
+      "env_vars": null,
+      "executed": 1552506033,
+      "handlers": [],
       "high_flap_threshold": 0,
-      "interval": 20,
-      "low_flap_threshold": 0,
-      "publish": true,
-      "runtime_assets": [],
-      "subscriptions": [
-        "testing"
-      ],
-      "proxy_entity_name": "",
-      "check_hooks": null,
-      "stdin": false,
-      "ttl": 0,
-      "timeout": 0,
-      "duration": 0.010849143,
-      "executed": 1542667666,
       "history": [
         {
-          "status": 1,
-          "executed": 1542667666
+          "executed": 1552505833,
+          "status": 0
+        },
+        {
+          "executed": 1552505843,
+          "status": 0
         }
       ],
-      "issued": 1542667666,
-      "output": "",
-      "state": "failing",
-      "status": 1,
-      "total_state_change": 0,
-      "last_ok": 0,
+      "interval": 10,
+      "issued": 1552506033,
+      "last_ok": 1552506033,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "curl_timings",
+        "namespace": "default"
+      },
       "occurrences": 1,
       "occurrences_watermark": 1,
-      "output_metric_format": "",
-      "output_metric_handlers": [],
-      "env_vars": null,
+      "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+      "output_metric_format": "graphite_plaintext",
+      "output_metric_handlers": [
+        "influx-db"
+      ],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
       "metadata": {
-        "name": "check-nginx",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
-    }
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
+  }
+}
+{{< /highlight >}}
+
+### Example metric-only event
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
+      "metadata": {
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
   }
 }
 {{< /highlight >}}
@@ -380,3 +1004,6 @@ example      | {{< highlight json >}}
 [5]: ../../guides/aggregate-metrics-statsd/
 [6]: ../../guides/extract-metrics-with-checks
 [7]: ../checks/#check-specification
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes
+[26]: ../rbac#namespaces

--- a/content/sensu-go/5.2/reference/events.md
+++ b/content/sensu-go/5.2/reference/events.md
@@ -557,7 +557,7 @@ example      | {{< highlight shell >}}
 
 state         |      |
 -------------|------
-description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+description  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}

--- a/content/sensu-go/5.3/api/events.md
+++ b/content/sensu-go/5.3/api/events.md
@@ -171,72 +171,73 @@ output         | {{< highlight shell >}}
 
 ### `/events` (POST)
 
-/events (POST) | 
-----------------|------
-description     | Create a Sensu event.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
-payload         | {{< highlight shell >}}
-{
-  "timestamp": 1542667666,
+The `/events` API endpoint provides HTTP POST access to create an event and send it to the Sensu pipeline.
+
+#### EXAMPLE {#events-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/events` API to create an event.
+The request includes information about the check and entity represented by the event and returns a successful HTTP 200 OK response and the event definition.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
   "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "...": "...",
-      "arch": "amd64"
-    },
-    "subscriptions": [
-      "testing",
-      "entity:webserver01"
-    ],
+    "entity_class": "proxy",
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server1",
+      "namespace": "default"
     }
   },
   "check": {
-    "check_hooks": null,
-    "duration": 2.033888684,
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
-    "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "output": "",
+    "output": "Server error",
     "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events
+
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+#### API Specification {#events-post-specification}
+
+/events (POST) | 
+----------------|------
+description     | Create a Sensu event for a new entity and check combination. To create an event for an existing entity and check combination or to update an existing event, use the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
+payload         | {{< highlight shell >}}
+{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "state": "failing",
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section for the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Conflict**: 409 (Event already exists for the entity and check)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/events/:entity` API endpoint {#the-eventsentity-api-endpoint}
 
@@ -464,64 +465,209 @@ output               | {{< highlight json >}}
 
 ### `/events/:entity/:check` (PUT) {#eventsentitycheck-put}
 
+The `/events/:entity/:check` API endpoint provides HTTP PUT access to create or update an event and send it to the Sensu pipeline.
+
 #### EXAMPLE {#eventsentitycheck-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `sensu-go-entity` entity and the `check-cpu` check, resulting in a 200 (OK) HTTP response code.
+In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `server1` entity and the `server-health` check and process it using the `slack` event handler.
+The event includes a status code of `1`, indicating a warning, and an output message of "Server error".
 
 {{< highlight shell >}}
 curl -X PUT \
 -H "Authorization: Bearer TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
-  }
+  },
+  "timestamp": 1552582569
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
-
-HTTP/1.1 200 OK
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
 
+The request returns a 200 (OK) HTTP response code and the resulting event definition.
+
+{{< highlight shell >}}
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+You can use sensuctl or the [Sensu dashboard](../../dashboard/overview) to see the event.
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+You should see the event with the status and output specified in the request.
+
+{{< highlight shell >}}
+    Entity        Check                   Output                 Status   Silenced             Timestamp            
+────────────── ──────────── ─────────────────────────────────── ──────── ────────── ─────────────────────────────── 
+    server1      server-health   Server error             1      false      2019-03-14 16:56:09 +0000 UTC 
+{{< /highlight >}}
 
 #### API Specification {#eventsentitycheck-put-specification}
 
 /events/:entity/:check (PUT) | 
 ----------------|------
 description     | Creates an event for a given entity and check.
-example url     | http://hostname:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
+example url     | http://hostname:8080/api/core/v2/namespaces/default/events/server1/server-health
 payload         | {{< highlight shell >}}
 {
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}
+{{< /highlight >}}
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section below.
+response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+#### Payload parameters {#eventsentitycheck-put-parameters}
+
+The `/events/:entity/:check` PUT endpoint requires a request payload containing an `entity` scope and a `check` scope.
+The `entity` scope contains information about the component of your infrastructure represented by the event.
+At a minimum, Sensu requires the `entity` scope to contain the `entity_class` (`agent` or `proxy`) and the entity `name` and `namespace` within a `metadata` scope.
+For more information about entity attributes, see the [entity specification](../../reference/entities#specification).
+
+The `check` scope contains information about the event status and how the event was created.
+At a minimum, Sensu requires the `check` scope to contain a `name` within a `metadata` scope and either an `interval` or `cron` attribute.
+For more information about check attributes, see the [check specification](../../reference/checks#specification).
+
+**Example request with minimum required event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
   }
-}
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
-payload parameters | <ul><li>`timestamp` (required, integer): Unix timestamp for the event, for example `1542667666`</li><li>`entity` scope containing the `entity_class` and a `metadata` scope containing `name` (string) and `namespace` (string)</li><li>`check` scope containing `interval` (integer) or `cron` (string), and a `metadata` scope containing `name` (string) and `namespace` (string)</li>
-response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+The minimum required attributes shown above let you create an event using the `/events/:entity/:check` PUT endpoint, however the request can include any attributes defined in the [event specification](../../reference/events).
+To create useful, actionable events, we recommend adding check attributes such as the event `status` (`0` for OK, `1` for warning, `2` for critical), an `output` message, and one or more event `handlers`.
+For more information about these attributes and their available values, see the [event specification](../../reference/events).
+
+While a `timestamp` is not required to create an event, Sensu assigns a timestamp of `0` (January 1, 1970) to events without a specified timestamp, so we recommend adding a Unix timestamp when creating events.
+
+**Example request with minimum recommended event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
+{{< /highlight >}}
+
+#### Creating metric events
+
+In addition to the `entity` and `check` scopes, Sensu events can include a `metrics` scope containing metrics in Sensu metric format.
+See the [events reference](../../reference/events#metrics) and for more information about Sensu metric format.
+
+**Example request including metrics**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "status": 0,
+    "output_metric_handlers": ["influxdb"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-metrics"
+    }
+  },
+  "metrics": {
+    "handlers": [
+      "influxdb"
+    ],
+    "points": [
+      {
+        "name": "server1.server-metrics.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "server1.server-metrics.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552582569
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-metrics
+{{< /highlight >}}
 
 ### `/events/:entity/:check` (DELETE) {#eventsentitycheck-delete}
 

--- a/content/sensu-go/5.3/reference/events.md
+++ b/content/sensu-go/5.3/reference/events.md
@@ -10,10 +10,22 @@ menu:
     parent: reference
 ---
 
-- [Specification](#events-specification)
-- [Examples](#example-check-only-event-data)
+- [How do events work?](#how-do-events-work)
+- [Creating events using the Sensu agent](#creating-events-using-the-sensu-agent)
+- [Creating events using the events API](#creating-events-using-the-events-api)
+- [Managing events](#managing-events)
+  - [Deleting events](#deleting-events)
+  - [Resolving events](#resolving-events)
+- [Event format](#event-format)
+- [Using event data](#using-event-data)
+- [Events specification](#events-specification)
+	- [Top-level attributes](#top-level-attributes)
+	- [Spec attributes](#spec-attributes)
+	- [Check attributes](#check-attributes)
+	- [Metric attributes](#metric-attributes)
+- [Examples](#examples)
 
-## How do Events work?
+## How do events work?
 
 An event is a generic container used by Sensu to provide context to checks
 and/or metrics. The context, called "event data," contains information about the
@@ -23,7 +35,7 @@ These generic containers allow Sensu to handle different types of events in the
 pipeline. Since events are polymorphic in nature, it is important to never
 assume their contents, or lack-thereof.
 
-## Check-only events
+### Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu
 server, regardless of the status indicated by the check result. An event is
@@ -33,7 +45,7 @@ forwarded to the Sensu backend for processing. Potentially noteworthy events may
 be processed by one or more event handlers to do things such as send an email or
 invoke an automated action.
 
-## Metric-only events
+### Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the
 [Statsd listener][5]. The agent will translate the statsd metrics to Sensu
@@ -41,7 +53,7 @@ Metric Format, and place them inside an event. These events, since they do not
 contain checks, bypass the store, and are sent off to the event pipeline and
 corresponding event handlers.
 
-## Check and metric events
+### Check and metric events
 
 Events that contain _both_ a check and metrics, most likely originated from
 [check output metric extraction][6]. If a check is configured for metric
@@ -50,187 +62,195 @@ Metric Format. Both the check results, and resulting (extracted) metrics are
 stored inside the event. Event handlers from `event.Check.Handlers` and
 `event.Metrics.Handlers` will be invoked.
 
+## Creating events using the Sensu agent
+
+The Sensu agent is a powerful event producer and monitoring automation tool.
+You can use Sensu agents to produce events automatically using service checks and metric checks.
+Sensu agents can also act as a collector for metrics throughout your infrastructure.
+
+- [Creating events using service checks](../agent#creating-monitoring-events-using-service-checks)
+- [Creating events using metric checks](../../guides/extract-metrics-with-checks)
+- [Creating events using the agent API](../agent#creating-monitoring-events-using-the-agent-api)
+- [Creating events using the agent TCP and UDP sockets](../agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets)
+- [Creating events using the StatsD listener](../agent#creating-monitoring-events-using-the-statsd-listener)
+
+## Creating events using the events API
+
+You can send events directly to the Sensu pipeline using the events API.
+To create an event, send a JSON event definition to the [events API PUT endpoint](../../api/events#eventsentitycheck-put).
+
+## Managing events
+
+You can manage event using the [Sensu dashboard](../../dashboard/overview), [events API](../../api/events), and the [sensuctl](../../sensuctl/reference) command line tool.
+
+### Viewing events
+
+To list all events:
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+To show event details in the default [output format](../../sensuctl/reference/#preferred-output-format):
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name
+{{< /highlight >}}
+
+With both the `list` and `info` commands, you can specify an [output format](../../sensuctl/reference/#preferred-output-format) using the `--format` flag:
+
+- `yaml` or `wrapped-json` formats for use with [`sensuctl create`][sc]
+- `json` format for use with the [events API](../../api/events)
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name --format yaml
+{{< /highlight >}}
+
+### Deleting events
+
+To delete an event:
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name
+{{< /highlight >}}
+
+You can use the `--skip-confirm` flag to skip the confirmation step.
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name --skip-confirm
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Deleted
+{{< /highlight >}}
+
+### Resolving events
+
+You can use sensuctl to change the status of an event to `0` (OK).
+Events resolved by sensuctl include the output message: "Resolved manually by sensuctl".
+
+{{< highlight shell >}}
+sensuctl event resolve entity-name check-name
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Resolved
+{{< /highlight >}}
+
+## Event format
+
+Sensu events contain:
+
+- `entity` scope (required)
+  - Information about the source of the event, including any attributes defined in the [entity specification](../entities#entities-specification)
+- `check` scope (optional if the `metrics` scope is present)
+  - Information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification)
+  - Information about the event and its history, including any check attributes defined in the [event specification on this page](#check-attributes)
+- `metrics` scope (optional if the `check` scope is present)
+  - Metric points in [Sensu metric format](#metrics)
+- `timestamp`
+  - Time that the event occurred in seconds since the Unix epoch
+
+## Using event data
+
+Event data is powerful tool for automating monitoring workflows.
+For example, see [the guide to reducing alert fatigue](guides/reduce-alert-fatigue/) by filtering events based on the event `occurrences` attribute.
+
 ## Events specification
 
-### Attributes
-|timestamp   |      |
--------------|------
-description  | The time of the Event occurrence in epoch time.
-type         | integer
-example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+### Top-level attributes
 
-|silenced (deprecated)    |      |
+type         | 
 -------------|------
-description  | If the event is to be silenced.
-type         | boolean
-example      | {{< highlight shell >}}"silenced": false{{< /highlight >}}
-_NOTE: Silenced has been deprecated from Event. Please see [check specification][7]._
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Events should always be of type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Event"{{< /highlight >}}
 
-|check       |      |
+api_version  | 
 -------------|------
-description  | The [check attributes][1] used to obtain the check result.
-type         | Check
+description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.3, this attribute should always be `core/v2`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level scope containing the event `namespace`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference](#metadata-attributes) for details.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "namespace": "default"
+}{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the event [spec attributes][sp].
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
 example      | {{< highlight shell >}}
-{
+"spec": {
   "check": {
     "check_hooks": null,
-    "duration": 1.903135228,
-    "executed": 1522100915,
+    "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
     "high_flap_threshold": 0,
     "history": [
       {
-        "executed": 1522100315
+        "executed": 1552505833,
+        "status": 0
       },
       {
-        "executed": 1522100915
+        "executed": 1552505843,
+        "status": 0
       }
     ],
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
+    "interval": 10,
+    "issued": 1552506033,
+    "last_ok": 1552506033,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "round_robin": false,
-    "duration": 0.010849143,
-    "executed": 1542667666,
-    "history": [
-      {
-        "status": 1,
-        "executed": 1542667666
-      }
-    ],
-    "issued": 1542667666,
-    "output": "",
-    "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
     "occurrences": 1,
     "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
-    "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
-}
-{{< /highlight >}}
-
-<a name="metrics">
-
-|metrics     |      |
--------------|------
-description  | The metrics collected by the entity.
-type         | Metrics
-example      | {{< highlight json >}}
-{
-  "metrics": {
-    "handlers": [
+    "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+    "output_metric_format": "graphite_plaintext",
+    "output_metric_handlers": [
       "influx-db"
     ],
-    "points": [
-      {
-        "name": "weather.temperature",
-        "value": 82,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      },
-      {
-        "name": "weather.humidity",
-        "value": 30,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      }
-    ]
-  }
-}
-{{< /highlight >}}
-
-|entity      |      |
--------------|------
-description  | The [entity attributes][2] from the originating entity (agent or proxy).
-type         | Entity
-example      | {{< highlight json >}}
-{
-  "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "os": "linux",
-      "platform": "centos",
-      "platform_family": "rhel",
-      "platform_version": "7.4.1708",
-      "network": {
-        "interfaces": [
-          {
-            "name": "lo",
-            "addresses": [
-              "127.0.0.1/8",
-              "::1/128"
-            ]
-          },
-          {
-            "name": "enp0s3",
-            "mac": "08:00:27:11:ad:d2",
-            "addresses": [
-              "10.0.2.15/24",
-              "fe80::26a5:54ec:cf0d:9704/64"
-            ]
-          },
-          {
-            "name": "enp0s8",
-            "mac": "08:00:27:bc:be:60",
-            "addresses": [
-              "172.28.128.3/24",
-              "fe80::a00:27ff:febc:be60/64"
-            ]
-          }
-        ]
-      },
-      "arch": "amd64"
-    },
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "testing",
-      "entity:webserver01"
+      "entity:sensu-go-sandbox"
     ],
-    "last_seen": 1542667635,
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  },
+  "entity": {
     "deregister": false,
     "deregistration": {},
-    "user": "agent",
+    "entity_class": "agent",
+    "last_seen": 1552495139,
+    "metadata": {
+      "name": "sensu-go-sandbox",
+      "namespace": "default"
+    },
     "redact": [
       "password",
       "passwd",
@@ -242,75 +262,464 @@ example      | {{< highlight json >}}
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
+    "subscriptions": [
+      "entity:sensu-go-sandbox"
+    ],
+    "system": {
+      "arch": "amd64",
+      "hostname": "sensu-go-sandbox",
+      "network": {
+        "interfaces": [
+          {
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ],
+            "name": "lo"
+          },
+          {
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::5a94:f67a:1bfc:a579/64"
+            ],
+            "mac": "08:00:27:8b:c9:3f",
+            "name": "eth0"
+          }
+        ]
+      },
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804"
+    },
+    "user": "agent"
+  },
+  "metrics": {
+    "handlers": [
+      "influx-db"
+    ],
+    "points": [
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552506033
 }
 {{< /highlight >}}
 
-## Example check-only event data
+### Metadata attributes
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][26] that this event belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+### Spec attributes
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred in seconds since the Unix epoch
+required     | false
+type         | Integer
+default      | `0`
+example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+
+|entity      |      |
+-------------|------
+description  | The [entity attributes][2] from the originating entity (agent or proxy).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"entity": {
+  "deregister": false,
+  "deregistration": {},
+  "entity_class": "agent",
+  "last_seen": 1552495139,
+  "metadata": {
+    "name": "sensu-go-sandbox",
+    "namespace": "default"
+  },
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "system": {
+    "arch": "amd64",
+    "hostname": "sensu-go-sandbox",
+    "network": {
+      "interfaces": [
+        {
+          "addresses": [
+            "127.0.0.1/8",
+            "::1/128"
+          ],
+          "name": "lo"
+        },
+        {
+          "addresses": [
+            "10.0.2.15/24",
+            "fe80::5a94:f67a:1bfc:a579/64"
+          ],
+          "mac": "08:00:27:8b:c9:3f",
+          "name": "eth0"
+        }
+      ]
+    },
+    "os": "linux",
+    "platform": "centos",
+    "platform_family": "rhel",
+    "platform_version": "7.5.1804"
+  },
+  "user": "agent"
+}
+{{< /highlight >}}
+
+|check       |      |
+-------------|------
+description  | The [check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification](#check-attributes) and the [check specification](../checks#check-specification).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"check": {
+  "check_hooks": null,
+  "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+  "duration": 0.060790838,
+  "env_vars": null,
+  "executed": 1552506033,
+  "handlers": [],
+  "high_flap_threshold": 0,
+  "history": [
+    {
+      "executed": 1552505833,
+      "status": 0
+    },
+    {
+      "executed": 1552505843,
+      "status": 0
+    }
+  ],
+  "interval": 10,
+  "issued": 1552506033,
+  "last_ok": 1552506033,
+  "low_flap_threshold": 0,
+  "metadata": {
+    "name": "curl_timings",
+    "namespace": "default"
+  },
+  "occurrences": 1,
+  "occurrences_watermark": 1,
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005",
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+  "proxy_entity_name": "",
+  "publish": true,
+  "round_robin": false,
+  "runtime_assets": [],
+  "state": "passing",
+  "status": 0,
+  "stdin": false,
+  "subdue": null,
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "timeout": 0,
+  "total_state_change": 0,
+  "ttl": 0
+}
+{{< /highlight >}}
+
+<a name="metrics"></a>
+
+|metrics     |      |
+-------------|------
+description  | The metrics collected by the entity in Sensu metric format. See the [metrics attributes](#metric-attributes).
+type         | Map
+required     | false
+example      | {{< highlight shell >}}
+"metrics": {
+  "handlers": [
+    "influx-db"
+  ],
+  "points": [
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_total",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.005
+    },
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.004
+    }
+  ]
+}
+{{< /highlight >}}
+
+### Check attributes
+
+Sensu events include a `check` scope containing information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification), and information about the event and its history, including the attributes defined below.
+
+duration     |      |
+-------------|------
+description  | Command execution time in seconds
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
+
+executed     |      |
+-------------|------
+description  | Time that the check request was executed
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+history      |      |
+-------------|------
+description  | Check status history for the last 21 check executions. See the [history attributes](#history-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"history": [
+  {
+    "executed": 1552505983,
+    "status": 0
+  },
+  {
+    "executed": 1552505993,
+    "status": 0
+  }
+]
+{{< /highlight >}}
+
+issued       |      |
+-------------|------
+description  | Time that the check request was issued in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"issued": 1552506033{{< /highlight >}}
+
+last_ok      |      |
+-------------|------
+description  | The last time that the check returned an OK `status` (`0`) in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"last_ok": 1552506033{{< /highlight >}}
+
+occurrences  |      |
+-------------|------
+description  | The number of times an event with the same status has occurred for the given entity and check
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"occurrences": 1{{< /highlight >}}
+
+occurrences_watermark | |
+-------------|------
+description  | The highest number of occurrences for the given entity and check at the current status
+required     | false 
+type         | Integer
+example      | {{< highlight shell >}}"occurrences_watermark": 1{{< /highlight >}}\
+
+output       |      |
+-------------|------
+description  | The output from the execution of the check command
+required     | false
+type         | String
+example      | {{< highlight shell >}}
+"output": "sensu-go-sandbox.curl_timings.time_total 0.005"
+{{< /highlight >}}
+
+state         |      |
+-------------|------
+description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+total_state_change | |
+-------------|------
+description  | The total state change percentage for the check's history
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"total_state_change": 0{{< /highlight >}}
+
+#### History attributes
+
+executed     |      |
+-------------|------
+description  |Time that the check request was executed in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+### Metric attributes
+
+handlers     |      |
+-------------|------
+description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"handlers": [
+  "influx-db"
+]
+{{< /highlight >}}
+
+points       |      |
+-------------|------
+description  | Metric data points including a name, timestamp, value, and tags. See the [points attributes](#points-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"points": [
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_total",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.005
+  },
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.004
+  }
+]
+{{< /highlight >}}
+
+#### Points attributes
+
+name         |      |
+-------------|------
+description  | The metric name in the format `$entity.$check.$metric` where `$entity` is the entity name, `$check` is the check name, and `$metric` is the metric name.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"name": "sensu-go-sandbox.curl_timings.time_total"{{< /highlight >}}
+
+tags         |      |
+-------------|------
+description  | Optional tags to include with the metric
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"tags": []{{< /highlight >}}
+
+timestamp    |      |
+-------------|------
+description  | Time that the metric was collected in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"timestamp": 1552506033{{< /highlight >}}
+
+value        |      |
+-------------|------
+description  | The metric value
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"value": 0.005{{< /highlight >}}
+
+## Examples
+
+### Example check-only event data
 
 {{< highlight json >}}
 {
   "type": "Event",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "namespace": "default"
   },
   "spec": {
-    "timestamp": 1542667666,
-    "entity": {
-      "entity_class": "agent",
-      "system": {
-        "hostname": "webserver01",
-        "os": "linux",
-        "platform": "centos",
-        "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "network": {
-          "interfaces": [
-            {
-              "name": "lo",
-              "addresses": [
-                "127.0.0.1/8",
-                "::1/128"
-              ]
-            },
-            {
-              "name": "enp0s3",
-              "mac": "08:00:27:11:ad:d2",
-              "addresses": [
-                "10.0.2.15/24",
-                "fe80::26a5:54ec:cf0d:9704/64"
-              ]
-            },
-            {
-              "name": "enp0s8",
-              "mac": "08:00:27:bc:be:60",
-              "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:febc:be60/64"
-              ]
-            }
-          ]
-        },
-        "arch": "amd64"
-      },
-      "subscriptions": [
-        "testing",
-        "entity:webserver01"
+    "check": {
+      "check_hooks": null,
+      "command": "check-cpu.sh -w 75 -c 90",
+      "duration": 1.07055808,
+      "env_vars": null,
+      "executed": 1552594757,
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "history": [
+        {
+          "executed": 1552594757,
+          "status": 0
+        }
       ],
-      "last_seen": 1542667635,
+      "interval": 60,
+      "issued": 1552594757,
+      "last_ok": 1552594758,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "check-cpu",
+        "namespace": "default"
+      },
+      "occurrences": 1,
+      "occurrences_watermark": 1,
+      "output": "CPU OK - Usage:3.96\n",
+      "output_metric_format": "",
+      "output_metric_handlers": [],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "linux"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
       "deregister": false,
       "deregistration": {},
-      "user": "agent",
+      "entity_class": "agent",
+      "last_seen": 1552594641,
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default"
+      },
       "redact": [
         "password",
         "passwd",
@@ -321,56 +730,269 @@ example      | {{< highlight json >}}
         "secret_key",
         "private_key",
         "secret"
-      ]
+      ],
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-centos",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::9688:67ca:3d78:ced9/64"
+              ],
+              "mac": "08:00:27:11:ad:d2",
+              "name": "enp0s3"
+            },
+            {
+              "addresses": [
+                "172.28.128.3/24",
+                "fe80::a00:27ff:fe6b:c1e9/64"
+              ],
+              "mac": "08:00:27:6b:c1:e9",
+              "name": "enp0s8"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.4.1708"
+      },
+      "user": "agent"
     },
+    "timestamp": 1552594758
+  }
+}
+{{< /highlight >}}
+
+### Example event with check and metric data
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
     "check": {
       "check_hooks": null,
-      "duration": 2.033888684,
-      "executed": 1522170513,
-      "command": "http_check.sh http://localhost:80",
-      "handlers": [
-        "slack"
-      ],
+      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "duration": 0.060790838,
+      "env_vars": null,
+      "executed": 1552506033,
+      "handlers": [],
       "high_flap_threshold": 0,
-      "interval": 20,
-      "low_flap_threshold": 0,
-      "publish": true,
-      "runtime_assets": [],
-      "subscriptions": [
-        "testing"
-      ],
-      "proxy_entity_name": "",
-      "check_hooks": null,
-      "stdin": false,
-      "ttl": 0,
-      "timeout": 0,
-      "round_robin": false,
-      "duration": 0.010849143,
-      "executed": 1542667666,
       "history": [
         {
-          "status": 1,
-          "executed": 1542667666
+          "executed": 1552505833,
+          "status": 0
+        },
+        {
+          "executed": 1552505843,
+          "status": 0
         }
       ],
-      "issued": 1542667666,
-      "output": "",
-      "state": "failing",
-      "status": 1,
-      "total_state_change": 0,
-      "last_ok": 0,
+      "interval": 10,
+      "issued": 1552506033,
+      "last_ok": 1552506033,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "curl_timings",
+        "namespace": "default"
+      },
       "occurrences": 1,
       "occurrences_watermark": 1,
-      "output_metric_format": "",
-      "output_metric_handlers": [],
-      "env_vars": null,
+      "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+      "output_metric_format": "graphite_plaintext",
+      "output_metric_handlers": [
+        "influx-db"
+      ],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
       "metadata": {
-        "name": "check-nginx",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
-    }
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
+  }
+}
+{{< /highlight >}}
+
+### Example metric-only event
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
+      "metadata": {
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
   }
 }
 {{< /highlight >}}
@@ -382,3 +1004,6 @@ example      | {{< highlight json >}}
 [5]: ../../guides/aggregate-metrics-statsd/
 [6]: ../../guides/extract-metrics-with-checks
 [7]: ../checks/#check-specification
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes
+[26]: ../rbac#namespaces

--- a/content/sensu-go/5.3/reference/events.md
+++ b/content/sensu-go/5.3/reference/events.md
@@ -557,7 +557,7 @@ example      | {{< highlight shell >}}
 
 state         |      |
 -------------|------
-description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+description  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}

--- a/content/sensu-go/5.4/api/events.md
+++ b/content/sensu-go/5.4/api/events.md
@@ -171,72 +171,71 @@ output         | {{< highlight shell >}}
 
 ### `/events` (POST)
 
-/events (POST) | 
-----------------|------
-description     | Create a Sensu event.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
-payload         | {{< highlight shell >}}
-{
-  "timestamp": 1542667666,
+The `/events` API endpoint provides HTTP POST access to create an event and send it to the Sensu pipeline.
+
+#### EXAMPLE {#events-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/events` API to create an event.
+The request includes information about the check and entity represented by the event and returns a successful HTTP 200 OK response and the event definition.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
   "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "...": "...",
-      "arch": "amd64"
-    },
-    "subscriptions": [
-      "testing",
-      "entity:webserver01"
-    ],
+    "entity_class": "proxy",
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server1",
+      "namespace": "default"
     }
   },
   "check": {
-    "check_hooks": null,
-    "duration": 2.033888684,
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
-    "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "duration": 0.010849143,
-    "output": "",
+    "output": "Server error",
     "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
     "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "name": "server-health"
+    }
+  }
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events
+
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+#### API Specification {#events-post-specification}
+
+/events (POST) | 
+----------------|------
+description     | Create a Sensu event for a new entity and check combination. To create an event for an existing entity and check combination or to update an existing event, use the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
+payload         | {{< highlight shell >}}
+{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "state": "failing",
+    "status": 2,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
     }
   }
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section for the [`/events/:entity/:check` PUT endpoint](#eventsentitycheck-put).
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Conflict**: 409 (Event already exists for the entity and check)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/events/:entity` API endpoint {#the-eventsentity-api-endpoint}
 
@@ -464,64 +463,203 @@ output               | {{< highlight json >}}
 
 ### `/events/:entity/:check` (PUT) {#eventsentitycheck-put}
 
+The `/events/:entity/:check` API endpoint provides HTTP PUT access to create or update an event and send it to the Sensu pipeline.
+
 #### EXAMPLE {#eventsentitycheck-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `sensu-go-entity` entity and the `check-cpu` check, resulting in a 200 (OK) HTTP response code.
+In the following example, an HTTP PUT request is submitted to the `/events/:entity/:check` API to create an event for the `server1` entity and the `server-health` check and process it using the `slack` event handler.
+The event includes a status code of `1`, indicating a warning, and an output message of "Server error".
 
 {{< highlight shell >}}
 curl -X PUT \
 -H "Authorization: Bearer TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
   }
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
-
-HTTP/1.1 200 OK
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
 
+The request returns a 200 (OK) HTTP response code and the resulting event definition.
+
+{{< highlight shell >}}
+HTTP/1.1 200 OK
+{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{{< /highlight >}}
+
+You can use sensuctl or the [Sensu dashboard](../../dashboard/overview) to see the event.
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+You should see the event with the status and output specified in the request.
+
+{{< highlight shell >}}
+    Entity        Check                   Output                 Status   Silenced             Timestamp            
+────────────── ───────────── ─────────────────────────────────── ──────── ────────── ─────────────────────────────── 
+    server1    server-health   Server error                         1       false      2019-03-14 16:56:09 +0000 UTC 
+{{< /highlight >}}
 
 #### API Specification {#eventsentitycheck-put-specification}
 
 /events/:entity/:check (PUT) | 
 ----------------|------
 description     | Creates an event for a given entity and check.
-example url     | http://hostname:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu
+example url     | http://hostname:8080/api/core/v2/namespaces/default/events/server1/server-health
 payload         | {{< highlight shell >}}
 {
-  "timestamp": 1542667666,
   "entity": {
-    "entity_class": "agent",
+    "entity_class": "proxy",
     "metadata": {
-      "name": "sensu-go-sandbox",
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  }
+}
+{{< /highlight >}}
+payload parameters | See the [payload parameters](#eventsentitycheck-put-parameters) section below.
+response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+#### Payload parameters {#eventsentitycheck-put-parameters}
+
+The `/events/:entity/:check` PUT endpoint requires a request payload containing an `entity` scope and a `check` scope.
+The `entity` scope contains information about the component of your infrastructure represented by the event.
+At a minimum, Sensu requires the `entity` scope to contain the `entity_class` (`agent` or `proxy`) and the entity `name` and `namespace` within a `metadata` scope.
+For more information about entity attributes, see the [entity specification](../../reference/entities#specification).
+
+The `check` scope contains information about the event status and how the event was created.
+At a minimum, Sensu requires the `check` scope to contain a `name` within a `metadata` scope and either an `interval` or `cron` attribute.
+For more information about check attributes, see the [check specification](../../reference/checks#specification).
+
+**Example request with minimum required event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
       "namespace": "default"
     }
   },
   "check": {
     "interval": 60,
     "metadata": {
-      "name": "check-cpu",
-      "namespace": "default"
+      "name": "server-health"
     }
   }
-}
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
 {{< /highlight >}}
-payload parameters | <ul><li>`timestamp` (required, integer): Unix timestamp for the event, for example `1542667666`</li><li>`entity` scope containing the `entity_class` and a `metadata` scope containing `name` (string) and `namespace` (string)</li><li>`check` scope containing `interval` (integer) or `cron` (string), and a `metadata` scope containing `name` (string) and `namespace` (string)</li>
-response codes   | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+The minimum required attributes shown above let you create an event using the `/events/:entity/:check` PUT endpoint, however the request can include any attributes defined in the [event specification](../../reference/events).
+To create useful, actionable events, we recommend adding check attributes such as the event `status` (`0` for OK, `1` for warning, `2` for critical), an `output` message, and one or more event `handlers`.
+For more information about these attributes and their available values, see the [event specification](../../reference/events).
+
+**Example request with minimum recommended event attributes**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "output": "Server error",
+    "status": 1,
+    "handlers": ["slack"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-health"
+    }
+  }
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health
+{{< /highlight >}}
+
+#### Creating metric events
+
+In addition to the `entity` and `check` scopes, Sensu events can include a `metrics` scope containing metrics in Sensu metric format.
+See the [events reference](../../reference/events#metrics) and for more information about Sensu metric format.
+
+**Example request including metrics**
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "entity": {
+    "entity_class": "proxy",
+    "metadata": {
+      "name": "server1",
+      "namespace": "default"
+    }
+  },
+  "check": {
+    "status": 0,
+    "output_metric_handlers": ["influxdb"],
+    "interval": 60,
+    "metadata": {
+      "name": "server-metrics"
+    }
+  },
+  "metrics": {
+    "handlers": [
+      "influxdb"
+    ],
+    "points": [
+      {
+        "name": "server1.server-metrics.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "server1.server-metrics.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  }
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-metrics
+{{< /highlight >}}
 
 ### `/events/:entity/:check` (DELETE) {#eventsentitycheck-delete}
 

--- a/content/sensu-go/5.4/reference/events.md
+++ b/content/sensu-go/5.4/reference/events.md
@@ -174,7 +174,7 @@ example      | {{< highlight shell >}}"type": "Event"{{< /highlight >}}
 
 api_version  | 
 -------------|------
-description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.3, this attribute should always be `core/v2`.
+description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.4, this attribute should always be `core/v2`.
 required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
 type         | String
 example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}

--- a/content/sensu-go/5.4/reference/events.md
+++ b/content/sensu-go/5.4/reference/events.md
@@ -558,7 +558,7 @@ example      | {{< highlight shell >}}
 
 state         |      |
 -------------|------
-description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
+description  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}

--- a/content/sensu-go/5.4/reference/events.md
+++ b/content/sensu-go/5.4/reference/events.md
@@ -10,10 +10,23 @@ menu:
     parent: reference
 ---
 
-- [Specification](#events-specification)
-- [Examples](#example-check-only-event-data)
 
-## How do Events work?
+- [How do events work?](#how-do-events-work)
+- [Creating events using the Sensu agent](#creating-events-using-the-sensu-agent)
+- [Creating events using the events API](#creating-events-using-the-events-api)
+- [Managing events](#managing-events)
+  - [Deleting events](#deleting-events)
+  - [Resolving events](#resolving-events)
+- [Event format](#event-format)
+- [Using event data](#using-event-data)
+- [Events specification](#events-specification)
+	- [Top-level attributes](#top-level-attributes)
+	- [Spec attributes](#spec-attributes)
+	- [Check attributes](#check-attributes)
+	- [Metric attributes](#metric-attributes)
+- [Examples](#examples)
+
+## How do events work?
 
 An event is a generic container used by Sensu to provide context to checks
 and/or metrics. The context, called "event data," contains information about the
@@ -23,7 +36,7 @@ These generic containers allow Sensu to handle different types of events in the
 pipeline. Since events are polymorphic in nature, it is important to never
 assume their contents, or lack-thereof.
 
-## Check-only events
+### Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu
 server, regardless of the status indicated by the check result. An event is
@@ -33,7 +46,7 @@ forwarded to the Sensu backend for processing. Potentially noteworthy events may
 be processed by one or more event handlers to do things such as send an email or
 invoke an automated action.
 
-## Metric-only events
+### Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the
 [Statsd listener][5]. The agent will translate the statsd metrics to Sensu
@@ -41,7 +54,7 @@ Metric Format, and place them inside an event. These events, since they do not
 contain checks, bypass the store, and are sent off to the event pipeline and
 corresponding event handlers.
 
-## Check and metric events
+### Check and metric events
 
 Events that contain _both_ a check and metrics, most likely originated from
 [check output metric extraction][6]. If a check is configured for metric
@@ -50,187 +63,195 @@ Metric Format. Both the check results, and resulting (extracted) metrics are
 stored inside the event. Event handlers from `event.Check.Handlers` and
 `event.Metrics.Handlers` will be invoked.
 
+## Creating events using the Sensu agent
+
+The Sensu agent is a powerful event producer and monitoring automation tool.
+You can use Sensu agents to produce events automatically using service checks and metric checks.
+Sensu agents can also act as a collector for metrics throughout your infrastructure.
+
+- [Creating events using service checks](../agent#creating-monitoring-events-using-service-checks)
+- [Creating events using metric checks](../../guides/extract-metrics-with-checks)
+- [Creating events using the agent API](../agent#creating-monitoring-events-using-the-agent-api)
+- [Creating events using the agent TCP and UDP sockets](../agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets)
+- [Creating events using the StatsD listener](../agent#creating-monitoring-events-using-the-statsd-listener)
+
+## Creating events using the events API
+
+You can send events directly to the Sensu pipeline using the events API.
+To create an event, send a JSON event definition to the [events API PUT endpoint](../../api/events#eventsentitycheck-put).
+
+## Managing events
+
+You can manage event using the [Sensu dashboard](../../dashboard/overview), [events API](../../api/events), and the [sensuctl](../../sensuctl/reference) command line tool.
+
+### Viewing events
+
+To list all events:
+
+{{< highlight shell >}}
+sensuctl event list
+{{< /highlight >}}
+
+To show event details in the default [output format](../../sensuctl/reference/#preferred-output-format):
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name
+{{< /highlight >}}
+
+With both the `list` and `info` commands, you can specify an [output format](../../sensuctl/reference/#preferred-output-format) using the `--format` flag:
+
+- `yaml` or `wrapped-json` formats for use with [`sensuctl create`][sc]
+- `json` format for use with the [events API](../../api/events)
+
+{{< highlight shell >}}
+sensuctl event info entity-name check-name --format yaml
+{{< /highlight >}}
+
+### Deleting events
+
+To delete an event:
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name
+{{< /highlight >}}
+
+You can use the `--skip-confirm` flag to skip the confirmation step.
+
+{{< highlight shell >}}
+sensuctl event delete entity-name check-name --skip-confirm
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Deleted
+{{< /highlight >}}
+
+### Resolving events
+
+You can use sensuctl to change the status of an event to `0` (OK).
+Events resolved by sensuctl include the output message: "Resolved manually by sensuctl".
+
+{{< highlight shell >}}
+sensuctl event resolve entity-name check-name
+{{< /highlight >}}
+
+You should see a confirmation message on success.
+
+{{< highlight shell >}}
+Resolved
+{{< /highlight >}}
+
+## Event format
+
+Sensu events contain:
+
+- `entity` scope (required)
+  - Information about the source of the event, including any attributes defined in the [entity specification](../entities#entities-specification)
+- `check` scope (optional if the `metrics` scope is present)
+  - Information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification)
+  - Information about the event and its history, including any check attributes defined in the [event specification on this page](#check-attributes)
+- `metrics` scope (optional if the `check` scope is present)
+  - Metric points in [Sensu metric format](#metrics)
+- `timestamp`
+  - Time that the event occurred in seconds since the Unix epoch
+
+## Using event data
+
+Event data is powerful tool for automating monitoring workflows.
+For example, see [the guide to reducing alert fatigue](guides/reduce-alert-fatigue/) by filtering events based on the event `occurrences` attribute.
+
 ## Events specification
 
-### Attributes
-|timestamp   |      |
--------------|------
-description  | The time of the Event occurrence in epoch time.
-type         | integer
-example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+### Top-level attributes
 
-|silenced (deprecated)    |      |
+type         | 
 -------------|------
-description  | If the event is to be silenced.
-type         | boolean
-example      | {{< highlight shell >}}"silenced": false{{< /highlight >}}
-_NOTE: Silenced has been deprecated from Event. Please see [check specification][7]._
+description  | Top-level attribute specifying the [`sensuctl create`][sc] resource type. Events should always be of type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"type": "Event"{{< /highlight >}}
 
-|check       |      |
+api_version  | 
 -------------|------
-description  | The [check attributes][1] used to obtain the check result.
-type         | Check
+description  | Top-level attribute specifying the Sensu API group and version. For events in Sensu backend version 5.3, this attribute should always be `core/v2`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | String
+example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
+
+metadata     | 
+-------------|------
+description  | Top-level scope containing the event `namespace`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes reference](#metadata-attributes) for details.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"metadata": {
+  "namespace": "default"
+}{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the event [spec attributes][sp].
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+type         | Map of key-value pairs
 example      | {{< highlight shell >}}
-{
+"spec": {
   "check": {
     "check_hooks": null,
-    "duration": 1.903135228,
-    "executed": 1522100915,
+    "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
     "high_flap_threshold": 0,
     "history": [
       {
-        "executed": 1522100315
+        "executed": 1552505833,
+        "status": 0
       },
       {
-        "executed": 1522100915
+        "executed": 1552505843,
+        "status": 0
       }
     ],
-    "command": "http_check.sh http://localhost:80",
-    "handlers": [
-      "slack"
-    ],
-    "high_flap_threshold": 0,
-    "interval": 20,
+    "interval": 10,
+    "issued": 1552506033,
+    "last_ok": 1552506033,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": [],
-    "subscriptions": [
-      "testing"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "round_robin": false,
-    "duration": 0.010849143,
-    "executed": 1542667666,
-    "history": [
-      {
-        "status": 1,
-        "executed": 1542667666
-      }
-    ],
-    "issued": 1542667666,
-    "output": "",
-    "state": "failing",
-    "status": 1,
-    "total_state_change": 0,
-    "last_ok": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
     "occurrences": 1,
     "occurrences_watermark": 1,
-    "output_metric_format": "",
-    "output_metric_handlers": [],
-    "env_vars": null,
-    "metadata": {
-      "name": "check-nginx",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
-}
-{{< /highlight >}}
-
-<a name="metrics">
-
-|metrics     |      |
--------------|------
-description  | The metrics collected by the entity.
-type         | Metrics
-example      | {{< highlight json >}}
-{
-  "metrics": {
-    "handlers": [
+    "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+    "output_metric_format": "graphite_plaintext",
+    "output_metric_handlers": [
       "influx-db"
     ],
-    "points": [
-      {
-        "name": "weather.temperature",
-        "value": 82,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      },
-      {
-        "name": "weather.humidity",
-        "value": 30,
-        "timestamp": 1465839830,
-        "tags": [
-          {
-            "name": "location",
-            "value": "us-midwest"
-          },
-          {
-            "name": "season",
-            "value": "summer"
-          }
-        ]
-      }
-    ]
-  }
-}
-{{< /highlight >}}
-
-|entity      |      |
--------------|------
-description  | The [entity attributes][2] from the originating entity (agent or proxy).
-type         | Entity
-example      | {{< highlight json >}}
-{
-  "entity": {
-    "entity_class": "agent",
-    "system": {
-      "hostname": "webserver01",
-      "os": "linux",
-      "platform": "centos",
-      "platform_family": "rhel",
-      "platform_version": "7.4.1708",
-      "network": {
-        "interfaces": [
-          {
-            "name": "lo",
-            "addresses": [
-              "127.0.0.1/8",
-              "::1/128"
-            ]
-          },
-          {
-            "name": "enp0s3",
-            "mac": "08:00:27:11:ad:d2",
-            "addresses": [
-              "10.0.2.15/24",
-              "fe80::26a5:54ec:cf0d:9704/64"
-            ]
-          },
-          {
-            "name": "enp0s8",
-            "mac": "08:00:27:bc:be:60",
-            "addresses": [
-              "172.28.128.3/24",
-              "fe80::a00:27ff:febc:be60/64"
-            ]
-          }
-        ]
-      },
-      "arch": "amd64"
-    },
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "testing",
-      "entity:webserver01"
+      "entity:sensu-go-sandbox"
     ],
-    "last_seen": 1542667635,
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  },
+  "entity": {
     "deregister": false,
     "deregistration": {},
-    "user": "agent",
+    "entity_class": "agent",
+    "last_seen": 1552495139,
+    "metadata": {
+      "name": "sensu-go-sandbox",
+      "namespace": "default"
+    },
     "redact": [
       "password",
       "passwd",
@@ -242,75 +263,464 @@ example      | {{< highlight json >}}
       "private_key",
       "secret"
     ],
-    "metadata": {
-      "name": "webserver01",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
-  }
+    "subscriptions": [
+      "entity:sensu-go-sandbox"
+    ],
+    "system": {
+      "arch": "amd64",
+      "hostname": "sensu-go-sandbox",
+      "network": {
+        "interfaces": [
+          {
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ],
+            "name": "lo"
+          },
+          {
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::5a94:f67a:1bfc:a579/64"
+            ],
+            "mac": "08:00:27:8b:c9:3f",
+            "name": "eth0"
+          }
+        ]
+      },
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804"
+    },
+    "user": "agent"
+  },
+  "metrics": {
+    "handlers": [
+      "influx-db"
+    ],
+    "points": [
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_total",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.005
+      },
+      {
+        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+        "tags": [],
+        "timestamp": 1552506033,
+        "value": 0.004
+      }
+    ]
+  },
+  "timestamp": 1552506033
 }
 {{< /highlight >}}
 
-## Example check-only event data
+### Metadata attributes
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][26] that this event belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+### Spec attributes
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred in seconds since the Unix epoch
+required     | false
+type         | Integer
+default      | Time that the event occurred
+example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+
+|entity      |      |
+-------------|------
+description  | The [entity attributes][2] from the originating entity (agent or proxy).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"entity": {
+  "deregister": false,
+  "deregistration": {},
+  "entity_class": "agent",
+  "last_seen": 1552495139,
+  "metadata": {
+    "name": "sensu-go-sandbox",
+    "namespace": "default"
+  },
+  "redact": [
+    "password",
+    "passwd",
+    "pass",
+    "api_key",
+    "api_token",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "secret"
+  ],
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "system": {
+    "arch": "amd64",
+    "hostname": "sensu-go-sandbox",
+    "network": {
+      "interfaces": [
+        {
+          "addresses": [
+            "127.0.0.1/8",
+            "::1/128"
+          ],
+          "name": "lo"
+        },
+        {
+          "addresses": [
+            "10.0.2.15/24",
+            "fe80::5a94:f67a:1bfc:a579/64"
+          ],
+          "mac": "08:00:27:8b:c9:3f",
+          "name": "eth0"
+        }
+      ]
+    },
+    "os": "linux",
+    "platform": "centos",
+    "platform_family": "rhel",
+    "platform_version": "7.5.1804"
+  },
+  "user": "agent"
+}
+{{< /highlight >}}
+
+|check       |      |
+-------------|------
+description  | The [check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification](#check-attributes) and the [check specification](../checks#check-specification).
+type         | Map
+required     | true
+example      | {{< highlight shell >}}
+"check": {
+  "check_hooks": null,
+  "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+  "duration": 0.060790838,
+  "env_vars": null,
+  "executed": 1552506033,
+  "handlers": [],
+  "high_flap_threshold": 0,
+  "history": [
+    {
+      "executed": 1552505833,
+      "status": 0
+    },
+    {
+      "executed": 1552505843,
+      "status": 0
+    }
+  ],
+  "interval": 10,
+  "issued": 1552506033,
+  "last_ok": 1552506033,
+  "low_flap_threshold": 0,
+  "metadata": {
+    "name": "curl_timings",
+    "namespace": "default"
+  },
+  "occurrences": 1,
+  "occurrences_watermark": 1,
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005",
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+  "proxy_entity_name": "",
+  "publish": true,
+  "round_robin": false,
+  "runtime_assets": [],
+  "state": "passing",
+  "status": 0,
+  "stdin": false,
+  "subdue": null,
+  "subscriptions": [
+    "entity:sensu-go-sandbox"
+  ],
+  "timeout": 0,
+  "total_state_change": 0,
+  "ttl": 0
+}
+{{< /highlight >}}
+
+<a name="metrics"></a>
+
+|metrics     |      |
+-------------|------
+description  | The metrics collected by the entity in Sensu metric format. See the [metrics attributes](#metric-attributes).
+type         | Map
+required     | false
+example      | {{< highlight shell >}}
+"metrics": {
+  "handlers": [
+    "influx-db"
+  ],
+  "points": [
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_total",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.005
+    },
+    {
+      "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+      "tags": [],
+      "timestamp": 1552506033,
+      "value": 0.004
+    }
+  ]
+}
+{{< /highlight >}}
+
+### Check attributes
+
+Sensu events include a `check` scope containing information about how the event was created, including any attributes defined in the [check specification](../checks#check-specification), and information about the event and its history, including the attributes defined below.
+
+duration     |      |
+-------------|------
+description  | Command execution time in seconds
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
+
+executed     |      |
+-------------|------
+description  | Time that the check request was executed
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+history      |      |
+-------------|------
+description  | Check status history for the last 21 check executions. See the [history attributes](#history-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"history": [
+  {
+    "executed": 1552505983,
+    "status": 0
+  },
+  {
+    "executed": 1552505993,
+    "status": 0
+  }
+]
+{{< /highlight >}}
+
+issued       |      |
+-------------|------
+description  | Time that the check request was issued in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"issued": 1552506033{{< /highlight >}}
+
+last_ok      |      |
+-------------|------
+description  | The last time that the check returned an OK `status` (`0`) in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"last_ok": 1552506033{{< /highlight >}}
+
+occurrences  |      |
+-------------|------
+description  | The number of times an event with the same status has occurred for the given entity and check
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"occurrences": 1{{< /highlight >}}
+
+occurrences_watermark | |
+-------------|------
+description  | The highest number of occurrences for the given entity and check at the current status
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"occurrences_watermark": 1{{< /highlight >}}\
+
+output       |      |
+-------------|------
+description  | The output from the execution of the check command
+required     | false
+type         | String
+example      | {{< highlight shell >}}
+"output": "sensu-go-sandbox.curl_timings.time_total 0.005"
+{{< /highlight >}}
+
+state         |      |
+-------------|------
+description  | The state of the check: `passing`, `failing`, or `flapping` (a rapid change in check result status)
+required     | false
+type         | String
+example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+total_state_change | |
+-------------|------
+description  | The total state change percentage for the check's history
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"total_state_change": 0{{< /highlight >}}
+
+#### History attributes
+
+executed     |      |
+-------------|------
+description  |Time that the check request was executed in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}
+
+status       |      |
+-------------|------
+description  | Exit status code produced by the check<ul><li><code>0</code> indicates “OK”</li><li><code>1</code> indicates “WARNING”</li><li><code>2</code> indicates “CRITICAL”</li><li>exit status codes other than <code>0</code>, <code>1</code>, or <code>2</code> indicate an “UNKNOWN” or custom status</li></ul>
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"status": 0{{< /highlight >}}
+
+### Metric attributes
+
+handlers     |      |
+-------------|------
+description  | An array of Sensu handlers to use for events created by the check. Each array item must be a string.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"handlers": [
+  "influx-db"
+]
+{{< /highlight >}}
+
+points       |      |
+-------------|------
+description  | Metric data points including a name, timestamp, value, and tags. See the [points attributes](#points-attributes).
+required     | false
+type         | Array
+example      | {{< highlight shell >}}
+"points": [
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_total",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.005
+  },
+  {
+    "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+    "tags": [],
+    "timestamp": 1552506033,
+    "value": 0.004
+  }
+]
+{{< /highlight >}}
+
+#### Points attributes
+
+name         |      |
+-------------|------
+description  | The metric name in the format `$entity.$check.$metric` where `$entity` is the entity name, `$check` is the check name, and `$metric` is the metric name.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"name": "sensu-go-sandbox.curl_timings.time_total"{{< /highlight >}}
+
+tags         |      |
+-------------|------
+description  | Optional tags to include with the metric
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"tags": []{{< /highlight >}}
+
+timestamp    |      |
+-------------|------
+description  | Time that the metric was collected in seconds since the Unix epoch
+required     | false
+type         | Integer
+example      | {{< highlight shell >}}"timestamp": 1552506033{{< /highlight >}}
+
+value        |      |
+-------------|------
+description  | The metric value
+required     | false
+type         | Float
+example      | {{< highlight shell >}}"value": 0.005{{< /highlight >}}
+
+## Examples
+
+### Example check-only event data
 
 {{< highlight json >}}
 {
   "type": "Event",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "namespace": "default"
   },
   "spec": {
-    "timestamp": 1542667666,
-    "entity": {
-      "entity_class": "agent",
-      "system": {
-        "hostname": "webserver01",
-        "os": "linux",
-        "platform": "centos",
-        "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "network": {
-          "interfaces": [
-            {
-              "name": "lo",
-              "addresses": [
-                "127.0.0.1/8",
-                "::1/128"
-              ]
-            },
-            {
-              "name": "enp0s3",
-              "mac": "08:00:27:11:ad:d2",
-              "addresses": [
-                "10.0.2.15/24",
-                "fe80::26a5:54ec:cf0d:9704/64"
-              ]
-            },
-            {
-              "name": "enp0s8",
-              "mac": "08:00:27:bc:be:60",
-              "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:febc:be60/64"
-              ]
-            }
-          ]
-        },
-        "arch": "amd64"
-      },
-      "subscriptions": [
-        "testing",
-        "entity:webserver01"
+    "check": {
+      "check_hooks": null,
+      "command": "check-cpu.sh -w 75 -c 90",
+      "duration": 1.07055808,
+      "env_vars": null,
+      "executed": 1552594757,
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "history": [
+        {
+          "executed": 1552594757,
+          "status": 0
+        }
       ],
-      "last_seen": 1542667635,
+      "interval": 60,
+      "issued": 1552594757,
+      "last_ok": 1552594758,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "check-cpu",
+        "namespace": "default"
+      },
+      "occurrences": 1,
+      "occurrences_watermark": 1,
+      "output": "CPU OK - Usage:3.96\n",
+      "output_metric_format": "",
+      "output_metric_handlers": [],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "linux"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
       "deregister": false,
       "deregistration": {},
-      "user": "agent",
+      "entity_class": "agent",
+      "last_seen": 1552594641,
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default"
+      },
       "redact": [
         "password",
         "passwd",
@@ -321,56 +731,269 @@ example      | {{< highlight json >}}
         "secret_key",
         "private_key",
         "secret"
-      ]
+      ],
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-centos",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::9688:67ca:3d78:ced9/64"
+              ],
+              "mac": "08:00:27:11:ad:d2",
+              "name": "enp0s3"
+            },
+            {
+              "addresses": [
+                "172.28.128.3/24",
+                "fe80::a00:27ff:fe6b:c1e9/64"
+              ],
+              "mac": "08:00:27:6b:c1:e9",
+              "name": "enp0s8"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.4.1708"
+      },
+      "user": "agent"
     },
+    "timestamp": 1552594758
+  }
+}
+{{< /highlight >}}
+
+### Example event with check and metric data
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
     "check": {
       "check_hooks": null,
-      "duration": 2.033888684,
-      "executed": 1522170513,
-      "command": "http_check.sh http://localhost:80",
-      "handlers": [
-        "slack"
-      ],
+      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "duration": 0.060790838,
+      "env_vars": null,
+      "executed": 1552506033,
+      "handlers": [],
       "high_flap_threshold": 0,
-      "interval": 20,
-      "low_flap_threshold": 0,
-      "publish": true,
-      "runtime_assets": [],
-      "subscriptions": [
-        "testing"
-      ],
-      "proxy_entity_name": "",
-      "check_hooks": null,
-      "stdin": false,
-      "ttl": 0,
-      "timeout": 0,
-      "round_robin": false,
-      "duration": 0.010849143,
-      "executed": 1542667666,
       "history": [
         {
-          "status": 1,
-          "executed": 1542667666
+          "executed": 1552505833,
+          "status": 0
+        },
+        {
+          "executed": 1552505843,
+          "status": 0
         }
       ],
-      "issued": 1542667666,
-      "output": "",
-      "state": "failing",
-      "status": 1,
-      "total_state_change": 0,
-      "last_ok": 0,
+      "interval": 10,
+      "issued": 1552506033,
+      "last_ok": 1552506033,
+      "low_flap_threshold": 0,
+      "metadata": {
+        "name": "curl_timings",
+        "namespace": "default"
+      },
       "occurrences": 1,
       "occurrences_watermark": 1,
-      "output_metric_format": "",
-      "output_metric_handlers": [],
-      "env_vars": null,
+      "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1552506033\nsensu-go-sandbox.curl_timings.time_namelookup 0.004",
+      "output_metric_format": "graphite_plaintext",
+      "output_metric_handlers": [
+        "influx-db"
+      ],
+      "proxy_entity_name": "",
+      "publish": true,
+      "round_robin": false,
+      "runtime_assets": [],
+      "state": "passing",
+      "status": 0,
+      "stdin": false,
+      "subdue": null,
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "timeout": 0,
+      "total_state_change": 0,
+      "ttl": 0
+    },
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
       "metadata": {
-        "name": "check-nginx",
-        "namespace": "default",
-        "labels": null,
-        "annotations": null
-      }
-    }
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
+  }
+}
+{{< /highlight >}}
+
+### Example metric-only event
+
+{{< highlight json >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
+    "entity": {
+      "deregister": false,
+      "deregistration": {},
+      "entity_class": "agent",
+      "last_seen": 1552495139,
+      "metadata": {
+        "name": "sensu-go-sandbox",
+        "namespace": "default"
+      },
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "subscriptions": [
+        "entity:sensu-go-sandbox"
+      ],
+      "system": {
+        "arch": "amd64",
+        "hostname": "sensu-go-sandbox",
+        "network": {
+          "interfaces": [
+            {
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ],
+              "name": "lo"
+            },
+            {
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::5a94:f67a:1bfc:a579/64"
+              ],
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
+            }
+          ]
+        },
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804"
+      },
+      "user": "agent"
+    },
+    "metrics": {
+      "handlers": [
+        "influx-db"
+      ],
+      "points": [
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_total",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.005
+        },
+        {
+          "name": "sensu-go-sandbox.curl_timings.time_namelookup",
+          "tags": [],
+          "timestamp": 1552506033,
+          "value": 0.004
+        }
+      ]
+    },
+    "timestamp": 1552506033
   }
 }
 {{< /highlight >}}
@@ -382,3 +1005,6 @@ example      | {{< highlight json >}}
 [5]: ../../guides/aggregate-metrics-statsd/
 [6]: ../../guides/extract-metrics-with-checks
 [7]: ../checks/#check-specification
+[sc]: ../../sensuctl/reference#creating-resources
+[sp]: #spec-attributes
+[26]: ../rbac#namespaces

--- a/content/sensu-go/5.4/reference/events.md
+++ b/content/sensu-go/5.4/reference/events.md
@@ -558,7 +558,7 @@ example      | {{< highlight shell >}}
 
 state         |      |
 -------------|------
-description  | The state of the check: `passing`, `failing`, or `flapping` (a rapid change in check result status)
+description  | The state of the check: `passing`, `failing`, or `flapping`. You can use the `low_flap_threshold` and `high_flap_threshold` [check attributes](../checks#spec-attributes) to configure `flapping` state detection.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"state": "passing"{{< /highlight >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Adds event attributes to the events reference (Closes #1078)
- Adds payload parameter details and request examples to the event API docs (Closes #1257)
- Removes requirement for including a timestamp when creating an event via the API (Closes #1326)

## To do
- [x] Copy to all versions
- [x] Include note about event timestamps for versions 5.3 and earlier
