### PR TITLE
Support agent labels and annotations via command line

### DIFF
--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -504,8 +504,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu at `/usr/share/doc/sensu-go-agent-5.0.0/agent.yml.example`.
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary

--- a/content/sensu-go/5.1/reference/agent.md
+++ b/content/sensu-go/5.1/reference/agent.md
@@ -504,8 +504,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu at `/usr/share/doc/sensu-go-agent-5.1.1/agent.yml.example`.
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary

--- a/content/sensu-go/5.2/reference/agent.md
+++ b/content/sensu-go/5.2/reference/agent.md
@@ -506,8 +506,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu at `/usr/share/doc/sensu-go-agent-5.2.1/agent.yml.example`.
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 Sensu agents can also be configured using environment variables.

--- a/content/sensu-go/5.3/reference/agent.md
+++ b/content/sensu-go/5.3/reference/agent.md
@@ -513,8 +513,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu at `/usr/share/doc/sensu-go-agent-5.3.0/agent.yml.example`.
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary

--- a/content/sensu-go/5.4/reference/agent.md
+++ b/content/sensu-go/5.4/reference/agent.md
@@ -519,8 +519,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu at `/usr/share/doc/sensu-go-agent-5.4.0/agent.yml.example`.
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary

--- a/content/sensu-go/5.5/reference/agent.md
+++ b/content/sensu-go/5.5/reference/agent.md
@@ -529,8 +529,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu packages at `/usr/share/doc/sensu-go-agent-5.5.1/agent.yml.example` or [available here](/sensu-go/5.5/files/agent.yml).
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary

--- a/content/sensu-go/5.6/reference/agent.md
+++ b/content/sensu-go/5.6/reference/agent.md
@@ -643,8 +643,9 @@ description  | Custom attributes to include with event data, which can be querie
 required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores, but must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
-example               | {{< highlight shell >}}# Command line example
+example               | {{< highlight shell >}}# Command line examples
 sensu-agent start --labels proxy_type=website
+sensu-agent start --labels example_key1="example value" example_key2="example value"
 
 # /etc/sensu/agent.yml example
 labels:

--- a/content/sensu-go/5.6/reference/agent.md
+++ b/content/sensu-go/5.6/reference/agent.md
@@ -529,8 +529,9 @@ System clocks between agents and the backend should be synchronized to a central
 
 ## Configuration
 
-You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` [configuration flags][24].
+You can specify the agent configuration using a `/etc/sensu/agent.yml` file or using `sensu-agent start` command-line flags.
 See the example config file provided with Sensu packages at `/usr/share/doc/sensu-go-agent-5.6.0/agent.yml.example` or [available here](/sensu-go/5.6/files/agent.yml).
+Configuration provided via command-line flags overrides attributes specified in a configuration file.
 The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 
 ### Configuration summary

--- a/content/sensu-go/5.6/reference/agent.md
+++ b/content/sensu-go/5.6/reference/agent.md
@@ -585,7 +585,10 @@ description  |Arbitrary, non-identifying metadata to include with event data. In
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
-example      | {{< highlight shell >}}
+example      | {{< highlight shell >}}# Command line examples
+sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
+
 # /etc/sensu/agent.yml example
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Adds an example for configuration agent annotations via command line flag
- Clarifies config precedence between file and flags

To do:

- [x] Copy https://github.com/sensu/sensu-docs/pull/1393/commits/488a3ee8c58aef0fb2a110efe57255e4a501bda7 to all versions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1391