### PR TITLE
fix invalid MSI links in 5.12 install instructions

### DIFF
--- a/content/sensu-go/5.12/installation/install-sensu.md
+++ b/content/sensu-go/5.12/installation/install-sensu.md
@@ -257,7 +257,7 @@ sudo yum install sensu-go-agent
 Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0.5657_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x64.msi"
 
 # Or for Windows 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0_5657_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x86.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0.5657_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x86.msi"
 
 # Install the Sensu agent
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x64.msi /qn

--- a/content/sensu-go/5.12/installation/install-sensu.md
+++ b/content/sensu-go/5.12/installation/install-sensu.md
@@ -254,13 +254,13 @@ sudo yum install sensu-go-agent
 
 {{< highlight "Windows" >}}
 # Download the Sensu agent for Windows amd64
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0.4171_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.4171_en-US.x64.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0.5657_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x64.msi"
 
 # Or for Windows 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0_2380_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.4171_en-US.x86.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.12.0/sensu-go-agent_5.12.0_5657_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x86.msi"
 
 # Install the Sensu agent
-msiexec.exe /i $env:userprofile\sensu-go-agent_5.12.0.4171_en-US.x64.msi /qn
+msiexec.exe /i $env:userprofile\sensu-go-agent_5.12.0.5657_en-US.x64.msi /qn
 {{< /highlight >}}
 
 # Or via Chocolatey


### PR DESCRIPTION
## Description

Fixes MSI links in the install guide for 5.12

## Motivation and Context

Links for 5.12 x64 and 386 MSIs are invalid.

## Review Instructions

Please validate new links by testing the instructions
