### PR TITLE
Move CentOS 8 package and remove licensed tier

### DIFF
--- a/content/sensu-go/5.14/release-notes.md
+++ b/content/sensu-go/5.14/release-notes.md
@@ -49,13 +49,10 @@ Read the [upgrade guide][1] for information on upgrading to the latest version o
 
 See the [upgrade guide][1] to upgrade Sensu to version 5.14.2.
 
-**NEW FEATURES**
-
-- ([Licensed tier][79]) Added build package for CentOS 8 (`el/8`).
-
 **IMPROVEMENTS:**
 
 - Upgraded etcd to 3.3.17.
+- Added build package for CentOS 8 (`el/8`).
 - Sensu Go now uses serializable event reads, which helps improve performance.
 
 **FIXES:**


### PR DESCRIPTION
Correction to align with language used for other packages in release notes. For other packages, we did not designate packages as "Licensed tier."