### PR TITLE
Document etcd-cipher-suites backend config option

### DIFF
--- a/content/sensu-go/5.8/files/backend.yml
+++ b/content/sensu-go/5.8/files/backend.yml
@@ -60,4 +60,4 @@ state-dir: "/var/lib/sensu/sensu-backend"
 #etcd-trusted-ca-file: "/path/to/ssl/key.pem"
 #no-embed-etcd: false
 #etcd-cipher-suits
-#  - example-cipher
+#  - TLS_EXAMPLE

--- a/content/sensu-go/5.8/files/backend.yml
+++ b/content/sensu-go/5.8/files/backend.yml
@@ -59,3 +59,5 @@ state-dir: "/var/lib/sensu/sensu-backend"
 #etcd-peer-trusted-ca-file: "/path/to/ssl/key.pem"
 #etcd-trusted-ca-file: "/path/to/ssl/key.pem"
 #no-embed-etcd: false
+#etcd-cipher-suits
+#  - example-cipher

--- a/content/sensu-go/5.8/guides/securing-sensu.md
+++ b/content/sensu-go/5.8/guides/securing-sensu.md
@@ -37,6 +37,8 @@ etcd-peer-cert-file: "/path/to/your/peer/cert"
 etcd-peer-key-file: "/path/to/your/peer/key"
 etcd-peer-client-cert-auth: "true"
 etcd-peer-trusted-ca-file: "/path/to/your/peer/ca/file"
+etcd-cipher-suites
+ - your-cipher
 {{< /highlight >}}
 
 ## Securing the API and the dashboard

--- a/content/sensu-go/5.8/guides/securing-sensu.md
+++ b/content/sensu-go/5.8/guides/securing-sensu.md
@@ -37,8 +37,6 @@ etcd-peer-cert-file: "/path/to/your/peer/cert"
 etcd-peer-key-file: "/path/to/your/peer/key"
 etcd-peer-client-cert-auth: "true"
 etcd-peer-trusted-ca-file: "/path/to/your/peer/ca/file"
-etcd-cipher-suites
- - your-cipher
 {{< /highlight >}}
 
 ## Securing the API and the dashboard

--- a/content/sensu-go/5.8/reference/backend.md
+++ b/content/sensu-go/5.8/reference/backend.md
@@ -657,16 +657,17 @@ no-embed-etcd: true{{< /highlight >}}
 
 | etcd-cipher-suites    |      |
 ------------------------|------
-description             | List of ciphers to use for etcd TLS configuration. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers.
+description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed below and in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
+available cipher suites       | <ul><li>`TLS_RSA_WITH_RC4_128_SHA                uint16 = 0x0005`</li><li>`TLS_RSA_WITH_3DES_EDE_CBC_SHA           uint16 = 0x000a`</li><li>`TLS_RSA_WITH_AES_128_CBC_SHA            uint16 = 0x002f`</li><li>`TLS_RSA_WITH_AES_256_CBC_SHA            uint16 = 0x0035`</li><li>`TLS_RSA_WITH_AES_128_CBC_SHA256         uint16 = 0x003c`</li><li>`TLS_RSA_WITH_AES_128_GCM_SHA256         uint16 = 0x009c`</li><li>`TLS_RSA_WITH_AES_256_GCM_SHA384         uint16 = 0x009d`</li><li>`TLS_ECDHE_ECDSA_WITH_RC4_128_SHA        uint16 = 0xc007`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA    uint16 = 0xc009`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA    uint16 = 0xc00a`</li><li>`TLS_ECDHE_RSA_WITH_RC4_128_SHA          uint16 = 0xc011`</li><li>`TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA     uint16 = 0xc012`</li><li>`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA      uint16 = 0xc013`</li><li>`TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA      uint16 = 0xc014`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 uint16 = 0xc023`</li><li>`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256   uint16 = 0xc027`</li><li>`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256   uint16 = 0xc02f`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 uint16 = 0xc02b`</li><li>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   uint16 = 0xc030`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 uint16 = 0xc02c`</li><li>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305    uint16 = 0xcca8`</li><li>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305  uint16 = 0xcca9`</li><ul>
 type                    | List
 example                 | {{< highlight shell >}}# Command line examples
-sensu-backend start --etcd-cipher-suites example-cipher,example-cipher
-sensu-backend start --etcd-cipher-suites example-cipher --etcd-cipher-suites example-cipher
+sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 
 # /etc/sensu/backend.yml example
 etcd-cipher-suites:
-  - example-cipher
-  - example-cipher
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /highlight >}}
 
 [1]: ../../installation/install-sensu#install-the-sensu-backend

--- a/content/sensu-go/5.8/reference/backend.md
+++ b/content/sensu-go/5.8/reference/backend.md
@@ -212,6 +212,7 @@ Store Flags:
       --etcd-peer-trusted-ca-file string           path to the peer server TLS trusted CA file
       --etcd-trusted-ca-file string                path to the client server TLS trusted CA cert file
       --no-embed-etcd                              don't embed etcd, use external etcd instead
+      --etcd-cipher-suites                         list of ciphers to use for etcd TLS configuration
 {{< /highlight >}}
 
 ### General configuration flags
@@ -652,6 +653,21 @@ sensu-backend start --no-embed-etcd
 
 # /etc/sensu/backend.yml example
 no-embed-etcd: true{{< /highlight >}}
+
+
+| etcd-cipher-suites    |      |
+------------------------|------
+description             | List of ciphers to use for etcd TLS configuration. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers.
+type                    | List
+example                 | {{< highlight shell >}}# Command line examples
+sensu-backend start --etcd-cipher-suites example-cipher,example-cipher
+sensu-backend start --etcd-cipher-suites example-cipher --etcd-cipher-suites example-cipher
+
+# /etc/sensu/backend.yml example
+etcd-cipher-suites:
+  - example-cipher
+  - example-cipher
+{{< /highlight >}}
 
 [1]: ../../installation/install-sensu#install-the-sensu-backend
 [2]: https://github.com/etcd-io/etcd/blob/master/Documentation/docs.md

--- a/content/sensu-go/5.8/reference/backend.md
+++ b/content/sensu-go/5.8/reference/backend.md
@@ -654,11 +654,36 @@ sensu-backend start --no-embed-etcd
 # /etc/sensu/backend.yml example
 no-embed-etcd: true{{< /highlight >}}
 
+<a name="etcd-cipher-suites"></a>
 
 | etcd-cipher-suites    |      |
 ------------------------|------
-description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed below and in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
-available cipher suites       | <ul><li>`TLS_RSA_WITH_RC4_128_SHA                uint16 = 0x0005`</li><li>`TLS_RSA_WITH_3DES_EDE_CBC_SHA           uint16 = 0x000a`</li><li>`TLS_RSA_WITH_AES_128_CBC_SHA            uint16 = 0x002f`</li><li>`TLS_RSA_WITH_AES_256_CBC_SHA            uint16 = 0x0035`</li><li>`TLS_RSA_WITH_AES_128_CBC_SHA256         uint16 = 0x003c`</li><li>`TLS_RSA_WITH_AES_128_GCM_SHA256         uint16 = 0x009c`</li><li>`TLS_RSA_WITH_AES_256_GCM_SHA384         uint16 = 0x009d`</li><li>`TLS_ECDHE_ECDSA_WITH_RC4_128_SHA        uint16 = 0xc007`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA    uint16 = 0xc009`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA    uint16 = 0xc00a`</li><li>`TLS_ECDHE_RSA_WITH_RC4_128_SHA          uint16 = 0xc011`</li><li>`TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA     uint16 = 0xc012`</li><li>`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA      uint16 = 0xc013`</li><li>`TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA      uint16 = 0xc014`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 uint16 = 0xc023`</li><li>`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256   uint16 = 0xc027`</li><li>`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256   uint16 = 0xc02f`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 uint16 = 0xc02b`</li><li>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   uint16 = 0xc030`</li><li>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 uint16 = 0xc02c`</li><li>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305    uint16 = 0xcca8`</li><li>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305  uint16 = 0xcca9`</li><ul>
+description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
+default                  | {{< highlight shell >}}
+etcd-cipher-suites:
+  - TLS_RSA_WITH_RC4_128_SHA
+  - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+  - TLS_RSA_WITH_AES_128_CBC_SHA
+  - TLS_RSA_WITH_AES_256_CBC_SHA
+  - TLS_RSA_WITH_AES_128_CBC_SHA256
+  - TLS_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+  - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+{{< /highlight >}}
 type                    | List
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Updates the backend reference to include the etc-cipher-suites attribute
- Updates the example backend config file
- Updates the securing Sensu guide
- Added defaults based on https://github.com/etcd-io/etcd/blob/master/pkg/tlsutil/cipher_suites.go

To do:
- [x] Add more information in the reference and guide (Reference: https://github.com/sensu/sensu-go/issues/2914)
- [x] Add realistic example
- [x] Open PR for example file in sensu-enterprise-go

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1468 
