### PR TITLE
Add missing `.gz` from FreeBSD AMD64 tar link

### DIFF
--- a/content/sensu-go/5.14/installation/verify.md
+++ b/content/sensu-go/5.14/installation/verify.md
@@ -187,7 +187,7 @@ Now that you’ve installed Sensu:
 [29]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_windows_386.zip
 [30]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_darwin_amd64.tar.gz
 [31]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_darwin_amd64.zip
-[32]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_freebsd_amd64.tar
+[32]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_freebsd_amd64.tar.gz
 [33]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_freebsd_amd64.zip
 [34]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_freebsd_386.tar.gz
 [35]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_freebsd_386.zip


### PR DESCRIPTION
`.gz` missing from https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.2/sensu-go_5.14.2_freebsd_amd64.tar link