### PR TITLE
Fix all links in top-of-page TOCs in Go docs

### DIFF
--- a/content/sensu-go/5.0/api/cluster-roles.md
+++ b/content/sensu-go/5.0/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.0/guides/securing-sensu.md
+++ b/content/sensu-go/5.0/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.0/reference/backend.md
+++ b/content/sensu-go/5.0/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -53,7 +53,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.1/api/cluster-roles.md
+++ b/content/sensu-go/5.1/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.1/guides/securing-sensu.md
+++ b/content/sensu-go/5.1/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.1/reference/backend.md
+++ b/content/sensu-go/5.1/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -53,7 +53,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.10/api/cluster-roles.md
+++ b/content/sensu-go/5.10/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.10/guides/securing-sensu.md
+++ b/content/sensu-go/5.10/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.10/guides/troubleshooting.md
+++ b/content/sensu-go/5.10/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.10/reference/assets.md
+++ b/content/sensu-go/5.10/reference/assets.md
@@ -17,7 +17,7 @@ menu:
 - [Asset specification](#asset-specification)
 - [Examples](#examples)
 - [Sharing an asset on Bonsai](#sharing-an-asset-on-bonsai)
-- [Deleting Assets](#deleting-assets)
+- [Deleting assets](#deleting-assets)
 
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read the [guide to using assets][23] to get started.
@@ -841,7 +841,7 @@ example      | {{< highlight yml >}}
   -  "entity.system.arch == 'amd64'"
 {{< /highlight >}}
 
-## Deleting Assets
+## Deleting assets
 
 As of Sensu Go 5.12, assets can be deleted using the `/assets (DELETE)` endpoint, or via `sensuctl` (`sensuctl asset delete`). Note that when an asset is removed from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (checks, filters, mutators, handlers, hooks). You must also update resources and remove any reference to the deleted asset. Failure to do so will result in errors like: `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/5.10/reference/backend.md
+++ b/content/sensu-go/5.10/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -25,7 +25,7 @@ menu:
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
   - [Event logging](#event-logging)
-  - [Example](/sensu-go/5.10/files/backend.yml)
+  - [Example](/sensu-go/5.10/files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -55,7 +55,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.11/api/cluster-roles.md
+++ b/content/sensu-go/5.11/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.11/guides/securing-sensu.md
+++ b/content/sensu-go/5.11/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.11/guides/troubleshooting.md
+++ b/content/sensu-go/5.11/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.11/reference/assets.md
+++ b/content/sensu-go/5.11/reference/assets.md
@@ -17,7 +17,7 @@ menu:
 - [Asset specification](#asset-specification)
 - [Examples](#examples)
 - [Sharing an asset on Bonsai](#sharing-an-asset-on-bonsai)
-- [Deleting Assets](#deleting-assets)
+- [Deleting assets](#deleting-assets)
 
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read the [guide to using assets][23] to get started.
@@ -841,7 +841,7 @@ example      | {{< highlight yml >}}
   -  "entity.system.arch == 'amd64'"
 {{< /highlight >}}
 
-## Deleting Assets
+## Deleting assets
 
 As of Sensu Go 5.12, assets can be deleted using the `/assets (DELETE)` endpoint, or via `sensuctl` (`sensuctl asset delete`). Note that when an asset is removed from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (checks, filters, mutators, handlers, hooks). You must also update resources and remove any reference to the deleted asset. Failure to do so will result in errors like: `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/5.11/reference/backend.md
+++ b/content/sensu-go/5.11/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -26,7 +26,7 @@ menu:
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
   - [Advanced configuration options](#advanced-configuration-options)
   - [Event logging](#event-logging)
-  - [Example](../../files/backend.yml)
+  - [Example](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -56,7 +56,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.12/api/cluster-roles.md
+++ b/content/sensu-go/5.12/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.12/guides/securing-sensu.md
+++ b/content/sensu-go/5.12/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.12/guides/troubleshooting.md
+++ b/content/sensu-go/5.12/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.12/reference/assets.md
+++ b/content/sensu-go/5.12/reference/assets.md
@@ -17,7 +17,7 @@ menu:
 - [Asset specification](#asset-specification)
 - [Examples](#examples)
 - [Sharing an asset on Bonsai](#sharing-an-asset-on-bonsai)
-- [Deleting Assets](#deleting-assets)
+- [Deleting assets](#deleting-assets)
 
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read the [guide to using assets][23] to get started.
@@ -841,7 +841,7 @@ example      | {{< highlight yml >}}
   -  "entity.system.arch == 'amd64'"
 {{< /highlight >}}
 
-## Deleting Assets
+## Deleting assets
 
 As of Sensu Go 5.12, assets can be deleted using the `/assets (DELETE)` endpoint, or via `sensuctl` (`sensuctl asset delete`). Note that when an asset is removed from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (checks, filters, mutators, handlers, hooks). You must also update resources and remove any reference to the deleted asset. Failure to do so will result in errors like: `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/5.12/reference/backend.md
+++ b/content/sensu-go/5.12/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -26,7 +26,7 @@ menu:
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
   - [Advanced configuration options](#advanced-configuration-options)
   - [Event logging](#event-logging)
-  - [Example](../../files/backend.yml)
+  - [Example](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -56,7 +56,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.13/api/cluster-roles.md
+++ b/content/sensu-go/5.13/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.13/guides/securing-sensu.md
+++ b/content/sensu-go/5.13/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.13/guides/troubleshooting.md
+++ b/content/sensu-go/5.13/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.13/reference/assets.md
+++ b/content/sensu-go/5.13/reference/assets.md
@@ -17,7 +17,7 @@ menu:
 - [Asset specification](#asset-specification)
 - [Examples](#examples)
 - [Sharing an asset on Bonsai](#sharing-an-asset-on-bonsai)
-- [Deleting Assets](#deleting-assets)
+- [Deleting assets](#deleting-assets)
 
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read the [guide to using assets][23] to get started.
@@ -841,7 +841,7 @@ example      | {{< highlight yml >}}
   -  "entity.system.arch == 'amd64'"
 {{< /highlight >}}
 
-## Deleting Assets
+## Deleting assets
 
 As of Sensu Go 5.12, assets can be deleted using the `/assets (DELETE)` endpoint, or via `sensuctl` (`sensuctl asset delete`). Note that when an asset is removed from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (checks, filters, mutators, handlers, hooks). You must also update resources and remove any reference to the deleted asset. Failure to do so will result in errors like: `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/5.13/reference/backend.md
+++ b/content/sensu-go/5.13/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -26,7 +26,7 @@ menu:
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
   - [Advanced configuration options](#advanced-configuration-options)
   - [Event logging](#event-logging)
-  - [Example](../../files/backend.yml)
+  - [Example](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -56,7 +56,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.14/api/cluster-roles.md
+++ b/content/sensu-go/5.14/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.14/guides/clustering.md
+++ b/content/sensu-go/5.14/guides/clustering.md
@@ -18,10 +18,6 @@ menu:
 - [Cluster health](#cluster-health)
 - [Managing cluster members](#add-a-cluster-member)
 - [Security](#security)
-  - [Client-to-server transport security with HTTPS](#client-to-server-with-https)
-  - [Client-to-server authentication with HTTPS client certificates](#client-to-server-auth-with-https)
-  - [Peer communication authentication with HTTPS client certificates](#peer-auth-https)
-  - [Sensu agent with HTTPS](#sensu-agent-https)
 - [Using an external etcd cluster](#using-an-external-etcd-cluster)
 - [Troubleshooting](#troubleshooting)
 

--- a/content/sensu-go/5.14/guides/securing-sensu.md
+++ b/content/sensu-go/5.14/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [Etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 * [Sensu agent TLS authentication](#sensu-agent-tls-authentication)
 * [Creating self-signed certificates](#creating-self-signed-certificates)

--- a/content/sensu-go/5.14/guides/troubleshooting.md
+++ b/content/sensu-go/5.14/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.14/reference/assets.md
+++ b/content/sensu-go/5.14/reference/assets.md
@@ -17,7 +17,7 @@ menu:
 - [Asset specification](#asset-specification)
 - [Examples](#examples)
 - [Sharing an asset on Bonsai](#sharing-an-asset-on-bonsai)
-- [Deleting Assets](#deleting-assets)
+- [Deleting assets](#deleting-assets)
 
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read the [guide to using assets][23] to get started.
@@ -841,7 +841,7 @@ example      | {{< highlight yml >}}
   -  "entity.system.arch == 'amd64'"
 {{< /highlight >}}
 
-## Deleting Assets
+## Deleting assets
 
 As of Sensu Go 5.12, assets can be deleted using the `/assets (DELETE)` endpoint, or via `sensuctl` (`sensuctl asset delete`). Note that when an asset is removed from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (checks, filters, mutators, handlers, hooks). You must also update resources and remove any reference to the deleted asset. Failure to do so will result in errors like: `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/5.14/reference/backend.md
+++ b/content/sensu-go/5.14/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -26,7 +26,7 @@ menu:
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
   - [Advanced configuration options](#advanced-configuration-options)
   - [Event logging](#event-logging)
-  - [Example](../../files/backend.yml)
+  - [Example](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -56,7 +56,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.15/api/cluster-roles.md
+++ b/content/sensu-go/5.15/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.15/guides/clustering.md
+++ b/content/sensu-go/5.15/guides/clustering.md
@@ -18,10 +18,6 @@ menu:
 - [Cluster health](#cluster-health)
 - [Managing cluster members](#add-a-cluster-member)
 - [Security](#security)
-  - [Client-to-server transport security with HTTPS](#client-to-server-with-https)
-  - [Client-to-server authentication with HTTPS client certificates](#client-to-server-auth-with-https)
-  - [Peer communication authentication with HTTPS client certificates](#peer-auth-https)
-  - [Sensu agent with HTTPS](#sensu-agent-https)
 - [Using an external etcd cluster](#using-an-external-etcd-cluster)
 - [Troubleshooting](#troubleshooting)
 

--- a/content/sensu-go/5.15/guides/securing-sensu.md
+++ b/content/sensu-go/5.15/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [Etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 * [Sensu agent TLS authentication](#sensu-agent-tls-authentication)
 * [Generating certificates with cfssl](#generating-certificates)

--- a/content/sensu-go/5.15/guides/troubleshooting.md
+++ b/content/sensu-go/5.15/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.15/reference/assets.md
+++ b/content/sensu-go/5.15/reference/assets.md
@@ -17,7 +17,7 @@ menu:
 - [Asset specification](#asset-specification)
 - [Examples](#examples)
 - [Sharing an asset on Bonsai](#sharing-an-asset-on-bonsai)
-- [Deleting Assets](#deleting-assets)
+- [Deleting assets](#deleting-assets)
 
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read the [guide to using assets][23] to get started.
@@ -841,7 +841,7 @@ example      | {{< highlight yml >}}
   -  "entity.system.arch == 'amd64'"
 {{< /highlight >}}
 
-## Deleting Assets
+## Deleting assets
 
 As of Sensu Go 5.12, assets can be deleted using the `/assets (DELETE)` endpoint, or via `sensuctl` (`sensuctl asset delete`). Note that when an asset is removed from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (checks, filters, mutators, handlers, hooks). You must also update resources and remove any reference to the deleted asset. Failure to do so will result in errors like: `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/5.15/reference/backend.md
+++ b/content/sensu-go/5.15/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -27,7 +27,7 @@ menu:
   - [Advanced configuration options](#advanced-configuration-options)
   - [Configuration via environment variables](#configuration-via-environment-variables)
   - [Event logging](#event-logging)
-  - [Example](../../files/backend.yml)
+  - [Example](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -57,7 +57,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.2/api/cluster-roles.md
+++ b/content/sensu-go/5.2/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.2/guides/securing-sensu.md
+++ b/content/sensu-go/5.2/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.2/reference/backend.md
+++ b/content/sensu-go/5.2/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -53,7 +53,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.3/api/cluster-roles.md
+++ b/content/sensu-go/5.3/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.3/guides/securing-sensu.md
+++ b/content/sensu-go/5.3/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.3/reference/backend.md
+++ b/content/sensu-go/5.3/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -53,7 +53,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.4/api/cluster-roles.md
+++ b/content/sensu-go/5.4/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.4/guides/securing-sensu.md
+++ b/content/sensu-go/5.4/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.4/reference/backend.md
+++ b/content/sensu-go/5.4/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -53,7 +53,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.5/api/cluster-roles.md
+++ b/content/sensu-go/5.5/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.5/guides/securing-sensu.md
+++ b/content/sensu-go/5.5/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.5/reference/backend.md
+++ b/content/sensu-go/5.5/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -24,7 +24,7 @@ menu:
   - [Security configuration](#security-configuration-flags)
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
-  - [Example](/sensu-go/5.5/files/backend.yml)
+  - [Example](/sensu-go/5.5/files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -54,7 +54,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.6/api/cluster-roles.md
+++ b/content/sensu-go/5.6/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.6/guides/securing-sensu.md
+++ b/content/sensu-go/5.6/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.6/reference/backend.md
+++ b/content/sensu-go/5.6/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -24,7 +24,7 @@ menu:
   - [Security configuration](#security-configuration-flags)
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
-  - [Example](/sensu-go/5.6/files/backend.yml)
+  - [Example](/sensu-go/5.6/files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -54,7 +54,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.7/api/cluster-roles.md
+++ b/content/sensu-go/5.7/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.7/guides/securing-sensu.md
+++ b/content/sensu-go/5.7/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.7/reference/backend.md
+++ b/content/sensu-go/5.7/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -24,7 +24,7 @@ menu:
   - [Security configuration](#security-configuration-flags)
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
-  - [Example](/sensu-go/5.7/files/backend.yml)
+  - [Example](/sensu-go/5.7/files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -54,7 +54,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.8/api/cluster-roles.md
+++ b/content/sensu-go/5.8/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.8/guides/securing-sensu.md
+++ b/content/sensu-go/5.8/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.8/reference/backend.md
+++ b/content/sensu-go/5.8/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -24,7 +24,7 @@ menu:
   - [Security configuration](#security-configuration-flags)
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
-  - [Example](/sensu-go/5.8/files/backend.yml)
+  - [Example](/sensu-go/5.8/files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -54,7 +54,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 

--- a/content/sensu-go/5.9/api/cluster-roles.md
+++ b/content/sensu-go/5.9/api/cluster-roles.md
@@ -14,7 +14,7 @@ menu:
 	- [`/clusterroles` (POST)](#clusterroles-post)
 - [The `/clusterroles/:clusterrole` API endpoint](#the-clusterrolesclusterrole-api-endpoint)
 	- [`/clusterroles/:clusterrole` (GET)](#clusterrolesclusterrole-get)
-  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolescluster-put)
+  - [`/clusterroles/:clusterrole` (PUT)](#clusterrolesclusterrole-put)
   - [`/clusterroles/:clusterrole` (DELETE)](#clusterrolesclusterrole-delete)
 
 ## The `/clusterroles` API endpoint

--- a/content/sensu-go/5.9/guides/securing-sensu.md
+++ b/content/sensu-go/5.9/guides/securing-sensu.md
@@ -13,8 +13,7 @@ menu:
 As with any piece of software, it is critical to minimize any attack surface exposed by the software. Sensu is no different. The following component pieces need to be secured in order for Sensu to be considered production ready:
 
 * [etcd peer communication](#securing-etcd-peer-communication)
-* [Backend API](#securing-the-api-and-the-dashboard)
-* [Dashboard](#securing-the-api-and-the-dashboard)
+* [API and dashboard](#securing-the-api-and-the-dashboard)
 * [Sensu agent to server communication](#securing-sensu-agent-to-server-communication)
 
 We'll cover securing each one of those pieces, starting with etcd peer communication.

--- a/content/sensu-go/5.9/guides/troubleshooting.md
+++ b/content/sensu-go/5.9/guides/troubleshooting.md
@@ -17,7 +17,7 @@ menu:
 - [Sensu backend startup errors](#sensu-backend-startup-errors)
 - [Permission issues](#permission-issues)
 - [Handlers and filters](#troubleshooting-handlers-and-filters)
-- [Assets not working properly](#asset-issues)
+- [Assets](#asset-issues)
 
 ## Service logging
 

--- a/content/sensu-go/5.9/reference/backend.md
+++ b/content/sensu-go/5.9/reference/backend.md
@@ -13,8 +13,8 @@ menu:
 
 - [Installation][1]
 - [Creating event pipelines](#event-pipeline)
-- [Scheduling checks](#check-scheduling)
-- [Service management](#operation)
+- [Check scheduling](#check-scheduling)
+- [Operation and service management](#operation)
   - [Starting and stopping the service](#starting-the-service)
   - [Clustering](#clustering)
   - [Time synchronization](#time-synchronization)
@@ -25,7 +25,7 @@ menu:
   - [Dashboard configuration](#dashboard-configuration-flags)
   - [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags)
   - [Event logging](#event-logging)
-  - [Example](/sensu-go/5.9/files/backend.yml)
+  - [Example](/sensu-go/5.9/files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, [Sensu dashboard][6], and `sensu-backend` command-line tool.
@@ -55,7 +55,7 @@ For information about creating and managing checks, see:
 - [Guide to collecting metrics with checks][4]
 - [Checks reference documentation][5]
 
-## Operation
+## Operation and service management {#operation}
 
 _NOTE: Commands in this section may require administrative privileges._
 


### PR DESCRIPTION
## Description
Fixes all broken/changed links in top-of-page tables of contents in Sensu Go docs. Removes TOC items that are no longer part of the doc where appropriate.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1771
