### PR TITLE
Add timezone to cron attribute table

### DIFF
--- a/content/sensu-go/5.15/reference/checks.md
+++ b/content/sensu-go/5.15/reference/checks.md
@@ -573,7 +573,7 @@ example      | {{< highlight shell >}}"interval": 60{{< /highlight >}}
 
 |cron        |      |
 -------------|------
-description  | When the check should be executed, using [cron syntax][14] or [these predefined schedules][15].
+description  | When the check should be executed, using [cron syntax][14] or [these predefined schedules][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute.
 required     | true (unless `interval` is configured)
 type         | String
 example      | {{< highlight shell >}}"cron": "0 0 * * *"{{< /highlight >}}


### PR DESCRIPTION
@nikkixdev just realized we should probably add the timezone info to the `cron` attribute table further along in the doc too.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1933
