### PR TITLE
Fix name of continue token header

### DIFF
--- a/content/sensu-go/5.4/api/overview.md
+++ b/content/sensu-go/5.4/api/overview.md
@@ -90,7 +90,7 @@ For example, the following response indicates that there are more than two names
 {{< highlight shell >}}
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
+Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
 [
   {
     "name": "default"

--- a/content/sensu-go/5.5/api/overview.md
+++ b/content/sensu-go/5.5/api/overview.md
@@ -90,7 +90,7 @@ For example, the following response indicates that there are more than two names
 {{< highlight shell >}}
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
+Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
 [
   {
     "name": "default"

--- a/content/sensu-go/5.6/api/overview.md
+++ b/content/sensu-go/5.6/api/overview.md
@@ -91,7 +91,7 @@ For example, the following response indicates that there are more than two names
 {{< highlight shell >}}
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
+Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
 [
   {
     "name": "default"

--- a/content/sensu-go/5.7/api/overview.md
+++ b/content/sensu-go/5.7/api/overview.md
@@ -91,7 +91,7 @@ For example, the following response indicates that there are more than two names
 {{< highlight shell >}}
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
+Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
 [
   {
     "name": "default"


### PR DESCRIPTION
## Description

Change the name of the continue header from `X-Sensu-Continue` to `Sensu-Continue`. The latter was only used during development and was changed to `Sensu-Continue` right before the pagination feature got merged and released.

## Motivation and Context

There was a late change in the name of the header that holds the continue token for pagination and I most likely failed to communicate that to you @apaskulin. Sorry!

Addresses https://github.com/sensu/sensu-go/issues/2913.
