### PR TITLE
[WIP] Automatic table of contents

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,6 +19,12 @@
   {{ partial "header" . }}
 </header>
 
+<aside class="thirdcolumn">
+    {{ if isset .Params "toc" }}
+    {{ partial "toc.html" . }}
+  {{ end }}
+</aside>
+
 <main class="main">
   <div class="drawer">
     {{ partial "drawer" . }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,3 @@
+<div class="autotoc">
+    {{ .TableOfContents }}
+    </div>

--- a/static/stylesheets/docs-overrides.css
+++ b/static/stylesheets/docs-overrides.css
@@ -1910,3 +1910,51 @@ img[alt=ssl_example] {
 .copy:hover {
   background-color: #c2cad6;
 }
+
+.thirdcolumn {
+  display: none;
+}
+
+@media (min-width: 1700px) {
+  .thirdcolumn {
+    position: fixed;
+    right: 0px;
+    padding-top: 170px;
+    padding-right: 10px;
+    display: inline;
+    width: 12%;
+  }
+}
+
+.autotoc {
+  padding-left: 30px;
+  font-family: 'Work Sans';
+  font-weight: 600;
+  font-size: 14px;
+  color: #5F6065;
+  border-bottom: 0;
+  -webkit-transition: color 240ms cubic-bezier(0.2, 0.3, 0.25, 0.9);
+  transition: color 240ms cubic-bezier(0.2, 0.3, 0.25, 0.9);
+}
+
+.autotoc a:hover {
+  color: #46474b;
+}
+
+
+.autotoc ul > li > ul > li {
+  line-height: 1.375;
+  padding: 0 0 10px 0px;
+}
+
+.autotoc ul > li > ul > li > a {
+  line-height: 1.375;
+  padding: 0 0 10px 0px;
+  display: inline-block;
+}
+
+.autotoc ul > li > ul > li > ul > li {
+  line-height: 1.375;
+  padding: 0 0 8px 0px;
+  font-weight: 400;
+}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Adds an automatic table of contents (TOC) in a right sidebar that appears at 1700px screen width when a page includes the `toc` frontmatter element.

![Screen Shot 2019-04-19 at 11 12 25 AM](https://user-images.githubusercontent.com/11339965/56437471-6de64480-6294-11e9-9049-f53343a04c66.png)

Objectives:

- Users can easily see the contents of a page.
- Users can keep track of their place within the page as they read.
- To ease adoption, the TOC should be conditional, activated by a frontmatter element.
- TOC should not interfere with content at smaller screen widths.
- Reference design: https://docs.mesosphere.com/1.12/metrics/metrics-api/

Notes:

- While easy to access, Hugo's built-in TOC variable is difficult to style due to the nested lists and lack of scoping to specific heading levels. See `https://github.com/gohugoio/hugo/issues/1778`
- As screen width increases, too much space appears to the left of the TOC. See the reference design linked above for ideal behavior.
- Really long TOCs overrun page length.
- Styling could be improved.
- To do: Add some javascript that highlights lines in the TOC as the user scrolls through the page. (See https://codepen.io/joxmar/pen/NqqMEg)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #603
 
## Review Instructions
<!--- Optional -->
Run locally, add a `toc` element to the frontmatter of a page, then increase screen width until the TOC appears.