### PR TITLE
Add supported versions page

### DIFF
--- a/content/sensu-go/5.0/getting-started/versions.md
+++ b/content/sensu-go/5.0/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.0"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.0:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.1/getting-started/versions.md
+++ b/content/sensu-go/5.1/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.1"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.1:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.2/getting-started/versions.md
+++ b/content/sensu-go/5.2/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.2"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.2:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.3/getting-started/versions.md
+++ b/content/sensu-go/5.3/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.3"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.3:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.4/getting-started/versions.md
+++ b/content/sensu-go/5.4/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.4"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.4:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.5/getting-started/versions.md
+++ b/content/sensu-go/5.5/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.5"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.5:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.6/getting-started/versions.md
+++ b/content/sensu-go/5.6/getting-started/versions.md
@@ -1,0 +1,33 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
+version: "5.6"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.6:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.7/getting-started/versions.md
+++ b/content/sensu-go/5.7/getting-started/versions.md
@@ -1,0 +1,34 @@
+---
+title: "Supported versions"
+linkTitle: "Supported Versions"
+description: ""
+version: "5.7"
+weight: 5
+product: "Sensu Go"
+menu:
+  sensu-go-5.7:
+    parent: getting-started
+---
+
+We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
+Sensu uses [semantic versioning](/sensu-go/latest/release-notes/#versioning), which guarantees backwards compatibility for minor and patch releases, so you can upgrade with confidence.
+See the [upgrade guide](../../installation/upgrade) to upgrade to the latest version.
+
+Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
+To learn more about Sensu support and licensing, see the [getting started guide](../enterprise).
+
+| version                     | release date     | status    | end of support date |
+| --------------------------- | ---------------- | --------- | ------------------- |
+5.7.0 ([docs](/sensu-go/5.7)) |                  | Pre-release
+**5.6.0** ([docs](/sensu-go/5.6)) | [April 30, 2019](/sensu-go/5.6/release-notes/#5-6-0-release-notes)     | Supported
+5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
+5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
+5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Not recommended
+5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
+5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
+5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
+5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 1, 2019

--- a/content/sensu-go/5.7/getting-started/versions.md
+++ b/content/sensu-go/5.7/getting-started/versions.md
@@ -1,7 +1,7 @@
 ---
 title: "Supported versions"
 linkTitle: "Supported Versions"
-description: ""
+description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
 version: "5.7"
 weight: 5
 product: "Sensu Go"
@@ -11,8 +11,7 @@ menu:
 ---
 
 We recommend updating Sensu frequently to stay in sync with the latest features and fixes.
-Sensu uses [semantic versioning](/sensu-go/latest/release-notes/#versioning), which guarantees backwards compatibility for minor and patch releases, so you can upgrade with confidence.
-See the [upgrade guide](../../installation/upgrade) to upgrade to the latest version.
+See the [upgrade guide](/sensu-go/latest/installation/upgrade) to upgrade to the latest version.
 
 Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
 Documentation for versions that have reached end of support is provided as a PDF and on [GitHub](https://github.com/sensu/sensu-docs/tree/master/content/sensu-go).
@@ -30,5 +29,5 @@ To learn more about Sensu support and licensing, see the [getting started guide]
 5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
 5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
 5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
-5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended
+5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended | June 3, 2019
 5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019

--- a/content/sensu-go/5.7/getting-started/versions.md
+++ b/content/sensu-go/5.7/getting-started/versions.md
@@ -25,10 +25,10 @@ To learn more about Sensu support and licensing, see the [getting started guide]
 5.5.1 ([docs](/sensu-go/5.5)) | [April 17, 2019](/sensu-go/5.5/release-notes/#5-5-1-release-notes)    | Supported
 5.5.0 ([docs](/sensu-go/5.5)) | [April 4, 2019](/sensu-go/5.5/release-notes/#5-5-0-release-notes)     | Supported
 5.4.0 ([docs](/sensu-go/5.4)) | [March 27, 2019](/sensu-go/5.4/release-notes/#5-4-0-release-notes)    | Supported
-5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Not recommended
+5.3.0 ([docs](/sensu-go/5.3)) | [March 11, 2019](/sensu-go/5.3/release-notes/#5-3-0-release-notes)    | Supported
 5.2.1 ([docs](/sensu-go/5.2)) | [February 11, 2019](/sensu-go/5.2/release-notes/#5-2-1-release-notes) | Not recommended
 5.2.0 ([docs](/sensu-go/5.2)) | [February 7, 2019](/sensu-go/5.2/release-notes/#5-2-0-release-notes)  | Not recommended
 5.1.1 ([docs](/sensu-go/5.1)) | [January 24, 2019](/sensu-go/5.1/release-notes/#5-1-1-release-notes)  | Not recommended
 5.1.0 ([docs](/sensu-go/5.1)) | [December 19, 2018](/sensu-go/5.1/release-notes/#5-1-0-release-notes) | Not recommended 
 5.0.1 ([docs](/sensu-go/5.0)) | [December 12, 2018](/sensu-go/5.0/release-notes/#5-0-1-release-notes) | Not recommended
-5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 1, 2019
+5.0.0 ([docs](/sensu-go/5.0)) | [December 5, 2018](/sensu-go/5.0/release-notes/#5-0-0-release-notes)  | Not recommended | June 3, 2019


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Creates a page that improves visibility for Sensu's supported versions policy and allows us to set end-of-support dates on which we can expire old content.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
As minor releases become more frequent with Sensu Go, we'd like to set up a process that allows us to reduce the number of versions maintained by the Sensu docs project over time.

## Review Instructions
<!--- Optional -->
As a starting point, this first draft assumes available statuses of Pre-release, Supported (by the period defined in the Sensu terms), Not recommended (technically outside official support but still maintained in the docs), and Not supported (content expired from the docs). 
