### PR TITLE
Correct link to bonsai

### DIFF
--- a/content/sensu-go/5.13/sensuctl/reference.md
+++ b/content/sensu-go/5.13/sensuctl/reference.md
@@ -771,7 +771,7 @@ These are useful if you want to know what cluster you're connecting to, or what 
 
 ## Interacting with Bonsai
 
-Sensuctl supports both installing asset definitions directly from [Bonsai](34) and checking your Sensu backend for outdated assets.
+Sensuctl supports both installing asset definitions directly from [Bonsai][34] and checking your Sensu backend for outdated assets.
 
 ### Usage
 

--- a/content/sensu-go/5.14/sensuctl/reference.md
+++ b/content/sensu-go/5.14/sensuctl/reference.md
@@ -744,7 +744,7 @@ These are useful if you want to know what cluster you're connecting to, or what 
 
 ## Interacting with Bonsai
 
-Sensuctl supports both installing asset definitions directly from [Bonsai](34) and checking your Sensu backend for outdated assets.
+Sensuctl supports both installing asset definitions directly from [Bonsai][34] and checking your Sensu backend for outdated assets.
 
 ### Usage
 


### PR DESCRIPTION
## Description
We had parentheses around reference 34 instead of brackets. Fixed.

## Motivation and Context
Closes #1814 
