### PR TITLE
Style updates: max-width tables and code block margin

### DIFF
--- a/static/stylesheets/docs-overrides.css
+++ b/static/stylesheets/docs-overrides.css
@@ -745,6 +745,10 @@ code {
   margin: 1.5em 0;
 }
 
+.article table {
+  width: 100%;
+}
+
 .article table th {
   background-color: #2C3458;
   font-family: 'Work Sans';

--- a/static/stylesheets/docs-overrides.css
+++ b/static/stylesheets/docs-overrides.css
@@ -932,7 +932,7 @@ code {
 
 .article pre,
 .drawer pre {
-  margin: 0 0 35px 0;
+  margin: 0 0 25px 0;
   padding: 0;
   border-radius: 2px;
   display: block;


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
### Sets tables to max width

#### Before:
![Screen Shot 2019-04-16 at 3 43 24 PM](https://user-images.githubusercontent.com/11339965/56249375-63436980-6060-11e9-803c-068294bc51e0.png)

#### After:
![Screen Shot 2019-04-16 at 3 43 54 PM](https://user-images.githubusercontent.com/11339965/56249391-6dfdfe80-6060-11e9-84be-60fe48b01143.png)

### Slightly reduces the margin after code blocks

#### Before:
![Screen Shot 2019-04-16 at 3 51 47 PM](https://user-images.githubusercontent.com/11339965/56249317-26777280-6060-11e9-918e-2e05ffcdc2d7.png)

#### After:

![Screen Shot 2019-04-16 at 3 51 57 PM](https://user-images.githubusercontent.com/11339965/56249325-2f684400-6060-11e9-9095-dd53bb395e3a.png)
