### PR TITLE
Correct address in /auth spec example urls

### DIFF
--- a/content/sensu-go/5.1/api/auth.md
+++ b/content/sensu-go/5.1/api/auth.md
@@ -1,6 +1,6 @@
 ---
-title: "Authorization API"
-description: "Sensu Go authorization API reference documentation"
+title: "Authentication API"
+description: "The authentication API provides HTTP access to test user credentials. Here’s a reference for the authentication API in Sensu Go, including an example for how to query the authentication API to determine whether credentials are valid. Read on for the full reference."
 version: "5.1"
 product: "Sensu Go"
 menu:
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.10/api/auth.md
+++ b/content/sensu-go/5.10/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.11/api/auth.md
+++ b/content/sensu-go/5.11/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.12/api/auth.md
+++ b/content/sensu-go/5.12/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.13/api/auth.md
+++ b/content/sensu-go/5.13/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.14/api/auth.md
+++ b/content/sensu-go/5.14/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.15/api/auth.md
+++ b/content/sensu-go/5.15/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.16/api/auth.md
+++ b/content/sensu-go/5.16/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.2/api/auth.md
+++ b/content/sensu-go/5.2/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.3/api/auth.md
+++ b/content/sensu-go/5.3/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.4/api/auth.md
+++ b/content/sensu-go/5.4/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.5/api/auth.md
+++ b/content/sensu-go/5.5/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.6/api/auth.md
+++ b/content/sensu-go/5.6/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.7/api/auth.md
+++ b/content/sensu-go/5.7/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.8/api/auth.md
+++ b/content/sensu-go/5.8/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."

--- a/content/sensu-go/5.9/api/auth.md
+++ b/content/sensu-go/5.9/api/auth.md
@@ -41,7 +41,7 @@ HTTP/1.1 200 OK
 /auth (GET)          |     |
 ---------------------|------
 description          | Generates an access token to the API using basic authentication. Access tokens last for around 15 minutes. When your token expires, you should see a 401 Unauthorized response from the API. To generate a new access token, use the [`/auth/token` API endpoint](#authtoken-post).
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth
 output               | {{< highlight json >}}
 {
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -72,14 +72,14 @@ HTTP/1.1 200 OK
 /auth/test (GET)     |     |
 ---------------------|------
 description          | Tests a given username and password.
-example url          | http://hostname:8080/api/core/v2/auth/test
+example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/auth/token` API endpoint {#the-authtoken-api-endpoint}
 
 ### `/auth/token` (POST) {#authtoken-post}
 
-The `/auth/test` API endpoint provides HTTP POST access to renew an access token.
+The `/auth/token` API endpoint provides HTTP POST access to renew an access token.
 
 #### EXAMPLE {#authtoken-post-example}
 
@@ -104,7 +104,7 @@ HTTP/1.1 200 OK
 /auth/token (POST)   |     |
 ---------------------|------
 description          | Generates a new access token using a refresh token and an expired access token
-example url          | http://hostname:8080/api/core/v2/auth
+example url          | http://hostname:8080/auth/token
 example payload | {{< highlight shell >}}
 {
   "refresh_token": "eyJhbGciOiJIUzI1NiIs..."


### PR DESCRIPTION
## Description
Correct the example url address path in /auth endpoint specs

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1967