### PR TITLE
Add Katacoda tutorial

### DIFF
--- a/content/sensu-go/5.11/getting-started/demo.md
+++ b/content/sensu-go/5.11/getting-started/demo.md
@@ -3,7 +3,7 @@ title: "Sensu live demo"
 linkTitle: "Live Demo"
 description: "Explore the Sensu dashboard and sensuctl command line tool with a live demo that monitors the Sensu docs site. See entities, monitoring events, and active service and metric checks."
 version: "5.11"
-weight: 2
+weight: 3
 product: "Sensu Go"
 menu:
   sensu-go-5.11:

--- a/content/sensu-go/5.11/getting-started/get-started.md
+++ b/content/sensu-go/5.11/getting-started/get-started.md
@@ -12,11 +12,11 @@ menu:
 
 ### Learn Sensu in 15 minutes
 
-Create your first monitoring event pipeline using a local development environment pre-installed with the essential Sensu stack.
+Get started with Sensu, and create your first monitoring event pipeline.
 
-- [Download the sandbox and learn Sensu Go][7]
-- [See more sandbox lessons][1]
-- [Join the community][8]
+- [Get started in your browser with an interactive tutorial][13]
+- [Download the sandbox][7]
+- [Check out the live demo][1]
 
 ### Install Sensu Go (free tier)
 
@@ -42,7 +42,7 @@ Sensu Go's core is open source software, freely available under an MIT license.
 - [Learn about OSS-tier features][12]
 - [Build from source][11]
 
-[1]: ../sandbox
+[1]: ../demo
 [2]: ../../installation/install-sensu
 [3]: https://sensu.io/products/enterprise
 [4]: https://sensu.io/sales/
@@ -54,3 +54,4 @@ Sensu Go's core is open source software, freely available under an MIT license.
 [10]: https://github.com/sensu/sensu-go
 [11]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#building
 [12]: https://sensu.io/products
+[13]: ../tutorial

--- a/content/sensu-go/5.11/getting-started/sandbox.md
+++ b/content/sensu-go/5.11/getting-started/sandbox.md
@@ -3,7 +3,7 @@ title: "Sensu sandbox"
 linkTitle: "Sandbox"
 description: "The Sensu sandbox makes it easy to learn Sensu Go. You’ll learn Sensu by building your first monitoring workflow and setting up container and application monitoring. There’s also a lesson plan for upgrading from Sensu 1.x to Sensu Go!"
 version: "5.11"
-weight: 2
+weight: 4
 product: "Sensu Go"
 menu:
   sensu-go-5.11:

--- a/content/sensu-go/5.11/getting-started/tutorial.md
+++ b/content/sensu-go/5.11/getting-started/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Interactive Tutorial"
-description: ""
+description: "Get started with Sensu in your browser with an interactive tutorial. Learn the basics of Sensu Go and monitor a web server."
 version: "5.11"
 weight: 3
 product: "Sensu Go"

--- a/content/sensu-go/5.11/getting-started/tutorial.md
+++ b/content/sensu-go/5.11/getting-started/tutorial.md
@@ -14,7 +14,7 @@ menu:
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/sandbox"
     data-katacoda-color="2c3458"
-    style="height: 600px; padding-top: 20px;"></div>
+    style="height: 800px; padding-top: 10px;"></div>
 
 <br><br>
 [**<-- Back to getting started**](../get-started)

--- a/content/sensu-go/5.11/getting-started/tutorial.md
+++ b/content/sensu-go/5.11/getting-started/tutorial.md
@@ -1,0 +1,20 @@
+---
+title: "Interactive Tutorial"
+description: ""
+version: "5.11"
+weight: 3
+product: "Sensu Go"
+layout: "katacoda-wide"
+menu:
+  sensu-go-5.11:
+    parent: getting-started
+---
+
+<script src="//katacoda.com/embed.js"></script>
+<div id="katacoda-scenario-1"
+    data-katacoda-id="sensu/sandbox"
+    data-katacoda-color="2c3458"
+    style="height: 600px; padding-top: 20px;"></div>
+
+<br><br>
+[**<-- Back to getting started**](../get-started)

--- a/content/sensu-go/5.12/getting-started/demo.md
+++ b/content/sensu-go/5.12/getting-started/demo.md
@@ -3,7 +3,7 @@ title: "Sensu live demo"
 linkTitle: "Live Demo"
 description: "Explore the Sensu dashboard and sensuctl command line tool with a live demo that monitors the Sensu docs site. See entities, monitoring events, and active service and metric checks."
 version: "5.12"
-weight: 2
+weight: 3
 product: "Sensu Go"
 menu:
   sensu-go-5.12:

--- a/content/sensu-go/5.12/getting-started/get-started.md
+++ b/content/sensu-go/5.12/getting-started/get-started.md
@@ -12,11 +12,11 @@ menu:
 
 ### Learn Sensu in 15 minutes
 
-Create your first monitoring event pipeline using a local development environment pre-installed with the essential Sensu stack.
+Get started with Sensu, and create your first monitoring event pipeline.
 
-- [Download the sandbox and learn Sensu Go][7]
-- [See more sandbox lessons][1]
-- [Join the community][8]
+- [Get started in your browser with an interactive tutorial][13]
+- [Download the sandbox][7]
+- [Check out the live demo][1]
 
 ### Install Sensu Go (free tier)
 
@@ -42,7 +42,7 @@ Sensu Go's core is open source software, freely available under an MIT license.
 - [Learn about OSS-tier features][12]
 - [Build from source][11]
 
-[1]: ../sandbox
+[1]: ../demo
 [2]: ../../installation/install-sensu
 [3]: https://sensu.io/products/enterprise
 [4]: https://sensu.io/sales/
@@ -54,3 +54,4 @@ Sensu Go's core is open source software, freely available under an MIT license.
 [10]: https://github.com/sensu/sensu-go
 [11]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#building
 [12]: https://sensu.io/products
+[13]: ../tutorial

--- a/content/sensu-go/5.12/getting-started/sandbox.md
+++ b/content/sensu-go/5.12/getting-started/sandbox.md
@@ -3,7 +3,7 @@ title: "Sensu sandbox"
 linkTitle: "Sandbox"
 description: "The Sensu sandbox makes it easy to learn Sensu Go. You’ll learn Sensu by building your first monitoring workflow and setting up container and application monitoring. There’s also a lesson plan for upgrading from Sensu 1.x to Sensu Go!"
 version: "5.12"
-weight: 2
+weight: 4
 product: "Sensu Go"
 menu:
   sensu-go-5.12:

--- a/content/sensu-go/5.12/getting-started/tutorial.md
+++ b/content/sensu-go/5.12/getting-started/tutorial.md
@@ -1,0 +1,20 @@
+---
+title: "Interactive Tutorial"
+description: "Get started with Sensu in your browser with an interactive tutorial. Learn the basics of Sensu Go and monitor a web server."
+version: "5.12"
+weight: 3
+product: "Sensu Go"
+layout: "katacoda-wide"
+menu:
+  sensu-go-5.12:
+    parent: getting-started
+---
+
+<script src="//katacoda.com/embed.js"></script>
+<div id="katacoda-scenario-1"
+    data-katacoda-id="sensu/sandbox"
+    data-katacoda-color="2c3458"
+    style="height: 800px; padding-top: 10px;"></div>
+
+<br><br>
+[**<-- Back to getting started**](../get-started)

--- a/layouts/_default/katacoda-wide.html
+++ b/layouts/_default/katacoda-wide.html
@@ -1,0 +1,72 @@
+{{ partial "head" . }}
+
+<script type="text/javascript" src="{{ "/javascripts/application.js" | absURL }}"></script>
+
+{{ if (eq (trim .Site.Params.provider " " | lower) "github") | and (isset .Site.Params "repo_url") }}
+  {{ $repo_id := replace .Site.Params.repo_url "https://github.com/" ""}}
+  {{ .Scratch.Set "repo_id" $repo_id }}
+{{ end }}
+
+{{ partial "header" . }}
+
+<main class="main">
+
+  <article class="katacodawide">
+    <div class="wrapper">
+
+      {{ if isset .Params "version" }}
+        {{ partial "platformDropdown.html" . }}
+      {{ end }}
+      {{ .Content }}
+
+      <script async type="text/javascript" src="{{"/js/clip.js" | absURL }}"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
+      
+      {{ partial "pagination.html" . }}
+    </div>
+  </article>
+
+  <div class="results" role="status" aria-live="polite">
+    <div class="scrollable">
+      <div class="wrapper">
+        <div class="meta"></div>
+        <div class="list"></div>
+      </div>
+    </div>
+  </div>
+</main>
+
+{{ partial "footer" . }}
+
+<script>
+$( document ).ready(function() {
+  applyTipBoxes();
+});
+
+function boldFirstWord(element) {
+  newElement = element.html().replace(/(^\w+)/, '<strong>$1</strong>');
+  element.html(newElement);
+}
+
+function boldFirstTwoWords(element) {
+  newElement = element.html().replace(/(^\w+ \w+)/, '<strong>$1</strong>');
+  element.html(newElement);
+}
+
+function applyTipBoxes() {
+  $('em').wrap(function() {
+    if ($(this).text().includes('NOTE:')) {
+      boldFirstWord($(this));
+      return '<div class="alert-note"></div>';
+    } else if ($(this).text().includes('WARNING:')) {
+      boldFirstWord($(this));
+      return '<div class="alert-warning"></div>';
+    } else if ($(this).text().includes('PRO TIP:')) {
+      boldFirstTwoWords($(this));
+      return '<div class="alert-tip"></div>';
+    }
+  });
+}
+</script>
+
+{{ partial "footer_js" . }}

--- a/static/stylesheets/scss/_layout.scss
+++ b/static/stylesheets/scss/_layout.scss
@@ -14,6 +14,12 @@ main {
   }
 }
 
+.katacodawide {
+  background-color: white;
+  flex: 0 0 100%;
+  padding: 10px 0px;
+}
+
 .article {
   background-color: white;
   border-left: 2px solid #eaeaea;


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- Adds a new layout to use for Katacoda scenarios that allows for a wider iframe
- Adds a page for the getting started, monitoring event pipeline tutorial
- Adjusts the sidebar weights of the some of the getting started pages
- Links to the tutorial from the main getting started page

<img width="1438" alt="Screen Shot 2019-07-25 at 11 10 49 AM" src="https://user-images.githubusercontent.com/11339965/61897983-33acc480-aecd-11e9-92de-5db3134ccc74.png">

To do in a future PR:

- Implement custom Katacoda environment to speed up scenario initialization. "The environments are a build-time config, meaning unless the container is setup to restart on boot, it won't be running automatically."
- Further customize look and feel of scenario

