### PR TITLE
Remove default value for handler timeout attribute

### DIFF
--- a/content/sensu-core/0.29/reference/handlers.md
+++ b/content/sensu-core/0.29/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.0/reference/handlers.md
+++ b/content/sensu-core/1.0/reference/handlers.md
@@ -321,7 +321,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.1/reference/handlers.md
+++ b/content/sensu-core/1.1/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.2/reference/handlers.md
+++ b/content/sensu-core/1.2/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.3/reference/handlers.md
+++ b/content/sensu-core/1.3/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.4/reference/handlers.md
+++ b/content/sensu-core/1.4/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.5/reference/handlers.md
+++ b/content/sensu-core/1.5/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.6/reference/handlers.md
+++ b/content/sensu-core/1.6/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.7/reference/handlers.md
+++ b/content/sensu-core/1.7/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 

--- a/content/sensu-core/1.8/reference/handlers.md
+++ b/content/sensu-core/1.8/reference/handlers.md
@@ -318,7 +318,6 @@ timeout     |
 description | The handler execution duration timeout in seconds (hard stop). Only used by `pipe` and `tcp` handler types.
 required    | false
 type        | Integer
-default     | `10`
 example     | {{< highlight shell >}}"timeout": 30{{< /highlight >}}
 
 handle_silenced | 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Remove default value for timeout in `handler` as there actually isn't a default for it.

## Motivation and Context
Closes #1714 

## Review Instructions
<!--- Optional -->
