### PR TITLE
Fix table for trusted-ca-file in backend reference

### DIFF
--- a/content/sensu-go/5.10/reference/backend.md
+++ b/content/sensu-go/5.10/reference/backend.md
@@ -372,7 +372,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.11/reference/backend.md
+++ b/content/sensu-go/5.11/reference/backend.md
@@ -379,7 +379,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.12/reference/backend.md
+++ b/content/sensu-go/5.12/reference/backend.md
@@ -379,7 +379,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.13/reference/backend.md
+++ b/content/sensu-go/5.13/reference/backend.md
@@ -379,7 +379,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.14/reference/backend.md
+++ b/content/sensu-go/5.14/reference/backend.md
@@ -447,7 +447,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.15/reference/backend.md
+++ b/content/sensu-go/5.15/reference/backend.md
@@ -478,7 +478,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.7/reference/backend.md
+++ b/content/sensu-go/5.7/reference/backend.md
@@ -366,7 +366,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.8/reference/backend.md
+++ b/content/sensu-go/5.8/reference/backend.md
@@ -369,7 +369,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example

--- a/content/sensu-go/5.9/reference/backend.md
+++ b/content/sensu-go/5.9/reference/backend.md
@@ -372,7 +372,6 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | trusted-ca-file |      |
 ------------------|------
 description       | Path to the primary backend CA file, as well as specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between Sensu Dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
-
 type              | String
 default           | `""`
 example           | {{< highlight shell >}}# Command line example


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Removes an extra space that broke the table for `trusted-ca-file` in the backend reference.

## Motivation and Context
To make the table render properly.

## Review Instructions
Before:

<img width="870" alt="Screen Shot 2019-11-21 at 9 45 26 AM" src="https://user-images.githubusercontent.com/19964713/69362880-371a4780-0c44-11ea-872d-81e9360f7832.png">

After:

<img width="876" alt="Screen Shot 2019-11-21 at 9 45 31 AM" src="https://user-images.githubusercontent.com/19964713/69362895-3da8bf00-0c44-11ea-90bc-8aa97cc717cf.png">
