### PR TITLE
Add additional context to view check hook output

### DIFF
--- a/content/sensu-go/5.0/reference/hooks.md
+++ b/content/sensu-go/5.0/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.1/reference/hooks.md
+++ b/content/sensu-go/5.1/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.10/reference/hooks.md
+++ b/content/sensu-go/5.10/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.2/reference/hooks.md
+++ b/content/sensu-go/5.2/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.3/reference/hooks.md
+++ b/content/sensu-go/5.3/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.4/reference/hooks.md
+++ b/content/sensu-go/5.4/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.5/reference/hooks.md
+++ b/content/sensu-go/5.5/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.6/reference/hooks.md
+++ b/content/sensu-go/5.6/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.7/reference/hooks.md
+++ b/content/sensu-go/5.7/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.8/reference/hooks.md
+++ b/content/sensu-go/5.8/reference/hooks.md
@@ -42,6 +42,34 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format yaml
+{{< /highlight >}}
+
+{{< highlight shell >}}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    ...
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes

--- a/content/sensu-go/5.9/reference/hooks.md
+++ b/content/sensu-go/5.9/reference/hooks.md
@@ -55,7 +55,7 @@ metadata:
   namespace: default
 spec:
   check:
-    "...": "..."
+    ...
     hooks:
     - command: df -hT / | grep '/'
       duration: 0.002904412

--- a/content/sensu-go/5.9/reference/hooks.md
+++ b/content/sensu-go/5.9/reference/hooks.md
@@ -45,38 +45,29 @@ and published in the resulting event.
 You can use `sensuctl` to view this data:
 
 {{< highlight shell >}}
-sensuctl event info entity_name check_name --format wrapped-json
+sensuctl event info entity_name check_name --format yaml
 {{< /highlight >}}
 
 {{< highlight shell >}}
-{
-  "type": "Event",
-  "api_version": "core/v2",
-  "metadata": {
-    "namespace": "default"
-  },
-  "spec": {
-    "check": {
-      "...": "...",
-      "hooks": [
-        {
-          "command": "df -hT / | grep '/'",
-          "duration": 0.002904412,
-          "executed": 1559948435,
-          "issued": 0,
-          "metadata": {
-            "name": "root_disk",
-            "namespace": "default"
-          },
-          "output": "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n",
-          "status": 0,
-          "stdin": false,
-          "timeout": 60
-        }
-      ]
-    }
-  }
-}
+type: Event
+api_version: core/v2
+metadata:
+  namespace: default
+spec:
+  check:
+    "...": "..."
+    hooks:
+    - command: df -hT / | grep '/'
+      duration: 0.002904412
+      executed: 1559948435
+      issued: 0
+      metadata:
+        name: root_disk
+        namespace: default
+      output: "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n"
+      status: 0
+      stdin: false
+      timeout: 60
 {{< /highlight >}}
 
 ## Hooks specification

--- a/content/sensu-go/5.9/reference/hooks.md
+++ b/content/sensu-go/5.9/reference/hooks.md
@@ -42,6 +42,43 @@ See the [check specification][6] to configure the `check_hooks` attribute.
 The hook command output, status, executed timestamp and duration are captured
 and published in the resulting event.
 
+You can use `sensuctl` to view this data:
+
+{{< highlight shell >}}
+sensuctl event info entity_name check_name --format wrapped-json
+{{< /highlight >}}
+
+{{< highlight shell >}}
+{
+  "type": "Event",
+  "api_version": "core/v2",
+  "metadata": {
+    "namespace": "default"
+  },
+  "spec": {
+    "check": {
+      "...": "...",
+      "hooks": [
+        {
+          "command": "df -hT / | grep '/'",
+          "duration": 0.002904412,
+          "executed": 1559948435,
+          "issued": 0,
+          "metadata": {
+            "name": "root_disk",
+            "namespace": "default"
+          },
+          "output": "/dev/mapper/centos-root xfs    41G  1.6G   40G   4% /\n",
+          "status": 0,
+          "stdin": false,
+          "timeout": 60
+        }
+      ]
+    }
+  }
+}
+{{< /highlight >}}
+
 ## Hooks specification
 
 ### Top-level attributes


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Adds more details on where to see the output of a check `hook` command.

## Motivation and Context
In working with `hooks` for the first time, I found it difficult to find where you can view the output. Until https://github.com/sensu/web/issues/38 is resolved as it is a more natural place to find this data, users should be provided more details on how to do so.

## Review Instructions
- [x] Copy to all versions
