### PR TITLE
Fix menu version check

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -22,7 +22,7 @@
       {{ if not (and (in $k "sensu-enterprise-dashboard") (eq $.Section "sensu-enterprise")) }}
 
         <!-- check if we're looking at the section index, or a sub section -->
-        {{ if (in $k $version) }}
+        {{ if ne (strings.TrimSuffix $version $k) $k }}
           {{ $niceName := $.Params.product }}
 
           <!-- ex. Sensu Core -->


### PR DESCRIPTION
## Description

Fixes a navigation bug caused by searching for a version substring in a product string, rather than verifying the substring occurs at the end of the product string. In other words:

Check for `"sensu-go-5.10" ends with "5.1"` (which is `false`) instead of `"sensu-go-5.10" contains "5.1"` (which is `true`).

## Motivation and Context

Fixes rendering the same menu more than once on Sensu Go 5.1.

Resolves #1526 
