### PR TITLE
Remove metrics object from sensctl event response

### DIFF
--- a/content/sensu-go/5.4/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.4/getting-started/learn-sensu.md
@@ -345,36 +345,23 @@ After about 10 seconds, we can see the event produced by the entity:
 {{< highlight shell >}}
 sensuctl event info sensu-go-sandbox curl_timings --format json | jq .
 ...
-  "metrics": {
-    "handlers": [
-      "influx-db"
-    ],
-    "points": [
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_total",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      },
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      },
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_connect",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      }
-    ]
-  }
+  "history": [
+    {
+      "status": 0,
+      "executed": 1556472457
+    },
+  ],
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1556472657\n...",
+  ...
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+...
 {{< /highlight >}}
 
-Because we configured a metric format, the Sensu agent was able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics.
+Because we configured a metric format, the Sensu agent is able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics (not shown in the output), which are then sent to the InfluxDB handler that reads Sensu-formatted metrics and converts them to a format InfluxDB accepts.
 Metric support isn't limited to just Graphite; the Sensu agent can extract metrics in multiple line protocol formats, including Nagios performance data.
-.
 
 **5. See the HTTP response code events for Nginx in [Grafana](http://localhost:4002/d/go01/sensu-go-sandbox).**
 

--- a/content/sensu-go/5.5/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.5/getting-started/learn-sensu.md
@@ -351,7 +351,7 @@ sensuctl event info sensu-go-sandbox curl_timings --format json | jq .
       "executed": 1556472457
     },
   ],
-  "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1556472657\n...
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1556472657\n...",
   ...
   "output_metric_format": "graphite_plaintext",
   "output_metric_handlers": [

--- a/content/sensu-go/5.5/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.5/getting-started/learn-sensu.md
@@ -345,34 +345,22 @@ After about 10 seconds, we can see the event produced by the entity:
 {{< highlight shell >}}
 sensuctl event info sensu-go-sandbox curl_timings --format json | jq .
 ...
-  "metrics": {
-    "handlers": [
-      "influx-db"
-    ],
-    "points": [
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_total",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      },
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      },
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_connect",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      }
-    ]
-  }
+  "history": [
+    {
+      "status": 0,
+      "executed": 1556472457
+    },
+  ],
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1556472657\n...
+  ...
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+...
 {{< /highlight >}}
 
-Because we configured a metric format, the Sensu agent was able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics.
+Because we configured a metric format, the Sensu agent is able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics (not shown int he output), which are then sent to the InfluxDB handler that knows how to read Sensu-formatted metrics and convert them to a format InfluxDB will accept.
 Metric support isn't limited to just Graphite; the Sensu agent can extract metrics in multiple line protocol formats, including Nagios performance data.
 .
 

--- a/content/sensu-go/5.5/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.5/getting-started/learn-sensu.md
@@ -362,7 +362,6 @@ sensuctl event info sensu-go-sandbox curl_timings --format json | jq .
 
 Because we configured a metric format, the Sensu agent is able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics (not shown in the output), which are then sent to the InfluxDB handler that reads Sensu-formatted metrics and converts them to a format InfluxDB accepts.
 Metric support isn't limited to just Graphite; the Sensu agent can extract metrics in multiple line protocol formats, including Nagios performance data.
-.
 
 **5. See the HTTP response code events for Nginx in [Grafana](http://localhost:4002/d/go01/sensu-go-sandbox).**
 

--- a/content/sensu-go/5.5/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.5/getting-started/learn-sensu.md
@@ -360,7 +360,7 @@ sensuctl event info sensu-go-sandbox curl_timings --format json | jq .
 ...
 {{< /highlight >}}
 
-Because we configured a metric format, the Sensu agent is able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics (not shown int he output), which are then sent to the InfluxDB handler that knows how to read Sensu-formatted metrics and convert them to a format InfluxDB will accept.
+Because we configured a metric format, the Sensu agent is able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics (not shown in the output), which are then sent to the InfluxDB handler that reads Sensu-formatted metrics and converts them to a format InfluxDB accepts.
 Metric support isn't limited to just Graphite; the Sensu agent can extract metrics in multiple line protocol formats, including Nagios performance data.
 .
 

--- a/content/sensu-go/5.6/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.6/getting-started/learn-sensu.md
@@ -345,36 +345,23 @@ After about 10 seconds, we can see the event produced by the entity:
 {{< highlight shell >}}
 sensuctl event info sensu-go-sandbox curl_timings --format json | jq .
 ...
-  "metrics": {
-    "handlers": [
-      "influx-db"
-    ],
-    "points": [
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_total",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      },
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_namelookup",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      },
-      {
-        "name": "sensu-go-sandbox.curl_timings.time_connect",
-        "value": 0.005,
-        "timestamp": 1543532948,
-        "tags": []
-      }
-    ]
-  }
+  "history": [
+    {
+      "status": 0,
+      "executed": 1556472457
+    },
+  ],
+  "output": "sensu-go-sandbox.curl_timings.time_total 0.005 1556472657\n...",
+  ...
+  "output_metric_format": "graphite_plaintext",
+  "output_metric_handlers": [
+    "influx-db"
+  ],
+...
 {{< /highlight >}}
 
-Because we configured a metric format, the Sensu agent was able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics.
+Because we configured a metric format, the Sensu agent is able to convert the Graphite-formatted metrics provided by the check command into a set of Sensu-formatted metrics (not shown in the output), which are then sent to the InfluxDB handler that reads Sensu-formatted metrics and converts them to a format InfluxDB accepts.
 Metric support isn't limited to just Graphite; the Sensu agent can extract metrics in multiple line protocol formats, including Nagios performance data.
-.
 
 **5. See the HTTP response code events for Nginx in [Grafana](http://localhost:4002/d/go01/sensu-go-sandbox).**
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Closes #1386 

## Motivation and Context
As of Sensu Go 5.4, metrics are no longer stored in etcd. The output in the sandbox walkthrough still shows that.

## Review Instructions
- [ ] Copy to 5.4 and 5.6.
