### PR TITLE
Propagate list add to resource_names description back through all versions

### DIFF
--- a/content/sensu-go/5.0/reference/rbac.md
+++ b/content/sensu-go/5.0/reference/rbac.md
@@ -535,7 +535,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.1/reference/rbac.md
+++ b/content/sensu-go/5.1/reference/rbac.md
@@ -543,7 +543,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.10/reference/rbac.md
+++ b/content/sensu-go/5.10/reference/rbac.md
@@ -548,7 +548,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.11/reference/rbac.md
+++ b/content/sensu-go/5.11/reference/rbac.md
@@ -548,7 +548,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.12/reference/rbac.md
+++ b/content/sensu-go/5.12/reference/rbac.md
@@ -550,7 +550,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.13/reference/rbac.md
+++ b/content/sensu-go/5.13/reference/rbac.md
@@ -550,7 +550,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.15/reference/rbac.md
+++ b/content/sensu-go/5.15/reference/rbac.md
@@ -550,7 +550,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.2/reference/rbac.md
+++ b/content/sensu-go/5.2/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.3/reference/rbac.md
+++ b/content/sensu-go/5.3/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.4/reference/rbac.md
+++ b/content/sensu-go/5.4/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.5/reference/rbac.md
+++ b/content/sensu-go/5.5/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.6/reference/rbac.md
+++ b/content/sensu-go/5.6/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.7/reference/rbac.md
+++ b/content/sensu-go/5.7/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.8/reference/rbac.md
+++ b/content/sensu-go/5.8/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}

--- a/content/sensu-go/5.9/reference/rbac.md
+++ b/content/sensu-go/5.9/reference/rbac.md
@@ -545,7 +545,7 @@ example      | {{< highlight shell >}}"resources": ["checks"]{{< /highlight >}}
 
 resource_names    | 
 -------------|------ 
-description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `delete`, and `update` verbs.
+description  | Specific resource names that the rule has permission to access. Resource name permissions are only available for `get`, `list`, `update`, and `delete` verbs.
 required     | false
 type         | Array
 example      | {{< highlight shell >}}"resource_names": ["check-cpu"]{{< /highlight >}}


### PR DESCRIPTION
In `resource_names` description, add `list` (see https://github.com/sensu/sensu-docs/pull/1850)
