### PR TITLE
Remove extra "the" from 5.4.0 change log

### DIFF
--- a/content/sensu-go/5.4/release-notes.md
+++ b/content/sensu-go/5.4/release-notes.md
@@ -51,7 +51,7 @@ See the [upgrading guide][1] to upgrade Sensu to version 5.4.0.
 - The `sensuctl handler delete` and `sensuctl filter delete` commands now correctly delete resources from the currently configured namespace.
 - The agent now terminates consistently on SIGTERM and SIGINT.
 - In the event of a loss of connection with the backend, the agent now attempts to reconnect to any backends specified in its configuration.
-- The dashboard now handles cases in which the the creator of a silence is inaccessible.
+- The dashboard now handles cases in which the creator of a silence is inaccessible.
 - The dashboard event details page now displays "-" in the command field if no command is associated with the event.
 
 ## 5.3.0 release notes


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Removes an extra "the" from the 5.4.0 change log.

## Motivation and Context
To fix a typo.
