### PR TITLE
Update README to reflect newer hugo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then visit http://localhost:1313/ in the browser of your choice.
 ### Troubleshooting
 Here are some things you might try if you encounter an issue working with the site:
 
-* Run `yarn hugo-version` to print the running version of Hugo. Version 0.34 or newer is required.
+* Run `yarn hugo-version` to print the running version of Hugo. Version 0.56.1 or newer is required.
 * If you're seeing stale page content, try using `yarn server --disableFastRender` to ensure all pages are rebuilt as you make changes.
 * If you're still having trouble viewing the site, [open an issue](), and we'll be happy to help!
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context

In #1641 we upgraded Hugo to 0.56.1 so this should now be considered the required version.

## Review Instructions

Consider whether pointing folks to `HUGO_VERSION` in Gruntfile.js is a better way to document the version we're using.