### PR TITLE
RBAC reference and guide updates

### DIFF
--- a/content/sensu-go/5.0/guides/create-read-only-user.md
+++ b/content/sensu-go/5.0/guides/create-read-only-user.md
@@ -12,8 +12,11 @@ menu:
     parent: guides
 ---
 
-## What is RBAC?
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with *namespaces*, *roles*, *users*, and *role bindings*.
+Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
+
+By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
+This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
 
 ## Why use RBAC?
 RBAC allows you to exercise fine-grained control over how Sensu users interact 
@@ -21,46 +24,53 @@ with Sensu resources. Using RBAC rules, you can easily achieve **multitenancy**
 so different projects and teams can share a Sensu instance. 
 
 ## How to create a read-only user
-By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu.
-Using sensuctl configured as the [default `admin` user][2], you can create new roles for users that give as much or as little access as you see fit.
+In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-In this section, you'll create a user with read-only access to resources within the `default` namespace.
-Sensu includes a default read-only role called `view` that you can use to create a read-only user.
-
-1. Create a user with the username `alice`:
+1. Create a user with the username `alice` and assign them to the group `ops`:
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a `read-only-user` role binding to assign the `view` role to the `alice` user:
+2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< highlight shell >}}
-sensuctl role-binding create read-only-user --cluster-role=view --user=alice
+sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /highlight >}}
 
-## How to create an event-reader user
-Now let's say you want to create a user that has read-only access to only events within the `default` namespace.
-Since this user needs different permissions from those provided by the default `view` role, you'll need to create a role before creating the user and role binding.
-
-1. Create an `event-reader` role with `get` and `list` permissions for `events` within the `default` namespace:
+3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role create event-reader --verb get,list --resource events --namespace default
+sensuctl role-binding create ops-read-only --role=read-only --group=ops
+{{< /highlight >}}
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+All users in the `ops` group now have read-only access to all resources within the default namespace.
+You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+
+## How to create a cluster-wide event-reader user
+Now let's say you want to create a user that has read-only access to events across all namespaces.
+Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
+
+1. Create a user with the username `bob` and assign them to the group `ops`:
+{{< highlight shell >}}
+sensuctl user create bob --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a user with the username `bob`:
+2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< highlight shell >}}
-sensuctl user create bob  --password 'password'
+sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /highlight >}}
 
-3. Create an `event-reader-binding` role binding to assign the `event-reader` role to the `bob` user:
+3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role-binding create event-reader-binding --role=event-reader --user=bob
+sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /highlight >}}
+
+All users in the `ops` group now have read-only access to events across all namespaces.
 
 ## Next steps
 
-You now know how to create a role, create a user, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
+You now know how to create a user, create a role, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
 
-* Read the [RBAC reference][1] for in-depth documentation on role-based access control and information about cluster-wide permissions.
+* Read the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
 [1]: ../../reference/rbac
 [2]: ../../reference/rbac#default-user

--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -12,9 +12,12 @@ menu:
 
 - [Namespaces](#namespaces): [Managing namespaces](#viewing-namespaces) | [Specification](#namespace-specification) | [Examples](#namespace-examples)
 - [Resources](#resources): [Namespaced resource types](#namespaced-resource-types) | [Cluster-wide resource types](#cluster-wide-resource-types)
-- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Groups](#groups)
+- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Examples](#user-example) | [Groups](#groups)
 - [Roles and cluster roles](#roles-and-cluster-roles): [Managing roles](#viewing-roles) | [Specification](#role-and-cluster-role-specification) | [Examples](#role-examples)
 - [Role bindings and cluster role bindings](#role-bindings-and-cluster-role-bindings): [Managing role bindings](#viewing-role-bindings) | [Specification](#role-binding-and-cluster-role-binding-specification) | [Examples](#role-binding-examples)
+- [Assigning user permissions within a namespace](#assigning-user-permissions-within-a-namespace)
+- [Assigning group permissions within a namespace](#assigning-group-permissions-within-a-namespace)
+- [Assigning group permissions across all namespaces](#assigning-group-permissions-across-all-namespaces)
 
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
@@ -27,7 +30,7 @@ RBAC allows management and access of users and resources based on **namespaces**
 Sensu access controls apply to [sensuctl][2], the Sensu [API][19], and the Sensu [dashboard][3].
 
 ## Namespaces
-Namespaces help teams use different resources (entities, checks, handlers, etc.) within Sensu and impose their own controls on those resources.
+Namespaces help teams use different resources (entities, checks, handlers, etc.) within Sensu and impose their own controls on those resources.
 A Sensu instance can have multiple namespaces, each with their own set of managed resources.
 Resource names need to be unique within a namespace, but not across namespaces.
 
@@ -67,8 +70,6 @@ To delete a namespace:
 sensuctl namespace delete [NAMESPACE-NAME]
 {{< /highlight >}}
 
-_WARNING: This deletes every resource definition associated with the namespace._
-
 To get help managing namespaces with sensuctl:
 
 {{< highlight shell >}}
@@ -93,13 +94,9 @@ For example, to assign a check called `check-cpu` to the `production` namespace,
   "spec": {
     "check_hooks": null,
     "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": [
-      "slack"
-    ],
+    "handlers": ["slack"],
     "interval": 30,
-    "subscriptions": [
-      "system"
-    ],
+    "subscriptions": ["system"],
     "timeout": 0,
     "ttl": 0
   }
@@ -118,9 +115,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "production"{{< /highlight >}}
 
-### Namespace examples
+### Namespace example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -146,6 +143,7 @@ Namespaced resources must belong to a single namespace and can be accessed by [r
 | `checks` | [Check][6] resources within a namespace |
 | `entities` | [Entity][7] resources within a namespace |
 | `events` | [Event][8] resources within a namespace |
+| `extensions` | Placeholder type
 | `filters`   | [Filter][22] resources within a namespace  |
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
@@ -198,24 +196,24 @@ Once authenticated, you can change the password using the `change-password` comm
 sensuctl user change-password
 {{< /highlight >}}
 
-Sensu also includes an `agent` user that is used internally by the Sensu agent and should not be modified.
-
-_WARNING: Modification of the `agent` user can result in non-functional Sensu agents._
+Sensu also includes an `agent` user that is used internally by the Sensu agent.
+You can configure an agent's user credentials using the [`user` and `password` agent configuration flags](../reference/agent/#security-configuration-flags).
 
 ### Viewing users
-You can use [sensuctl][2] to see a list of all users within Sensu:
+You can use [sensuctl][2] to see a list of all users within Sensu.
+The following example returns a list of users in `yaml` format for use with `sensuctl create`.
 
 {{< highlight shell >}}
-sensuctl user list
+sensuctl user list --format yaml
 {{< /highlight >}}
 
 ### Creating a user
 You can use [sensuctl][2] to create a user.
-For example, the following command creates a user with the username `alice` and the password `password`.
+For example, the following command creates a user with the username `alice`, creates a password, and assigns the user to the `ops` and `dev` groups.
 Passwords must have at least eight characters.
 
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops,dev
 {{< /highlight >}}
 
 ### Assigning user permissions
@@ -227,8 +225,6 @@ To assign permissions to a user:
 3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing users
-
-You can use [sensuctl][2] to view, create, and manage users.
 
 To change the password for a user:
 
@@ -266,7 +262,7 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"password": "P@ssw0rd!"{{< /highlight >}}
 
-groups     | 
+groups       | 
 -------------|------ 
 description  | Groups to which the user belongs.
 required     | false 
@@ -281,18 +277,33 @@ type         | Boolean
 default      | false
 example      | {{< highlight shell >}}"disabled": false{{< /highlight >}}
 
+### User example
+
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
+
+{{< highlight json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+   "username": "alice",
+    "disabled": false,
+    "groups": ["ops", "dev"]
+  }
+}
+{{< /highlight >}}
+
 ## Groups
 
 A group is a set of users within Sensu.
 Groups can be assigned one or more roles and inherit all permissions from each role assigned to them.
 Users can be assigned to one or more groups.
+Groups are not a resource type within Sensu; you can create and manage groups only within user definitions.
 
 ### Default group
 
-Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20].
-Additionally, Sensu includes a `system:agents` group used internally by Sensu agents.
-
-_WARNING: Modification of the `system:agents` group can result in non-functional Sensu agents._
+Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20] and a `system:agents` group used internally by Sensu agents.
 
 ### Assigning a user to a group
 
@@ -330,7 +341,7 @@ sensuctl user remove-groups USERNAME
 ## Roles and cluster roles
 
 A role is a set of permissions controlling access to Sensu resources.
-**Roles** specify permissions for resources within a namespace while **cluster roles**  can include permissions for [cluster-wide resources][18].
+**Roles** specify permissions for resources within a namespace while **cluster roles** can include permissions for [cluster-wide resources][18].
 You can use [roles bindings][23] to assign roles to user and groups.
 To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] (not a cluster role binding) to restrict permissions within a specific namespace.
 
@@ -383,6 +394,13 @@ For example, the following command creates an admin role restricted to the produ
 
 {{< highlight shell >}}
 sensuctl role create prod-admin --verb get,list,create,update,delete --resource * --namespace production
+{{< /highlight >}}
+
+Once you've create the role, [create a role binding][23] (or [cluster role binding][35]) to assign the role to users and groups.
+For example, to assign the `prod-admin` role created above to the `oncall` group, create the following role binding.
+
+{{< highlight shell >}}
+sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /highlight >}}
 
 ### Creating a cluster-wide role
@@ -472,16 +490,16 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}
 
-### Role examples
+### Role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader",
+    "name": "namespaced-resources-all-verbs",
     "namespace": "default"
   },
   "spec": {
@@ -489,40 +507,38 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
 }
 {{< /highlight >}}
 
-### Cluster role examples
+### Cluster role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "name": "global-event-reader"
+    "name": "all-resources-all-verbs"
   },
   "spec": {
     "rules": [
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
@@ -531,9 +547,8 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ## Role bindings and cluster role bindings
 
-A **role binding** assigns a **role** or **cluster role** to a user or set of users.
-A **cluster role binding** assigns a **cluster role** to a user or set of users.
-Roles bindings apply roles within a namespace while cluster role bindings apply across namespaces and resource types.
+A **role binding** assigns a **role** or **cluster role** to users and groups within a namesapce.
+A **cluster role binding** assigns a **cluster role** to users and groups across namespaces and resource types.
 
 To create and manage role bindings within a namespace, [create a role][25] with `rolebindings` permissions within that namespace, and log in by [configuring sensuctl][26].
 
@@ -583,14 +598,6 @@ To create a cluster role binding:
 {{< highlight shell >}}
 sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
 {{< /highlight >}}
-
-### Assigning user permissions
-
-To assign permissions to a user:
-
-1. [Create the user][27].
-2. [Create a role][25] or (for cluster-wide access) a [cluster role][28].
-3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing role bindings
 
@@ -665,9 +672,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "alice"{{< /highlight >}}
 
-### Role binding examples
+### Role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -692,9 +699,9 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 }
 {{< /highlight >}}
 
-### Cluster role binding examples
+### Cluster role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -720,7 +727,7 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ### Role and role binding examples
 
-The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `development` namespace.
+The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `default` namespace.
 
 {{< highlight text >}}
 {
@@ -728,7 +735,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "workflow-creator",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "rules": [
@@ -745,7 +752,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "dev-binding",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "role_ref": {
@@ -755,6 +762,201 @@ The following role and role binding give a `dev` group access to create and mana
     "subjects": [
       {
         "name": "dev",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+## Example workflows
+
+### Assigning user permissions within a namespace
+
+To assign permissions to a user:
+
+1. [Create the user][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the user.
+
+For example, the following configuration creates a user `alice`, a role `default-admin`, and a role binding `alice-default-admin`, giving `alice` full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "alice-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "alice",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+### Assigning group permissions within a namespace
+
+To assign permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a role `default-admin`, and a role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+_PRO TIP: To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] to restrict permissions within a specific namespace._
+
+### Assigning group permissions across all namespaces
+
+To assign cluster-wide permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a cluster role][28].
+3. [Create a cluster role binding][29]) to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a cluster role `default-admin`, and a cluster role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] and [cluster-wide resource types][18] across all namespaces.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "groups": ["ops"]
+  }
+}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+
+      }
+    ]
+  }
+}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
         "type": "Group"
       }
     ]
@@ -793,3 +995,7 @@ The following role and role binding give a `dev` group access to create and mana
 [29]: #creating-a-role-binding
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../sensuctl/reference#creating-resources
+[32]: ../../installation/auth
+[33]: ../../getting-started/enterprise
+[34]: ../../installation/auth
+[35]: #cluster-role-bindings

--- a/content/sensu-go/5.1/guides/create-read-only-user.md
+++ b/content/sensu-go/5.1/guides/create-read-only-user.md
@@ -12,8 +12,11 @@ menu:
     parent: guides
 ---
 
-## What is RBAC?
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with *namespaces*, *roles*, *users*, and *role bindings*.
+Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
+
+By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
+This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
 
 ## Why use RBAC?
 RBAC allows you to exercise fine-grained control over how Sensu users interact 
@@ -21,46 +24,53 @@ with Sensu resources. Using RBAC rules, you can easily achieve **multitenancy**
 so different projects and teams can share a Sensu instance. 
 
 ## How to create a read-only user
-By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu.
-Using sensuctl configured as the [default `admin` user][2], you can create new roles for users that give as much or as little access as you see fit.
+In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-In this section, you'll create a user with read-only access to resources within the `default` namespace.
-Sensu includes a default read-only role called `view` that you can use to create a read-only user.
-
-1. Create a user with the username `alice`:
+1. Create a user with the username `alice` and assign them to the group `ops`:
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a `read-only-user` role binding to assign the `view` role to the `alice` user:
+2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< highlight shell >}}
-sensuctl role-binding create read-only-user --cluster-role=view --user=alice
+sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /highlight >}}
 
-## How to create an event-reader user
-Now let's say you want to create a user that has read-only access to only events within the `default` namespace.
-Since this user needs different permissions from those provided by the default `view` role, you'll need to create a role before creating the user and role binding.
-
-1. Create an `event-reader` role with `get` and `list` permissions for `events` within the `default` namespace:
+3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role create event-reader --verb get,list --resource events --namespace default
+sensuctl role-binding create ops-read-only --role=read-only --group=ops
+{{< /highlight >}}
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+All users in the `ops` group now have read-only access to all resources within the default namespace.
+You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+
+## How to create a cluster-wide event-reader user
+Now let's say you want to create a user that has read-only access to events across all namespaces.
+Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
+
+1. Create a user with the username `bob` and assign them to the group `ops`:
+{{< highlight shell >}}
+sensuctl user create bob --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a user with the username `bob`:
+2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< highlight shell >}}
-sensuctl user create bob  --password 'password'
+sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /highlight >}}
 
-3. Create an `event-reader-binding` role binding to assign the `event-reader` role to the `bob` user:
+3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role-binding create event-reader-binding --role=event-reader --user=bob
+sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /highlight >}}
+
+All users in the `ops` group now have read-only access to events across all namespaces.
 
 ## Next steps
 
-You now know how to create a role, create a user, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
+You now know how to create a user, create a role, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
 
-* Read the [RBAC reference][1] for in-depth documentation on role-based access control and information about cluster-wide permissions.
+* Read the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
 [1]: ../../reference/rbac
 [2]: ../../reference/rbac#default-user

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -12,9 +12,12 @@ menu:
 
 - [Namespaces](#namespaces): [Managing namespaces](#viewing-namespaces) | [Specification](#namespace-specification) | [Examples](#namespace-examples)
 - [Resources](#resources): [Namespaced resource types](#namespaced-resource-types) | [Cluster-wide resource types](#cluster-wide-resource-types)
-- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Groups](#groups)
+- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Examples](#user-example) | [Groups](#groups)
 - [Roles and cluster roles](#roles-and-cluster-roles): [Managing roles](#viewing-roles) | [Specification](#role-and-cluster-role-specification) | [Examples](#role-examples)
 - [Role bindings and cluster role bindings](#role-bindings-and-cluster-role-bindings): [Managing role bindings](#viewing-role-bindings) | [Specification](#role-binding-and-cluster-role-binding-specification) | [Examples](#role-binding-examples)
+- [Assigning user permissions within a namespace](#assigning-user-permissions-within-a-namespace)
+- [Assigning group permissions within a namespace](#assigning-group-permissions-within-a-namespace)
+- [Assigning group permissions across all namespaces](#assigning-group-permissions-across-all-namespaces)
 
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
@@ -67,8 +70,6 @@ To delete a namespace:
 sensuctl namespace delete [NAMESPACE-NAME]
 {{< /highlight >}}
 
-_WARNING: This deletes every resource definition associated with the namespace._
-
 To get help managing namespaces with sensuctl:
 
 {{< highlight shell >}}
@@ -93,13 +94,9 @@ For example, to assign a check called `check-cpu` to the `production` namespace,
   "spec": {
     "check_hooks": null,
     "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": [
-      "slack"
-    ],
+    "handlers": ["slack"],
     "interval": 30,
-    "subscriptions": [
-      "system"
-    ],
+    "subscriptions": ["system"],
     "timeout": 0,
     "ttl": 0
   }
@@ -118,9 +115,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "production"{{< /highlight >}}
 
-### Namespace examples
+### Namespace example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -146,6 +143,7 @@ Namespaced resources must belong to a single namespace and can be accessed by [r
 | `checks` | [Check][6] resources within a namespace |
 | `entities` | [Entity][7] resources within a namespace |
 | `events` | [Event][8] resources within a namespace |
+| `extensions` | Placeholder type
 | `filters`   | [Filter][22] resources within a namespace  |
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
@@ -198,24 +196,24 @@ Once authenticated, you can change the password using the `change-password` comm
 sensuctl user change-password
 {{< /highlight >}}
 
-Sensu also includes an `agent` user that is used internally by the Sensu agent and should not be modified.
-
-_WARNING: Modification of the `agent` user can result in non-functional Sensu agents._
+Sensu also includes an `agent` user that is used internally by the Sensu agent.
+You can configure an agent's user credentials using the [`user` and `password` agent configuration flags](../reference/agent/#security-configuration-flags).
 
 ### Viewing users
-You can use [sensuctl][2] to see a list of all users within Sensu:
+You can use [sensuctl][2] to see a list of all users within Sensu.
+The following example returns a list of users in `yaml` format for use with `sensuctl create`.
 
 {{< highlight shell >}}
-sensuctl user list
+sensuctl user list --format yaml
 {{< /highlight >}}
 
 ### Creating a user
 You can use [sensuctl][2] to create a user.
-For example, the following command creates a user with the username `alice` and the password `password`.
+For example, the following command creates a user with the username `alice`, creates a password, and assigns the user to the `ops` and `dev` groups.
 Passwords must have at least eight characters.
 
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops,dev
 {{< /highlight >}}
 
 ### Assigning user permissions
@@ -227,8 +225,6 @@ To assign permissions to a user:
 3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing users
-
-You can use [sensuctl][2] to view, create, and manage users.
 
 To test the password for a user:
 
@@ -274,7 +270,7 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"password": "P@ssw0rd!"{{< /highlight >}}
 
-groups     | 
+groups       | 
 -------------|------ 
 description  | Groups to which the user belongs.
 required     | false 
@@ -289,18 +285,33 @@ type         | Boolean
 default      | false
 example      | {{< highlight shell >}}"disabled": false{{< /highlight >}}
 
+### User example
+
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
+
+{{< highlight json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+   "username": "alice",
+    "disabled": false,
+    "groups": ["ops", "dev"]
+  }
+}
+{{< /highlight >}}
+
 ## Groups
 
 A group is a set of users within Sensu.
 Groups can be assigned one or more roles and inherit all permissions from each role assigned to them.
 Users can be assigned to one or more groups.
+Groups are not a resource type within Sensu; you can create and manage groups only within user definitions.
 
 ### Default group
 
-Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20].
-Additionally, Sensu includes a `system:agents` group used internally by Sensu agents.
-
-_WARNING: Modification of the `system:agents` group can result in non-functional Sensu agents._
+Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20] and a `system:agents` group used internally by Sensu agents.
 
 ### Assigning a user to a group
 
@@ -338,7 +349,7 @@ sensuctl user remove-groups USERNAME
 ## Roles and cluster roles
 
 A role is a set of permissions controlling access to Sensu resources.
-**Roles** specify permissions for resources within a namespace while **cluster roles**  can include permissions for [cluster-wide resources][18].
+**Roles** specify permissions for resources within a namespace while **cluster roles** can include permissions for [cluster-wide resources][18].
 You can use [roles bindings][23] to assign roles to user and groups.
 To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] (not a cluster role binding) to restrict permissions within a specific namespace.
 
@@ -391,6 +402,13 @@ For example, the following command creates an admin role restricted to the produ
 
 {{< highlight shell >}}
 sensuctl role create prod-admin --verb get,list,create,update,delete --resource * --namespace production
+{{< /highlight >}}
+
+Once you've create the role, [create a role binding][23] (or [cluster role binding][35]) to assign the role to users and groups.
+For example, to assign the `prod-admin` role created above to the `oncall` group, create the following role binding.
+
+{{< highlight shell >}}
+sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /highlight >}}
 
 ### Creating a cluster-wide role
@@ -480,16 +498,16 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}
 
-### Role examples
+### Role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader",
+    "name": "namespaced-resources-all-verbs",
     "namespace": "default"
   },
   "spec": {
@@ -497,40 +515,38 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
 }
 {{< /highlight >}}
 
-### Cluster role examples
+### Cluster role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "name": "global-event-reader"
+    "name": "all-resources-all-verbs"
   },
   "spec": {
     "rules": [
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
@@ -539,9 +555,8 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ## Role bindings and cluster role bindings
 
-A **role binding** assigns a **role** or **cluster role** to a user or set of users.
-A **cluster role binding** assigns a **cluster role** to a user or set of users.
-Roles bindings apply roles within a namespace while cluster role bindings apply across namespaces and resource types.
+A **role binding** assigns a **role** or **cluster role** to users and groups within a namesapce.
+A **cluster role binding** assigns a **cluster role** to users and groups across namespaces and resource types.
 
 To create and manage role bindings within a namespace, [create a role][25] with `rolebindings` permissions within that namespace, and log in by [configuring sensuctl][26].
 
@@ -591,14 +606,6 @@ To create a cluster role binding:
 {{< highlight shell >}}
 sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
 {{< /highlight >}}
-
-### Assigning user permissions
-
-To assign permissions to a user:
-
-1. [Create the user][27].
-2. [Create a role][25] or (for cluster-wide access) a [cluster role][28].
-3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing role bindings
 
@@ -673,9 +680,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "alice"{{< /highlight >}}
 
-### Role binding examples
+### Role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -700,9 +707,9 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 }
 {{< /highlight >}}
 
-### Cluster role binding examples
+### Cluster role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -728,7 +735,7 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ### Role and role binding examples
 
-The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `development` namespace.
+The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `default` namespace.
 
 {{< highlight text >}}
 {
@@ -736,7 +743,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "workflow-creator",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "rules": [
@@ -753,7 +760,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "dev-binding",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "role_ref": {
@@ -763,6 +770,201 @@ The following role and role binding give a `dev` group access to create and mana
     "subjects": [
       {
         "name": "dev",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+## Example workflows
+
+### Assigning user permissions within a namespace
+
+To assign permissions to a user:
+
+1. [Create the user][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the user.
+
+For example, the following configuration creates a user `alice`, a role `default-admin`, and a role binding `alice-default-admin`, giving `alice` full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "alice-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "alice",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+### Assigning group permissions within a namespace
+
+To assign permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a role `default-admin`, and a role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+_PRO TIP: To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] to restrict permissions within a specific namespace._
+
+### Assigning group permissions across all namespaces
+
+To assign cluster-wide permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a cluster role][28].
+3. [Create a cluster role binding][29]) to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a cluster role `default-admin`, and a cluster role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] and [cluster-wide resource types][18] across all namespaces.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "groups": ["ops"]
+  }
+}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+
+      }
+    ]
+  }
+}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
         "type": "Group"
       }
     ]
@@ -801,3 +1003,7 @@ The following role and role binding give a `dev` group access to create and mana
 [29]: #creating-a-role-binding
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../sensuctl/reference#creating-resources
+[32]: ../../installation/auth
+[33]: ../../getting-started/enterprise
+[34]: ../../installation/auth
+[35]: #cluster-role-bindings

--- a/content/sensu-go/5.2/guides/create-read-only-user.md
+++ b/content/sensu-go/5.2/guides/create-read-only-user.md
@@ -12,8 +12,11 @@ menu:
     parent: guides
 ---
 
-## What is RBAC?
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with *namespaces*, *roles*, *users*, and *role bindings*.
+Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
+
+By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
+This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
 
 ## Why use RBAC?
 RBAC allows you to exercise fine-grained control over how Sensu users interact 
@@ -21,46 +24,53 @@ with Sensu resources. Using RBAC rules, you can easily achieve **multitenancy**
 so different projects and teams can share a Sensu instance. 
 
 ## How to create a read-only user
-By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu.
-Using sensuctl configured as the [default `admin` user][2], you can create new roles for users that give as much or as little access as you see fit.
+In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-In this section, you'll create a user with read-only access to resources within the `default` namespace.
-Sensu includes a default read-only role called `view` that you can use to create a read-only user.
-
-1. Create a user with the username `alice`:
+1. Create a user with the username `alice` and assign them to the group `ops`:
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a `read-only-user` role binding to assign the `view` role to the `alice` user:
+2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< highlight shell >}}
-sensuctl role-binding create read-only-user --cluster-role=view --user=alice
+sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /highlight >}}
 
-## How to create an event-reader user
-Now let's say you want to create a user that has read-only access to only events within the `default` namespace.
-Since this user needs different permissions from those provided by the default `view` role, you'll need to create a role before creating the user and role binding.
-
-1. Create an `event-reader` role with `get` and `list` permissions for `events` within the `default` namespace:
+3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role create event-reader --verb get,list --resource events --namespace default
+sensuctl role-binding create ops-read-only --role=read-only --group=ops
+{{< /highlight >}}
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+All users in the `ops` group now have read-only access to all resources within the default namespace.
+You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+
+## How to create a cluster-wide event-reader user
+Now let's say you want to create a user that has read-only access to events across all namespaces.
+Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
+
+1. Create a user with the username `bob` and assign them to the group `ops`:
+{{< highlight shell >}}
+sensuctl user create bob --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a user with the username `bob`:
+2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< highlight shell >}}
-sensuctl user create bob  --password 'password'
+sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /highlight >}}
 
-3. Create an `event-reader-binding` role binding to assign the `event-reader` role to the `bob` user:
+3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role-binding create event-reader-binding --role=event-reader --user=bob
+sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /highlight >}}
+
+All users in the `ops` group now have read-only access to events across all namespaces.
 
 ## Next steps
 
-You now know how to create a role, create a user, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
+You now know how to create a user, create a role, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
 
-* Read the [RBAC reference][1] for in-depth documentation on role-based access control and information about cluster-wide permissions.
+* Read the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
 [1]: ../../reference/rbac
 [2]: ../../reference/rbac#default-user

--- a/content/sensu-go/5.2/reference/rbac.md
+++ b/content/sensu-go/5.2/reference/rbac.md
@@ -12,9 +12,12 @@ menu:
 
 - [Namespaces](#namespaces): [Managing namespaces](#viewing-namespaces) | [Specification](#namespace-specification) | [Examples](#namespace-examples)
 - [Resources](#resources): [Namespaced resource types](#namespaced-resource-types) | [Cluster-wide resource types](#cluster-wide-resource-types)
-- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Groups](#groups)
+- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Examples](#user-example) | [Groups](#groups)
 - [Roles and cluster roles](#roles-and-cluster-roles): [Managing roles](#viewing-roles) | [Specification](#role-and-cluster-role-specification) | [Examples](#role-examples)
 - [Role bindings and cluster role bindings](#role-bindings-and-cluster-role-bindings): [Managing role bindings](#viewing-role-bindings) | [Specification](#role-binding-and-cluster-role-binding-specification) | [Examples](#role-binding-examples)
+- [Assigning user permissions within a namespace](#assigning-user-permissions-within-a-namespace)
+- [Assigning group permissions within a namespace](#assigning-group-permissions-within-a-namespace)
+- [Assigning group permissions across all namespaces](#assigning-group-permissions-across-all-namespaces)
 
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
@@ -25,6 +28,7 @@ RBAC allows management and access of users and resources based on **namespaces**
 - **Role bindings** assign a role to a set of users and groups within a namespace; **cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
 
 Sensu access controls apply to [sensuctl][2], the Sensu [API][19], and the Sensu [dashboard][3].
+In addition to built-in RBAC, Sensu includes [enterprise-only][33] support for authentication using external [authentication providers][34].
 
 ## Namespaces
 Namespaces help teams use different resources (entities, checks, handlers, etc.) within Sensu and impose their own controls on those resources.
@@ -67,8 +71,6 @@ To delete a namespace:
 sensuctl namespace delete [NAMESPACE-NAME]
 {{< /highlight >}}
 
-_WARNING: This deletes every resource definition associated with the namespace._
-
 To get help managing namespaces with sensuctl:
 
 {{< highlight shell >}}
@@ -93,13 +95,9 @@ For example, to assign a check called `check-cpu` to the `production` namespace,
   "spec": {
     "check_hooks": null,
     "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": [
-      "slack"
-    ],
+    "handlers": ["slack"],
     "interval": 30,
-    "subscriptions": [
-      "system"
-    ],
+    "subscriptions": ["system"],
     "timeout": 0,
     "ttl": 0
   }
@@ -118,9 +116,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "production"{{< /highlight >}}
 
-### Namespace examples
+### Namespace example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -146,6 +144,7 @@ Namespaced resources must belong to a single namespace and can be accessed by [r
 | `checks` | [Check][6] resources within a namespace |
 | `entities` | [Entity][7] resources within a namespace |
 | `events` | [Event][8] resources within a namespace |
+| `extensions` | Placeholder type
 | `filters`   | [Filter][22] resources within a namespace  |
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
@@ -199,24 +198,24 @@ Once authenticated, you can change the password using the `change-password` comm
 sensuctl user change-password
 {{< /highlight >}}
 
-Sensu also includes an `agent` user that is used internally by the Sensu agent and should not be modified.
-
-_WARNING: Modification of the `agent` user can result in non-functional Sensu agents._
+Sensu also includes an `agent` user that is used internally by the Sensu agent.
+You can configure an agent's user credentials using the [`user` and `password` agent configuration flags](../reference/agent/#security-configuration-flags).
 
 ### Viewing users
-You can use [sensuctl][2] to see a list of all users within Sensu:
+You can use [sensuctl][2] to see a list of all users within Sensu.
+The following example returns a list of users in `yaml` format for use with `sensuctl create`.
 
 {{< highlight shell >}}
-sensuctl user list
+sensuctl user list --format yaml
 {{< /highlight >}}
 
 ### Creating a user
 You can use [sensuctl][2] to create a user.
-For example, the following command creates a user with the username `alice` and the password `password`.
+For example, the following command creates a user with the username `alice`, creates a password, and assigns the user to the `ops` and `dev` groups.
 Passwords must have at least eight characters.
 
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops,dev
 {{< /highlight >}}
 
 ### Assigning user permissions
@@ -228,8 +227,6 @@ To assign permissions to a user:
 3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing users
-
-You can use [sensuctl][2] to view, create, and manage users.
 
 To test the password for a user:
 
@@ -275,7 +272,7 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"password": "P@ssw0rd!"{{< /highlight >}}
 
-groups     | 
+groups       | 
 -------------|------ 
 description  | Groups to which the user belongs.
 required     | false 
@@ -290,18 +287,33 @@ type         | Boolean
 default      | false
 example      | {{< highlight shell >}}"disabled": false{{< /highlight >}}
 
+### User example
+
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
+
+{{< highlight json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+   "username": "alice",
+    "disabled": false,
+    "groups": ["ops", "dev"]
+  }
+}
+{{< /highlight >}}
+
 ## Groups
 
 A group is a set of users within Sensu.
 Groups can be assigned one or more roles and inherit all permissions from each role assigned to them.
 Users can be assigned to one or more groups.
+Groups are not a resource type within Sensu; you can create and manage groups only within user definitions.
 
 ### Default group
 
-Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20].
-Additionally, Sensu includes a `system:agents` group used internally by Sensu agents.
-
-_WARNING: Modification of the `system:agents` group can result in non-functional Sensu agents._
+Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20] and a `system:agents` group used internally by Sensu agents.
 
 ### Assigning a user to a group
 
@@ -339,7 +351,7 @@ sensuctl user remove-groups USERNAME
 ## Roles and cluster roles
 
 A role is a set of permissions controlling access to Sensu resources.
-**Roles** specify permissions for resources within a namespace while **cluster roles**  can include permissions for [cluster-wide resources][18].
+**Roles** specify permissions for resources within a namespace while **cluster roles** can include permissions for [cluster-wide resources][18].
 You can use [roles bindings][23] to assign roles to user and groups.
 To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] (not a cluster role binding) to restrict permissions within a specific namespace.
 
@@ -392,6 +404,13 @@ For example, the following command creates an admin role restricted to the produ
 
 {{< highlight shell >}}
 sensuctl role create prod-admin --verb get,list,create,update,delete --resource * --namespace production
+{{< /highlight >}}
+
+Once you've create the role, [create a role binding][23] (or [cluster role binding][35]) to assign the role to users and groups.
+For example, to assign the `prod-admin` role created above to the `oncall` group, create the following role binding.
+
+{{< highlight shell >}}
+sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /highlight >}}
 
 ### Creating a cluster-wide role
@@ -481,16 +500,16 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}
 
-### Role examples
+### Role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader",
+    "name": "namespaced-resources-all-verbs",
     "namespace": "default"
   },
   "spec": {
@@ -498,40 +517,38 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
 }
 {{< /highlight >}}
 
-### Cluster role examples
+### Cluster role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "name": "global-event-reader"
+    "name": "all-resources-all-verbs"
   },
   "spec": {
     "rules": [
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users", "providers"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
@@ -540,9 +557,8 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ## Role bindings and cluster role bindings
 
-A **role binding** assigns a **role** or **cluster role** to a user or set of users.
-A **cluster role binding** assigns a **cluster role** to a user or set of users.
-Roles bindings apply roles within a namespace while cluster role bindings apply across namespaces and resource types.
+A **role binding** assigns a **role** or **cluster role** to users and groups within a namesapce.
+A **cluster role binding** assigns a **cluster role** to users and groups across namespaces and resource types.
 
 To create and manage role bindings within a namespace, [create a role][25] with `rolebindings` permissions within that namespace, and log in by [configuring sensuctl][26].
 
@@ -592,14 +608,6 @@ To create a cluster role binding:
 {{< highlight shell >}}
 sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
 {{< /highlight >}}
-
-### Assigning user permissions
-
-To assign permissions to a user:
-
-1. [Create the user][27].
-2. [Create a role][25] or (for cluster-wide access) a [cluster role][28].
-3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing role bindings
 
@@ -674,9 +682,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "alice"{{< /highlight >}}
 
-### Role binding examples
+### Role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -701,9 +709,9 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 }
 {{< /highlight >}}
 
-### Cluster role binding examples
+### Cluster role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -729,7 +737,7 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ### Role and role binding examples
 
-The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `development` namespace.
+The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `default` namespace.
 
 {{< highlight text >}}
 {
@@ -737,7 +745,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "workflow-creator",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "rules": [
@@ -754,7 +762,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "dev-binding",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "role_ref": {
@@ -764,6 +772,201 @@ The following role and role binding give a `dev` group access to create and mana
     "subjects": [
       {
         "name": "dev",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+## Example workflows
+
+### Assigning user permissions within a namespace
+
+To assign permissions to a user:
+
+1. [Create the user][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the user.
+
+For example, the following configuration creates a user `alice`, a role `default-admin`, and a role binding `alice-default-admin`, giving `alice` full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "alice-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "alice",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+### Assigning group permissions within a namespace
+
+To assign permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a role `default-admin`, and a role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+_PRO TIP: To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] to restrict permissions within a specific namespace._
+
+### Assigning group permissions across all namespaces
+
+To assign cluster-wide permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a cluster role][28].
+3. [Create a cluster role binding][29]) to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a cluster role `default-admin`, and a cluster role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] and [cluster-wide resource types][18] across all namespaces.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "groups": ["ops"]
+  }
+}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users", "providers"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+
+      }
+    ]
+  }
+}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
         "type": "Group"
       }
     ]
@@ -803,3 +1006,6 @@ The following role and role binding give a `dev` group access to create and mana
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../sensuctl/reference#creating-resources
 [32]: ../../installation/auth
+[33]: ../../getting-started/enterprise
+[34]: ../../installation/auth
+[35]: #cluster-role-bindings

--- a/content/sensu-go/5.3/guides/create-read-only-user.md
+++ b/content/sensu-go/5.3/guides/create-read-only-user.md
@@ -12,8 +12,11 @@ menu:
     parent: guides
 ---
 
-## What is RBAC?
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with *namespaces*, *roles*, *users*, and *role bindings*.
+Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
+
+By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
+This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
 
 ## Why use RBAC?
 RBAC allows you to exercise fine-grained control over how Sensu users interact 
@@ -21,46 +24,53 @@ with Sensu resources. Using RBAC rules, you can easily achieve **multitenancy**
 so different projects and teams can share a Sensu instance. 
 
 ## How to create a read-only user
-By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu.
-Using sensuctl configured as the [default `admin` user][2], you can create new roles for users that give as much or as little access as you see fit.
+In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-In this section, you'll create a user with read-only access to resources within the `default` namespace.
-Sensu includes a default read-only role called `view` that you can use to create a read-only user.
-
-1. Create a user with the username `alice`:
+1. Create a user with the username `alice` and assign them to the group `ops`:
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a `read-only-user` role binding to assign the `view` role to the `alice` user:
+2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< highlight shell >}}
-sensuctl role-binding create read-only-user --cluster-role=view --user=alice
+sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /highlight >}}
 
-## How to create an event-reader user
-Now let's say you want to create a user that has read-only access to only events within the `default` namespace.
-Since this user needs different permissions from those provided by the default `view` role, you'll need to create a role before creating the user and role binding.
-
-1. Create an `event-reader` role with `get` and `list` permissions for `events` within the `default` namespace:
+3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role create event-reader --verb get,list --resource events --namespace default
+sensuctl role-binding create ops-read-only --role=read-only --group=ops
+{{< /highlight >}}
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+All users in the `ops` group now have read-only access to all resources within the default namespace.
+You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+
+## How to create a cluster-wide event-reader user
+Now let's say you want to create a user that has read-only access to events across all namespaces.
+Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
+
+1. Create a user with the username `bob` and assign them to the group `ops`:
+{{< highlight shell >}}
+sensuctl user create bob --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a user with the username `bob`:
+2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< highlight shell >}}
-sensuctl user create bob  --password 'password'
+sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /highlight >}}
 
-3. Create an `event-reader-binding` role binding to assign the `event-reader` role to the `bob` user:
+3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role-binding create event-reader-binding --role=event-reader --user=bob
+sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /highlight >}}
+
+All users in the `ops` group now have read-only access to events across all namespaces.
 
 ## Next steps
 
-You now know how to create a role, create a user, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
+You now know how to create a user, create a role, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
 
-* Read the [RBAC reference][1] for in-depth documentation on role-based access control and information about cluster-wide permissions.
+* Read the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
 [1]: ../../reference/rbac
 [2]: ../../reference/rbac#default-user

--- a/content/sensu-go/5.4/guides/create-read-only-user.md
+++ b/content/sensu-go/5.4/guides/create-read-only-user.md
@@ -12,8 +12,11 @@ menu:
     parent: guides
 ---
 
-## What is RBAC?
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with *namespaces*, *roles*, *users*, and *role bindings*.
+Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
+
+By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
+This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
 
 ## Why use RBAC?
 RBAC allows you to exercise fine-grained control over how Sensu users interact 
@@ -21,46 +24,53 @@ with Sensu resources. Using RBAC rules, you can easily achieve **multitenancy**
 so different projects and teams can share a Sensu instance. 
 
 ## How to create a read-only user
-By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu.
-Using sensuctl configured as the [default `admin` user][2], you can create new roles for users that give as much or as little access as you see fit.
+In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-In this section, you'll create a user with read-only access to resources within the `default` namespace.
-Sensu includes a default read-only role called `view` that you can use to create a read-only user.
-
-1. Create a user with the username `alice`:
+1. Create a user with the username `alice` and assign them to the group `ops`:
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a `read-only-user` role binding to assign the `view` role to the `alice` user:
+2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< highlight shell >}}
-sensuctl role-binding create read-only-user --cluster-role=view --user=alice
+sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /highlight >}}
 
-## How to create an event-reader user
-Now let's say you want to create a user that has read-only access to only events within the `default` namespace.
-Since this user needs different permissions from those provided by the default `view` role, you'll need to create a role before creating the user and role binding.
-
-1. Create an `event-reader` role with `get` and `list` permissions for `events` within the `default` namespace:
+3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role create event-reader --verb get,list --resource events --namespace default
+sensuctl role-binding create ops-read-only --role=read-only --group=ops
+{{< /highlight >}}
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+All users in the `ops` group now have read-only access to all resources within the default namespace.
+You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+
+## How to create a cluster-wide event-reader user
+Now let's say you want to create a user that has read-only access to events across all namespaces.
+Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
+
+1. Create a user with the username `bob` and assign them to the group `ops`:
+{{< highlight shell >}}
+sensuctl user create bob --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a user with the username `bob`:
+2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< highlight shell >}}
-sensuctl user create bob  --password 'password'
+sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /highlight >}}
 
-3. Create an `event-reader-binding` role binding to assign the `event-reader` role to the `bob` user:
+3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role-binding create event-reader-binding --role=event-reader --user=bob
+sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /highlight >}}
+
+All users in the `ops` group now have read-only access to events across all namespaces.
 
 ## Next steps
 
-You now know how to create a role, create a user, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
+You now know how to create a user, create a role, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
 
-* Read the [RBAC reference][1] for in-depth documentation on role-based access control and information about cluster-wide permissions.
+* Read the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
 [1]: ../../reference/rbac
 [2]: ../../reference/rbac#default-user

--- a/content/sensu-go/5.5/guides/create-read-only-user.md
+++ b/content/sensu-go/5.5/guides/create-read-only-user.md
@@ -12,7 +12,8 @@ menu:
     parent: guides
 ---
 
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with **namespaces**, **roles**, **users**, and **role bindings**.
+Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
 This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
@@ -25,7 +26,7 @@ so different projects and teams can share a Sensu instance.
 ## How to create a read-only user
 In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-1. Create a user with the username `alice` and assign them to the group `ops`::
+1. Create a user with the username `alice` and assign them to the group `ops`:
 {{< highlight shell >}}
 sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
@@ -44,13 +45,13 @@ You can also use role bindings to tie roles directly to users using the `--user`
 All users in the `ops` group now have read-only access to all resources within the default namespace.
 You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
 
-## How to create a cluster-wide read-only user
-Now let's say you want to create a user that has read-only access to only events across all namespaces.
+## How to create a cluster-wide event-reader user
+Now let's say you want to create a user that has read-only access to events across all namespaces.
 Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
 
 1. Create a user with the username `bob` and assign them to the group `ops`:
 {{< highlight shell >}}
-sensuctl user create bob --password=password --groups=ops
+sensuctl user create bob --password='password' --groups=ops
 {{< /highlight >}}
 
 2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:

--- a/content/sensu-go/5.5/guides/create-read-only-user.md
+++ b/content/sensu-go/5.5/guides/create-read-only-user.md
@@ -12,8 +12,10 @@ menu:
     parent: guides
 ---
 
-## What is RBAC?
-**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with *namespaces*, *roles*, *users*, and *role bindings*.
+**Role-based access control** (RBAC) is Sensu's local user management system. RBAC currently supports the management of users and permissions with **namespaces**, **roles**, **users**, and **role bindings**.
+
+By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.
+This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the default [`admin` user][2].
 
 ## Why use RBAC?
 RBAC allows you to exercise fine-grained control over how Sensu users interact 
@@ -21,46 +23,53 @@ with Sensu resources. Using RBAC rules, you can easily achieve **multitenancy**
 so different projects and teams can share a Sensu instance. 
 
 ## How to create a read-only user
-By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu.
-Using sensuctl configured as the [default `admin` user][2], you can create new roles for users that give as much or as little access as you see fit.
+In this section, you'll create a user and assign them read-only access to resources within the `default` namespace using a **role** and a **role binding**.
 
-In this section, you'll create a user with read-only access to resources within the `default` namespace.
-Sensu includes a default read-only role called `view` that you can use to create a read-only user.
-
-1. Create a user with the username `alice`:
+1. Create a user with the username `alice` and assign them to the group `ops`::
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops
 {{< /highlight >}}
 
-2. Create a `read-only-user` role binding to assign the `view` role to the `alice` user:
+2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< highlight shell >}}
-sensuctl role-binding create read-only-user --cluster-role=view --user=alice
+sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /highlight >}}
 
-## How to create an event-reader user
-Now let's say you want to create a user that has read-only access to only events within the `default` namespace.
-Since this user needs different permissions from those provided by the default `view` role, you'll need to create a role before creating the user and role binding.
-
-1. Create an `event-reader` role with `get` and `list` permissions for `events` within the `default` namespace:
+3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role create event-reader --verb get,list --resource events --namespace default
+sensuctl role-binding create ops-read-only --role=read-only --group=ops
+{{< /highlight >}}
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+All users in the `ops` group now have read-only access to all resources within the default namespace.
+You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+
+## How to create a cluster-wide read-only user
+Now let's say you want to create a user that has read-only access to only events across all namespaces.
+Since you want this role to have cluster-wide permissions, you'll need to create a **cluster role** and a **cluster role binding**.
+
+1. Create a user with the username `bob` and assign them to the group `ops`:
+{{< highlight shell >}}
+sensuctl user create bob --password=password --groups=ops
 {{< /highlight >}}
 
-2. Create a user with the username `bob`:
+2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< highlight shell >}}
-sensuctl user create bob  --password 'password'
+sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /highlight >}}
 
-3. Create an `event-reader-binding` role binding to assign the `event-reader` role to the `bob` user:
+3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< highlight shell >}}
-sensuctl role-binding create event-reader-binding --role=event-reader --user=bob
+sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /highlight >}}
+
+All users in the `ops` group now have read-only access to events across all namespaces.
 
 ## Next steps
 
-You now know how to create a role, create a user, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
+You now know how to create a user, create a role, and create a role binding to assign a role to a user. From this point, here are some recommended resources:
 
-* Read the [RBAC reference][1] for in-depth documentation on role-based access control and information about cluster-wide permissions.
+* Read the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
 [1]: ../../reference/rbac
 [2]: ../../reference/rbac#default-user

--- a/content/sensu-go/5.5/reference/rbac.md
+++ b/content/sensu-go/5.5/reference/rbac.md
@@ -12,9 +12,12 @@ menu:
 
 - [Namespaces](#namespaces): [Managing namespaces](#viewing-namespaces) | [Specification](#namespace-specification) | [Examples](#namespace-examples)
 - [Resources](#resources): [Namespaced resource types](#namespaced-resource-types) | [Cluster-wide resource types](#cluster-wide-resource-types)
-- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Groups](#groups)
+- [Users](#users): [Managing users](#viewing-users) | [Specification](#user-specification) | [Examples](#user-example) | [Groups](#groups)
 - [Roles and cluster roles](#roles-and-cluster-roles): [Managing roles](#viewing-roles) | [Specification](#role-and-cluster-role-specification) | [Examples](#role-examples)
 - [Role bindings and cluster role bindings](#role-bindings-and-cluster-role-bindings): [Managing role bindings](#viewing-role-bindings) | [Specification](#role-binding-and-cluster-role-binding-specification) | [Examples](#role-binding-examples)
+- [Assigning user permissions within a namespace](#assigning-user-permissions-within-a-namespace)
+- [Assigning group permissions within a namespace](#assigning-group-permissions-within-a-namespace)
+- [Assigning group permissions across all namespaces](#assigning-group-permissions-across-all-namespaces)
 
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows management and access of users and resources based on **namespaces**, **groups**, **roles**, and **bindings**.
@@ -68,8 +71,6 @@ To delete a namespace:
 sensuctl namespace delete [NAMESPACE-NAME]
 {{< /highlight >}}
 
-_WARNING: This deletes every resource definition associated with the namespace._
-
 To get help managing namespaces with sensuctl:
 
 {{< highlight shell >}}
@@ -94,13 +95,9 @@ For example, to assign a check called `check-cpu` to the `production` namespace,
   "spec": {
     "check_hooks": null,
     "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": [
-      "slack"
-    ],
+    "handlers": ["slack"],
     "interval": 30,
-    "subscriptions": [
-      "system"
-    ],
+    "subscriptions": ["system"],
     "timeout": 0,
     "ttl": 0
   }
@@ -119,9 +116,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "production"{{< /highlight >}}
 
-### Namespace examples
+### Namespace example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -147,6 +144,7 @@ Namespaced resources must belong to a single namespace and can be accessed by [r
 | `checks` | [Check][6] resources within a namespace |
 | `entities` | [Entity][7] resources within a namespace |
 | `events` | [Event][8] resources within a namespace |
+| `extensions` | placeholder type
 | `filters`   | [Filter][22] resources within a namespace  |
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
@@ -200,24 +198,24 @@ Once authenticated, you can change the password using the `change-password` comm
 sensuctl user change-password
 {{< /highlight >}}
 
-Sensu also includes an `agent` user that is used internally by the Sensu agent and should not be modified.
-
-_WARNING: Modification of the `agent` user can result in non-functional Sensu agents._
+Sensu also includes an `agent` user that is used internally by the Sensu agent.
+You can configure an agent's user credentials using the [`user` and `password` agent configuration flags](../reference/agent/#security-configuration-flags).
 
 ### Viewing users
-You can use [sensuctl][2] to see a list of all users within Sensu:
+You can use [sensuctl][2] to see a list of all users within Sensu.
+The following example returns a list of users in `yaml` format for use with `sensuctl create`.
 
 {{< highlight shell >}}
-sensuctl user list
+sensuctl user list --format yaml
 {{< /highlight >}}
 
 ### Creating a user
 You can use [sensuctl][2] to create a user.
-For example, the following command creates a user with the username `alice` and the password `password`.
+For example, the following command creates a user with the username `alice`, create a password, and assign them to the `ops` and `dev` groups.
 Passwords must have at least eight characters.
 
 {{< highlight shell >}}
-sensuctl user create alice --password 'password'
+sensuctl user create alice --password='password' --groups=ops,dev
 {{< /highlight >}}
 
 ### Assigning user permissions
@@ -229,8 +227,6 @@ To assign permissions to a user:
 3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing users
-
-You can use [sensuctl][2] to view, create, and manage users.
 
 To test the password for a user:
 
@@ -276,7 +272,7 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"password": "P@ssw0rd!"{{< /highlight >}}
 
-groups     | 
+groups       | 
 -------------|------ 
 description  | Groups to which the user belongs.
 required     | false 
@@ -291,18 +287,33 @@ type         | Boolean
 default      | false
 example      | {{< highlight shell >}}"disabled": false{{< /highlight >}}
 
+### User example
+
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
+
+{{< highlight json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+   "username": "alice",
+    "disabled": false,
+    "groups": ["ops", "dev"]
+  }
+}
+{{< /highlight >}}
+
 ## Groups
 
 A group is a set of users within Sensu.
 Groups can be assigned one or more roles and inherit all permissions from each role assigned to them.
 Users can be assigned to one or more groups.
+Groups are not a resource type within Sensu; you can create and manage groups only within user definitions.
 
 ### Default group
 
-Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20].
-Additionally, Sensu includes a `system:agents` group used internally by Sensu agents.
-
-_WARNING: Modification of the `system:agents` group can result in non-functional Sensu agents._
+Sensu includes a default `cluster-admins` group that contains the [default `admin` user][20] and a `system:agents` group used internally by Sensu agents.
 
 ### Assigning a user to a group
 
@@ -340,7 +351,7 @@ sensuctl user remove-groups USERNAME
 ## Roles and cluster roles
 
 A role is a set of permissions controlling access to Sensu resources.
-**Roles** specify permissions for resources within a namespace while **cluster roles**  can include permissions for [cluster-wide resources][18].
+**Roles** specify permissions for resources within a namespace while **cluster roles** can include permissions for [cluster-wide resources][18].
 You can use [roles bindings][23] to assign roles to user and groups.
 To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] (not a cluster role binding) to restrict permissions within a specific namespace.
 
@@ -393,6 +404,13 @@ For example, the following command creates an admin role restricted to the produ
 
 {{< highlight shell >}}
 sensuctl role create prod-admin --verb get,list,create,update,delete --resource * --namespace production
+{{< /highlight >}}
+
+Once you've create the role, [create a role binding][23] (or [cluster role binding][35]) to assign the role to users and groups.
+For example, to assign the `prod-admin` role created above to the `oncall` group, create the following role binding.
+
+{{< highlight shell >}}
+sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /highlight >}}
 
 ### Creating a cluster-wide role
@@ -482,16 +500,16 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}
 
-### Role examples
+### Role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader",
+    "name": "namespaced-resources-all-verbs",
     "namespace": "default"
   },
   "spec": {
@@ -499,40 +517,38 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
 }
 {{< /highlight >}}
 
-### Cluster role examples
+### Cluster role example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "name": "global-event-reader"
+    "name": "all-resources-all-verbs"
   },
   "spec": {
     "rules": [
       {
         "resource_names": [],
         "resources": [
-          "events"
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users", "providers"
         ],
-        "verbs": [
-          "get",
-          "list"
-        ]
+        "verbs": ["get", "list", "create", "update", "delete"]
       }
     ]
   }
@@ -541,9 +557,8 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ## Role bindings and cluster role bindings
 
-A **role binding** assigns a **role** or **cluster role** to a user or set of users.
-A **cluster role binding** assigns a **cluster role** to a user or set of users.
-Roles bindings apply roles within a namespace while cluster role bindings apply across namespaces and resource types.
+A **role binding** assigns a **role** or **cluster role** to users and groups within a namesapce.
+A **cluster role binding** assigns a **cluster role** to users and groups across namespaces and resource types.
 
 To create and manage role bindings within a namespace, [create a role][25] with `rolebindings` permissions within that namespace, and log in by [configuring sensuctl][26].
 
@@ -593,14 +608,6 @@ To create a cluster role binding:
 {{< highlight shell >}}
 sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
 {{< /highlight >}}
-
-### Assigning user permissions
-
-To assign permissions to a user:
-
-1. [Create the user][27].
-2. [Create a role][25] or (for cluster-wide access) a [cluster role][28].
-3. [Create a role binding][29] (or [cluster role binding][29]) to assign the role to the user.
 
 ### Managing role bindings
 
@@ -675,9 +682,9 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "alice"{{< /highlight >}}
 
-### Role binding examples
+### Role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -702,9 +709,9 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 }
 {{< /highlight >}}
 
-### Cluster role binding examples
+### Cluster role binding example
 
-The following examples are in `wrapped-json` format for use with [`sensuctl create`][31].
+The following examples is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {
@@ -730,7 +737,7 @@ The following examples are in `wrapped-json` format for use with [`sensuctl crea
 
 ### Role and role binding examples
 
-The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `development` namespace.
+The following role and role binding give a `dev` group access to create and manage Sensu workflows within the `default` namespace.
 
 {{< highlight text >}}
 {
@@ -738,7 +745,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "workflow-creator",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "rules": [
@@ -755,7 +762,7 @@ The following role and role binding give a `dev` group access to create and mana
   "api_version": "core/v2",
   "metadata": {
     "name": "dev-binding",
-    "namespace": "development"
+    "namespace": "default"
   },
   "spec": {
     "role_ref": {
@@ -765,6 +772,201 @@ The following role and role binding give a `dev` group access to create and mana
     "subjects": [
       {
         "name": "dev",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+## Example workflows
+
+### Assigning user permissions within a namespace
+
+To assign permissions to a user:
+
+1. [Create the user][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the user.
+
+For example, the following configuration creates a user `alice`, a role `default-admin`, and a role binding `alice-default-admin`, giving `alice` full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "alice-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "alice",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+### Assigning group permissions within a namespace
+
+To assign permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a role][25].
+3. [Create a role binding][29] to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a role `default-admin`, and a role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] within the `default` namespace.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice"
+  }
+}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+      }
+    ]
+  }
+}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+_PRO TIP: To avoid re-creating commonly used roles in each namespace, [create a cluster role][28] and use a [role binding][29] to restrict permissions within a specific namespace._
+
+### Assigning group permissions across all namespaces
+
+To assign cluster-wide permissions to group of users:
+
+1. [Create at least once user assigned to a group][27].
+2. [Create a cluster role][28].
+3. [Create a cluster role binding][29]) to assign the role to the group.
+
+For example, the following configuration creates a user `alice` assigned to the group `ops`, a cluster role `default-admin`, and a cluster role binding `ops-default-admin`, giving the `ops` group full permissions for [namespaced resource types][17] and [cluster-wide resource types][18] across all namespaces.
+You can add these resources to Sensu using [`sensuctl create`][31].
+
+{{< highlight text >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "groups": ["ops"]
+  }
+}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "default-admin"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": [],
+        "resources": [
+          "assets", "checks", "entities", "events", "filters", "handlers",
+          "hooks", "mutators", "rolebindings", "roles", "silenced",
+          "cluster", "clusterrolebindings", "clusterroles",
+          "namespaces", "users", "providers"
+        ],
+        "verbs": ["get", "list", "create", "update", "delete"]
+
+      }
+    ]
+  }
+}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops-default-admin"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
         "type": "Group"
       }
     ]
@@ -806,3 +1008,4 @@ The following role and role binding give a `dev` group access to create and mana
 [32]: ../../installation/auth
 [33]: ../../getting-started/enterprise
 [34]: ../../installation/auth
+[35]: #cluster-role-bindings

--- a/content/sensu-go/5.5/reference/rbac.md
+++ b/content/sensu-go/5.5/reference/rbac.md
@@ -144,7 +144,7 @@ Namespaced resources must belong to a single namespace and can be accessed by [r
 | `checks` | [Check][6] resources within a namespace |
 | `entities` | [Entity][7] resources within a namespace |
 | `events` | [Event][8] resources within a namespace |
-| `extensions` | placeholder type
+| `extensions` | Placeholder type
 | `filters`   | [Filter][22] resources within a namespace  |
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
@@ -211,7 +211,7 @@ sensuctl user list --format yaml
 
 ### Creating a user
 You can use [sensuctl][2] to create a user.
-For example, the following command creates a user with the username `alice`, create a password, and assign them to the `ops` and `dev` groups.
+For example, the following command creates a user with the username `alice`, creates a password, and assigns the user to the `ops` and `dev` groups.
 Passwords must have at least eight characters.
 
 {{< highlight shell >}}

--- a/content/sensu-go/5.5/reference/rbac.md
+++ b/content/sensu-go/5.5/reference/rbac.md
@@ -711,7 +711,7 @@ The following example is in `wrapped-json` format for use with [`sensuctl create
 
 ### Cluster role binding example
 
-The following examples is in `wrapped-json` format for use with [`sensuctl create`][31].
+The following example is in `wrapped-json` format for use with [`sensuctl create`][31].
 
 {{< highlight json >}}
 {


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Removes default role from RBAC guide
- Revises the second section of the guide to create cluster-wide permissions
- Adds examples workflows to the RBAC reference
- Clarifies concepts of groups and bindings
- Adds available types to examples so they can serve as templates
- Removes warnings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1270
Closes #1242

