### PR TITLE
Add --disableFastRender to yarn server command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
     grunt.log.writeln("Running Hugo server");
     grunt.util.spawn({
       cmd: "hugo",
-      args: ["server", ...args] , // pass arguments down
+      args: ["server", "--disableFastRender", ...args] , // pass arguments down
       opts: {stdio: 'inherit'}
     },
       function(error, result, code) {

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ Then visit http://localhost:1313/ in the browser of your choice.
 Here are some things you might try if you encounter an issue working with the site:
 
 * Run `yarn hugo-version` to print the running version of Hugo. Version 0.34 or newer is required.
-* If you're seeing stale page content, try using `yarn server --disableFastRender` to ensure all pages are rebuilt as you make changes.
-* If you're still having trouble viewing the site, [open an issue](), and we'll be happy to help!
+* If you're still having trouble viewing the site, [open an issue][issue], and we'll be happy to help!
 
 ### Theme
 This project uses a [fork](themes/hugo-material-docs/) of the wonderful [hugo-material-docs](https://github.com/digitalcraftsman/hugo-material-docs) theme.


### PR DESCRIPTION
## Description

Disables "fast render" in development.

## Motivation and Context

Resolves page rendering issues that can be experienced during Hugo
version upgrades, major configuration changes, etc.

Resolves #1663