### PR TITLE
Add namespace field to EtcdReplicators

### DIFF
--- a/content/sensu-go/5.15/api/federation.md
+++ b/content/sensu-go/5.15/api/federation.md
@@ -36,6 +36,8 @@ The `/etcd-replicators` endpoint provides HTTP GET access to a list of replicato
 
 The following example demonstrates a request to the `/etcd-replicators` endpoint, resulting in a list of replicators.
 
+_**NOTE**: If you did not specify a [namespace][2] when you created a replicator, the response will not include a `namespace` key-value pair._
+
 {{< highlight shell >}}
 curl http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators -H "Authorization: Bearer $SENSU_TOKEN"
 [
@@ -91,6 +93,8 @@ output         | {{< highlight shell >}}
 
 ### `/etcd-replicators` (POST)
 
+_**NOTE**: If you do not specify a [namespace][2] when you create a replicator, all namespaces for the given resource are replicated._
+
 /etcd-replicators (POST) | 
 ----------------|------
 description     | Creates a new replicator (if none exists).
@@ -124,7 +128,9 @@ The `/etcd-replicators/:etcd-replicator` endpoint provides HTTP GET access to da
 
 #### EXAMPLE {#etcd-replicatorsetcd-replicator-get-example}
 
-In the following example, querying the `/etcd-replicators/:etcd-replicator` endpoing returns a JSON Map containing the requested `:etcd-replicator`.
+In the following example, querying the `/etcd-replicators/:etcd-replicator` endpoint returns a JSON Map containing the requested `:etcd-replicator`.
+
+_**NOTE**: If you did not specify a [namespace][2] when you created the replicator, the response will not include a `namespace` key-value pair._
 
 {{< highlight shell >}}
 curl http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator -H "Authorization: Bearer $SENSU_TOKEN"
@@ -328,7 +334,7 @@ The `/clusters/:cluster` endpoint provides HTTP GET access to data for a specifi
 
 #### EXAMPLE {#clusterscluster-get-example}
 
-In the following example, querying the `/clusters/:cluster` endpoing returns a JSON Map containing the requested `:etcd-replicator`.
+In the following example, querying the `/clusters/:cluster` endpoint returns a JSON Map containing the requested `:etcd-replicator`.
 
 {{< highlight shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" \
@@ -459,5 +465,6 @@ example url               | http://hostname:8080/api/enterprise/federation/v1/cl
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 
-[1]: /../../getting-started/enterprise/
+[1]: ../../getting-started/enterprise/
+[2]: ../../reference/etcdreplicators#namespace-attribute
 

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -61,7 +61,7 @@ example      | {{< highlight shell >}}api_version: federation/v1{{< /highlight >
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the replicator `name`. Namespace is not supported, as EtcdReplicators are cluster-wide resources.
+description  | Top-level scope that contains the replicator `name`. Namespace is not supported because EtcdReplicators are cluster-wide resources.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -61,7 +61,7 @@ example      | {{< highlight shell >}}api_version: federation/v1{{< /highlight >
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the replicator `name`. Namespace is not supported because EtcdReplicators are cluster-wide resources.
+description  | Top-level scope that contains the replicator `name`. Namespace is not supported in the metadata because EtcdReplicators are cluster-wide resources.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -61,7 +61,7 @@ example      | {{< highlight shell >}}api_version: federation/v1{{< /highlight >
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the replicator `name`.
+description  | Top-level scope that contains the replicator `name`. Namespace is not supported, as EtcdReplicators are cluster-wide resources.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
@@ -145,6 +145,13 @@ description  | Name of the resource to replicate.
 required     | true
 type         | String
 example      | {{< highlight shell >}}resource: Role{{< /highlight >}}
+
+namespace    |      |
+-------------|-------
+description  | Namespace to constrain replication to. If not supplied, all namespaces for a given resource are replicated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}namespace: default{{< /highlight >}}
 
 replication_interval_seconds      |      |
 ----------------------------------|-------

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -166,7 +166,7 @@ example      | {{< highlight shell >}}replication_interval_seconds: 30{{< /highl
 
 If you replicate the following four examples for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources, you can expect a full replication of [RBAC policy][3].
 
-_**NOTE**: If you do not specify a [namespace][2] when you create a replicator, all namespaces for a given resource are replicated._
+_**NOTE**: If you do not specify a namespace when you create a replicator, all namespaces for a given resource are replicated._
 
 ### Example `Role` resource
 

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -148,7 +148,7 @@ example      | {{< highlight shell >}}resource: Role{{< /highlight >}}
 
 namespace    |      |
 -------------|-------
-description  | Namespace to constrain replication to. If not supplied, all namespaces for a given resource are replicated.
+description  | Namespace to constrain replication to. If you do not include `namespace`, all namespaces for a given resource are replicated.
 required     | false
 type         | String
 example      | {{< highlight shell >}}namespace: default{{< /highlight >}}

--- a/content/sensu-go/5.15/reference/etcdreplicators.md
+++ b/content/sensu-go/5.15/reference/etcdreplicators.md
@@ -12,8 +12,8 @@ menu:
 - [Create a replicator](#create-a-replicator)
 - [Delete a replicator](#delete-a-replicator)
 - [Replicator configuration](#replicator-configuration)
-- [etcd-replicators specification](#etcdreplicators-specification)
-- [Example etcd-replicators resources](#example-etcdreplicators-resources)
+- [etcd-replicators specification](#etcd-replicators-specification)
+- [Example etcd-replicators resources](#example-etcd-replicators-resources)
 
 **COMMERCIAL FEATURE**: Access the etcd-replicators datatype in the packaged Sensu Go distribution. For more information, see the [getting started guide][1].
 
@@ -146,6 +146,8 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}resource: Role{{< /highlight >}}
 
+<a name="namespace-attribute"></a>
+
 namespace    |      |
 -------------|-------
 description  | Namespace to constrain replication to. If you do not include `namespace`, all namespaces for a given resource are replicated.
@@ -163,6 +165,8 @@ example      | {{< highlight shell >}}replication_interval_seconds: 30{{< /highl
 ## Example etcd-replicators resources
 
 If you replicate the following four examples for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources, you can expect a full replication of [RBAC policy][3].
+
+_**NOTE**: If you do not specify a [namespace][2] when you create a replicator, all namespaces for a given resource are replicated._
 
 ### Example `Role` resource
 


### PR DESCRIPTION
A last minute change, the EtcdReplicator datatype has gained a
Namespace field, in order to resolve some issues stemming from an
implementation detail regarding namespaces.

This field is not represented in the metadata, as it does not
pertain to the replicator itself, but rather the resources that the
replicator will be replicating.

Signed-off-by: Eric Chlebek <eric@sensu.io>