### PR TITLE
bump js-yaml version to address security finding

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "conzole": "^0.2.0",
     "grunt": "^1.0.1",
-    "js-yaml": "^3.9.1",
+    "js-yaml": "^3.13.1",
     "string": "^3.3.3",
     "toml": "^2.3.2",
     "yaml": "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,9 +567,9 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-js-yaml@^3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Description

Bump js-yaml node module from 3.9.1 to 3.13.1

## Motivation and Context

Closes #1535 
