### PR TITLE
Correct typo in sensu-go backend example configuration

### DIFF
--- a/content/sensu-go/5.5/files/backend.yml
+++ b/content/sensu-go/5.5/files/backend.yml
@@ -49,7 +49,7 @@ state-dir: "/var/lib/sensu/sensu-backend"
 #etcd-initial-cluster: "http://127.0.0.1:2380"
 #etcd-initial-cluster-state: "new" # new or existing
 #etcd-initial-cluster-token: "sensu"
-#etc-key-file: "/path/to/ssl/key.pem"
+#etcd-key-file: "/path/to/ssl/key.pem"
 #etcd-listen-client-urls: "http://127.0.0.1:2379"
 #etcd-listen-peer-urls: "http://127.0.0.1:2380"
 #etcd-name: "default"

--- a/content/sensu-go/5.6/files/backend.yml
+++ b/content/sensu-go/5.6/files/backend.yml
@@ -49,7 +49,7 @@ state-dir: "/var/lib/sensu/sensu-backend"
 #etcd-initial-cluster: "http://127.0.0.1:2380"
 #etcd-initial-cluster-state: "new" # new or existing
 #etcd-initial-cluster-token: "sensu"
-#etc-key-file: "/path/to/ssl/key.pem"
+#etcd-key-file: "/path/to/ssl/key.pem"
 #etcd-listen-client-urls: "http://127.0.0.1:2379"
 #etcd-listen-peer-urls: "http://127.0.0.1:2380"
 #etcd-name: "default"

--- a/content/sensu-go/5.7/files/backend.yml
+++ b/content/sensu-go/5.7/files/backend.yml
@@ -49,7 +49,7 @@ state-dir: "/var/lib/sensu/sensu-backend"
 #etcd-initial-cluster: "http://127.0.0.1:2380"
 #etcd-initial-cluster-state: "new" # new or existing
 #etcd-initial-cluster-token: "sensu"
-#etc-key-file: "/path/to/ssl/key.pem"
+#etcd-key-file: "/path/to/ssl/key.pem"
 #etcd-listen-client-urls: "http://127.0.0.1:2379"
 #etcd-listen-peer-urls: "http://127.0.0.1:2380"
 #etcd-name: "default"

--- a/content/sensu-go/5.8/files/backend.yml
+++ b/content/sensu-go/5.8/files/backend.yml
@@ -49,7 +49,7 @@ state-dir: "/var/lib/sensu/sensu-backend"
 #etcd-initial-cluster: "http://127.0.0.1:2380"
 #etcd-initial-cluster-state: "new" # new or existing
 #etcd-initial-cluster-token: "sensu"
-#etc-key-file: "/path/to/ssl/key.pem"
+#etcd-key-file: "/path/to/ssl/key.pem"
 #etcd-listen-client-urls: "http://127.0.0.1:2379"
 #etcd-listen-peer-urls: "http://127.0.0.1:2380"
 #etcd-name: "default"


### PR DESCRIPTION
## Description

I found what I think is a typo in the sensu-go example configuration provided in the documentation.

## Motivation and Context

I was about to use this as my configuration file, and it had a typo.

## Review Instructions

- You might not want this backported to older versions of the documentation, your call.
- You might want this to be squashed.