### PR TITLE
Change colors to make EOL notification more noticeable

### DIFF
--- a/layouts/partials/alertSection.html
+++ b/layouts/partials/alertSection.html
@@ -4,7 +4,7 @@
   {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
     {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
     {{ $link := replace .RelPermalink .Params.version $product_info.latest }}
-    {{ $params := slice "#cc7d7c" $message $link }}
+    {{ $params := slice "#d5ab73" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 </div>

--- a/layouts/partials/eolSection.html
+++ b/layouts/partials/eolSection.html
@@ -5,28 +5,28 @@
   {{ if and (isset .Params "version") (eq .Params.product "Sensu Core") }}
     {{ $message := (printf "%s will reach EOL on December 31, 2019. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-core/../migration" ".." .Params.version }}
-    {{ $params := slice "#2c3458" $message $link }}
+    {{ $params := slice "#cc7d7c" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 
   {{ if and (isset .Params "version") (eq .Params.product "Uchiwa") }}
     {{ $message := (printf "%s will reach EOL on December 31, 2019. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-core/latest/migration" ".." .Params.version }}
-    {{ $params := slice "#2c3458" $message $link }}
+    {{ $params := slice "#cc7d7c" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 
   {{ if and (isset .Params "version") (eq .Params.product "Sensu Enterprise") }}
     {{ $message := (printf "%s will reach EOL on March 31, 2020. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-enterprise/../migration" ".." .Params.version }}
-    {{ $params := slice "#2c3458" $message $link }}
+    {{ $params := slice "#cc7d7c" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 
   {{ if and (isset .Params "version") (eq .Params.product "Sensu Enterprise Dashboard") }}
     {{ $message := (printf "%s will reach EOL on March 31, 2020. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-enterprise/latest/migration" ".." .Params.version }}
-    {{ $params := slice "#2c3458" $message $link }}
+    {{ $params := slice "#cc7d7c" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 </div>


### PR DESCRIPTION
## Description 

This change makes the EOL notification red and the documentation version notification a shade of orange.

## Motivation and context

We want to increase awareness of the impending EOL. I believe repurposing the shade of red we've been using for what is really a warning will draw more attention to this important message.

## Screenshot

![2019-09-06 at 4 27 PM](https://user-images.githubusercontent.com/148017/64464173-3aca1380-d0c4-11e9-9dd9-7a20e69928d0.png)
