### PR TITLE
correct note in agent - enabling on boot

### DIFF
--- a/content/sensu-go/5.0/reference/agent.md
+++ b/content/sensu-go/5.0/reference/agent.md
@@ -501,7 +501,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.1/reference/agent.md
+++ b/content/sensu-go/5.1/reference/agent.md
@@ -495,7 +495,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.10/reference/agent.md
+++ b/content/sensu-go/5.10/reference/agent.md
@@ -560,7 +560,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.11/reference/agent.md
+++ b/content/sensu-go/5.11/reference/agent.md
@@ -560,7 +560,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.12/reference/agent.md
+++ b/content/sensu-go/5.12/reference/agent.md
@@ -568,7 +568,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.13/reference/agent.md
+++ b/content/sensu-go/5.13/reference/agent.md
@@ -568,7 +568,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.2/reference/agent.md
+++ b/content/sensu-go/5.2/reference/agent.md
@@ -496,7 +496,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.3/reference/agent.md
+++ b/content/sensu-go/5.3/reference/agent.md
@@ -504,7 +504,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.4/reference/agent.md
+++ b/content/sensu-go/5.4/reference/agent.md
@@ -510,7 +510,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.5/reference/agent.md
+++ b/content/sensu-go/5.5/reference/agent.md
@@ -519,7 +519,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.6/reference/agent.md
+++ b/content/sensu-go/5.6/reference/agent.md
@@ -519,7 +519,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.7/reference/agent.md
+++ b/content/sensu-go/5.7/reference/agent.md
@@ -560,7 +560,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.8/reference/agent.md
+++ b/content/sensu-go/5.8/reference/agent.md
@@ -560,7 +560,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 

--- a/content/sensu-go/5.9/reference/agent.md
+++ b/content/sensu-go/5.9/reference/agent.md
@@ -560,7 +560,7 @@ To disable the agent from starting on system boot:
 sudo systemctl disable sensu-agent
 {{< /highlight >}}
 
-_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable._
+_NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable._
 
 {{< platformBlockClose >}}
 


### PR DESCRIPTION
## Description
In all versions of Sensu Go docs, in `/reference/agent/#enabling-on-boot`

Replace `NOTE: On older distributions of Linux, use `sudo chkconfig sensu-server on` to enable the agent and `sudo chkconfig sensu-server off` to disable.`

with `NOTE: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable.`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1764
