### PR TITLE
Document the configurable buffers and workers

### DIFF
--- a/content/sensu-go/5.11/reference/backend.md
+++ b/content/sensu-go/5.11/reference/backend.md
@@ -24,6 +24,7 @@ menu:
   - [Security configuration](#security-configuration-flags)
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
+  - [Advanced configuration options](#advanced-configuration-options)
   - [Event logging](#event-logging)
   - [Example](/sensu-go/5.11/files/backend.yml)
 
@@ -190,10 +191,16 @@ General Flags:
       --deregistration-handler string   default deregistration handler
       --event-log-buffer-size int       buffer size of the event logger (default 100000)
       --event-log-file string           path to the event log file
+      --eventd-buffer-size int          number of incoming events that can be buffered (default 100)
+      --eventd-workers int              number of workers spawned for processing incoming events (default 100)
   -h, --help                            help for start
       --insecure-skip-tls-verify        skip TLS verification (not recommended!)
+      --keepalived-buffer-size int      number of incoming keepalives that can be buffered (default 100)
+      --keepalived-workers int          number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                 TLS certificate key in PEM format
       --log-level string                logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --pipelined-buffer-size int       number of events to handle that can be buffered (default 100)
+      --pipelined-workers int           number of workers spawned for handling events through the event pipeline (default 100)
   -d, --state-dir string                path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string          TLS CA certificate bundle in PEM format used for etcd client (mutual TLS)
 
@@ -709,6 +716,77 @@ sensu-backend start --etcd-quota-backend-bytes 4294967296
 # /etc/sensu/backend.yml example
 etcd-quota-backend-bytes: 4294967296{{< /highlight >}}
 
+
+| eventd-buffer-size   |      |
+-----------------------|------
+description            | Number of incoming events that can be buffered before being processed by an eventd worker. _WARNING: Modify with caution. Increasing this value may result in higher memory usage._
+type                   | Integer
+default                | `100`
+example                | {{< highlight shell >}}# Command line example
+sensu-backend start --eventd-buffer-size 100
+
+
+# /etc/sensu/backend.yml example
+eventd-buffer-size: 100{{< /highlight >}}
+
+| eventd-workers       |      |
+-----------------------|------
+description            | Number of workers spawned for processing incoming events that are stored in the eventd buffer. _WARNING: Modify with caution. Increasing this value may result in higher CPU usage._
+type                   | Integer
+default                | `100`
+example                | {{< highlight shell >}}# Command line example
+sensu-backend start --eventd-workers 100
+
+# /etc/sensu/backend.yml example
+eventd-workers: 100{{< /highlight >}}
+
+
+| keepalived-buffer-size |      |
+-----------------------|------
+description            | Number of incoming keepalives that can be buffered before being processed by a keepalived worker. _WARNING: Modify with caution. Increasing this value may result in higher memory usage._
+type                   | Integer
+default                | `100`
+example                | {{< highlight shell >}}# Command line example
+sensu-backend start --keepalived-buffer-size 100
+
+# /etc/sensu/backend.yml example
+keepalived-buffer-size: 100{{< /highlight >}}
+
+
+| keepalived-workers |      |
+-----------------------|------
+description            | Number of workers spawned for processing incoming keepalives that are stored in the keepalived buffer. _WARNING: Modify with caution. Increasing this value may result in higher CPU usage._
+type                   | Integer
+default                | `100`
+example                | {{< highlight shell >}}# Command line example
+sensu-backend start --keepalived-workers 100
+
+# /etc/sensu/backend.yml example
+keepalived-workers: 100{{< /highlight >}}
+
+
+| pipelined-buffer-size |      |
+-----------------------|------
+description            | Number of events to handle that can be buffered before being processed by a pipelined worker. _WARNING: Modify with caution. Increasing this value may result in higher memory usage._
+type                   | Integer
+default                | `100`
+example                | {{< highlight shell >}}# Command line example
+sensu-backend start --pipelined-buffer-size 100
+
+# /etc/sensu/backend.yml example
+pipelined-buffer-size: 100{{< /highlight >}}
+
+
+| pipelined-workers |      |
+-----------------------|------
+description            | Number of workers spawned for handling events through the event pipeline that are stored in the pipelined buffer. _WARNING: Modify with caution. Increasing this value may result in higher CPU usage._
+type                   | Integer
+default                | `100`
+example                | {{< highlight shell >}}# Command line example
+sensu-backend start --pipelined-workers 100
+
+# /etc/sensu/backend.yml example
+pipelined-workers: 100{{< /highlight >}}
 
 ### Event logging
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

Closes https://github.com/sensu/sensu-docs/issues/1575

It documents the new configurable attributes for sensu-backend introduced via https://github.com/sensu/sensu-go/pull/3100.