### PR TITLE
Correct RabbitMQ configuration example in SSL guide

### DIFF
--- a/content/sensu-core/0.29/reference/ssl.md
+++ b/content/sensu-core/0.29/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.0/reference/ssl.md
+++ b/content/sensu-core/1.0/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.1/reference/ssl.md
+++ b/content/sensu-core/1.1/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.2/reference/ssl.md
+++ b/content/sensu-core/1.2/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.3/reference/ssl.md
+++ b/content/sensu-core/1.3/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.4/reference/ssl.md
+++ b/content/sensu-core/1.4/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.5/reference/ssl.md
+++ b/content/sensu-core/1.5/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.6/reference/ssl.md
+++ b/content/sensu-core/1.6/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an

--- a/content/sensu-core/1.7/reference/ssl.md
+++ b/content/sensu-core/1.7/reference/ssl.md
@@ -163,17 +163,19 @@ sudo service rabbitmq-server start
    section of the RabbitMQ reference documentation for more information.
 {{< highlight json >}}
 {
- "host": "127.0.0.1",
- "port": 5671,
- "vhost": "/sensu",
- "user": "sensu",
- "password": "secret",
- "heartbeat": 30,
- "prefetch": 50,
- "ssl": {
-   "cert_chain_file": "/etc/sensu/ssl/cert.pem",
-   "private_key_file": "/etc/sensu/ssl/key.pem"
- }
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5671,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50,
+    "ssl": {
+      "cert_chain_file": "/etc/sensu/ssl/cert.pem",
+      "private_key_file": "/etc/sensu/ssl/key.pem"
+    }
+  }
 }{{< /highlight >}}
    _WARNING: please note that by default, RabbitMQ will listen for SSL
    connections on port `5671` instead of `5672`, so if you are upgrading an


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Current RabbitMQ JSON example is missing the `rabbitmq` level.

## Motivation and Context
Users following this example will not have a working configuration and will have to know to open the RabbitMQ reference, asking in Community or open a support request.

## Review Instructions
I confirmed this works in my lab environment.
