### PR TITLE
Fix 'ready-only' typo in roles:delete url  and Learn Sensu sandbox

### DIFF
--- a/content/sensu-go/5.0/api/roles.md
+++ b/content/sensu-go/5.0/api/roles.md
@@ -213,7 +213,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -223,7 +223,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.0/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.0/getting-started/learn-sensu.md
@@ -433,7 +433,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.1/api/roles.md
+++ b/content/sensu-go/5.1/api/roles.md
@@ -213,7 +213,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -223,7 +223,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.1/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.1/getting-started/learn-sensu.md
@@ -433,7 +433,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.10/api/roles.md
+++ b/content/sensu-go/5.10/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.10/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.10/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.11/api/roles.md
+++ b/content/sensu-go/5.11/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.11/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.11/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.11/installation/install-sensu.md
+++ b/content/sensu-go/5.11/installation/install-sensu.md
@@ -371,7 +371,7 @@ Now that you've installed Sensu, here are some resources to help continue your j
 - [Send alerts to Slack](../../guides/send-slack-alerts)
 - [Monitor server resources](../../guides/monitor-server-resources)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://github.com/sensu/sensu-go/releases
 [2]: https://github.com/sensu/sensu-go/blob/5.1.1/packaging/files/windows/agent.yml.example

--- a/content/sensu-go/5.12/api/roles.md
+++ b/content/sensu-go/5.12/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.12/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.12/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.12/installation/install-sensu.md
+++ b/content/sensu-go/5.12/installation/install-sensu.md
@@ -374,7 +374,7 @@ Now that you've installed Sensu, here are some resources to help continue your j
 - [Send alerts to Slack](../../guides/send-slack-alerts)
 - [Monitor server resources](../../guides/monitor-server-resources)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://github.com/sensu/sensu-go/releases
 [2]: https://github.com/sensu/sensu-go/blob/5.1.1/packaging/files/windows/agent.yml.example

--- a/content/sensu-go/5.13/api/roles.md
+++ b/content/sensu-go/5.13/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.13/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.13/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.13/installation/install-sensu.md
+++ b/content/sensu-go/5.13/installation/install-sensu.md
@@ -374,7 +374,7 @@ Now that you've installed Sensu, here are some resources to help continue your j
 - [Send alerts to Slack](../../guides/send-slack-alerts)
 - [Monitor server resources](../../guides/monitor-server-resources)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://github.com/sensu/sensu-go/releases
 [2]: https://github.com/sensu/sensu-go/blob/5.1.1/packaging/files/windows/agent.yml.example

--- a/content/sensu-go/5.14/api/roles.md
+++ b/content/sensu-go/5.14/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.14/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.14/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.14/installation/install-sensu.md
+++ b/content/sensu-go/5.14/installation/install-sensu.md
@@ -375,7 +375,7 @@ Now that you've installed Sensu, here are some resources to help continue your j
 - [Send alerts to Slack](../../guides/send-slack-alerts)
 - [Monitor server resources](../../guides/monitor-server-resources)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://github.com/sensu/sensu-go/releases
 [2]: https://github.com/sensu/sensu-go/blob/5.1.1/packaging/files/windows/agent.yml.example

--- a/content/sensu-go/5.2/api/roles.md
+++ b/content/sensu-go/5.2/api/roles.md
@@ -213,7 +213,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -223,7 +223,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.2/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.2/getting-started/learn-sensu.md
@@ -433,7 +433,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.3/api/roles.md
+++ b/content/sensu-go/5.3/api/roles.md
@@ -213,7 +213,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -223,7 +223,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.3/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.3/getting-started/learn-sensu.md
@@ -433,7 +433,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.4/api/roles.md
+++ b/content/sensu-go/5.4/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.4/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.4/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.5/api/roles.md
+++ b/content/sensu-go/5.5/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.5/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.5/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.6/api/roles.md
+++ b/content/sensu-go/5.6/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.6/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.6/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.7/api/roles.md
+++ b/content/sensu-go/5.7/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.7/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.7/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.8/api/roles.md
+++ b/content/sensu-go/5.8/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.8/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.8/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets

--- a/content/sensu-go/5.9/api/roles.md
+++ b/content/sensu-go/5.9/api/roles.md
@@ -214,7 +214,7 @@ The following example shows a request to delete the role `read-only`, resulting 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/ready-only
+http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -224,7 +224,7 @@ HTTP/1.1 204 No Content
 /roles/:role (DELETE) | 
 --------------------------|------
 description               | Removes a role from Sensu given the role name.
-example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/ready-only
+example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../reference/rbac

--- a/content/sensu-go/5.9/getting-started/learn-sensu.md
+++ b/content/sensu-go/5.9/getting-started/learn-sensu.md
@@ -420,7 +420,7 @@ Here are some resources to help continue your journey:
 
 - [Install Sensu Go](../../installation/install-sensu)
 - [Collect StatsD metrics](../../guides/aggregate-metrics-statsd)
-- [Create a ready-only user](../../guides/create-read-only-user/)
+- [Create a read-only user](../../guides/create-read-only-user/)
 
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [2]: ../../reference/assets


### PR DESCRIPTION
## Description
Fixes "ready-only" typo in roles:delete URL and link text at the end of the Learn Sensu sandbox lesson

## Motivation and Context
Noticed when trying to find link mentioned in #1837 