### PR TITLE
Fix token substitution examples in 1.x migration guide

### DIFF
--- a/content/sensu-core/0.29/migration.md
+++ b/content/sensu-core/0.29/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.0/migration.md
+++ b/content/sensu-core/1.0/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.1/migration.md
+++ b/content/sensu-core/1.1/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.2/migration.md
+++ b/content/sensu-core/1.2/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.3/migration.md
+++ b/content/sensu-core/1.3/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.4/migration.md
+++ b/content/sensu-core/1.4/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.5/migration.md
+++ b/content/sensu-core/1.5/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.6/migration.md
+++ b/content/sensu-core/1.6/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.7/migration.md
+++ b/content/sensu-core/1.7/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-core/1.8/migration.md
+++ b/content/sensu-core/1.8/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/2.6/migration.md
+++ b/content/sensu-enterprise/2.6/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/2.7/migration.md
+++ b/content/sensu-enterprise/2.7/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/2.8/migration.md
+++ b/content/sensu-enterprise/2.8/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.0/migration.md
+++ b/content/sensu-enterprise/3.0/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.1/migration.md
+++ b/content/sensu-enterprise/3.1/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.2/migration.md
+++ b/content/sensu-enterprise/3.2/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.3/migration.md
+++ b/content/sensu-enterprise/3.3/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.4/migration.md
+++ b/content/sensu-enterprise/3.4/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.5/migration.md
+++ b/content/sensu-enterprise/3.5/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.

--- a/content/sensu-enterprise/3.6/migration.md
+++ b/content/sensu-enterprise/3.6/migration.md
@@ -174,7 +174,7 @@ Review your Sensu 1.x check configuration for the following attributes, and make
 
 | 1.x attribute | Manual updates required in Sensu Go config |
 | ------------- | ------------- |
-`::: foo :::` | Update the syntax for token substitution from triple colons to curly braces. For example: `{{{ foo }}}`
+`::: foo :::` | Update the syntax for token substitution from triple colons to double curly braces. For example: `{{ foo }}`
 `stdin: true`  | No updates required. Sensu Go checks accept data on stdin by default.
 `handlers: default` | Sensu Go no longer has the concept of a default handler, so you'll need to create a handler named `default` to continue using this pattern.
 `subdues` | Check subdues are not available in Sensu Go.


### PR DESCRIPTION
## Description

Fixes examples in the 1.x migration guide to show the correct double curly-brace syntax for token substitution.

## Motivation and Context

Accuracy :)