### PR TITLE
Correct license requirement

### DIFF
--- a/content/sensu-go/5.6/dashboard/overview.md
+++ b/content/sensu-go/5.6/dashboard/overview.md
@@ -46,6 +46,8 @@ You can create, edit, and delete Sensu checks using the dashboard checks page.
 
 ### Managing entities
 
+**ENTERPRISE ONLY**: Entity management in Sensu Go requires an enterprise license. To activate your enterprise license, see the [getting started guide][6].
+
 You can delete Sensu entities using the dashboard entities page.
 
 ### Themes

--- a/content/sensu-go/5.6/release-notes.md
+++ b/content/sensu-go/5.6/release-notes.md
@@ -37,7 +37,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.6.0.
 **NEW FEATURES:**
 
 - ([Enterprise-only][33]) Manage your Sensu checks from your browser: Sensu's web user interface now supports creating, editing, and deleting checks. See the [docs][32] to get started using the Sensu web UI.
-- The Sensu web UI now includes an option to delete entities.
+- ([Enterprise-only][33]) The Sensu web UI now includes an option to delete entities.
 - ([Enterprise-only][33]) Sensu now supports resource filtering in the Sensu API and sensuctl command line tool. Filter events using custom labels and resource attributes, such as event status and check subscriptions. See the [API docs][34] and [sensuctl reference][35] for usage examples.
 
 **IMPROVEMENTS:**


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Clarifies that an enterprise license is required to delete entities using the web UI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Tested using Sensu Go 5.6 on CentOS7
