### PR TITLE
Update etcd cipher suites

### DIFF
--- a/content/sensu-go/5.10/reference/backend.md
+++ b/content/sensu-go/5.10/reference/backend.md
@@ -663,31 +663,15 @@ no-embed-etcd: true{{< /highlight >}}
 
 | etcd-cipher-suites    |      |
 ------------------------|------
-description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
-default                  | {{< highlight shell >}}
+description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. The default cipher suites are determined by Go, based on the hardware used. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
+recommended             | {{< highlight shell >}}
 etcd-cipher-suites:
-  - TLS_RSA_WITH_RC4_128_SHA
-  - TLS_RSA_WITH_3DES_EDE_CBC_SHA
-  - TLS_RSA_WITH_AES_128_CBC_SHA
-  - TLS_RSA_WITH_AES_256_CBC_SHA
-  - TLS_RSA_WITH_AES_128_CBC_SHA256
-  - TLS_RSA_WITH_AES_128_GCM_SHA256
-  - TLS_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_RC4_128_SHA
-  - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
 example                 | {{< highlight shell >}}# Command line examples

--- a/content/sensu-go/5.8/reference/backend.md
+++ b/content/sensu-go/5.8/reference/backend.md
@@ -660,31 +660,15 @@ no-embed-etcd: true{{< /highlight >}}
 
 | etcd-cipher-suites    |      |
 ------------------------|------
-description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
-default                  | {{< highlight shell >}}
+description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. The default cipher suites are determined by Go, based on the hardware used. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
+recommended             | {{< highlight shell >}}
 etcd-cipher-suites:
-  - TLS_RSA_WITH_RC4_128_SHA
-  - TLS_RSA_WITH_3DES_EDE_CBC_SHA
-  - TLS_RSA_WITH_AES_128_CBC_SHA
-  - TLS_RSA_WITH_AES_256_CBC_SHA
-  - TLS_RSA_WITH_AES_128_CBC_SHA256
-  - TLS_RSA_WITH_AES_128_GCM_SHA256
-  - TLS_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_RC4_128_SHA
-  - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
 example                 | {{< highlight shell >}}# Command line examples

--- a/content/sensu-go/5.9/reference/backend.md
+++ b/content/sensu-go/5.9/reference/backend.md
@@ -663,31 +663,15 @@ no-embed-etcd: true{{< /highlight >}}
 
 | etcd-cipher-suites    |      |
 ------------------------|------
-description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
-default                  | {{< highlight shell >}}
+description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation](https://golang.org/pkg/crypto/tls/#pkg-constants). You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. The default cipher suites are determined by Go, based on the hardware used. _NOTE: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`._
+recommended             | {{< highlight shell >}}
 etcd-cipher-suites:
-  - TLS_RSA_WITH_RC4_128_SHA
-  - TLS_RSA_WITH_3DES_EDE_CBC_SHA
-  - TLS_RSA_WITH_AES_128_CBC_SHA
-  - TLS_RSA_WITH_AES_256_CBC_SHA
-  - TLS_RSA_WITH_AES_128_CBC_SHA256
-  - TLS_RSA_WITH_AES_128_GCM_SHA256
-  - TLS_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_RC4_128_SHA
-  - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
-  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
-  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
 example                 | {{< highlight shell >}}# Command line examples


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

Background: https://github.com/sensu/sensu-go/issues/3019

The list of cipher suites used by etcd appear to be sensitive to the declaration order and the process will mysteriously fail with the default list of ciphers provided in our documentation.

Considering the default cipher list and ordering depends on the hardware used, I'd suggest we provide a recommended list instead, which has been successfully tested.