### PR TITLE
fix for agent install on rhel, refer to correct script

### DIFF
--- a/content/sensu-go/5.11/installation/install-sensu.md
+++ b/content/sensu-go/5.11/installation/install-sensu.md
@@ -239,15 +239,15 @@ docker pull sensu/sensu-rhel
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
-# Install the sensu-go-backend package
+# Install the sensu-go-agent package
 sudo apt-get install sensu-go-agent
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
 # Add the Sensu repository
-curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
-# Install the sensu-go-backend package
+# Install the sensu-go-agent package
 sudo yum install sensu-go-agent
 {{< /highlight >}}
 

--- a/content/sensu-go/5.12/installation/install-sensu.md
+++ b/content/sensu-go/5.12/installation/install-sensu.md
@@ -239,15 +239,15 @@ docker pull sensu/sensu-rhel
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
-# Install the sensu-go-backend package
+# Install the sensu-go-agent package
 sudo apt-get install sensu-go-agent
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
 # Add the Sensu repository
-curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
-# Install the sensu-go-backend package
+# Install the sensu-go-agent package
 sudo yum install sensu-go-agent
 {{< /highlight >}}
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Small error in agent install instructions for RHEL/CentOS in 5.11 and 5.12 content
referencing debian install script instead of rpm install script.

Looks like regression instroduced in 5.11.  5.10 has correct instructions for RHEL/CentOS
