### PR TITLE
Correct licensed link in Sensuctl dump resources

### DIFF
--- a/content/sensu-go/5.13/sensuctl/reference.md
+++ b/content/sensu-go/5.13/sensuctl/reference.md
@@ -404,7 +404,7 @@ sensuctl dump handler,filter --format yaml --file my-handlers-and-filters.yaml
 
 ### sensuctl dump resource types
 
-_NOTE: The resource types with no synonym listed are [licensed-tier](https://sensu.io/features) features._
+_NOTE: The resource types with no synonym listed are [licensed-tier][30] features._
 
 Synonym | Fully qualified name 
 --------------------|---

--- a/content/sensu-go/5.14/sensuctl/reference.md
+++ b/content/sensu-go/5.14/sensuctl/reference.md
@@ -410,7 +410,7 @@ The table below lists supported `sensu dump` resource types. You can also use a 
 sensuctl dump --types
 {{< /highlight >}}
 
-_NOTE: The resource types with no synonym listed are [licensed-tier](../getting-started/enterprise/) features._
+_NOTE: The resource types with no synonym listed are [licensed-tier][30] features._
 
 Synonym | Fully qualified name 
 --------------------|---


### PR DESCRIPTION
## Description
Corrects the link to the licensed tier page in the docs

## Motivation and Context
Closes #1836 
