### PR TITLE
Move binary-only distributions to their own page

### DIFF
--- a/content/sensu-go/5.7/installation/install-sensu.md
+++ b/content/sensu-go/5.7/installation/install-sensu.md
@@ -17,13 +17,11 @@ Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only),
 See the list of [supported platforms][5] for more information.
 Sensu downloads are provided under the [Sensu License][13].
 
-In addition to packages, a binary-only distribution for Linux is available for [`amd64`][14], [`arm64`][15], [`armv5`][16], [`armv6`][17], [`armv7`][18], and [`386`][19] architectures.
-See the [verifying Sensu guide][12] to verify your download using checksums.
-
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS" >}}
 
 ## Install the Sensu backend
 The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and [Docker](#deploy-sensu-with-docker).
+In addition to packages, [binary-only distributions][20] for Linux are available for `amd64`, `arm64`, `armv5`, `armv6`, `armv7`, and `386` architectures.
 
 ### 1. Install the package
 
@@ -108,6 +106,7 @@ Now that you've installed the Sensu backend:
 
 ## Install the Sensu agent
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and [Docker](#deploy-sensu-with-docker).
+In addition to packages, [binary-only distributions][20] for Linux are available for `amd64`, `arm64`, `armv5`, `armv6`, `armv7`, and `386` architectures and for Windows `amd64` and `386` architectures.
 
 ### 1. Install the package
 
@@ -446,9 +445,4 @@ While it can be run from the docker container, doing so may be problematic.
 [11]: https://github.com/sensu/sensu-go/blob/master/packaging/files/backend.yml.example
 [12]: ../verify
 [13]: https://sensu.io/sensu-license
-[14]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_amd64.tar.gz
-[15]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_arm64.tar.gz
-[16]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_armv5.tar.gz
-[17]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_armv6.tar.gz
-[18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_armv7.tar.gz
-[19]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_386.tar.gz
+[20]: ../verify

--- a/content/sensu-go/5.7/installation/verify.md
+++ b/content/sensu-go/5.7/installation/verify.md
@@ -1,7 +1,7 @@
 ---
-title: "Verifying Sensu downloads"
-linkTitle: "Verify Sensu Downloads"
-description: "Sensu offers binary-only distributions for Linux, Windows, and macOS. Read the guide to learn how to verify your Sensu downloads using checksums."
+title: "Binary-only distributions"
+linkTitle: "Binary-Only Distributions"
+description: "Sensu offers binary-only distributions for Linux, Windows, and macOS. Read the guide to learn how to download and verify Sensu binaries."
 weight: 16
 product: "Sensu Go"
 version: "5.7"
@@ -12,16 +12,13 @@ menu:
     parent: installation
 ---
 
-Sensu binaries are available for download for Linux, Windows, and macOS.
-See the [installation guide][1] for more information.
-
-You can verify a Sensu download using SHA-512 checksums.
+In addition to [packages][1], Sensu binary-only distributions are available for Linux, Windows, and macOS.
 
 {{< platformBlock "Linux" >}}
 
 ### Linux
 
-Download Sensu for Linux.
+Download Sensu for Linux [`amd64`][14], [`arm64`][15], [`armv5`][16], [`armv6`][17], [`armv7`][18], or [`386`][19] architectures.
 
 {{< highlight shell >}}
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_amd64.tar.gz
@@ -45,7 +42,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterp
 
 ### Windows
 
-Download Sensu for Windows.
+Download the Sensu agent from Windows [`amd64`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_amd64.tar.gz) or [`386`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_386.tar.gz) architectures.
 
 {{< highlight text >}}
 Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_amd64.tar.gz  -OutFile "$env:userprofile\sensu-enterprise-go_5.7.0_windows_amd64.tar.gz"
@@ -89,6 +86,38 @@ The result should match the checksum for your platform.
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_checksums.txt && cat sensu-enterprise-go_5.7.0_checksums.txt
 {{< /highlight >}}
 
+Extract the archive.
+
+{{< highlight shell >}}
+tar -xvf sensu-enterprise-go_5.7.0_darwin_amd64.tar.gz
+{{< /highlight >}}
+
+Copy the executable into your PATH.
+
+{{< highlight shell >}}
+sudo cp sensuctl /usr/local/bin/
+{{< /highlight >}}
+
 {{< platformBlockClose >}}
 
+### Next steps
+
+Now that you’ve installed Sensu:
+
+- [Starting the Sensu backend][2]
+- [Starting the Sensu agent][3]
+- [sensuctl first-time setup][4]
+- [Monitoring server resources][5]
+
+[2]: ../../reference/backend#operation
+[3]: ../../reference/agent#operation
+[4]: ../../sensuctl/reference#first-time-setup
+[5]: ../../guides/monitor-server-resources
+
 [1]: ../install-sensu
+[14]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_amd64.tar.gz
+[15]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_arm64.tar.gz
+[16]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_armv5.tar.gz
+[17]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_armv6.tar.gz
+[18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_armv7.tar.gz
+[19]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_386.tar.gz

--- a/content/sensu-go/5.7/installation/verify.md
+++ b/content/sensu-go/5.7/installation/verify.md
@@ -42,7 +42,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterp
 
 ### Windows
 
-Download the Sensu agent from Windows [`amd64`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_amd64.tar.gz) or [`386`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_386.tar.gz) architectures.
+Download the Sensu agent for Windows [`amd64`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_amd64.tar.gz) or [`386`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_386.tar.gz) architectures.
 
 {{< highlight text >}}
 Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_windows_amd64.tar.gz  -OutFile "$env:userprofile\sensu-enterprise-go_5.7.0_windows_amd64.tar.gz"
@@ -113,7 +113,6 @@ Now that you’ve installed Sensu:
 [3]: ../../reference/agent#operation
 [4]: ../../sensuctl/reference#first-time-setup
 [5]: ../../guides/monitor-server-resources
-
 [1]: ../install-sensu
 [14]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_amd64.tar.gz
 [15]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-enterprise-go_5.7.0_linux_arm64.tar.gz

--- a/content/sensu-go/5.7/installation/verify.md
+++ b/content/sensu-go/5.7/installation/verify.md
@@ -12,7 +12,7 @@ menu:
     parent: installation
 ---
 
-In addition to [packages][1], Sensu binary-only distributions are available for Linux, Windows, and macOS.
+In addition to [packages][1], Sensu binary-only distributions are available for Linux, Windows (agent and CLI only), and macOS (CLI only).
 
 {{< platformBlock "Linux" >}}
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Re-purposes the download verification page for binary-only distributions in 5.7.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Preparation for adding Windows packaging docs in 5.7.