### PR TITLE
Add missing - in 3.6.2 TOC link

### DIFF
--- a/content/sensu-enterprise/3.6/changelog.md
+++ b/content/sensu-enterprise/3.6/changelog.md
@@ -11,7 +11,7 @@ _NOTE: Sensu Enterprise is built on Sensu Core. Sensu Core changes are documente
 
 ## Releases
 
-- [Enterprise 3.6.2 Release Notes](#enterprise v3-6-2)
+- [Enterprise 3.6.2 Release Notes](#enterprise-v3-6-2)
 - [Enterprise 3.6.1 Release Notes](#enterprise-v3-6-1)
 - [Enterprise 3.6.0 Release Notes](#enterprise-v3-6-0)
 - [Enterprise 3.5.0 Release Notes](#enterprise-v3-5-0)


### PR DESCRIPTION
Adds a missing hyphen in TOC link for 3.6.2 release notes so link will work