### PR TITLE
Add expected errors for backend startup

### DIFF
--- a/content/sensu-go/5.0/guides/troubleshooting.md
+++ b/content/sensu-go/5.0/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,5 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/
+

--- a/content/sensu-go/5.1/guides/troubleshooting.md
+++ b/content/sensu-go/5.1/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.10/guides/troubleshooting.md
+++ b/content/sensu-go/5.10/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -318,3 +332,5 @@ Which would allow the asset to be downloaded onto the target entity.
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: ../securing-sensu/#sensu-agent-tls-authentication
+[4]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.11/guides/troubleshooting.md
+++ b/content/sensu-go/5.11/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -318,3 +332,4 @@ Which would allow the asset to be downloaded onto the target entity.
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.12/guides/troubleshooting.md
+++ b/content/sensu-go/5.12/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -318,3 +332,4 @@ Which would allow the asset to be downloaded onto the target entity.
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.13/guides/troubleshooting.md
+++ b/content/sensu-go/5.13/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -318,3 +332,4 @@ Which would allow the asset to be downloaded onto the target entity.
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.14/guides/troubleshooting.md
+++ b/content/sensu-go/5.14/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+[TLS configuration][3] is recommended but not required. For more information, see [etcd security documentation][4].
 
 ## Permission issues
 
@@ -318,3 +332,5 @@ Which would allow the asset to be downloaded onto the target entity.
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: ../securing-sensu/#sensu-agent-tls-authentication
+[4]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.15/guides/troubleshooting.md
+++ b/content/sensu-go/5.15/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+[TLS configuration][3] is recommended but not required. For more information, see [etcd security documentation][4].
 
 ## Permission issues
 
@@ -318,3 +332,5 @@ Which would allow the asset to be downloaded onto the target entity.
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: ../securing-sensu/#sensu-agent-tls-authentication
+[4]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.2/guides/troubleshooting.md
+++ b/content/sensu-go/5.2/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.3/guides/troubleshooting.md
+++ b/content/sensu-go/5.3/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.4/guides/troubleshooting.md
+++ b/content/sensu-go/5.4/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.5/guides/troubleshooting.md
+++ b/content/sensu-go/5.5/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.6/guides/troubleshooting.md
+++ b/content/sensu-go/5.6/guides/troubleshooting.md
@@ -13,6 +13,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -74,6 +75,19 @@ following those logs are described. The name of the desired service, e.g.
 
 _NOTE: Platform versions described above are for reference only and do not
 supercede the documented [supported platforms][platforms]._
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][1].
 
 ## Permission issues
 
@@ -181,3 +195,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [journald-syslog]: ../systemd-logs
+[1]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.7/guides/troubleshooting.md
+++ b/content/sensu-go/5.7/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -96,6 +97,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -205,3 +219,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.8/guides/troubleshooting.md
+++ b/content/sensu-go/5.8/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 
@@ -96,6 +97,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -205,3 +219,4 @@ _NOTE: When multiple Sensu backends are configured in a cluster, event processin
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: https://etcd.io/docs/v3.4.0/op-guide/security/

--- a/content/sensu-go/5.9/guides/troubleshooting.md
+++ b/content/sensu-go/5.9/guides/troubleshooting.md
@@ -14,6 +14,7 @@ menu:
 - [Service logging](#service-logging)
 	- [Log levels](#log-levels)
 	- [Log file locations](#log-file-locations)
+- [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
 - [Assets not working properly](#asset-issues)
@@ -97,6 +98,19 @@ Get-Content -  Path "C:\scripts\test.txt" -Wait
 {{< /highlight >}}
 
 {{< platformBlockClose >}}
+
+## Sensu backend startup errors
+
+The following errors are expected when starting up a Sensu backend with the default configuration.
+
+{{< highlight shell >}}
+{"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
+{{< /highlight >}}
+
+The `serving insecure client requests` error is an expected warning from etcd.
+TLS configuration is recommended but not required. For more information, see [etcd security documentation][3].
 
 ## Permission issues
 
@@ -309,14 +323,13 @@ or
 Which would allow the asset to be downloaded onto the target entity.
 
 [agent-api]: ../../reference/agent#events-post
-
 [structured]: https://dzone.com/articles/what-is-structured-logging
 [journalctl]: https://www.digitalocean.com/community/tutorials/how-to-use-journalctl-to-view-and-manipulate-systemd-logs
 [platforms]: ../../installation/platforms
 [agent-ref]: ../../reference/agent/#restarting-the-service
 [backend-ref]: ../../reference/backend/#restarting-the-service
 [asset-ref]: ../../reference/assets/#asset-definition-multiple-builds
-
 [journald-syslog]: ../systemd-logs
 [1]: ../../reference/agent#operation
 [2]: ../../installation/verify
+[3]: https://etcd.io/docs/v3.4.0/op-guide/security/


### PR DESCRIPTION
## Description
Add list of expected errors when starting up the Sensu backend with the default configuration, plus additional explanation for one of these errors.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/426


If this is 👍 I will propagate for all Go versions