### PR TITLE
Conform the type attribute to not be uppercase

### DIFF
--- a/content/sensu-go/5.2/installation/auth.md
+++ b/content/sensu-go/5.2/installation/auth.md
@@ -99,7 +99,7 @@ Once you've configured the correct roles and bindings, log in to [sensuctl](../.
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.3/installation/auth.md
+++ b/content/sensu-go/5.3/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -540,7 +540,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.4/installation/auth.md
+++ b/content/sensu-go/5.4/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -540,7 +540,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.5/installation/auth.md
+++ b/content/sensu-go/5.5/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -540,7 +540,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.6/installation/auth.md
+++ b/content/sensu-go/5.6/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -586,7 +586,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.7/installation/auth.md
+++ b/content/sensu-go/5.7/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -586,7 +586,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.8/installation/auth.md
+++ b/content/sensu-go/5.8/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -586,7 +586,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [

--- a/content/sensu-go/5.9/installation/auth.md
+++ b/content/sensu-go/5.9/installation/auth.md
@@ -108,7 +108,7 @@ Active Directory users should head over to the [Active Directory section](#activ
 
 {{< highlight json >}}
 {
-  "Type": "ldap",
+  "type": "ldap",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [
@@ -586,7 +586,7 @@ Sensu offers enterprise-only support for using Microsoft Active Directory (AD) f
 
 {{< highlight json >}}
 {
-  "Type": "ad",
+  "type": "ad",
   "api_version": "authentication/v2",
   "spec": {
     "servers": [


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Makes any JSON example that uses the `type` attribute to not be upper case.

## Motivation and Context
While it might be valid to use `Type`, the documentation site uses `type` everywhere else.

## Review Instructions
<!--- Optional -->
