### PR TITLE
Add request for affected docs pages

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,6 +20,10 @@
 <!--- Not obligatory, but suggest a fix/reason for the bug, -->
 <!--- or ideas as to the implementation of the addition or change -->
 
+## Affected Docs Pages
+<!--- List the docs pages that need to be updated to resolve -->
+<!--- this issue -->
+
 ## Steps to Reproduce (for bugs)
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. Include code or configuration to reproduce, if relevant -->


### PR DESCRIPTION
When I edit this file, there's a message from GitHub saying we should update to the new issue template process: https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates