### PR TITLE
Update demo links to use https

### DIFF
--- a/content/sensu-go/5.10/getting-started/demo.md
+++ b/content/sensu-go/5.10/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.11/getting-started/demo.md
+++ b/content/sensu-go/5.11/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.3/getting-started/demo.md
+++ b/content/sensu-go/5.3/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.4/getting-started/demo.md
+++ b/content/sensu-go/5.4/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.5/getting-started/demo.md
+++ b/content/sensu-go/5.5/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.6/getting-started/demo.md
+++ b/content/sensu-go/5.6/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.7/getting-started/demo.md
+++ b/content/sensu-go/5.7/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.8/getting-started/demo.md
+++ b/content/sensu-go/5.8/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default

--- a/content/sensu-go/5.9/getting-started/demo.md
+++ b/content/sensu-go/5.9/getting-started/demo.md
@@ -10,16 +10,16 @@ menu:
     parent: getting-started
 ---
 
-<a href="http://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
+<a href="https://caviar.tf.sensu.io:3000" onclick="ga('send', 'event', 'Demo', 'Click', 'Main demo link');">See a live demo of the Sensu dashboard</a> (log in with username `guest` and password `i<3sensu`).
 
-Explore the <a href="http://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="http://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="http://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
+Explore the <a href="https://caviar.tf.sensu.io:3000/default/entities" onclick="ga('send', 'event', 'Demo', 'Click', 'Entities page');">entities page</a> to see what Sensu is monitoring, the <a href="https://caviar.tf.sensu.io:3000/default/events" onclick="ga('send', 'event', 'Demo', 'Click', 'Events page');">events page</a> to see the latest monitoring events, and the <a href="https://caviar.tf.sensu.io:3000/default/checks" onclick="ga('send', 'event', 'Demo', 'Click', 'Checks page');">checks page</a> to see active service and metric checks.
 
 You can also use the demo to try out sensuctl, the Sensu command line tool.
 First, [install sensuctl][1] on your workstation, then configure sensuctl to connect to the demo.
 
 {{< highlight shell >}}
 sensuctl configure
-? Sensu Backend URL: http://caviar.tf.sensu.io:8080
+? Sensu Backend URL: https://caviar.tf.sensu.io:8080
 ? Username: guest
 ? Password: i<3sensu
 ? Namespace: default


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Use `https` for demo dashboard and `sensuctl` endpoints.

## Motivation and Context
Closes #1699 

## Review Instructions
- [ ] Visit https://caviar.tf.sensu.io:3000 and observe a cert is now in place.
- [ ] Use https://caviar.tf.sensu.io:8080 with `sensuctl` and observe that it accepts configuration through `https`.
