### PR TITLE
Fix disable assets table and link

### DIFF
--- a/content/sensu-go/5.11/reference/agent.md
+++ b/content/sensu-go/5.11/reference/agent.md
@@ -793,8 +793,7 @@ config-file: "/sensu/agent.yml"{{< /highlight >}}
 
 | disable-assets |      |
 --------------|------
-description   | When set to `true`, disables [assets][] for the agent. In the event that an agent
-attempts to execute a check that requires an asset, the agent will respond with a status of `3`, and a message indicating that the agent could not execute the check because assets are disabled.
+description   | When set to `true`, disables [assets][29] for the agent. In the event that an agent attempts to execute a check that requires an asset, the agent will respond with a status of `3`, and a message indicating that the agent could not execute the check because assets are disabled.
 type          | Boolean
 default       | false
 example       | {{< highlight shell >}}# Command line example


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fix disable-asset table and link.

## Motivation and Context
To fix things.

## Review Instructions
Only 5.11 gets this as that is when the feature was added. 5.12 won't have it in this PR as #1688 will cover it.
