### PR TITLE
Change `silenceds` to `silenced`

### DIFF
--- a/content/sensu-go/5.13/sensuctl/reference.md
+++ b/content/sensu-go/5.13/sensuctl/reference.md
@@ -425,7 +425,7 @@ None | `federation/v1.Replicator`
 `namespaces` | `core/v2.Namespace`
 `roles` | `core/v2.Role`
 `rolebindings` | `core/v2.RoleBinding`
-`silenceds` | `core/v2.Silenced`
+`silenced` | `core/v2.Silenced`
 `tessen` | `core/v2.TessenConfig`
 `users` | `core/v2.User`
 


### PR DESCRIPTION
## Description
Remove 's' from `silenceds` (should be `silenced`) in list of sensuctl dump types

## Motivation and Context
Fix error introduced in https://github.com/sensu/sensu-docs/pull/1782
Confirmed via Eric in #engineering slack:
```
palourde 11:52 AM
@Eric Can you confirm that it’s silenceds here: https://github.com/sensu/sensu-docs/pull/1804/files#diff-42e38d2660dea09193c0936365f66bfcR434 ?
Eric:skier: 11:54 AM
Oops no, it’s the singular
```
