### PR TITLE
update grunt-env dependency to address lodash security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "bin/test"
   },
   "dependencies": {
-    "grunt-env": "^0.4.4",
+    "grunt-env": "^1.0.1",
     "hugo-cli": "^0.10.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,13 +1149,13 @@ grunt-contrib-watch@^1.1.0:
     lodash "^4.17.10"
     tiny-lr "^1.1.1"
 
-grunt-env@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/grunt-env/-/grunt-env-0.4.4.tgz#3b38843a8d737177ddc9f893879fb69ce1a0bc2f"
-  integrity sha1-OziEOo1zcXfdyfiTh5+2nOGgvC8=
+grunt-env@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/grunt-env/-/grunt-env-1.0.1.tgz#3738e862b61fae51184d8aa3c831284a33c2cf38"
+  integrity sha512-Hw4iIJ58yYA8kJaP4UUyfw807DUI1FRnow9hhRMnq366bwCnxiBWOgfZsYilcs3Jh1qsGC/i3+G+7/W18hA1TA==
   dependencies:
-    ini "~1.3.0"
-    lodash "~2.4.1"
+    ini "^1.3.5"
+    lodash "^4.17.14"
 
 grunt-known-options@~1.1.0:
   version "1.1.1"
@@ -1382,7 +1382,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@~1.3.0:
+ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -1616,11 +1616,6 @@ lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@~4.17.1
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
-  integrity sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
## Description

Updates dependency on grunt-env from `^0.4.4` to` ^1.0.1`

## Motivation and Context

Github security advisory on lodash < 4.17.13 seems to be stemming from 0.4.4 dependency on a much older version of lodash.

[Changes in grunt-env](https://github.com/jsoverson/grunt-env/compare/0.4.4..v1.0.1) seem minimal enough to accept provided that CI passes.

## Review Instructions
<!--- Optional -->
