### PR TITLE
Add EOL date text to front page product tiles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,6 +48,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-go"
     name = "Sensu Go"
     description = "The next-generation monitoring event pipeline"
+    notice = "Replaces Sensu Core and Enterprise"
     weight = 1
     latest = "5.12"
 
@@ -107,7 +108,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-core"
     name = "Sensu Core"
     description = "The original monitoring event pipeline"
-    eol = "December 31, 2019"
+    notice = "End of life: December 31, 2019"
     weight = 2
     latest = "1.8"
 
@@ -185,7 +186,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-enterprise"
     name = "Sensu Enterprise"
     description = "The powerful and simple monitoring product, built on Sensu Core"
-    eol = "March 31, 2020"
+    notice = "End of life: March 31, 2020"
     weight = 3
     latest = "3.6"
 
@@ -263,7 +264,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-enterprise-dashboard"
     name = "Sensu Enterprise Dashboard"
     description = "The dashboard for Sensu Enterprise, built on Uchiwa"
-    eol = "March 31, 2020"
+    notice = "End of life: March 31, 2020"
     weight = 4
     latest = "2.16"
 
@@ -327,7 +328,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "uchiwa"
     name = "Uchiwa"
     description = "An open source dashboard for Sensu Core"
-    eol = "December 31, 2019"
+    notice = "End of life: December 31, 2019"
     weight = 5
     latest = "1.0"
 

--- a/config.toml
+++ b/config.toml
@@ -107,6 +107,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-core"
     name = "Sensu Core"
     description = "The original monitoring event pipeline"
+    eol = "December 31, 2019"
     weight = 2
     latest = "1.8"
 
@@ -184,6 +185,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-enterprise"
     name = "Sensu Enterprise"
     description = "The powerful and simple monitoring product, built on Sensu Core"
+    eol = "March 31, 2020"
     weight = 3
     latest = "3.6"
 
@@ -261,6 +263,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "sensu-enterprise-dashboard"
     name = "Sensu Enterprise Dashboard"
     description = "The dashboard for Sensu Enterprise, built on Uchiwa"
+    eol = "March 31, 2020"
     weight = 4
     latest = "2.16"
 
@@ -324,6 +327,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     identifier = "uchiwa"
     name = "Uchiwa"
     description = "An open source dashboard for Sensu Core"
+    eol = "December 31, 2019"
     weight = 5
     latest = "1.0"
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,11 +22,11 @@
         <div class="product-grid--product--description">
           {{ .description }}
         </div>
-        {{ if .eol }}
+        {{ if .notice }}
         <br>
         <br>
-        <div class="product-grid--product--eol">
-          End of life: {{ .eol }}
+        <div class="product-grid--product--notice">
+          {{ .notice }}
         </div>
         {{ end }}
       </a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,6 +22,13 @@
         <div class="product-grid--product--description">
           {{ .description }}
         </div>
+        {{ if .eol }}
+        <br>
+        <br>
+        <div class="product-grid--product--eol">
+          End of life: {{ .eol }}
+        </div>
+        {{ end }}
       </a>
     {{ end }}
   </div>

--- a/static/stylesheets/scss/_product-grid.scss
+++ b/static/stylesheets/scss/_product-grid.scss
@@ -70,6 +70,16 @@
     }
   }
 
+  .product-grid--product--eol {
+    font-size: 1.8rem;
+    line-height: 1.25;
+    color: white;
+    @media (min-width: $breakpoint-md) {
+      font-size: 2rem;
+      font-weight: bold;
+    }
+  }
+
   .product-grid--product--title {
     font-size: 3.2rem;
     font-weight: 600;

--- a/static/stylesheets/scss/_product-grid.scss
+++ b/static/stylesheets/scss/_product-grid.scss
@@ -70,7 +70,7 @@
     }
   }
 
-  .product-grid--product--eol {
+  .product-grid--product--notice {
     font-size: 1.8rem;
     line-height: 1.25;
     color: white;


### PR DESCRIPTION
## Description

Adds EOL date to tiles of affected products on the front page of the docs.

## Motivation and Context

We want to maximize awareness of this upcoming EOL.

## Screenshot

![2019-09-06 at 5 10 PM](https://user-images.githubusercontent.com/148017/64465313-3a804700-d0c9-11e9-8ff0-7103a8c3b8da.png)

