### PR TITLE
Correct the menu frontmatter in 5.13 release-notes.md

### DIFF
--- a/content/sensu-go/5.13/release-notes.md
+++ b/content/sensu-go/5.13/release-notes.md
@@ -4,7 +4,7 @@ linkTitle: "Release Notes"
 description: "Read the Sensu Go release notes to learn about what's new in our latest release."
 product: "Sensu Go"
 version: "5.13"
-menu: "sensu-go-5.12"
+menu: "sensu-go-5.13"
 ---
 
 - [5.12.0 release notes](#5-12-0-release-notes)


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Correct the value of `menu` in the 5.13 release notes frontmatter.

## Motivation and Context

Seeing this error locally when I run the server:

```
Error: Error building site: "/Users/cwj/github/sensu-docs/content/sensu-go/5.13/release-notes.md:1:1": duplicate menu entry with identifier "Release Notes" in menu "sensu-go-5.12"
```

This change will fix it :)