### PR TITLE
Add note re: GET /checks does not include standalone checks

### DIFF
--- a/content/sensu-core/0.29/api/checks.md
+++ b/content/sensu-core/0.29/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.0/api/checks.md
+++ b/content/sensu-core/1.0/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.1/api/checks.md
+++ b/content/sensu-core/1.1/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.2/api/checks.md
+++ b/content/sensu-core/1.2/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.3/api/checks.md
+++ b/content/sensu-core/1.3/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.4/api/checks.md
+++ b/content/sensu-core/1.4/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.5/api/checks.md
+++ b/content/sensu-core/1.5/api/checks.md
@@ -25,6 +25,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.6/api/checks.md
+++ b/content/sensu-core/1.6/api/checks.md
@@ -26,6 +26,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.7/api/checks.md
+++ b/content/sensu-core/1.7/api/checks.md
@@ -26,6 +26,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in

--- a/content/sensu-core/1.8/api/checks.md
+++ b/content/sensu-core/1.8/api/checks.md
@@ -26,6 +26,8 @@ menu:
 The `/checks` API endpoint provides HTTP GET access to [subscription check][1]
 data.
 
+_**NOTE**: `GET /checks` responses do not include checks that are configured as [standalone checks][5]._
+
 #### EXAMPLE {#checks-get-example}
 
 The following example demonstrates a request to the `/checks` API, resulting in
@@ -265,3 +267,4 @@ response codes  | <ul><li>**Success**: 202 (Accepted)</li><li>**Malformed**: 400
 [2]:  ../../reference/checks#check-configuration
 [3]:  https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
 [4]:  ../overview#pagination
+[5]:  ../../reference/checks#standalone-checks


### PR DESCRIPTION
## Description
Add note explaining that the GET /checks response does not include standalone checks.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/123