### PR TITLE
Fix mobile search bug appearing on desktop load

### DIFF
--- a/static/stylesheets/override.css
+++ b/static/stylesheets/override.css
@@ -419,6 +419,10 @@ a .project {
     padding-top: 125px;
   }
 
+  #mobile-search {
+    display: none;
+  }
+
   .drawer .algolia-autocomplete {
     display: none !important;
   }


### PR DESCRIPTION
## Description

The mobile search no longer appears briefly on page load (before Algolia is fully loaded).

## Motivation and Context

Resolves #1454 