### PR TITLE
Replace downloads page links with links for individual platform packages

### DIFF
--- a/content/sensu-core/1.8/faq.md
+++ b/content/sensu-core/1.8/faq.md
@@ -33,9 +33,9 @@ Enterprise](https://sensu.io/features/enterprise) a try.
 | Solaris 11         | ❌     | ✅     | sparc   |                          |
 | IBM AIX 6.1 +      | ❌     | ✅     | powerpc |                          |
 | Windows 2012r2     | ✅     | ✅     | x86     | 32bit artifact built on 64bit platform |
-| Mac OS X 10.10     | ✅     | ❌     | x86     | See [Mac platform notes][4] for instructions |
-| Mac OS X 10.11     | ✅     | ❌     | x86     | See [Mac platform notes][4] for instructions |
-| Mac OS X 10.12     | ✅     | ❌     | x86     | See [Mac platform notes][4] for instructions |
+| Mac OS X 10.10     | ✅     | ❌     | x86     | See [Mac platform notes][5] for instructions |
+| Mac OS X 10.11     | ✅     | ❌     | x86     | See [Mac platform notes][5] for instructions |
+| Mac OS X 10.12     | ✅     | ❌     | x86     | See [Mac platform notes][5] for instructions |
 
 > Do I need RabbitMQ to be installed on every system I wish to monitor?
 
@@ -144,8 +144,8 @@ including RHEL, CentOS, Debian and Ubuntu.
 
 > Is Sensu available for Microsoft Windows?
 
-**Yes.** An MSI installer package is available on the
-[Downloads] page. Please visit the Sensu documentation for
+**Yes.** An [MSI installer package][1] is available.
+Please visit the Sensu documentation for
 more information on [configuring Sensu on
 Windows](../platforms/sensu-on-microsoft-windows/).
 
@@ -173,9 +173,9 @@ Frequently, Sensu staff or community members may ask you to print your configura
 
 > RabbitMQ is giving me an error about `wrong credentials`, but everything seems correct. What do I do?
 
-Due to [AMQP's][1] implementation in RabbitMQ, it's often difficult to distinguish a SSL handshake failure from a bad username/password combination. If you've ensured that the username/password combination in your configuration is correct, we encourage you to check your RabbitMQ/Erlang versions against [RabbitMQ's "Which Erlang" article][2] to see if your versions are able to reliably support TLS.
+Due to [AMQP's][2] implementation in RabbitMQ, it's often difficult to distinguish a SSL handshake failure from a bad username/password combination. If you've ensured that the username/password combination in your configuration is correct, we encourage you to check your RabbitMQ/Erlang versions against [RabbitMQ's "Which Erlang" article][3] to see if your versions are able to reliably support TLS.
 
-It's also worth noting that as of Sensu 0.27, our build processes changed and we [upgraded the version of OpenSSL][3], and upgrading your client (if < 0.27) may solve the issue.
+It's also worth noting that as of Sensu 0.27, our build processes changed and we [upgraded the version of OpenSSL][4], and upgrading your client (if < 0.27) may solve the issue.
 
 > What Firewall Rules Does Sensu Require?
 
@@ -207,8 +207,8 @@ See the table below for the location of the respective files needed:
 
 _NOTE: For `config.json`, it is not necessary to have this file present on either a Sensu client or server, provided that you have the rest of the configuration files present._
 
-[downloads]: https://sensuapp.org/downloads
-[1]: https://www.amqp.org/
-[2]: https://www.rabbitmq.com/which-erlang.html
-[3]: ../installation/upgrading/#tls-ssl-changes
-[4]: https://github.com/sensu/sensu-omnibus/blob/master/platform-docs/MAC_OS_X.md
+[1]: https://repositories.sensuapp.org/msi/
+[2]: https://www.amqp.org/
+[3]: https://www.rabbitmq.com/which-erlang.html
+[4]: ../installation/upgrading/#tls-ssl-changes
+[5]: https://github.com/sensu/sensu-omnibus/blob/master/platform-docs/MAC_OS_X.md

--- a/content/sensu-core/1.8/installation/install-sensu-client.md
+++ b/content/sensu-core/1.8/installation/install-sensu-client.md
@@ -42,14 +42,13 @@ To continue with this guide, please refer to the **Install Sensu Core**,
 **Configure Sensu**, and **Operating Sensu** instructions corresponding to the
 platform(s) where you will run your Sensu client(s).
 
-- [Ubuntu/Debian](../../platforms/sensu-on-ubuntu-debian/#sensu-core)
-- [RHEL/CentOS](../../platforms/sensu-on-rhel-centos/#sensu-core)
-- [Microsoft Windows](../../platforms/sensu-on-microsoft-windows/#sensu-core)
-- [Mac OS X](../../platforms/sensu-on-mac-os-x/#sensu-core)
 - [FreeBSD](../../platforms/sensu-on-freebsd/#sensu-core)
 - [IBM AIX](../../platforms/sensu-on-ibm-aix/#sensu-core)
+- [Mac OS X](../../platforms/sensu-on-mac-os-x/#sensu-core)
+- [Microsoft Windows](../../platforms/sensu-on-microsoft-windows/#sensu-core)
 - [Oracle Solaris](../../platforms/sensu-on-oracle-solaris/#sensu-core)
-
+- [RHEL/CentOS](../../platforms/sensu-on-rhel-centos/#sensu-core)
+- [Ubuntu/Debian](../../platforms/sensu-on-ubuntu-debian/#sensu-core)
 
 
 [1]:  ../installation-strategies#standalone

--- a/content/sensu-core/1.8/installation/install-sensu-server-api.md
+++ b/content/sensu-core/1.8/installation/install-sensu-server-api.md
@@ -18,16 +18,21 @@ The Sensu Server and API are available in two flavors:
 
 _NOTE: only one flavor of the Sensu server & API should be used at any given
 time. Sensu Enterprise users should skip Sensu Core server & API installation
-and jump directly to [installing Sensu Enterprise][2]._
+and jump directly to [installing Sensu Enterprise][9]._
 
 ## Sensu Core (OSS) {#sensu-core}
 
-Sensu Core is installed via native system installer package formats (e.g. .deb,
-.rpm, .msi, .pkg, etc), which are available for download from the [Sensu
-Downloads][3] page, and from package manager repositories for APT (for
-Ubuntu/Debian systems), and YUM (for RHEL/CentOS). The Sensu Core packages
-installs several processes, including `sensu-server`, `sensu-api`, and
-`sensu-client`.
+Sensu Core is installed via native system installer package formats (e.g. .deb, .rpm, .msi, .pkg, etc), which are available for download using the links listed below and from package manager repositories for APT (for Ubuntu/Debian systems) and YUM (for RHEL/CentOS).
+
+- [FreeBSD][1]
+- [IBM AIX][2]
+- [Mac OS X][3]
+- [Microsoft Windows][4]
+- [Solaris 10][5] or [Solaris 11][6]
+- [RHEL/CentOS][7]
+- [Ubuntu/Debian][8]
+
+The Sensu Core packages installs several processes, including `sensu-server`, `sensu-api`, and `sensu-client`.
 
 - [Install the Sensu Core server & API on Ubuntu/Debian](../../platforms/sensu-on-ubuntu-debian/#sensu-core)
 - [Install the Sensu Core server & API on RHEL/CentOS](../../platforms/sensu-on-rhel-centos/#sensu-core)
@@ -52,6 +57,12 @@ functionality of Sensu server and API in a single process.
 - [Install Sensu Enterprise on Ubuntu/Debian](../../platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../../platforms/sensu-on-rhel-centos/#sensu-enterprise)
 
-[1]:  ../installation-prerequisites
-[2]:  #sensu-enterprise
-[3]:  https://sensuapp.org/download
+[1]: https://repositories.sensuapp.org/freebsd/
+[2]: https://repositories.sensuapp.org/aix/
+[3]: https://repositories.sensuapp.org/osx/
+[4]: https://repositories.sensuapp.org/msi/
+[5]: https://repositories.sensuapp.org/solaris/pkg/
+[6]: https://repositories.sensuapp.org/solaris/ips/
+[7]: https://repositories.sensuapp.org/yum/
+[8]: https://repositories.sensuapp.org/apt/pool/
+[9]: #sensu-enterprise

--- a/content/sensu-core/1.8/overview/platforms.md
+++ b/content/sensu-core/1.8/overview/platforms.md
@@ -20,8 +20,16 @@ provides multiple processes, including the [Sensu server][2] (`sensu-server`),
 
 Installer packages are available for most modern operating systems via native
 installer packages (e.g. .deb, .rpm, .msi, .pkg, etc) which are available for
-[download from the Sensu website][5], and from package manager repositories for
+download using the links below and from package manager repositories for
 APT (for Ubuntu/Debian systems), and YUM (for RHEL/CentOS).
+
+- [FreeBSD][7]
+- [IBM AIX][8]
+- [Mac OS X][9]
+- [Microsoft Windows][10]
+- [Solaris 10][11] or [Solaris 11][12]
+- [RHEL/CentOS][13]
+- [Ubuntu/Debian][14]
 
 _NOTE: although Sensu Core packages are available for a variety of platforms
 &ndash; thus making it technically possible to run the `sensu-server` and
@@ -48,10 +56,10 @@ running the `sensu-server` and `sensu-api` processes._
 
 ## Sensu Enterprise
 
-[Sensu Enterprise][6] is designed to be a drop-in replacement for the Sensu Core
+[Sensu Enterprise][5] is designed to be a drop-in replacement for the Sensu Core
 server and API, _only_ (i.e. Sensu Enterprise uses the same client as Sensu
 Core). Sensu Enterprise provides a single process called `sensu-enterprise`
-which provides [added-value][7] replacements for the Sensu Core server
+which provides [added-value][6] replacements for the Sensu Core server
 (`sensu-server`) and API (`sensu-api`).
 
 ### Sensu Enterprise Server & API
@@ -72,6 +80,14 @@ by Sensu**.
 [2]:  ../../reference/server/
 [3]:  ../../api/overview/
 [4]:  ../../reference/clients/
-[5]:  https://sensuapp.org/download
+[5]:  https://sensu.io/products/enterprise
 [6]:  https://sensu.io/products/enterprise
-[7]:  https://sensu.io/products/enterprise
+[7]: https://repositories.sensuapp.org/freebsd/
+[8]: https://repositories.sensuapp.org/aix/
+[9]: https://repositories.sensuapp.org/osx/
+[10]: https://repositories.sensuapp.org/msi/
+[11]: https://repositories.sensuapp.org/solaris/pkg/
+[12]: https://repositories.sensuapp.org/solaris/ips/
+[13]: https://repositories.sensuapp.org/yum/
+[14]: https://repositories.sensuapp.org/apt/pool/
+

--- a/content/sensu-core/1.8/platforms/sensu-on-freebsd.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-freebsd.md
@@ -20,14 +20,11 @@ menu:
   - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
   - [Example transport configuration](#example-transport-configuration)
-- [Operating Sensu](#operating-sensu)
-  - [Managing the Sensu client process](#service-management)
 
 ## Install Sensu Core {#sensu-core}
 
 Sensu Core is installed on FreeBSD systems via a native system installer package
-(i.e. a .txz file), which is available for download from the [Sensu
-Downloads][1] page, and from [this repository (64-bit FreeBSD 10+ only)][2].
+(i.e. a .txz file), which is available for [download][1] and from [this repository (64-bit FreeBSD 10+ only)][2].
 
 _WARNING: FreeBSD packages are currently as a "beta" release. Support for
 running Sensu on FreeBSD will be provided on a best-effort basis until further
@@ -40,9 +37,8 @@ To install or upgrade to the latest version of Sensu, please ensure
 you have updated existing configurations to follow the repository URL
 format specified below._
 
-1. Download Sensu from the [Sensu Downloads][1] page.
-   _NOTE: FreeBSD packages are available for FreeBSD 10 and 11.
-   Please visit the [Sensu Downloads][1] page for more information._
+1. Download the Sensu [FreeBSD package][1].
+   _NOTE: FreeBSD packages are available for FreeBSD 10 and 11._
 
 2. Install the `sensu-1.4.1_1.txz` package using the `pkg` utility:
    {{< highlight shell >}}
@@ -118,11 +114,8 @@ connect to the configured [Sensu Transport][6].
 2. If the transport being used is running on a different host, additional configuration is required to tell the Sensu client how to connect to the transport.
 Please see [Redis][7] or [RabbitMQ][8] reference documentation for examples.
 
-## Operating Sensu
 
-Coming soon...
-
-[1]:  https://sensuapp.org/download
+[1]:  https://repositories.sensuapp.org/freebsd/
 [2]:  https://sensu.global.ssl.fastly.net/freebsd/
 [3]:  https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:10:amd64/sensu/sensu-1.4.1_1.txz
 [4]:  https://sensuapp.org/mit-license

--- a/content/sensu-core/1.8/platforms/sensu-on-ibm-aix.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-ibm-aix.md
@@ -28,8 +28,7 @@ menu:
 ## Install Sensu Core {#sensu-core}
 
 Sensu Core is installed on IBM AIX systems via a native system installer package
-(i.e. a .bff file), which is available for download from the [Sensu
-Downloads][1] page, and from [this repository][2].
+(i.e. a .bff file), which is available for [download][1] and from [this repository][2].
 
 ### Download and install Sensu using the Sensu .bff package {#download-and-install-sensu-core}
 
@@ -38,7 +37,7 @@ install or upgrade to the latest version of Sensu, please ensure you
 have updated existing configurations to follow the repository URL
 format specified below._
 
-1. Download Sensu from the [Sensu Downloads][1] page.
+1. Download the Sensu [AIX package][1].
 
 2. The Sensu installer package for IBM AIX systems is provided in **backup file
    format** (.bff). In order to install the content, you will need to know the
@@ -160,7 +159,7 @@ not working at this time, so any Ruby-based Sensu plugins that require FFI will
 not work (however all other plugins should work). It is possible that FFI
 support will be enabled in a future release.
 
-[1]:  https://sensuapp.org/downloads
+[1]:  https://repositories.sensuapp.org/aix/
 [2]:  https://sensu.global.ssl.fastly.net/aix/
 [3]:  https://sensu.global.ssl.fastly.net/aix/6.1/sensu-1.4.1-1.powerpc.bff
 [4]:  https://sensuapp.org/mit-license

--- a/content/sensu-core/1.8/platforms/sensu-on-mac-os-x.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-mac-os-x.md
@@ -26,9 +26,7 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
-Sensu Core is installed on Mac OS X systems via a native system installer
-package (i.e. a .pkg file), which is available for download from the
-[Sensu Downloads][1] page, and from [this repository][2].
+Sensu Core is installed on Mac OS X systems via a native system installer package (i.e. a .pkg file), which is available for [download][1].
 
 _WARNING: Mac OS X packages are currently as a "beta" release. Support for
 running Sensu on Mac OS X will be provided on a best-effort basis until further
@@ -36,7 +34,7 @@ notice._
 
 ### Download and install Sensu using the Sensu Universal .pkg file {#download-and-install-sensu-core}
 
-1. Download Sensu from the [Sensu Downloads][1] page.
+1. Download the Sensu [Mac OS X package][1].
    _NOTE: the Universal .pkg file supports OS X "Mavericks" (10.9) and newer.
    Mountain Lion users: please use [this installer][3]._
 
@@ -184,7 +182,7 @@ $ sudo -u _sensu /opt/sensu/bin/sensu-client -V
 1.4.1{{< /highlight >}}
 
 
-[1]:  https://sensu.io/features/downloads
+[1]:  https://repositories.sensuapp.org/osx/
 [2]:  http://repositories.sensuapp.org/osx/
 [3]:  http://repositories.sensuapp.org/osx/sensu-0.26.3-1.mountainlion.pkg
 [4]:  #configure-the-sensu-client-launchd-daemon

--- a/content/sensu-core/1.8/platforms/sensu-on-microsoft-windows.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-microsoft-windows.md
@@ -29,15 +29,14 @@ menu:
 ## Install Sensu Core {#sensu-core}
 
 Sensu Core is installed on Microsoft Windows systems via a native system
-installer package (i.e. a .msi file), which is available for download from the
-[Sensu Downloads][1] page, and from [this repository][2].
+installer package (i.e. a .msi file), which is available for [download][1] and from [this repository][2].
 
 ### Download and install Sensu using the Sensu MSI {#download-and-install-sensu-core}
 
 _NOTE: As of Sensu version 1.0, repository URLs have changed.
 To install or upgrade to the latest version of Sensu, please ensure you have updated existing configurations to follow the repository URL format specified below._
 
-1. Download Sensu from the [Sensu Downloads][1] page.
+1. Download the Sensu [Microsoft Windows package][1].
 
 2. Double-click the `sensu-1.4.1-1-x64.msi` installer package to launch the
    installer, accept the Sensu Core [MIT License][4] and install Sensu using the
@@ -180,7 +179,7 @@ sc start sensu-client
 sc stop sensu-client{{< /highlight >}}
 
 
-[1]:  https://sensuapp.org/download
+[1]:  https://repositories.sensuapp.org/msi/
 [2]:  https://sensu.global.ssl.fastly.net/msi/
 [3]:  https://sensu.global.ssl.fastly.net/msi/2012r2/sensu-1.4.1-1-x64.msi
 [4]:  https://sensuapp.org/mit-license

--- a/content/sensu-core/1.8/platforms/sensu-on-oracle-solaris.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-oracle-solaris.md
@@ -28,9 +28,7 @@ menu:
 ## Install Sensu {#sensu-core}
 
 Sensu Core is installed on Solaris systems via native system installer packages
-(i.e. .pkg or [IPS][13] .p5p files), which are available for download from
-the [Sensu Downloads][1] page, and from these repositories: [Solaris 10
-(.pkg)][2], and [Solaris 11 (IPS .p5p)][3].
+(i.e. .pkg or [IPS][13] .p5p files), which are available for download for [Solaris 10][1] and [Solaris 11][14] page and from the repositories for [Solaris 10 (.pkg)][2], and [Solaris 11 (IPS .p5p)][3].
 
 ### Download and install Sensu on Solaris 10 {#download-and-install-sensu-core-on-solaris-10}
 
@@ -39,7 +37,7 @@ To install or upgrade to the latest version of Sensu, please ensure
 you have updated existing configurations to follow the repository URL
 format specified below._
 
-1. Download Sensu from the [Sensu Downloads][1] page
+1. Download the Sensu [Solaris 10 package][1].
 
 2. Install the `sensu-1.4.1-1.i386.pkg` package using the `pkgadd` utility:
    {{< highlight shell >}}
@@ -58,8 +56,7 @@ svccfg import /lib/svc/manifest/site/sensu-client.xml{{< /highlight >}}
 
 ### Download and install Sensu on Solaris 11 {#download-and-install-sensu-core-on-solaris-11}
 
-1. Download Sensu from the [Sensu Downloads][1] page, or by using the `wget`
-   utility:
+1. Download the Sensu [Solaris 11 package][14] or use the `wget` utility:
    {{< highlight shell >}}
 wget https://sensu.global.ssl.fastly.net/solaris/ips/5.11/sensu-1.4.1-1.i386.p5p{{< /highlight >}}
 
@@ -164,17 +161,17 @@ $ svcadm enable sensu-client
 $ svcadm disable sensu-client
 $ svcadm restart sensu-client{{< /highlight >}}
 
-[?]:  #
-[1]:  https://sensuapp.org/download
-[2]:  https://sensu.global.ssl.fastly.net/solaris/pkg/
-[3]:  https://sensu.global.ssl.fastly.net/solaris/ips/
-[4]:  https://sensuapp.org/mit-license
-[5]:  ../../reference/configuration/
-[6]:  ../../reference/transport/
-[7]:  ../../reference/redis/#configure-sensu
-[8]:  ../../reference/rabbitmq/#sensu-rabbitmq-configuration
-[9]:  #configure-sensu
+[1]: https://repositories.sensuapp.org/solaris/pkg/
+[2]: https://sensu.global.ssl.fastly.net/solaris/pkg/
+[3]: https://sensu.global.ssl.fastly.net/solaris/ips/
+[4]: https://sensuapp.org/mit-license
+[5]: ../../reference/configuration/
+[6]: ../../reference/transport/
+[7]: ../../reference/redis/#configure-sensu
+[8]: ../../reference/rabbitmq/#sensu-rabbitmq-configuration
+[9]: #configure-sensu
 [10]: #example-transport-configuration
 [11]: #example-client-configuration
 [12]: ../../files/postinst.sh
 [13]: http://www.oracle.com/technetwork/server-storage/solaris11/technologies/ips-323421.html
+[14]: https://repositories.sensuapp.org/solaris/ips/

--- a/content/sensu-core/1.8/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-rhel-centos.md
@@ -39,10 +39,8 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
-Sensu Core is installed on RHEL and CentOS systems via a native system installer
-package (i.e. a .rpm file), which is available for download from the [Sensu
-Downloads][1] page, and from YUM package management repositories. The Sensu Core
-package installs several processes including `sensu-server`, `sensu-api`, and
+Sensu Core is installed on RHEL and CentOS systems via a native system installer package (i.e. a .rpm file), which is available for [download][1] and from YUM package management repositories.
+The Sensu Core package installs several processes including `sensu-server`, `sensu-api`, and
 `sensu-client`.
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
@@ -442,7 +440,7 @@ sudo service sensu-enterprise-dashboard stop{{< /highlight >}}
   IP address where the Sensu Enterprise Dashboard is running).
 
 
-[1]:  https://sensuapp.org/download
+[1]:  https://repositories.sensuapp.org/yum/
 [2]:  https://sensu.io/products/enterprise
 [3]:  ../../reference/configuration/
 [4]:  ../../reference/transport/

--- a/content/sensu-core/1.8/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.8/platforms/sensu-on-ubuntu-debian.md
@@ -39,11 +39,8 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
-Sensu Core is installed on Ubuntu and Debian systems via a native system
-installer package (i.e. a .deb file), which is available for download from the
-[Sensu Downloads][1] page, and from APT package management repositories. The
-Sensu Core package installs several processes including `sensu-server`,
-`sensu-api`, and `sensu-client`.
+Sensu Core is installed on Ubuntu and Debian systems via a native system installer package (i.e. a .deb file), which is available for [download][1] and from APT package management repositories.
+The Sensu Core package installs several processes including `sensu-server`, `sensu-api`, and `sensu-client`.
 
 Sensu packages for Debian target current [`stable` and `oldstable`
 releases][15].
@@ -458,7 +455,7 @@ sudo service sensu-enterprise-dashboard stop{{< /highlight >}}
   IP address where the Sensu Enterprise Dashboard is running).
 
 
-[1]:  https://sensuapp.org/download
+[1]:  https://repositories.sensuapp.org/apt/pool/
 [2]:  https://sensu.io/products/enterprise
 [3]:  ../../reference/configuration
 [4]:  ../../reference/transport


### PR DESCRIPTION
Jef noted on Slack:
"we seems to have dropped most of our download links for Sensu Core when transitioned to the new website.  The Sensu Core docs point to a downloads page on our main site that no longer exists. The linux instructions in the Sensu Core docs still work, but the exotic platforms like AIX, Win, OSX, etc. no longer have discoverable download links.
I'm assuming this was just an oops on our part, effectively EOL Core a couple of months early.
I've put the links in discourse in the context of the discussion,  but should we drive a change into the Sensu Core docs as well and point people to the correct repository.sensuapp.org directories for each platform?"

## Description
Replaced https://sensuapp.org/download and https://sensuapp.org/downloads links with individual platform links listed at https://discourse.sensu.io/t/sensu-core-download-all-the-versions/1406/2
