### PR TITLE
Remove lunr search indexing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,4 @@
 const sass = require('node-sass');
-var yaml = require("js-yaml");
-var S = require("string");
 
 var CONTENT_PATH_PREFIX = "content/";
 
@@ -131,99 +129,7 @@ module.exports = function(grunt) {
       });
   });
 
-  // define the actual lunr-index task for cli
-  grunt.registerTask("lunr-index", function() {
-
-    grunt.log.writeln("Build pages index");
-
-    // makes an array of the names of all the files
-    var indexPages = function() {
-      let pagesIndex = [];
-      // go through the folders recursively
-      grunt.file.recurse(CONTENT_PATH_PREFIX, function(abspath, rootdir, subdir, filename) {
-        grunt.verbose.writeln("Parse file:", abspath);
-
-        // push adds the processed file to the array of pages
-        const entry = processFile(abspath, filename);
-        if (entry !== null && entry !== undefined) {
-          pagesIndex.push(entry);
-        }
-      });
-      return pagesIndex;
-    };
-
-    // call the appropriate process for if it's a content file (md) or html page
-    var processFile = function(abspath, filename) {
-      var pageIndex;
-      if (S(filename).endsWith(".html")) {
-        pageIndex = processHTMLFile(abspath, filename);
-      } else if (S(filename).endsWith(".md")) {
-        pageIndex = processMDFile(abspath, filename);
-      }
-      return pageIndex;
-    };
-
-    // process html
-    var processHTMLFile = function(abspath, filename) {
-      // read the file contents
-      var content = grunt.file.read(abspath);
-      // the page name will be the filename, minus html
-      var pageName = S(filename).chompRight(".html").s;
-      // create the path to the file, minus everything before the path prefix
-      var href = "/" + S(abspath)
-        .chompLeft(CONTENT_PATH_PREFIX).s;
-      grunt.log.writeln("PageName (html)" + pageName);
-      return {
-        // return an object containing these values
-        title: pageName,
-        href: href,
-        // remove any tags and punctuation from the page
-        content: S(content).trim().stripTags().stripPunctuation().s
-      };
-    };
-
-    // process md
-    var processMDFile = function(abspath, filename) {
-      // read the file contents
-      var content = grunt.file.read(abspath);
-      var pageIndex;
-      // first separate the Front Matter from the content and parse it
-      content = content.split("---");
-      var frontMatter;
-      try {
-        frontMatter = yaml.load(content[1].trim());
-      } catch (e) {
-        grunt.log.writeln("Front matter failed: " + e.message);
-      }
-
-      // create the path to the file, minus everything before the path prefix
-      var href = S(abspath).chompLeft(CONTENT_PATH_PREFIX).chompRight(".md").s;
-      // href for index.md files stops at the folder name
-      if (filename === "index.md") {
-        href = S(abspath).chompLeft(CONTENT_PATH_PREFIX).chompRight(filename).s;
-      }
-
-      href = "/" + href
-
-      grunt.log.writeln("PageName (html)" + frontMatter.title);
-
-      // build Lunr index for this page
-      pageIndex = {
-        title: frontMatter.title,
-        tags: frontMatter.tags,
-        product: frontMatter.product,
-        version: frontMatter.version,
-        location: href,
-        display_name: frontMatter.product + " " + frontMatter.version + ": " + frontMatter.title,
-        content: S(content[2]).trim().stripTags().stripPunctuation().s
-      };
-      return pageIndex;
-    };
-    grunt.file.write("static/js/lunr/PagesIndex.json", JSON.stringify(indexPages()));
-    grunt.log.ok("Lunr index built");
-  });
-
-  grunt.registerTask("default", ["env", "lunr-index", "hugo-version", "sass:dist", "postcss:dist", "hugo-build",]);
-  grunt.registerTask("server", ["env", "lunr-index", "hugo-version", "sass:develop", "postcss:develop", "concurrent:target"]);
+  grunt.registerTask("default", ["env", "hugo-version", "sass:dist", "postcss:dist", "hugo-build",]);
+  grunt.registerTask("server", ["env", "hugo-version", "sass:develop", "postcss:develop", "concurrent:target"]);
   grunt.registerTask("hugo-version", ["env", "print-hugo-version",]);
 };

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-postcss": "^0.9.0",
     "grunt-sass": "^3.0.2",
-    "js-yaml": "^3.9.1",
     "node-sass": "^4.12.0",
-    "string": "^3.3.3",
     "toml": "^2.3.2",
     "yaml": "^0.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,13 +1435,6 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
 js-yaml@~3.5.2:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.5.5.tgz#0377c38017cabc7322b0d1fbcd25a491641f2fbe"
@@ -2546,10 +2539,6 @@ string-width@^1.0.1, string-width@^1.0.2:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
 string_decoder@0.10:
   version "0.10.31"


### PR DESCRIPTION
### Description

Removes grunt task and related dependencies for generating search index via Lunr

## Motivation and Context

We now use Algolia for search, so Lunr is no longer needed.

Also removes `string` and `js-yaml` javascript modules for which we have some open security alerts in #1586 .

## Review Instructions

I'll deploy to stage and we can confirm if search still works.