### PR TITLE
Scope search to current product and version

### DIFF
--- a/themes/hugo-material-docs/layouts/partials/footer_js.html
+++ b/themes/hugo-material-docs/layouts/partials/footer_js.html
@@ -92,7 +92,7 @@
     apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
     indexName: 'sensu',
     inputSelector: '#search', 
-    algoliaOptions: { 'facetFilters': [['tags:sensu-go','tags:plugins', 'tags:sensu-core', 'tags:sensu-enterprise', 'tags:sensu-enterprise-dashboard', 'tags:uchiwa'], ['version:5.5','version:1.0','version:2.15','version:1.7','version:3.4']]},
+    algoliaOptions: { 'facetFilters': [[{{ if isset .Page.Params "product" }}'tags:{{ .Section }}'{{ else }}'tags:sensu-go','tags:plugins', 'tags:sensu-core', 'tags:sensu-enterprise', 'tags:sensu-enterprise-dashboard', 'tags:uchiwa'{{end}}], [{{ if isset .Page.Params "product" }}'version:{{ .Page.Params.version }}'{{ else }}'version:5.5','version:1.0','version:2.15','version:1.7','version:3.4'{{end}}]]},
     debug: false
     });
     </script>


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
This PR scopes the Algolia search to the current product and version. For the home page, the search includes the latest version of all products (plus version 1.0 of Sensu Core).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Avoid user confusion when accidentally transported to another product

## Review Instructions
<!--- Optional -->
- From https://sensu-docs-stage.herokuapp.com, search for "checks". The first result should be for Uchiwa.
- From https://sensu-docs-stage.herokuapp.com/sensu-go/5.5/, search for "checks". The first result should be for Sensu Go.
- From https://sensu-docs-stage.herokuapp.com/uchiwa/1.0/, search for "entities". There should be no results.