### PR TITLE
5.7 release notes

### DIFF
--- a/content/sensu-go/5.7/release-notes.md
+++ b/content/sensu-go/5.7/release-notes.md
@@ -7,6 +7,7 @@ version: "5.7"
 menu: "sensu-go-5.7"
 ---
 
+- [5.7.0 release notes](#5-7-0-release-notes)
 - [5.6.0 release notes](#5-6-0-release-notes)
 - [5.5.1 release notes](#5-5-1-release-notes)
 - [5.5.0 release notes](#5-5-0-release-notes)
@@ -27,6 +28,26 @@ Sensu Go adheres to [semantic versioning][2] using MAJOR.MINOR.PATCH release num
 Read the [upgrade guide][1] for information on upgrading to the latest version of Sensu Go.
 
 ---
+
+## 5.7.0 release notes
+
+**May 9, 2019** &mdash; The latest release of Sensu Go, version 5.7.0, is now available for download.
+See the [upgrade guide][1] to upgrade Sensu to version 5.7.0.
+
+**NEW FEATURES:**
+
+- Unlicensed Sensu instances now display a notice in the Sensu web UI if the Sensu cluster includes more than 1,000 entities. See the [discourse post][] for more information.
+
+**IMPROVEMENTS:**
+
+- The Sensu agent for Windows now includes a service wrapper. See the [installation guide][] and the [agent reference][] to get started running the agent as a Windows service.
+
+**FIXES:**
+
+- The sensuctl CLI tool now displays correct color output on Windows.
+- The `sensuctl cluster` commands now output correctly in JSON and wrapped JSON formats.
+- Sensu now enforces resource separation between namespaces sharing a similar prefix.
+- The API now returns an error message if label and field selectors are used without a license.
 
 ## 5.6.0 release notes
 

--- a/content/sensu-go/5.7/release-notes.md
+++ b/content/sensu-go/5.7/release-notes.md
@@ -32,12 +32,12 @@ Read the [upgrade guide][1] for information on upgrading to the latest version o
 ## 5.7.0 release notes
 
 **May 9, 2019** &mdash; The latest release of Sensu Go, version 5.7.0, is now available for download.
-The latest release of Sensu Go, version 5.7.0, is now available for download. This is mainly a stability release with bug fixes. Additionally, we have added support for Windows packages and [updated our usage policy][].
+The latest release of Sensu Go, version 5.7.0, is now available for download. This is mainly a stability release with bug fixes. Additionally, we have added support for Windows packages and [updated our usage policy][44].
 See the [upgrade guide][1] to upgrade Sensu to version 5.7.0.
 
 **IMPROVEMENTS:**
 
-- The Sensu agent for Windows now includes a service wrapper. See the [installation guide][41] and the [agent reference][42] to get started running the agent as a Windows service.
+- The Sensu agent for Windows is now available as an MSI package, making it easier to install and operate. See the [installation guide][41] and the [agent reference][42] to get started.
 
 **FIXES:**
 
@@ -337,3 +337,4 @@ To get started with Sensu Go:
 [41]: /sensu-go/5.7/installation/install-sensu#windows-agent
 [42]: /sensu-go/5.7/reference/agent#operation
 [43]: /sensu-go/5.7/api/overview#filtering
+[44]: https://discourse.sensu.io/c/resources

--- a/content/sensu-go/5.7/release-notes.md
+++ b/content/sensu-go/5.7/release-notes.md
@@ -32,22 +32,18 @@ Read the [upgrade guide][1] for information on upgrading to the latest version o
 ## 5.7.0 release notes
 
 **May 9, 2019** &mdash; The latest release of Sensu Go, version 5.7.0, is now available for download.
+The latest release of Sensu Go, version 5.7.0, is now available for download. This is mainly a stability release with bug fixes. Additionally, we have added support for Windows packages and a modification to our usage policy: unlicensed Sensu instances now display a notice in the Sensu web UI if the Sensu cluster includes more than 1,000 entities. See the [Discourse post][] for more information.
 See the [upgrade guide][1] to upgrade Sensu to version 5.7.0.
-
-**NEW FEATURES:**
-
-- Unlicensed Sensu instances now display a notice in the Sensu web UI if the Sensu cluster includes more than 1,000 entities. See the [discourse post][] for more information.
 
 **IMPROVEMENTS:**
 
-- The Sensu agent for Windows now includes a service wrapper. See the [installation guide][] and the [agent reference][] to get started running the agent as a Windows service.
+- The Sensu agent for Windows now includes a service wrapper. See the [installation guide][41] and the [agent reference][42] to get started running the agent as a Windows service.
 
 **FIXES:**
 
-- The sensuctl CLI tool now displays correct color output on Windows.
-- The `sensuctl cluster` commands now output correctly in JSON and wrapped JSON formats.
 - Sensu now enforces resource separation between namespaces sharing a similar prefix.
-- The API now returns an error message if label and field selectors are used without a license.
+- The `sensuctl cluster` commands now output correctly in JSON and wrapped JSON formats.
+- The API now returns an error message if [label and field selectors][43] are used without a license.
 
 ## 5.6.0 release notes
 
@@ -338,3 +334,6 @@ To get started with Sensu Go:
 [38]: /sensu-go/5.6/installation/auth/#binding-attributes
 [39]: /sensu-go/5.6/installation/auth/#active-directory-binding-attributes
 [40]: /sensu-go/5.6/reference/agent#general-configuration-flags
+[41]: /sensu-go/5.7/installation/install-sensu#windows-agent
+[42]: /sensu-go/5.7/reference/agent#operation
+[43]: /sensu-go/5.7/api/overview#filtering

--- a/content/sensu-go/5.7/release-notes.md
+++ b/content/sensu-go/5.7/release-notes.md
@@ -32,7 +32,7 @@ Read the [upgrade guide][1] for information on upgrading to the latest version o
 ## 5.7.0 release notes
 
 **May 9, 2019** &mdash; The latest release of Sensu Go, version 5.7.0, is now available for download.
-The latest release of Sensu Go, version 5.7.0, is now available for download. This is mainly a stability release with bug fixes. Additionally, we have added support for Windows packages and a modification to our usage policy: unlicensed Sensu instances now display a notice in the Sensu web UI if the Sensu cluster includes more than 1,000 entities. See the [Discourse post][] for more information.
+The latest release of Sensu Go, version 5.7.0, is now available for download. This is mainly a stability release with bug fixes. Additionally, we have added support for Windows packages and [updated our usage policy][].
 See the [upgrade guide][1] to upgrade Sensu to version 5.7.0.
 
 **IMPROVEMENTS:**


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Adds release notes for Sensu Go 5.7

The following changelog items have been omitted from the release notes:

- Added LimitD, a backend daemon that collects and maintains a history of the total entity count.
- Added EntityLimiter, an API middleware that appends Sensu-Entity-Limit and Sensu-Entity-Count headers to all /api/core and /api/enterprise responses.
