### PR TITLE
Add language switcher for code samples

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,7 +32,7 @@ ignoreFiles = [ "sensu-doc-template.md" ]
 	permalink = "#"
 
 	# Custom assets
-	custom_css = []
+	custom_css = ["/stylesheets/language-toggle.css"]
 	custom_js  = []
 
 	# Syntax highlighting theme

--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -95,7 +95,75 @@
             dropdowns[i].classList.remove('open');
           };
         });
-      </script>
+
+        // Language Toggles
+        var languages = {
+          javascript: "JavaScript",
+          json: "JSON",
+          yml: "YML",
+        };
+        var toggles = document.getElementsByClassName('language-toggle');
+        for (var i=0; i < toggles.length; i++) {
+          var children = Array.prototype.slice.call(toggles[i].querySelectorAll('[data-lang]'));
+          console.log(children)
+          var langs = children.map(function(c) { return c.dataset.lang; });
+          console.log(langs)
+
+          // Add tabs
+          langs.forEach(function(lang) {
+            var el = document.createElement('span');
+            el.setAttribute('role', 'tab');
+            el.setAttribute('tabindex', '0');
+            el.setAttribute('data-lang', lang);
+            el.innerText = languages[lang] || lang;
+            el.addEventListener('click', function(e) {
+              return setLanguage(e.currentTarget.dataset.lang);
+            });
+            toggles[i].querySelector('.tabs').appendChild(el);
+          });
+
+          // Preselect preferred language. Default to the first listed.
+          toggles[i].querySelector('.languages').children[0].classList.add('active');
+        }
+
+        // Language Selection Event Handler
+        function setLanguage(lang) {
+          // Store the language
+          localStorage.setItem('lang', lang);
+
+          // Get all tabs in the document
+          var tabLists = Array.prototype.slice.call(document.querySelectorAll('.language-toggle .tabs'));
+          // Activate the correct tab
+          tabLists.forEach(function(tabList) {
+            var activeTab = tabList.querySelector('.active');
+            var selectedTab = tabList.querySelector('[data-lang="' + lang + '"]');
+            var allTabs = Array.prototype.slice.call(tabList.children);
+            allTabs.forEach(function(t) { return t.classList.remove('active'); });
+            if (selectedTab) {
+              selectedTab.classList.add('active');
+            } else if (activeTab) {
+              activeTab.classList.add('active');
+            } else {
+              allTabs[0].classList.add('active');
+            }
+          });
+
+          // Get all code sections that contain the user-selected language
+          var selector = '.language-toggle code[data-lang="' + lang + '"]';
+          var langBlockChildren = document.querySelectorAll(selector);
+          var langBlocks = Array.prototype.slice.call(langBlockChildren).map(function(el) { return el.closest('.languages'); });
+          // Hide all unselected code blocks
+          langBlocks.forEach(function(el) {
+            Array.prototype.slice.call(el.children).forEach(function(c) {
+              return c.classList.remove('active');
+            })
+          });
+          // Show all selected code blocks
+          langBlockChildren.forEach(function(el) { return el.closest('.highlight').classList.add('active'); });
+        }
+        // On load, set the language for all toggles that contain the user-selected language
+        setLanguage(localStorage.getItem('lang'));
+        </script>
     {{ end }}
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>

--- a/layouts/shortcodes/language-toggle.html
+++ b/layouts/shortcodes/language-toggle.html
@@ -1,0 +1,6 @@
+<div class="language-toggle">
+  <div class="tabs"></div>
+  <div class="languages">
+    {{ .Inner }}
+  </div>
+</div>

--- a/static/stylesheets/language-toggle.css
+++ b/static/stylesheets/language-toggle.css
@@ -1,0 +1,53 @@
+.language-toggle .languages > * {
+  display: none;
+}
+
+.language-toggle .languages .active {
+  display: block;
+}
+
+.language-toggle .tabs {
+  border: 1px solid #F1F2F6;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  color: #5F6065;
+  font-size: 13px;
+  overflow: hidden;
+  padding: 0 10px;
+}
+
+.language-toggle .tabs > * {
+  display: inline-block;
+  padding: 12px;
+  position: relative;
+}
+
+.language-toggle .tabs > ::after {
+  border-radius: 3px 3px 0 0;
+  bottom: 0;
+  content: "";
+  display: block;
+  height: 3px;
+  left: 0;
+  margin: 0 auto;
+  position: absolute;
+  right: 0;
+  width: 50%;
+}
+
+.language-toggle .tabs > :hover::after {
+  background: #5F6065;
+}
+
+.language-toggle .tabs .active {
+  color: #2C3458;
+  font-weight: bold;
+}
+
+.language-toggle .tabs .active::after {
+  background: #2C3458;
+}
+
+.language-toggle .tabs .active:hover::after {
+  background: #2C3458;
+}


### PR DESCRIPTION
## Description

Adds a `language-toggle` shortcode to support multiple languages for code samples.
Stores the language selection to `localStorage` for use on subsequent page loads.
Updates all toggles on the page when a language is selected.
Works with any language; not limited to JSON and YML.

## Motivation and Context

Sensu supports configuration in both JSON and YML. Currently the docs contain JSON examples, but we would like the ability to provide both language options.

Closes #1364

## Review Instructions

On any page, add multiple `highlight` shortcodes within the new `language-toggle` shortcode. It's as easy as that. For example:

```
{{< language-toggle >}}
{{< highlight json >}}
{
  "name": "check-mysql-status",
  "status": 1
}
{{< /highlight >}}

{{< highlight yml >}}
name: check-mysql-status
status: 1
{{< /highlight >}}
{{< /language-toggle >}}
```