### PR TITLE
Rename providers RBAC resource to authproviders

### DIFF
--- a/content/sensu-go/5.10/reference/rbac.md
+++ b/content/sensu-go/5.10/reference/rbac.md
@@ -197,7 +197,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -643,7 +643,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -667,7 +667,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1109,7 +1109,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.2/reference/rbac.md
+++ b/content/sensu-go/5.2/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.3/reference/rbac.md
+++ b/content/sensu-go/5.3/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.4/reference/rbac.md
+++ b/content/sensu-go/5.4/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.5/reference/rbac.md
+++ b/content/sensu-go/5.5/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.6/reference/rbac.md
+++ b/content/sensu-go/5.6/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.7/reference/rbac.md
+++ b/content/sensu-go/5.7/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.8/reference/rbac.md
+++ b/content/sensu-go/5.8/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 

--- a/content/sensu-go/5.9/reference/rbac.md
+++ b/content/sensu-go/5.9/reference/rbac.md
@@ -195,7 +195,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `clusterroles`   | Cluster-wide permission sets  |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
-| `providers` | [Authentication provider][32] configuration (licensed tier)|
+| `authproviders` | [Authentication provider][32] configuration (licensed tier)|
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -641,7 +641,7 @@ spec:
     - clusterroles
     - namespaces
     - users
-    - providers
+    - authproviders
     verbs:
     - get
     - list
@@ -665,7 +665,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1107,7 +1107,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "providers"
+          "namespaces", "users", "authproviders"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

I just realized the last-minute change we made to authentication providers wasn't reflected in the documentation. Authentication providers actually use `authproviders` as the name of the resource, e.g.:

```
{"component":"rbac","level":"debug","msg":"request authorized by the ClusterRoleBinding cluster-admin","time":"2019-06-13T15:18:39-04:00","zz_request":{"apiGroup":"authentication","apiVersion":"v2","namespace":"","resource":"authproviders","resourceName":"","username":"admin","verb":"list"}}
```