### PR TITLE
update external etcd section of clustering guide to cover auto-compaction

### DIFF
--- a/content/sensu-go/5.0/guides/clustering.md
+++ b/content/sensu-go/5.0/guides/clustering.md
@@ -437,7 +437,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -457,8 +457,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.1/guides/clustering.md
+++ b/content/sensu-go/5.1/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.10/guides/clustering.md
+++ b/content/sensu-go/5.10/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.11/guides/clustering.md
+++ b/content/sensu-go/5.11/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.12/guides/clustering.md
+++ b/content/sensu-go/5.12/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.2/guides/clustering.md
+++ b/content/sensu-go/5.2/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.3/guides/clustering.md
+++ b/content/sensu-go/5.3/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.4/guides/clustering.md
+++ b/content/sensu-go/5.4/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.5/guides/clustering.md
+++ b/content/sensu-go/5.5/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.6/guides/clustering.md
+++ b/content/sensu-go/5.6/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.7/guides/clustering.md
+++ b/content/sensu-go/5.7/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.8/guides/clustering.md
+++ b/content/sensu-go/5.8/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 

--- a/content/sensu-go/5.9/guides/clustering.md
+++ b/content/sensu-go/5.9/guides/clustering.md
@@ -435,7 +435,7 @@ backend-url:
 
 ## Using an external etcd cluster
 
-To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer. To stand up an external etcd cluster, you can follow etcd's [clustering guide][12] using the same store configuration.
 
 In this example, we will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13]. Below is how you would start etcd for `backend-1` from our three node configuration example above.
 
@@ -455,8 +455,12 @@ etcd \
 --peer-trusted-ca-file=./ca.pem \
 --peer-cert-file=./backend-1.pem \
 --peer-key-file=./backend-1-key.pem \
---peer-client-cert-auth
+--peer-client-cert-auth \
+--auto-compaction-mode revision \
+--auto-compaction-retention 2
 {{< /highlight >}}
+
+_NOTE: The `auto-compaction-mode` and `auto-compaction-retention` flags are of particular significance. Without these settings your database may quickly reach etcd's maximum database size limit._
 
 In order to inform Sensu that you'd like to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using our CA.
 


### PR DESCRIPTION
## Description

Updates the clustering guide to detail minimum etcd version and required auto-compaction flags.

## Motivation and Context

Closes #1626 

## Review Instructions

I'm seeking confirmation regarding minimum etcd version added here. I based this assertion on the etcd changelog entry indicating that 3.3.2 included the fix from https://github.com/etcd-io/etcd/pull/9339 which makes our recommended auto-compaction settings work as expected.

## To Do

- [x] Confirm minimum etcd version
- [ ] Copy to all documentation versions