### PR TITLE
Adds note for unattended MSI install

### DIFF
--- a/content/sensu-go/5.10/installation/install-sensu.md
+++ b/content/sensu-go/5.10/installation/install-sensu.md
@@ -163,6 +163,8 @@ Start the installation wizard.
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.10.2.4539_en-US.x64.msi
 {{< /highlight >}}
 
+_NOTE: To make this an unattended install, you can use `/qn` as part of the install command._
+
 {{< platformBlockClose >}}
 
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS Windows" >}}

--- a/content/sensu-go/5.11/installation/install-sensu.md
+++ b/content/sensu-go/5.11/installation/install-sensu.md
@@ -163,6 +163,8 @@ Start the installation wizard.
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.11.1.5015_en-US.x64.msi
 {{< /highlight >}}
 
+_NOTE: To make this an unattended install, you can use `/qn` as part of the install command._
+
 {{< platformBlockClose >}}
 
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS Windows" >}}

--- a/content/sensu-go/5.12/installation/install-sensu.md
+++ b/content/sensu-go/5.12/installation/install-sensu.md
@@ -163,6 +163,8 @@ Start the installation wizard.
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.12.0.5015_en-US.x64.msi
 {{< /highlight >}}
 
+_NOTE: To make this an unattended install, you can use `/qn` as part of the install command._
+
 {{< platformBlockClose >}}
 
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS Windows" >}}

--- a/content/sensu-go/5.7/installation/install-sensu.md
+++ b/content/sensu-go/5.7/installation/install-sensu.md
@@ -163,6 +163,8 @@ Start the installation wizard.
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.7.0.2380_en-US.x64.msi
 {{< /highlight >}}
 
+_NOTE: To make this an unattended install, you can use `/qn` as part of the install command._
+
 {{< platformBlockClose >}}
 
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS Windows" >}}

--- a/content/sensu-go/5.8/installation/install-sensu.md
+++ b/content/sensu-go/5.8/installation/install-sensu.md
@@ -163,6 +163,8 @@ Start the installation wizard.
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.8.0.2735_en-US.x64.msi
 {{< /highlight >}}
 
+_NOTE: To make this an unattended install, you can use `/qn` as part of the install command._
+
 {{< platformBlockClose >}}
 
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS Windows" >}}

--- a/content/sensu-go/5.9/installation/install-sensu.md
+++ b/content/sensu-go/5.9/installation/install-sensu.md
@@ -163,6 +163,8 @@ Start the installation wizard.
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.9.0.3043_en-US.x64.msi
 {{< /highlight >}}
 
+_NOTE: To make this an unattended install, you can use `/qn` as part of the install command._
+
 {{< platformBlockClose >}}
 
 {{< platformBlock "Ubuntu/Debian RHEL/CentOS Windows" >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Adds `/qn` flags for installation of Windows MSI. This allows for unattended installs of the agent. Should help provide an easier experience for Windows admins when installing the agent via automation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Closes #1612 

## Review Instructions
<!--- Optional -->
