### PR TITLE
fix ref links in TOCs

### DIFF
--- a/content/sensu-go/5.10/api/authproviders.md
+++ b/content/sensu-go/5.10/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.11/api/authproviders.md
+++ b/content/sensu-go/5.11/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.12/api/authproviders.md
+++ b/content/sensu-go/5.12/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.13/api/authproviders.md
+++ b/content/sensu-go/5.13/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.2/api/authproviders.md
+++ b/content/sensu-go/5.2/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 ## The `/authproviders` API endpoints {#the-authproviders-api-endpoints}

--- a/content/sensu-go/5.3/api/authproviders.md
+++ b/content/sensu-go/5.3/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.4/api/authproviders.md
+++ b/content/sensu-go/5.4/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.5/api/authproviders.md
+++ b/content/sensu-go/5.5/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.6/api/authproviders.md
+++ b/content/sensu-go/5.6/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.7/api/authproviders.md
+++ b/content/sensu-go/5.7/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.8/api/authproviders.md
+++ b/content/sensu-go/5.8/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].

--- a/content/sensu-go/5.9/api/authproviders.md
+++ b/content/sensu-go/5.9/api/authproviders.md
@@ -11,9 +11,9 @@ menu:
 
 - [The `authproviders` API endpoints](#the-authproviders-api-endpoints) (licensed tier)
   - [`/authproviders` (GET)](#authproviders-get)
-- [The `authproviders/:name` API endpoints](#the-providersname-api-endpoints) (licensed tier)
-  - [`authproviders/:name` (GET)](#providersname-get)
-  - [`authproviders/:name` (PUT)](#providersname-put)
+- [The `authproviders/:name` API endpoints](#the-authprovidersname-api-endpoints) (licensed tier)
+  - [`authproviders/:name` (GET)](#authprovidersname-get)
+  - [`authproviders/:name` (PUT)](#authprovidersname-put)
   - [`authproviders/:name` (DELETE)](#authprovidersname-delete)
 
 **LICENSED TIER**: Unlock authentication providers in Sensu Go with a Sensu license. To activate your license, see the [getting started guide][2].


### PR DESCRIPTION
## Description
Fix TOC ref links to:
The authproviders/:name API endpoints (licensed tier)
authproviders/:name (GET)
authproviders/:name (PUT)

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1767