### PR TITLE
Edits for documenting the new default_upn_domain attribute

### DIFF
--- a/content/sensu-go/5.11/installation/auth.md
+++ b/content/sensu-go/5.11/installation/auth.md
@@ -442,15 +442,6 @@ example      | {{< highlight shell >}}
 }
 {{< /highlight >}}
 
-| default_upn_domain |     |
--------------|------
-description  | Enables UPN authentication when set. The default UPN suffix that will be appended to the username when a domain is not specified during login (e.g. `user` becomes `user@defaultdomain.xyz`).
-required     | false
-type         | String
-example      | {{< highlight shell >}}
-"default_upn_domain": "example.org"
-{{< /highlight >}}
-
 ### Binding attributes
 
 | user_dn    |      |
@@ -705,6 +696,7 @@ spec:
       user_dn: cn=binder,cn=users,dc=acme,dc=org
     client_cert_file: /path/to/ssl/cert.pem
     client_key_file: /path/to/ssl/key.pem
+    default_upn_domain: example.org
     group_search:
       attribute: member
       base_dn: dc=acme,dc=org
@@ -737,6 +729,7 @@ spec:
         "trusted_ca_file": "/path/to/trusted-certificate-authorities.pem",
         "client_cert_file": "/path/to/ssl/cert.pem",
         "client_key_file": "/path/to/ssl/key.pem",
+        "default_upn_domain": "example.org",
         "binding": {
           "user_dn": "cn=binder,cn=users,dc=acme,dc=org",
           "password": "P@ssw0rd!"
@@ -811,6 +804,7 @@ example      | {{< highlight shell >}}
       "trusted_ca_file": "/path/to/trusted-certificate-authorities.pem",
       "client_cert_file": "/path/to/ssl/cert.pem",
       "client_key_file": "/path/to/ssl/key.pem",
+      "default_upn_domain": "example.org",
       "binding": {
         "user_dn": "cn=binder,cn=users,dc=acme,dc=org",
         "password": "P@ssw0rd!"
@@ -851,6 +845,7 @@ example      | {{< highlight shell >}}
     "trusted_ca_file": "/path/to/trusted-certificate-authorities.pem",
     "client_cert_file": "/path/to/ssl/cert.pem",
     "client_key_file": "/path/to/ssl/key.pem",
+    "default_upn_domain": "example.org",
     "binding": {
       "user_dn": "cn=binder,cn=users,dc=acme,dc=org",
       "password": "P@ssw0rd!"
@@ -980,6 +975,15 @@ example      | {{< highlight shell >}}
   "name_attribute": "displayName",
   "object_class": "person"
 }
+{{< /highlight >}}
+
+| default_upn_domain |     |
+-------------|------
+description  | Enables UPN authentication when set. The default UPN suffix that will be appended to the username when a domain is not specified during login (for example: `user` becomes `user@defaultdomain.xyz`).
+required     | false
+type         | String
+example      | {{< highlight shell >}}
+"default_upn_domain": "example.org"
 {{< /highlight >}}
 
 ### Active Directory binding attributes


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Moves the `default_upn_domain` to the AD section per https://github.com/sensu/sensu-docs/pull/1574#issuecomment-508167533
- Adds the `default_upn_domain` attribute to the AD examples

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Edits for #1574
