### PR TITLE
Start with "entity" definition

### DIFF
--- a/content/sensu-go/5.14/reference/entities.md
+++ b/content/sensu-go/5.14/reference/entities.md
@@ -33,10 +33,13 @@ We call these monitored parts of an infrastructure "entities".
 An entity not only provides context to event data (what/where the event is from) but an event's uniqueness is determined by the check name and the name of the entity upon which the check ran.
 In addition, an entity can contain system information such as the hostname, OS, platform, and version.
 
-Agent entities are monitoring agents, which are installed and run on every system that needs to be monitored.
+Agent entities are monitoring agents that are installed and run on every system that needs to be monitored.
 The entity is responsible for registering the system with the Sensu backend service, sending keepalive messages (the Sensu heartbeat mechanism), and executing monitoring checks.
-Each entity is a member of one or more `subscriptions` – a list of roles and/or responsibilities assigned to the agent entity (ex: a webserver or a database).
+Each entity is a member of one or more `subscriptions`: a list of roles and/or responsibilities assigned to the agent entity (ex: a webserver or a database).
 Sensu entities will "subscribe" to (or watch for) check requests published by the Sensu backend (via the Sensu Transport), execute the corresponding requests locally, and publish the results of the check back to the transport (to be processed by a Sensu backend).
+
+[Proxy entities][13] are dynamically created entities that are added to the entity store if an entity does not already exist for a check result.
+Proxy entities allow Sensu to monitor external resources on systems where a Sensu agent cannot be installed (like a network switch or website) using the defined check `ProxyEntityName` to create a proxy entity for the external resource.
 
 ## Usage limits
 
@@ -44,7 +47,8 @@ This version of Sensu has no functional limitations based on entity count. If yo
 
 ## Proxy entities
 
-Proxy entities (formerly known as proxy clients or just-in-time/JIT clients) are dynamically created entities that are added to the entity store if an entity does not already exist for a check result. Proxy entities allow Sensu to monitor external resources on systems and devices where a Sensu agent cannot be installed (like a network switch or website) using the defined check `ProxyEntityName` to create a proxy entity for the external resource.
+Proxy entities (formerly known as proxy clients or just-in-time/JIT clients) are dynamically created entities that are added to the entity store if an entity does not already exist for a check result.
+Proxy entities allow Sensu to monitor external resources on systems and devices where a Sensu agent cannot be installed (like a network switch or website) using the defined check `ProxyEntityName` to create a proxy entity for the external resource.
 
 Proxy entity registration differs from keepalive-based registration because the registration event happens while processing a check result (not a keepalive message).
 
@@ -792,3 +796,4 @@ spec:
 [10]: https://discourse.sensu.io/t/introducing-usage-limits-in-the-sensu-go-free-tier/1156
 [11]: ../checks#round-robin-checks
 [12]: ../../guides/monitor-external-resources/#using-a-proxy-entity-to-monitor-a-website
+[13]: #proxy-entities

--- a/content/sensu-go/5.14/reference/entities.md
+++ b/content/sensu-go/5.14/reference/entities.md
@@ -28,12 +28,15 @@ menu:
 
 ## How do entities work?
 
-Agent entities are monitoring agents, which are installed and run on every system that needs to be monitored. The entity is responsible for registering the system with the Sensu backend service, sending keepalive messages (the Sensu heartbeat mechanism), and executing monitoring checks. Each entity is a member of one or more `subscriptions` – a list of roles and/or responsibilities assigned to the agent entity (ex: a webserver or a database). Sensu entities will "subscribe" to (or watch for) check requests published by the Sensu backend (via the Sensu Transport), execute the corresponding requests locally, and publish the results of the check back to the transport (to be processed by a Sensu backend).
-
 An entity represents anything (ex: server, container, network switch) that needs to be monitored, including the full range of infrastructure, runtime and application types that compose a complete monitoring environment (from server hardware to serverless functions).
 We call these monitored parts of an infrastructure "entities".
 An entity not only provides context to event data (what/where the event is from) but an event's uniqueness is determined by the check name and the name of the entity upon which the check ran.
 In addition, an entity can contain system information such as the hostname, OS, platform, and version.
+
+Agent entities are monitoring agents, which are installed and run on every system that needs to be monitored.
+The entity is responsible for registering the system with the Sensu backend service, sending keepalive messages (the Sensu heartbeat mechanism), and executing monitoring checks.
+Each entity is a member of one or more `subscriptions` – a list of roles and/or responsibilities assigned to the agent entity (ex: a webserver or a database).
+Sensu entities will "subscribe" to (or watch for) check requests published by the Sensu backend (via the Sensu Transport), execute the corresponding requests locally, and publish the results of the check back to the transport (to be processed by a Sensu backend).
 
 ## Usage limits
 


### PR DESCRIPTION
## Description
Start /reference/entities with definition of "entity" rather than explanation of agent entities. The definition was in the second paragraph for some reason, so I just reversed the order of the first and second paragraphs.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1872