### PR TITLE
Add release notes for Sensu Go 5.10

### DIFF
--- a/content/sensu-go/5.10/dashboard/overview.md
+++ b/content/sensu-go/5.10/dashboard/overview.md
@@ -54,8 +54,6 @@ You can create, edit, and delete Sensu checks using the dashboard checks page.
 
 ### Managing entities
 
-**LICENSED TIER**: Unlock entity management in the Sensu Go dashboard with a Sensu license. To activate your license, see the [getting started guide][6].
-
 You can delete Sensu entities using the dashboard entities page.
 
 ### Managing handlers

--- a/content/sensu-go/5.10/installation/install-sensu.md
+++ b/content/sensu-go/5.10/installation/install-sensu.md
@@ -151,16 +151,16 @@ sudo yum install sensu-go-agent
 
 #### Windows {#windows-agent}
 
-Download the Sensu agent for Windows [`amd64`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0.3043_en-US.x64.msi) or [`386`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0_2380_en-US.x86.msi) architectures.
+Download the Sensu agent for Windows [`amd64`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0.4171_en-US.x64.msi) or [`386`](https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0_2380_en-US.x86.msi) architectures.
 
 {{< highlight text >}}
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0.3043_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.10.0.3043_en-US.x64.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0.4171_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.10.0.4171_en-US.x64.msi"
 {{< /highlight >}}
 
 Start the installation wizard.
 
 {{< highlight text >}}
-msiexec.exe /i $env:userprofile\sensu-go-agent_5.10.0.3043_en-US.x64.msi
+msiexec.exe /i $env:userprofile\sensu-go-agent_5.10.0.4171_en-US.x64.msi
 {{< /highlight >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/5.10/reference/rbac.md
+++ b/content/sensu-go/5.10/reference/rbac.md
@@ -198,6 +198,7 @@ Cluster-wide resources cannot be assigned to a namespace and can only be accesse
 | `namespaces` | Resource partitions within a Sensu instance |
 | `users` | People or agents interacting with Sensu |
 | `authproviders` | [Authentication provider][32] configuration (licensed tier)|
+| `license` | Sensu [license][37]
 
 ### Special resource types
 Special resources types can be accessed by both [roles][13] and [cluster roles][21].
@@ -644,6 +645,7 @@ spec:
     - namespaces
     - users
     - authproviders
+    - license
     verbs:
     - get
     - list
@@ -667,7 +669,7 @@ spec:
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders"
+          "namespaces", "users", "authproviders", "license"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1109,7 +1111,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
           "assets", "checks", "entities", "events", "filters", "handlers",
           "hooks", "mutators", "rolebindings", "roles", "silenced",
           "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders"
+          "namespaces", "users", "authproviders", "license"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
 
@@ -1174,3 +1176,4 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [34]: ../../installation/auth
 [35]: #cluster-role-bindings
 [36]: ../../sensuctl/reference#creating-resources-across-namespaces
+[37]: ../license

--- a/content/sensu-go/5.10/release-notes.md
+++ b/content/sensu-go/5.10/release-notes.md
@@ -7,6 +7,7 @@ version: "5.10"
 menu: "sensu-go-5.10"
 ---
 
+- [5.10.0 release notes](#5-10-0-release-notes)
 - [5.9.0 release notes](#5-9-0-release-notes)
 - [5.8.0 release notes](#5-8-0-release-notes)
 - [5.7.0 release notes](#5-7-0-release-notes)
@@ -30,6 +31,37 @@ Sensu Go adheres to [semantic versioning][2] using MAJOR.MINOR.PATCH release num
 Read the [upgrade guide][1] for information on upgrading to the latest version of Sensu Go.
 
 ---
+
+## 5.10.0 release notes
+
+**June 19, 2019** &mdash; The latest release of Sensu Go, version 5.10.0, is now available for download.
+There are some exciting feature additions in this release, including the ability to perform advanced filtering in the web UI and use PostgreSQL as a scalable event store. This release also includes key bug fixes, most notably around high CPU usage.
+See the [upgrade guide][1] to upgrade Sensu to version 5.10.0.
+
+**NEW FEATURES:**
+
+- ([Licensed tier][60]) The Sensu web UI now includes fast, predictive filtering for viewing checks, entities, events, handlers, and silences. Select the filter bar and start building custom views using suggested attributes and values.
+- Free-tier Sensu instances can now delete entities in the web UI entities page. See the [docs][65] to get started using the Sensu web UI.
+- ([Licensed tier][60]) Sensu now supports using an external PostgreSQL instance for event storage in place of etcd. PostgreSQL can handle significantly higher volumes of Sensu events, letting you scale Sensu beyond etcd's storage limits. See the [datastore reference][61] for more information.
+- Sensu now includes a cluster ID API endpoint and `sensuctl cluster id` command to return the unique Sensu cluster ID. See the [cluster API docs][62] for more information.
+
+**IMPROVEMENTS:**
+
+- The `sensuctl create` command now supports specifying the namespace for a group of resources at the time of creation, allowing you to replicate resources across namespaces without manual editing. See the [sensuctl reference][63] for more information and usage examples.
+- Sensu cluster roles can now include permissions to manage your Sensu license using the `license` resource type. See the [RBAC reference][64] to create a cluster role.
+- The web UI now displays up to 100,000 events and entities on the homepage.
+
+**FIXES:**
+
+- Sensu now optimizes scheduling for proxy checks, solving an issue with high CPU usage when evaluating proxy entity attributes.
+- Check `state` and `total_state_change` attributes now update as expected based on check history.
+- Incident and entity links in the web UI homepage now navigate to the correct views.
+- The web UI now displays non-standard cron statements correctly, for example: `@weekly`.
+- On sign in, the web UI now ensures that users are directed to a valid namespace.
+- In the web UI, code block scrollbars now display only when necessary.
+- The web UI now displays the handler `timeout` attribute correctly.
+- When editing resources, the web UI now fetches the latest resource prior to editing.
+- The web UI now handles array values correctly when creating and editing resources.
 
 ## 5.9.0 release notes
 
@@ -410,3 +442,9 @@ To get started with Sensu Go:
 [57]: /sensu-go/5.9/installation/install-sensu
 [58]: /sensu-go/5.9/reference/events#occurrences-and-occurrences-watermark
 [59]: /sensu-go/5.9/installation/upgrade/#upgrading-sensu-clusters-from-5-7-0-or-earlier-to-5-8-0-or-later
+[60]: /sensu-go/latest/getting-started/enterprise
+[61]: /sensu-go/5.10/reference/datastore
+[62]: /sensu-go/5.10/api/cluster#the-clusterid-API-endpoint
+[63]: /sensu-go/5.10/sensuctl/reference#creating-resources-across-namespaces
+[64]: /sensu-go/5.10/reference/rbac/#assigning-group-permissions-across-all-namespaces
+[65]: /sensu-go/5.10/dashboard/overview

--- a/content/sensu-go/5.10/release-notes.md
+++ b/content/sensu-go/5.10/release-notes.md
@@ -54,6 +54,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.10.0.
 **FIXES:**
 
 - Sensu now optimizes scheduling for proxy checks, solving an issue with high CPU usage when evaluating proxy entity attributes.
+- The Sensu API now validates resource namespaces and types in request bodies to ensure RBAC permissions are enforced.
 - Check `state` and `total_state_change` attributes now update as expected based on check history.
 - Incident and entity links in the web UI homepage now navigate to the correct views.
 - The web UI now displays non-standard cron statements correctly, for example: `@weekly`.

--- a/content/sensu-go/5.10/release-notes.md
+++ b/content/sensu-go/5.10/release-notes.md
@@ -40,7 +40,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.10.0.
 
 **NEW FEATURES:**
 
-- ([Licensed tier][60]) The Sensu web UI now includes fast, predictive filtering for viewing checks, entities, events, handlers, and silences. Select the filter bar and start building custom views using suggested attributes and values.
+- ([Licensed tier][60]) The Sensu web UI now includes fast, predictive filtering for viewing checks, entities, events, handlers, and silences, including the ability to filter based on custom labels. Select the filter bar and start building custom views using suggested attributes and values.
 - Free-tier Sensu instances can now delete entities in the web UI entities page. See the [docs][65] to get started using the Sensu web UI.
 - ([Licensed tier][60]) Sensu now supports using an external PostgreSQL instance for event storage in place of etcd. PostgreSQL can handle significantly higher volumes of Sensu events, letting you scale Sensu beyond etcd's storage limits. See the [datastore reference][61] for more information.
 - Sensu now includes a cluster ID API endpoint and `sensuctl cluster id` command to return the unique Sensu cluster ID. See the [cluster API docs][62] for more information.


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Adds release notes for Sensu Go 5.10
- Updates the dashboard overview to list entity deletion as free-tier
- Adds license as an RBAC resource type
- Updates the build ID in Windows package names

The following changelog items are omitted from the release notes:

- The resources metadata are now validated with the request URI.
- [Web] Use new filter syntax on homepage; avoids having to filter entire set of events.
- [Web] Updating the embedded assets no longer requires node & yarn.
- [Web] Publish tessen metrics for homepage tile click events.
- Added a SetNamespace(string) function to enterprise resources to satisfy the Resource interface.
- Added POST /api/core/v2/tessen/metrics.
- Added the ability in TessenD to listen for metric points on the message bus, populate, and send them to the Tessen service.
- Added a tag to all Tessen metrics to differentiate internal builds.
- [Web] Updated embedded web assets from 275386a ... 46cd0ee
- Refactoring of the REST API.
- Changed the identifying cluster id in TessenD from the etcd cluster id to the sensu cluster id.
- [GraphQL] Updates PutResource mutation to accept an upsert boolean flag parameter. The upsert param defaults to true, but if set to false the mutation will return an error when attempting to create a duplicate resource.
- Eventd has been refactored. Users should not perceive any changes, but a substantial amount of business logic has been moved into other packages.
- Eventd now uses a constant number of requests to etcd when working with silenced entries, instead of a number that is proportional to the number of subscriptions in a check.