### PR TITLE
Remove agent socket TTL example

### DIFF
--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -276,32 +276,6 @@ default      | `1`
 type         | Integer
 example      | {{< highlight shell >}}"interval": 60{{< /highlight >}}
 
-### Creating a "dead man's switch"
-
-The Sensu agent socket in combination with check TTLs can be used to create what's commonly referred to as a "dead man's switch".
-Outside of the software industry, a dead man's switch is a switch that is triggered automatically if a human operator becomes incapacitated (source: [Wikipedia][20]).
-However, Sensu is more interested in detecting silent failures than incapacitated human operators.
-
-By using check TTLs, Sensu is able to set an expectation that a Sensu agent continues to publish results for a check at a regular interval.
-If a Sensu agent fails to publish a check result and the check TTL expires, Sensu creates an alert to indicate the silent failure.
-For more information on check TTLs, please refer to [the check attributes reference][14].
-
-A great use case for the Sensu agent socket is to create a dead man's switch to ensure that backup scripts continue to run successfully at regular intervals.
-If an external source sends a Sensu check result with a check TTL to the Sensu agent socket, Sensu expects another check result from the same external source before the TTL expires.
-
-The following is an example of external check result input via the Sensu agent TCP socket using a check TTL to create a dead man's switch for MySQL backups.
-The example uses a check TTL of `25200` seconds (7 hours).
-A MySQL backup script using the following code would be expected to continue to send a check
-result at least once every 7 hours or Sensu creates an alert to indicate the silent failure.
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "backed up mysql successfully | size_mb=568", "status": 0}' | nc localhost 3030
-{{< /highlight >}}
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "failed to backup mysql", "status": 1}' | nc localhost 3030
-{{< /highlight >}}
-
 ## Creating monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.

--- a/content/sensu-go/5.1/reference/agent.md
+++ b/content/sensu-go/5.1/reference/agent.md
@@ -276,32 +276,6 @@ default      | `1`
 type         | Integer
 example      | {{< highlight shell >}}"interval": 60{{< /highlight >}}
 
-### Creating a "dead man's switch"
-
-The Sensu agent socket in combination with check TTLs can be used to create what's commonly referred to as a "dead man's switch".
-Outside of the software industry, a dead man's switch is a switch that is triggered automatically if a human operator becomes incapacitated (source: [Wikipedia][20]).
-However, Sensu is more interested in detecting silent failures than incapacitated human operators.
-
-By using check TTLs, Sensu is able to set an expectation that a Sensu agent continues to publish results for a check at a regular interval.
-If a Sensu agent fails to publish a check result and the check TTL expires, Sensu creates an alert to indicate the silent failure.
-For more information on check TTLs, please refer to [the check attributes reference][14].
-
-A great use case for the Sensu agent socket is to create a dead man's switch to ensure that backup scripts continue to run successfully at regular intervals.
-If an external source sends a Sensu check result with a check TTL to the Sensu agent socket, Sensu expects another check result from the same external source before the TTL expires.
-
-The following is an example of external check result input via the Sensu agent TCP socket using a check TTL to create a dead man's switch for MySQL backups.
-The example uses a check TTL of `25200` seconds (7 hours).
-A MySQL backup script using the following code would be expected to continue to send a check
-result at least once every 7 hours or Sensu creates an alert to indicate the silent failure.
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "backed up mysql successfully | size_mb=568", "status": 0}' | nc localhost 3030
-{{< /highlight >}}
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "failed to backup mysql", "status": 1}' | nc localhost 3030
-{{< /highlight >}}
-
 ## Creating monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.

--- a/content/sensu-go/5.2/reference/agent.md
+++ b/content/sensu-go/5.2/reference/agent.md
@@ -277,32 +277,6 @@ default      | `1`
 type         | Integer
 example      | {{< highlight shell >}}"interval": 60{{< /highlight >}}
 
-### Creating a "dead man's switch"
-
-The Sensu agent socket in combination with check TTLs can be used to create what's commonly referred to as a "dead man's switch".
-Outside of the software industry, a dead man's switch is a switch that is triggered automatically if a human operator becomes incapacitated (source: [Wikipedia][20]).
-However, Sensu is more interested in detecting silent failures than incapacitated human operators.
-
-By using check TTLs, Sensu is able to set an expectation that a Sensu agent continues to publish results for a check at a regular interval.
-If a Sensu agent fails to publish a check result and the check TTL expires, Sensu creates an alert to indicate the silent failure.
-For more information on check TTLs, please refer to [the check attributes reference][14].
-
-A great use case for the Sensu agent socket is to create a dead man's switch to ensure that backup scripts continue to run successfully at regular intervals.
-If an external source sends a Sensu check result with a check TTL to the Sensu agent socket, Sensu expects another check result from the same external source before the TTL expires.
-
-The following is an example of external check result input via the Sensu agent TCP socket using a check TTL to create a dead man's switch for MySQL backups.
-The example uses a check TTL of `25200` seconds (7 hours).
-A MySQL backup script using the following code would be expected to continue to send a check
-result at least once every 7 hours or Sensu creates an alert to indicate the silent failure.
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "backed up mysql successfully | size_mb=568", "status": 0}' | nc localhost 3030
-{{< /highlight >}}
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "failed to backup mysql", "status": 1}' | nc localhost 3030
-{{< /highlight >}}
-
 ## Creating monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.

--- a/content/sensu-go/5.3/reference/agent.md
+++ b/content/sensu-go/5.3/reference/agent.md
@@ -285,32 +285,6 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"handlers": ["slack", "influxdb"]{{< /highlight >}}
 
-### Creating a "dead man's switch"
-
-The Sensu agent socket in combination with check TTLs can be used to create what's commonly referred to as a "dead man's switch".
-Outside of the software industry, a dead man's switch is a switch that is triggered automatically if a human operator becomes incapacitated (source: [Wikipedia][20]).
-However, Sensu is more interested in detecting silent failures than incapacitated human operators.
-
-By using check TTLs, Sensu is able to set an expectation that a Sensu agent continues to publish results for a check at a regular interval.
-If a Sensu agent fails to publish a check result and the check TTL expires, Sensu creates an alert to indicate the silent failure.
-For more information on check TTLs, please refer to [the check attributes reference][14].
-
-A great use case for the Sensu agent socket is to create a dead man's switch to ensure that backup scripts continue to run successfully at regular intervals.
-If an external source sends a Sensu check result with a check TTL to the Sensu agent socket, Sensu expects another check result from the same external source before the TTL expires.
-
-The following is an example of external check result input via the Sensu agent TCP socket using a check TTL to create a dead man's switch for MySQL backups.
-The example uses a check TTL of `25200` seconds (7 hours).
-A MySQL backup script using the following code would be expected to continue to send a check
-result at least once every 7 hours or Sensu creates an alert to indicate the silent failure.
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "backed up mysql successfully | size_mb=568", "status": 0}' | nc localhost 3030
-{{< /highlight >}}
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "failed to backup mysql", "status": 1}' | nc localhost 3030
-{{< /highlight >}}
-
 ## Creating monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.

--- a/content/sensu-go/5.4/reference/agent.md
+++ b/content/sensu-go/5.4/reference/agent.md
@@ -291,32 +291,6 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"handlers": ["slack", "influxdb"]{{< /highlight >}}
 
-### Creating a "dead man's switch"
-
-The Sensu agent socket in combination with check TTLs can be used to create what's commonly referred to as a "dead man's switch".
-Outside of the software industry, a dead man's switch is a switch that is triggered automatically if a human operator becomes incapacitated (source: [Wikipedia][20]).
-However, Sensu is more interested in detecting silent failures than incapacitated human operators.
-
-By using check TTLs, Sensu is able to set an expectation that a Sensu agent continues to publish results for a check at a regular interval.
-If a Sensu agent fails to publish a check result and the check TTL expires, Sensu creates an alert to indicate the silent failure.
-For more information on check TTLs, please refer to [the check attributes reference][14].
-
-A great use case for the Sensu agent socket is to create a dead man's switch to ensure that backup scripts continue to run successfully at regular intervals.
-If an external source sends a Sensu check result with a check TTL to the Sensu agent socket, Sensu expects another check result from the same external source before the TTL expires.
-
-The following is an example of external check result input via the Sensu agent TCP socket using a check TTL to create a dead man's switch for MySQL backups.
-The example uses a check TTL of `25200` seconds (7 hours).
-A MySQL backup script using the following code would be expected to continue to send a check
-result at least once every 7 hours or Sensu creates an alert to indicate the silent failure.
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "backed up mysql successfully | size_mb=568", "status": 0}' | nc localhost 3030
-{{< /highlight >}}
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "failed to backup mysql", "status": 1}' | nc localhost 3030
-{{< /highlight >}}
-
 ## Creating monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.

--- a/content/sensu-go/5.5/reference/agent.md
+++ b/content/sensu-go/5.5/reference/agent.md
@@ -291,32 +291,6 @@ required     | false
 type         | Array
 example      | {{< highlight shell >}}"handlers": ["slack", "influxdb"]{{< /highlight >}}
 
-### Creating a "dead man's switch"
-
-The Sensu agent socket in combination with check TTLs can be used to create what's commonly referred to as a "dead man's switch".
-Outside of the software industry, a dead man's switch is a switch that is triggered automatically if a human operator becomes incapacitated (source: [Wikipedia][20]).
-However, Sensu is more interested in detecting silent failures than incapacitated human operators.
-
-By using check TTLs, Sensu is able to set an expectation that a Sensu agent continues to publish results for a check at a regular interval.
-If a Sensu agent fails to publish a check result and the check TTL expires, Sensu creates an alert to indicate the silent failure.
-For more information on check TTLs, please refer to [the check attributes reference][14].
-
-A great use case for the Sensu agent socket is to create a dead man's switch to ensure that backup scripts continue to run successfully at regular intervals.
-If an external source sends a Sensu check result with a check TTL to the Sensu agent socket, Sensu expects another check result from the same external source before the TTL expires.
-
-The following is an example of external check result input via the Sensu agent TCP socket using a check TTL to create a dead man's switch for MySQL backups.
-The example uses a check TTL of `25200` seconds (7 hours).
-A MySQL backup script using the following code would be expected to continue to send a check
-result at least once every 7 hours or Sensu creates an alert to indicate the silent failure.
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "backed up mysql successfully | size_mb=568", "status": 0}' | nc localhost 3030
-{{< /highlight >}}
-
-{{< highlight shell >}}
-echo '{"name": "backup_mysql", "ttl": 25200, "output": "failed to backup mysql", "status": 1}' | nc localhost 3030
-{{< /highlight >}}
-
 ## Creating monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
The examples shown in https://docs.sensu.io/sensu-go/5.4/reference/agent/#creating-a-dead-man-s-switch do not work because the agent socket ignores all attributes that aren't listed in the [socket event specification](https://docs.sensu.io/sensu-go/5.4/reference/agent/#socket-event-specification). This PR removes the dead man's switch section from all versions of the agent reference. This content can be re-added following the resolution of https://github.com/sensu/sensu-go/issues/2858.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1348