### PR TITLE
Add missing replicator elements ca_cert, cert, and key

### DIFF
--- a/content/sensu-go/5.15/api/federation.md
+++ b/content/sensu-go/5.15/api/federation.md
@@ -46,7 +46,10 @@ curl http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators -H "Aut
       "name": "my_replicator"
     },
     "spec": {
-      "insecure": true,
+      "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+      "cert": "/path/to/ssl/cert.pem",
+      "key": "/path/to/ssl/key.pem",
+      "insecure": false,
       "url": "http://remote-etcd.example.com:2379",
       "api_version": "core/v2",
       "resource": "CheckConfig",
@@ -73,7 +76,10 @@ output         | {{< highlight shell >}}
       "name": "my_replicator"
     },
     "spec": {
-      "insecure": true,
+      "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+      "cert": "/path/to/ssl/cert.pem",
+      "key": "/path/to/ssl/key.pem",
+      "insecure": false,
       "url": "http://remote-etcd.example.com:2379",
       "api_version": "core/v2",
       "resource": "CheckConfig",
@@ -97,7 +103,10 @@ payload         | {{< highlight shell >}}
     "name": "my_replicator"
   },
   "spec": {
-    "insecure": true,
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
+    "insecure": false,
     "url": "http://remote-etcd.example.com:2379",
     "api_version": "core/v2",
     "resource": "CheckConfig",
@@ -126,7 +135,10 @@ curl http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_repl
     "name": "my_replicator"
   },
   "spec": {
-    "insecure": true,
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
+    "insecure": false,
     "url": "http://remote-etcd.example.com:2379",
     "api_version": "core/v2",
     "resource": "CheckConfig",
@@ -151,7 +163,10 @@ output               | {{< highlight json >}}
     "name": "my_replicator"
   },
   "spec": {
-    "insecure": true,
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
+    "insecure": false,
     "url": "http://remote-etcd.example.com:2379",
     "api_version": "core/v2",
     "resource": "CheckConfig",
@@ -177,7 +192,10 @@ curl -X PUT \
     "name": "my_replicator"
   },
   "spec": {
-    "insecure": true,
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
+    "insecure": false,
     "url": "http://remote-etcd.example.com:2379",
     "api_version": "core/v2",
     "resource": "CheckConfig",
@@ -203,7 +221,10 @@ payload         | {{< highlight shell >}}
     "name": "my_replicator"
   },
   "spec": {
-    "insecure": true,
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
+    "insecure": false,
     "url": "http://remote-etcd.example.com:2379",
     "api_version": "core/v2",
     "resource": "CheckConfig",

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -61,12 +61,15 @@ example      | {{< highlight shell >}}api_version: federation/v1{{< /highlight >
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the replicator `name`.
+description  | Top-level scope that contains the replicator `name`, `ca_cert`, `cert`, and `key`.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 metadata:
   name: my_replicator
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  key: /path/to/ssl/key.pem
 {{< /highlight >}}
 
 spec         |      |
@@ -91,6 +94,27 @@ description  | The replicator name used internally by Sensu.
 required     | true
 type         | String
 example      | {{< highlight shell >}}name: my_replicator{{< /highlight >}}
+
+ca_cert      |      |
+-------------|------
+description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
+required     | true
+type         | String
+example      | {{< highlight shell >}}ca_cert: /path/to/trusted-certificate-authorities.pem{{< /highlight >}}
+
+cert         |      |
+-------------|------
+description  | Path to the PEM-format certificate to use for TLS client authentication.
+required     | true
+type         | String
+example      | {{< highlight shell >}}cert: /path/to/ssl/cert.pem{{< /highlight >}}
+
+key          |      |
+-------------|------
+description  | Path to the PEM-format key file associated with the `cert` to use for TLS client authentication.
+required     | true
+type         | String
+example      | {{< highlight shell >}}key: /path/to/ssl/key.pem{{< /highlight >}}
 
 #### Spec attributes
 
@@ -178,6 +202,9 @@ api_version: federation/v1
 type: EtcdReplicator
 metadata:
   name: rolebinding_replicator
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  key: /path/to/ssl/key.pem
 spec:
   insecure: false
   url: http://127.0.0.1:3379
@@ -191,7 +218,10 @@ spec:
   "api_version": "federation/v1",
   "type": "EtcdReplicator",
   "metadata": {
-    "name": "rolebinding_replicator"
+    "name": "rolebinding_replicator",
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem"
   },
   "spec": {
     "insecure": false,
@@ -214,6 +244,9 @@ api_version: federation/v1
 type: EtcdReplicator
 metadata:
   name: clusterrole_replicator
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  key: /path/to/ssl/key.pem
 spec:
   insecure: false
   url: http://127.0.0.1:3379
@@ -228,6 +261,9 @@ spec:
   "type": "EtcdReplicator",
   "metadata": {
     "name": "clusterrole_replicator"
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem"
   },
   "spec": {
     "insecure": false,
@@ -250,6 +286,9 @@ api_version: federation/v1
 type: EtcdReplicator
 metadata:
   name: clusterrolebinding_replicator
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  key: /path/to/ssl/key.pem
 spec:
   insecure: false
   url: http://127.0.0.1:3379
@@ -264,6 +303,9 @@ spec:
   "type": "EtcdReplicator",
   "metadata": {
     "name": "clusterrolebinding_replicator"
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem"
   },
   "spec": {
     "insecure": false,

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -61,15 +61,12 @@ example      | {{< highlight shell >}}api_version: federation/v1{{< /highlight >
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the replicator `name`, `ca_cert`, `cert`, and `key`.
+description  | Top-level scope that contains the replicator `name`.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 metadata:
   name: my_replicator
-  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
-  cert: /path/to/ssl/cert.pem
-  key: /path/to/ssl/key.pem
 {{< /highlight >}}
 
 spec         |      |
@@ -79,6 +76,9 @@ required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 spec:
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  key: /path/to/ssl/key.pem
   insecure: false
   url: http://127.0.0.1:3379
   api_version: core/v2
@@ -94,6 +94,8 @@ description  | The replicator name used internally by Sensu.
 required     | true
 type         | String
 example      | {{< highlight shell >}}name: my_replicator{{< /highlight >}}
+
+#### Spec attributes
 
 ca_cert      |      |
 -------------|------
@@ -115,8 +117,6 @@ description  | Path to the PEM-format key file associated with the `cert` to use
 required     | true
 type         | String
 example      | {{< highlight shell >}}key: /path/to/ssl/key.pem{{< /highlight >}}
-
-#### Spec attributes
 
 insecure     |      |
 -------------|-------
@@ -167,6 +167,9 @@ type: EtcdReplicator
 metadata:
   name: role_replicator
 spec:
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  key: /path/to/ssl/key.pem
   insecure: false
   url: http://127.0.0.1:3379
   api_version: core/v2
@@ -182,6 +185,9 @@ spec:
     "name": "role_replicator"
   },
   "spec": {
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
     "insecure": false,
     "url": "http://127.0.0.1:3379",
     "api_version": "core/v2",
@@ -202,10 +208,10 @@ api_version: federation/v1
 type: EtcdReplicator
 metadata:
   name: rolebinding_replicator
+spec:
   ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
   cert: /path/to/ssl/cert.pem
   key: /path/to/ssl/key.pem
-spec:
   insecure: false
   url: http://127.0.0.1:3379
   api_version: core/v2
@@ -218,12 +224,12 @@ spec:
   "api_version": "federation/v1",
   "type": "EtcdReplicator",
   "metadata": {
-    "name": "rolebinding_replicator",
-    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
-    "cert": "/path/to/ssl/cert.pem",
-    "key": "/path/to/ssl/key.pem"
+    "name": "rolebinding_replicator"
   },
   "spec": {
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
     "insecure": false,
     "url": "http://127.0.0.1:3379",
     "api_version": "core/v2",
@@ -244,10 +250,10 @@ api_version: federation/v1
 type: EtcdReplicator
 metadata:
   name: clusterrole_replicator
+spec:
   ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
   cert: /path/to/ssl/cert.pem
   key: /path/to/ssl/key.pem
-spec:
   insecure: false
   url: http://127.0.0.1:3379
   api_version: core/v2
@@ -261,11 +267,11 @@ spec:
   "type": "EtcdReplicator",
   "metadata": {
     "name": "clusterrole_replicator"
-    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
-    "cert": "/path/to/ssl/cert.pem",
-    "key": "/path/to/ssl/key.pem"
   },
   "spec": {
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
     "insecure": false,
     "url": "http://127.0.0.1:3379",
     "api_version": "core/v2",
@@ -286,10 +292,10 @@ api_version: federation/v1
 type: EtcdReplicator
 metadata:
   name: clusterrolebinding_replicator
+spec:
   ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
   cert: /path/to/ssl/cert.pem
   key: /path/to/ssl/key.pem
-spec:
   insecure: false
   url: http://127.0.0.1:3379
   api_version: core/v2
@@ -303,11 +309,11 @@ spec:
   "type": "EtcdReplicator",
   "metadata": {
     "name": "clusterrolebinding_replicator"
-    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
-    "cert": "/path/to/ssl/cert.pem",
-    "key": "/path/to/ssl/key.pem"
   },
   "spec": {
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "key": "/path/to/ssl/key.pem",
     "insecure": false,
     "url": "http://127.0.0.1:3379",
     "api_version": "core/v2",

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -100,21 +100,21 @@ example      | {{< highlight shell >}}name: my_replicator{{< /highlight >}}
 ca_cert      |      |
 -------------|------
 description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
-required     | true
+required     | true if `insecure: false` (which is the default configuration). If `insecure: true`, `ca_cert` is not required.
 type         | String
 example      | {{< highlight shell >}}ca_cert: /path/to/trusted-certificate-authorities.pem{{< /highlight >}}
 
 cert         |      |
 -------------|------
 description  | Path to the PEM-format certificate to use for TLS client authentication.
-required     | true
+required     | true if `insecure: false` (which is the default configuration). If `insecure: true`, `cert` is not required.
 type         | String
 example      | {{< highlight shell >}}cert: /path/to/ssl/cert.pem{{< /highlight >}}
 
 key          |      |
 -------------|------
 description  | Path to the PEM-format key file associated with the `cert` to use for TLS client authentication.
-required     | true
+required     | true if `insecure: false` (which is the default configuration). If `insecure: true`, `key` is not required.
 type         | String
 example      | {{< highlight shell >}}key: /path/to/ssl/key.pem{{< /highlight >}}
 


### PR DESCRIPTION
## Description
Add `ca_cert`, `cert`, and `key` to etcd replicators reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1937
