### PR TITLE
Update change user password command to include required flags.

### DIFF
--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -261,7 +261,7 @@ To assign permissions to a user:
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -269,7 +269,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.10/reference/rbac.md
+++ b/content/sensu-go/5.10/reference/rbac.md
@@ -273,7 +273,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.2/reference/rbac.md
+++ b/content/sensu-go/5.2/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.3/reference/rbac.md
+++ b/content/sensu-go/5.3/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.4/reference/rbac.md
+++ b/content/sensu-go/5.4/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.5/reference/rbac.md
+++ b/content/sensu-go/5.5/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.6/reference/rbac.md
+++ b/content/sensu-go/5.6/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.7/reference/rbac.md
+++ b/content/sensu-go/5.7/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.8/reference/rbac.md
+++ b/content/sensu-go/5.8/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:

--- a/content/sensu-go/5.9/reference/rbac.md
+++ b/content/sensu-go/5.9/reference/rbac.md
@@ -271,7 +271,7 @@ An empty response indicates valid credentials; a request-unauthorized response i
 To change the password for a user:
 
 {{< highlight shell >}}
-sensuctl user change-password USERNAME
+sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
 To disable a user:


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
The current change user password command needs updated to include required flags.

## Motivation and Context
Makes it easier for users to be given the exact command they need to change a users password, including required flags.

Without them, `sensuctl` returns an error.

## Review Instructions
<!--- Optional -->
