### PR TITLE
use product-versions layout for plugins index

### DIFF
--- a/content/plugins/_index.md
+++ b/content/plugins/_index.md
@@ -5,5 +5,6 @@ weight: -100
 menu: "plugins"
 product: "Plugins"
 version: "latest"
+layout: "product-versions"
 ---
 


### PR DESCRIPTION

## Description

Updates plugins index frontmatter so the page uses the `product-versions` layout

## Motivation and Context

Visiting `/plugins/` currently displays a blank page

## Review Instructions
<!--- Optional -->
