### PR TITLE
Fix incorrect highlight syntax, broken relative links, missing description

### DIFF
--- a/content/sensu-go/5.10/guides/scale-event-storage.md
+++ b/content/sensu-go/5.10/guides/scale-event-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
 linkTitle: "Scaling with Enterprise datastore"
-description: ""
+description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
 weight: 39
 version: "5.10"
 product: "Sensu Go"
@@ -13,21 +13,21 @@ menu:
 
 Sensu Go's licensed-tier datastore feature enables scaling your monitoring to many thousands of events per second.
 
-- [Why use the Enterprise datastore?](#why-enterprise-datastore)
+- [Why use the Enterprise datastore?](#why-use-the-enterprise-datastore)
 - [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres-for-sensu)
-- [Configure Sensu](#configure-sensu-for-postgres)
-- [Revert to built-in datastore](#revert-to-builtin-datastore)
+- [Configure Postgres](#configure-postgres)
+- [Configure Sensu](#configure-sensu)
+- [Revert to built-in datastore](#revert-to-built-in-datastore)
 
-## Why use the Enterprise datastore? {#why-enterprise-datastore}
+## Why use the Enterprise datastore?
 
-For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization. 
+For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization.
 
-Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][2] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second. 
+Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][1] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
 
 This rate of events should be more than sufficient for many installations but assumes an ideal scenario where Sensu backend nodes use direct-attached, dedicated non-volatile memory express (NVMe) storage and are connected to a dedicated LAN. Deployments on public cloud providers are not likely to achieve similar results due to sharing both disk and network bandwidth with other tenants. Following the cloud provider's recommended practices may also become a factor because many operators are inclined to deploy a cluster across multiple availability zones. In such a deployment cluster, communication happens over shared WAN links, which are subject to uncontrolled variability in throughput and latency.
 
-Using the Enterprise datastore can help operators achieve much higher rates of event processing and minimize the replication communication between etcd peers. The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connections (and their keepalives) and processes more than 36,000 events per second under ideal conditions. 
+Using the Enterprise datastore can help operators achieve much higher rates of event processing and minimize the replication communication between etcd peers. The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connections (and their keepalives) and processes more than 36,000 events per second under ideal conditions.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Using the Enterprise datastore can help operators achieve much higher rates of e
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-## Configure Postgres {#configure-postgres-for-sensu}
+## Configure Postgres
 
 Before Sensu can start writing events to Postgres, you need a database and an account with permissions to write to that database. To provide consistent event throughput, we strongly recommend exclusively dedicating your Postgres instance to storage of Sensu events.
 
@@ -68,9 +68,9 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore](#revert-to-builtin-datastore) below._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore][2] below._
 
-## Configure Sensu {#configure-sensu-for-postgres}
+## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward. Create a `PostgresConfig` resource that describes the database connection as a data source name (DSN):
 
@@ -109,13 +109,13 @@ This configuration is written to disk as `my-postgres.yml`, and you can install 
 sensuctl create -f my-postgres.yml
 {{< /highlight >}}
 
-The Sensu backend is now configured to use Postgres for event storage! 
+The Sensu backend is now configured to use Postgres for event storage!
 
 In the web UI and in `sensuctl`, event history will appear incomplete. When Postgres configuration is provided and the backend successfully connects to the database, etcd event history is not migrated. New events will be written to Postgres as they are processed, with the Postgres datastore ultimately being brought up to date with the current state of your monitored infrastructure.
 
 Aside from event history, which is not migrated from etcd, there's no observable difference when using Postgres as the event store, and neither interface supports displaying the PostgresConfig type.
 
-To verify that the change was effective and your connection to Postgres was successful, look at the [`sensu-backend` log][4]:
+To verify that the change was effective and your connection to Postgres was successful, look at the [sensu-backend log][4]:
 
 {{< highlight shell >}}
 {"component":"store","level":"warning","msg":"trying to enable external event store","time":"2019-10-02T23:31:38Z"}
@@ -141,17 +141,18 @@ sensu_events=# select sensu_entity from events where sensu_check = 'keepalive';
  i-424242
  i-434343
 (3 rows)
-{{ /highlight }}
+{{< /highlight >}}
 
 
-### Revert to built-in datastore (#revert-to-builtin-datastore)
+## Revert to built-in datastore
 
 In Sensu Go 5.10 there is no supported method for viewing or deleting a PostgresConfig resource.
 To delete PostgresConfig resources and thereby revert to the built-in datastore, please upgrade to the latest version of Sensu Go.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd._
 
-[2]: https://github.com/sensu/sensu-perf
-[3]: ../getting-started/enterprise
-[4]: ../guides/troubleshooting/#log-file-locations
+[1]: https://github.com/sensu/sensu-perf
+[2]: #revert-to-built-in-datastore
+[3]: ../../getting-started/enterprise
+[4]: ../../guides/troubleshooting/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD

--- a/content/sensu-go/5.11/guides/scale-event-storage.md
+++ b/content/sensu-go/5.11/guides/scale-event-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
 linkTitle: "Scaling with Enterprise datastore"
-description: ""
+description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
 weight: 39
 version: "5.11"
 product: "Sensu Go"
@@ -13,17 +13,17 @@ menu:
 
 Sensu Go's licensed-tier datastore feature enables scaling your monitoring to many thousands of events per second.
 
-- [Why use the Enterprise datastore?](#why-enterprise-datastore)
+- [Why use the Enterprise datastore?](#why-use-the-enterprise-datastore)
 - [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres-for-sensu)
-- [Configure Sensu](#configure-sensu-for-postgres)
-- [Revert to built-in datastore](#revert-to-builtin-datastore)
+- [Configure Postgres](#configure-postgres)
+- [Configure Sensu](#configure-sensu)
+- [Revert to built-in datastore](#revert-to-built-in-datastore)
 
-## Why use the Enterprise datastore? {#why-enterprise-datastore}
+## Why use the Enterprise datastore?
 
 For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization.
 
-Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][2] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
+Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][1] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
 
 This rate of events should be more than sufficient for many installations but assumes an ideal scenario where Sensu backend nodes use direct-attached, dedicated non-volatile memory express (NVMe) storage and are connected to a dedicated LAN. Deployments on public cloud providers are not likely to achieve similar results due to sharing both disk and network bandwidth with other tenants. Following the cloud provider's recommended practices may also become a factor because many operators are inclined to deploy a cluster across multiple availability zones. In such a deployment cluster, communication happens over shared WAN links, which are subject to uncontrolled variability in throughput and latency.
 
@@ -36,7 +36,7 @@ Using the Enterprise datastore can help operators achieve much higher rates of e
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-## Configure Postgres {#configure-postgres-for-sensu}
+## Configure Postgres
 
 Before Sensu can start writing events to Postgres, you need a database and an account with permissions to write to that database. To provide consistent event throughput, we strongly recommend exclusively dedicating your Postgres instance to storage of Sensu events.
 
@@ -68,9 +68,9 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore](#revert-to-builtin-datastore) below._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore][2] below._
 
-## Configure Sensu {#configure-sensu-for-postgres}
+## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward. Create a `PostgresConfig` resource that describes the database connection as a data source name (DSN):
 
@@ -115,7 +115,7 @@ In the web UI and in `sensuctl`, event history will appear incomplete. When Post
 
 Aside from event history, which is not migrated from etcd, there's no observable difference when using Postgres as the event store, and neither interface supports displaying the PostgresConfig type.
 
-To verify that the change was effective and your connection to Postgres was successful, look at the [`sensu-backend` log][4]:
+To verify that the change was effective and your connection to Postgres was successful, look at the [sensu-backend log][4]:
 
 {{< highlight shell >}}
 {"component":"store","level":"warning","msg":"trying to enable external event store","time":"2019-10-02T23:31:38Z"}
@@ -141,10 +141,10 @@ sensu_events=# select sensu_entity from events where sensu_check = 'keepalive';
  i-424242
  i-434343
 (3 rows)
-{{ /highlight }}
+{{< /highlight >}}
 
 
-### Revert to built-in datastore (#revert-to-builtin-datastore)
+## Revert to built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource. In this example, my-postgres.yml contains the same configuration you used to configure the enterprise event store earlier in this guide:
 
@@ -161,9 +161,11 @@ To verify that the change was effective, look for messages similar to these in t
 
 Similar to enabling Postgres, switching back to the etcd datastore does not migrate current event data from one store to another. You may observe old events in the web UI or  sensuctl output until the etcd datastore catches up with the current state of your monitored infrastructure.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd._
 
-[2]: https://github.com/sensu/sensu-perf
-[3]: ../getting-started/enterprise
-[4]: ../guides/troubleshooting/#log-file-locations
+
+[1]: https://github.com/sensu/sensu-perf
+[2]: #revert-to-built-in-datastore
+[3]: ../../getting-started/enterprise
+[4]: ../../guides/troubleshooting/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD

--- a/content/sensu-go/5.12/guides/scale-event-storage.md
+++ b/content/sensu-go/5.12/guides/scale-event-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
 linkTitle: "Scaling with Enterprise datastore"
-description: ""
+description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
 weight: 39
 version: "5.12"
 product: "Sensu Go"
@@ -13,17 +13,17 @@ menu:
 
 Sensu Go's licensed-tier datastore feature enables scaling your monitoring to many thousands of events per second.
 
-- [Why use the Enterprise datastore?](#why-enterprise-datastore)
+- [Why use the Enterprise datastore?](#why-use-the-enterprise-datastore)
 - [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres-for-sensu)
-- [Configure Sensu](#configure-sensu-for-postgres)
-- [Revert to built-in datastore](#revert-to-builtin-datastore)
+- [Configure Postgres](#configure-postgres)
+- [Configure Sensu](#configure-sensu)
+- [Revert to built-in datastore](#revert-to-built-in-datastore)
 
-## Why use the Enterprise datastore? {#why-enterprise-datastore}
+## Why use the Enterprise datastore?
 
 For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization.
 
-Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][2] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
+Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][1] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
 
 This rate of events should be more than sufficient for many installations but assumes an ideal scenario where Sensu backend nodes use direct-attached, dedicated non-volatile memory express (NVMe) storage and are connected to a dedicated LAN. Deployments on public cloud providers are not likely to achieve similar results due to sharing both disk and network bandwidth with other tenants. Following the cloud provider's recommended practices may also become a factor because many operators are inclined to deploy a cluster across multiple availability zones. In such a deployment cluster, communication happens over shared WAN links, which are subject to uncontrolled variability in throughput and latency.
 
@@ -36,7 +36,7 @@ Using the Enterprise datastore can help operators achieve much higher rates of e
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-## Configure Postgres {#configure-postgres-for-sensu}
+## Configure Postgres
 
 Before Sensu can start writing events to Postgres, you need a database and an account with permissions to write to that database. To provide consistent event throughput, we strongly recommend exclusively dedicating your Postgres instance to storage of Sensu events.
 
@@ -68,9 +68,9 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore](#revert-to-builtin-datastore) below._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore][2] below._
 
-## Configure Sensu {#configure-sensu-for-postgres}
+## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward. Create a `PostgresConfig` resource that describes the database connection as a data source name (DSN):
 
@@ -115,7 +115,7 @@ In the web UI and in `sensuctl`, event history will appear incomplete. When Post
 
 Aside from event history, which is not migrated from etcd, there's no observable difference when using Postgres as the event store, and neither interface supports displaying the PostgresConfig type.
 
-To verify that the change was effective and your connection to Postgres was successful, look at the [`sensu-backend` log][4]:
+To verify that the change was effective and your connection to Postgres was successful, look at the [sensu-backend log][4]:
 
 {{< highlight shell >}}
 {"component":"store","level":"warning","msg":"trying to enable external event store","time":"2019-10-02T23:31:38Z"}
@@ -141,10 +141,10 @@ sensu_events=# select sensu_entity from events where sensu_check = 'keepalive';
  i-424242
  i-434343
 (3 rows)
-{{ /highlight }}
+{{< /highlight >}}
 
 
-### Revert to built-in datastore (#revert-to-builtin-datastore)
+## Revert to built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource. In this example, my-postgres.yml contains the same configuration you used to configure the enterprise event store earlier in this guide:
 
@@ -161,9 +161,11 @@ To verify that the change was effective, look for messages similar to these in t
 
 Similar to enabling Postgres, switching back to the etcd datastore does not migrate current event data from one store to another. You may observe old events in the web UI or  sensuctl output until the etcd datastore catches up with the current state of your monitored infrastructure.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd._
 
-[2]: https://github.com/sensu/sensu-perf
-[3]: ../getting-started/enterprise
-[4]: ../guides/troubleshooting/#log-file-locations
+
+[1]: https://github.com/sensu/sensu-perf
+[2]: #revert-to-built-in-datastore
+[3]: ../../getting-started/enterprise
+[4]: ../../guides/troubleshooting/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD

--- a/content/sensu-go/5.13/guides/scale-event-storage.md
+++ b/content/sensu-go/5.13/guides/scale-event-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
 linkTitle: "Scaling with Enterprise datastore"
-description: ""
+description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
 weight: 39
 version: "5.13"
 product: "Sensu Go"
@@ -13,17 +13,17 @@ menu:
 
 Sensu Go's licensed-tier datastore feature enables scaling your monitoring to many thousands of events per second.
 
-- [Why use the Enterprise datastore?](#why-enterprise-datastore)
+- [Why use the Enterprise datastore?](#why-use-the-enterprise-datastore)
 - [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres-for-sensu)
-- [Configure Sensu](#configure-sensu-for-postgres)
-- [Revert to built-in datastore](#revert-to-builtin-datastore)
+- [Configure Postgres](#configure-postgres)
+- [Configure Sensu](#configure-sensu)
+- [Revert to built-in datastore](#revert-to-built-in-datastore)
 
-## Why use the Enterprise datastore? {#why-enterprise-datastore}
+## Why use the Enterprise datastore?
 
 For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization.
 
-Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][2] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
+Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][1] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
 
 This rate of events should be more than sufficient for many installations but assumes an ideal scenario where Sensu backend nodes use direct-attached, dedicated non-volatile memory express (NVMe) storage and are connected to a dedicated LAN. Deployments on public cloud providers are not likely to achieve similar results due to sharing both disk and network bandwidth with other tenants. Following the cloud provider's recommended practices may also become a factor because many operators are inclined to deploy a cluster across multiple availability zones. In such a deployment cluster, communication happens over shared WAN links, which are subject to uncontrolled variability in throughput and latency.
 
@@ -36,7 +36,7 @@ Using the Enterprise datastore can help operators achieve much higher rates of e
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-## Configure Postgres {#configure-postgres-for-sensu}
+## Configure Postgres
 
 Before Sensu can start writing events to Postgres, you need a database and an account with permissions to write to that database. To provide consistent event throughput, we strongly recommend exclusively dedicating your Postgres instance to storage of Sensu events.
 
@@ -68,9 +68,9 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore](#revert-to-builtin-datastore) below._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore][2] below._
 
-## Configure Sensu {#configure-sensu-for-postgres}
+## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward. Create a `PostgresConfig` resource that describes the database connection as a data source name (DSN):
 
@@ -115,7 +115,7 @@ In the web UI and in `sensuctl`, event history will appear incomplete. When Post
 
 Aside from event history, which is not migrated from etcd, there's no observable difference when using Postgres as the event store, and neither interface supports displaying the PostgresConfig type.
 
-To verify that the change was effective and your connection to Postgres was successful, look at the [`sensu-backend` log][4]:
+To verify that the change was effective and your connection to Postgres was successful, look at the [sensu-backend log][4]:
 
 {{< highlight shell >}}
 {"component":"store","level":"warning","msg":"trying to enable external event store","time":"2019-10-02T23:31:38Z"}
@@ -141,10 +141,10 @@ sensu_events=# select sensu_entity from events where sensu_check = 'keepalive';
  i-424242
  i-434343
 (3 rows)
-{{ /highlight }}
+{{< /highlight >}}
 
 
-### Revert to built-in datastore (#revert-to-builtin-datastore)
+## Revert to built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource. In this example, my-postgres.yml contains the same configuration you used to configure the enterprise event store earlier in this guide:
 
@@ -161,9 +161,11 @@ To verify that the change was effective, look for messages similar to these in t
 
 Similar to enabling Postgres, switching back to the etcd datastore does not migrate current event data from one store to another. You may observe old events in the web UI or  sensuctl output until the etcd datastore catches up with the current state of your monitored infrastructure.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd._
 
-[2]: https://github.com/sensu/sensu-perf
-[3]: ../getting-started/enterprise
-[4]: ../guides/troubleshooting/#log-file-locations
+
+[1]: https://github.com/sensu/sensu-perf
+[2]: #revert-to-built-in-datastore
+[3]: ../../getting-started/enterprise
+[4]: ../../guides/troubleshooting/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD

--- a/content/sensu-go/5.14/guides/scale-event-storage.md
+++ b/content/sensu-go/5.14/guides/scale-event-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
 linkTitle: "Scaling with Enterprise datastore"
-description: ""
+description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
 weight: 39
 version: "5.14"
 product: "Sensu Go"
@@ -13,17 +13,17 @@ menu:
 
 Sensu Go's licensed-tier datastore feature enables scaling your monitoring to many thousands of events per second.
 
-- [Why use the Enterprise datastore?](#why-enterprise-datastore)
+- [Why use the Enterprise datastore?](#why-use-the-enterprise-datastore)
 - [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres-for-sensu)
-- [Configure Sensu](#configure-sensu-for-postgres)
-- [Revert to built-in datastore](#revert-to-builtin-datastore)
+- [Configure Postgres](#configure-postgres)
+- [Configure Sensu](#configure-sensu)
+- [Revert to built-in datastore](#revert-to-built-in-datastore)
 
-## Why use the Enterprise datastore? {#why-enterprise-datastore}
+## Why use the Enterprise datastore?
 
 For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization.
 
-Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][2] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
+Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][1] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
 
 This rate of events should be more than sufficient for many installations but assumes an ideal scenario where Sensu backend nodes use direct-attached, dedicated non-volatile memory express (NVMe) storage and are connected to a dedicated LAN. Deployments on public cloud providers are not likely to achieve similar results due to sharing both disk and network bandwidth with other tenants. Following the cloud provider's recommended practices may also become a factor because many operators are inclined to deploy a cluster across multiple availability zones. In such a deployment cluster, communication happens over shared WAN links, which are subject to uncontrolled variability in throughput and latency.
 
@@ -36,7 +36,7 @@ Using the Enterprise datastore can help operators achieve much higher rates of e
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-## Configure Postgres {#configure-postgres-for-sensu}
+## Configure Postgres
 
 Before Sensu can start writing events to Postgres, you need a database and an account with permissions to write to that database. To provide consistent event throughput, we strongly recommend exclusively dedicating your Postgres instance to storage of Sensu events.
 
@@ -68,9 +68,9 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore](#revert-to-builtin-datastore) below._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore][2] below._
 
-## Configure Sensu {#configure-sensu-for-postgres}
+## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward. Create a `PostgresConfig` resource that describes the database connection as a data source name (DSN):
 
@@ -115,7 +115,7 @@ In the web UI and in `sensuctl`, event history will appear incomplete. When Post
 
 Aside from event history, which is not migrated from etcd, there's no observable difference when using Postgres as the event store, and neither interface supports displaying the PostgresConfig type.
 
-To verify that the change was effective and your connection to Postgres was successful, look at the [`sensu-backend` log][4]:
+To verify that the change was effective and your connection to Postgres was successful, look at the [sensu-backend log][4]:
 
 {{< highlight shell >}}
 {"component":"store","level":"warning","msg":"trying to enable external event store","time":"2019-10-02T23:31:38Z"}
@@ -141,10 +141,10 @@ sensu_events=# select sensu_entity from events where sensu_check = 'keepalive';
  i-424242
  i-434343
 (3 rows)
-{{ /highlight }}
+{{< /highlight >}}
 
 
-### Revert to built-in datastore (#revert-to-builtin-datastore)
+## Revert to built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource. In this example, my-postgres.yml contains the same configuration you used to configure the enterprise event store earlier in this guide:
 
@@ -161,9 +161,11 @@ To verify that the change was effective, look for messages similar to these in t
 
 Similar to enabling Postgres, switching back to the etcd datastore does not migrate current event data from one store to another. You may observe old events in the web UI or  sensuctl output until the etcd datastore catches up with the current state of your monitored infrastructure.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd._
 
-[2]: https://github.com/sensu/sensu-perf
-[3]: ../getting-started/enterprise
-[4]: ../guides/troubleshooting/#log-file-locations
+
+[1]: https://github.com/sensu/sensu-perf
+[2]: #revert-to-built-in-datastore
+[3]: ../../getting-started/enterprise
+[4]: ../../guides/troubleshooting/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD

--- a/content/sensu-go/5.15/guides/scale-event-storage.md
+++ b/content/sensu-go/5.15/guides/scale-event-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
 linkTitle: "Scaling with Enterprise datastore"
-description: ""
+description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
 weight: 39
 version: "5.15"
 product: "Sensu Go"
@@ -13,17 +13,17 @@ menu:
 
 Sensu Go's licensed-tier datastore feature enables scaling your monitoring to many thousands of events per second.
 
-- [Why use the Enterprise datastore?](#why-enterprise-datastore)
+- [Why use the Enterprise datastore?](#why-use-the-enterprise-datastore)
 - [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres-for-sensu)
-- [Configure Sensu](#configure-sensu-for-postgres)
-- [Revert to built-in datastore](#revert-to-builtin-datastore)
+- [Configure Postgres](#configure-postgres)
+- [Configure Sensu](#configure-sensu)
+- [Revert to built-in datastore](#revert-to-built-in-datastore)
 
-## Why use the Enterprise datastore? {#why-enterprise-datastore}
+## Why use the Enterprise datastore?
 
 For each unique entity/check pair, Sensu records the latest event object in its datastore. By default, Sensu uses the embedded etcd datastore for event storage. The embedded etcd datastore helps you get started, but as the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore. In a clustered deployment of etcd, whether embedded or external to Sensu, each event received by a member of the cluster must be replicated to other members, increasing network and disk IO utilization.
 
-Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][2] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
+Our team documented configuration and testing of Sensu running on bare metal infrastructure in the [sensu/sensu-perf][1] project. This configuration comfortably handled 12,000 Sensu agent connections (and their keepalives) and processed more than 8,500 events per second.
 
 This rate of events should be more than sufficient for many installations but assumes an ideal scenario where Sensu backend nodes use direct-attached, dedicated non-volatile memory express (NVMe) storage and are connected to a dedicated LAN. Deployments on public cloud providers are not likely to achieve similar results due to sharing both disk and network bandwidth with other tenants. Following the cloud provider's recommended practices may also become a factor because many operators are inclined to deploy a cluster across multiple availability zones. In such a deployment cluster, communication happens over shared WAN links, which are subject to uncontrolled variability in throughput and latency.
 
@@ -36,7 +36,7 @@ Using the Enterprise datastore can help operators achieve much higher rates of e
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-## Configure Postgres {#configure-postgres-for-sensu}
+## Configure Postgres
 
 Before Sensu can start writing events to Postgres, you need a database and an account with permissions to write to that database. To provide consistent event throughput, we strongly recommend exclusively dedicating your Postgres instance to storage of Sensu events.
 
@@ -68,9 +68,9 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore](#revert-to-builtin-datastore) below._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd. See [Revert to built-in datastore][2] below._
 
-## Configure Sensu {#configure-sensu-for-postgres}
+## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward. Create a `PostgresConfig` resource that describes the database connection as a data source name (DSN):
 
@@ -115,7 +115,7 @@ In the web UI and in `sensuctl`, event history will appear incomplete. When Post
 
 Aside from event history, which is not migrated from etcd, there's no observable difference when using Postgres as the event store, and neither interface supports displaying the PostgresConfig type.
 
-To verify that the change was effective and your connection to Postgres was successful, look at the [`sensu-backend` log][4]:
+To verify that the change was effective and your connection to Postgres was successful, look at the [sensu-backend log][4]:
 
 {{< highlight shell >}}
 {"component":"store","level":"warning","msg":"trying to enable external event store","time":"2019-10-02T23:31:38Z"}
@@ -141,10 +141,10 @@ sensu_events=# select sensu_entity from events where sensu_check = 'keepalive';
  i-424242
  i-434343
 (3 rows)
-{{ /highlight }}
+{{< /highlight >}}
 
 
-### Revert to built-in datastore (#revert-to-builtin-datastore)
+## Revert to built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource. In this example, my-postgres.yml contains the same configuration you used to configure the enterprise event store earlier in this guide:
 
@@ -161,9 +161,11 @@ To verify that the change was effective, look for messages similar to these in t
 
 Similar to enabling Postgres, switching back to the etcd datastore does not migrate current event data from one store to another. You may observe old events in the web UI or  sensuctl output until the etcd datastore catches up with the current state of your monitored infrastructure.
 
-_NOTE: If your Sensu Go license expires, event storage will automatically revert to etcd._
+_**NOTE**: If your Sensu Go license expires, event storage will automatically revert to etcd._
 
-[2]: https://github.com/sensu/sensu-perf
-[3]: ../getting-started/enterprise
-[4]: ../guides/troubleshooting/#log-file-locations
+
+[1]: https://github.com/sensu/sensu-perf
+[2]: #revert-to-built-in-datastore
+[3]: ../../getting-started/enterprise
+[4]: ../../guides/troubleshooting/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD


### PR DESCRIPTION
- A close-highlight tag was missing <>, which was preventing the last section and the links from displaying correctly.
- The relative links needed another ../ to display properly.
- Needed a description in the front matter.

