### PR TITLE
Update guide nav titles, page titles, and nav order

### DIFF
--- a/content/sensu-go/5.16/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.16/guides/aggregate-metrics-statsd.md
@@ -1,8 +1,8 @@
 ---
-title: "How to aggregate metrics with the Sensu StatsD listener"
-linkTitle: "Aggregating StatsD Metrics"
+title: "Aggregate metrics with the Sensu StatsD listener"
+linkTitle: "Aggregate StatsD Metrics"
 description: "StatsD allows you to measure anything and everything. You can monitor application performance by collecting custom metrics in your code and sending them to a StatsD server or you can monitor system levels of CPU, I/O, network etc. with collection daemons. Sensu agents include a listener to send StatsD metrics to the event pipeline. Read the guide to get started."
-weight: 20
+weight: 50
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/clustering.md
+++ b/content/sensu-go/5.16/guides/clustering.md
@@ -1,8 +1,8 @@
 ---
-title: "How to run a Sensu cluster"
-linkTitle: "Running a Sensu Cluster"
+title: "Run a Sensu cluster"
+linkTitle: "Run a Sensu Cluster"
 description: "Clustering is important to make Sensu more highly available, reliable, and durable. It can help you cope with the loss of a backend node, prevent data loss, and distribute the network load of agents. Read the guide to configure a Sensu cluster."
-weight: 120
+weight: 150
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/contact-routing.md
+++ b/content/sensu-go/5.16/guides/contact-routing.md
@@ -1,8 +1,8 @@
 ---
-title: "How to route alerts using filters"
-linkTitle: "Routing Alerts with Filters"
+title: "Route alerts with filters"
+linkTitle: "Route Alerts"
 description: "Every alert has an ideal first responder: a team or individual with the knowledge to triage and address the issue. Sensu contact routing lets you alert the right people using their preferred contact method, reducing mean time to response and recovery."
-weight: 39
+weight: 130
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/create-read-only-user.md
+++ b/content/sensu-go/5.16/guides/create-read-only-user.md
@@ -1,8 +1,8 @@
 ---
-title: "How to create a read-only user with RBAC"
-linkTitle: "Creating a Read Only User"
+title: "Create a read-only user with RBAC"
+linkTitle: "Create a Read-Only User"
 description: "RBAC allows you to exercise fine-grained control over how Sensu users interact with Sensu resources. Using RBAC rules, you can easily achieve multitenancy so different projects and teams can share a Sensu instance. Read the guide to get started creating users with Sensu RBAC."
-weight: 100
+weight: 190
 version: "5.16"
 product: "Sensu Go"
 platformContent: False

--- a/content/sensu-go/5.16/guides/deploying.md
+++ b/content/sensu-go/5.16/guides/deploying.md
@@ -1,8 +1,8 @@
 ---
-title: "Planning your Sensu Go deployment"
-linkTitle: "Deploying Sensu"
+title: "Deploy Sensu"
+linkTitle: "Deploy Sensu"
 description: "In this guide we'll describes various considerations, recommendations and architectures for a production-ready deployment"
-weight: 101
+weight: 140
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/enrich-events-with-hooks.md
+++ b/content/sensu-go/5.16/guides/enrich-events-with-hooks.md
@@ -1,8 +1,8 @@
 ---
-title: "How to augment event data using check hooks"
-linkTitle: "Augmenting Event Data"
+title: "Augment event data with check hooks"
+linkTitle: "Augment Event Data"
 description: "Check hooks allow Sensu users to automate data collection routinely performed by operators investigating monitoring alerts, freeing precious operator time! This guides helps you put in place a check hook which captures the process tree in the event that a service check returns a critical status."
-weight: 25
+weight: 40
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/extract-metrics-with-checks.md
+++ b/content/sensu-go/5.16/guides/extract-metrics-with-checks.md
@@ -1,8 +1,8 @@
 ---
-title: "How to collect and extract metrics using Sensu checks"
-linkTitle: "Collecting Service Metrics"
+title: "Collect metrics with Sensu checks"
+linkTitle: "Collect Service Metrics"
 description: "Sensu supports industry-standard metric formats like Nagios Performance Data, Graphite Plaintext Protocol, InfluxDB Line Protocol, and OpenTSDB Data Specification. Read the guide to get started collecting metrics with Sensu."
-weight: 17
+weight: 30
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.16/guides/influx-db-metric-handler.md
@@ -1,8 +1,8 @@
 ---
-title: "How to populate InfluxDB metrics using handlers"
-linkTitle: "Storing Metrics with InfluxDB"
+title: "Populate metrics in InfluxDB with handlers"
+linkTitle: "Populate Metrics in InfluxDB"
 description: "Sensu event handlers are actions executed by the Sensu backend on events. This guide helps you populate Sensu metrics into the time series database InfluxDB. "
-weight: 35
+weight: 70
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.16/guides/install-check-executables-with-assets.md
@@ -1,8 +1,8 @@
 ---
-title: "How to install plugins using assets"
-linkTitle: "Installing Plugins with Assets"
+title: "Install plugins with assets"
+linkTitle: "Install Plugins with Assets"
 description: "Assets are shareable, reusable packages that make it easy to deploy Sensu plugins. You can use assets to provide the plugins, libraries, and runtimes you need to power your monitoring workflows. Read the guide to get started using assets."
-weight: 40
+weight: 100
 version: "5.16"
 product: "Sensu Go"
 platformContent: False

--- a/content/sensu-go/5.16/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.16/guides/monitor-external-resources.md
@@ -1,8 +1,8 @@
 ---
-title: "How to monitor external resources with proxy requests and entities"
-linkTitle: "Monitoring External Resources"
+title: "Monitor external resources with proxy requests and entities"
+linkTitle: "Monitor External Resources"
 description: "Proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed, like a network switch or a website. Read the guide to get started monitoring a website with proxy entities."
-weight: 15
+weight: 20
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.16/guides/monitor-server-resources.md
@@ -1,6 +1,6 @@
 ---
-title: "How to monitor server resources with checks"
-linkTitle: "Monitoring Server Resources"
+title: "Monitor server resources with checks"
+linkTitle: "Monitor Server Resources"
 description: "Here’s how to monitor server resources with checks. You’ll learn about Sensu checks, why you should use checks, and how to use them to monitor a service. Read the guide to learn more."
 weight: 10
 version: "5.16"

--- a/content/sensu-go/5.16/guides/plan-maintenance.md
+++ b/content/sensu-go/5.16/guides/plan-maintenance.md
@@ -1,8 +1,8 @@
 ---
-title: "How to plan maintenance windows using silencing"
-linkTitle: "Planning Maintenance"
+title: "Plan maintenance windows with silencing"
+linkTitle: "Plan Maintenance Windows"
 description: "Perform system maintenance without getting overloaded with alerts. Sensu silencing bypasses event handlers during a maintenance period, giving operators the ability to quiet incoming alerts while coordinating their response. Read the guide to get started."
-weight: 50
+weight: 200
 version: "5.16"
 product: "Sensu Go"
 platformContent: False

--- a/content/sensu-go/5.16/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.16/guides/reduce-alert-fatigue.md
@@ -1,8 +1,8 @@
 ---
-title: "How to reduce alert fatigue with filters"
-linkTitle: "Reducing Alert Fatigue"
+title: "Reduce alert fatigue with filters"
+linkTitle: "Reduce Alert Fatigue"
 description: "Here’s how to reduce alert fatigue with Sensu. In this guide, you’ll learn about Sensu filters — why to use them, how they reduce alert fatigue, and how to put them into action."
-weight: 38
+weight: 120
 version: "5.16"
 product: "Sensu Go"
 platformContent: False

--- a/content/sensu-go/5.16/guides/scale-event-storage.md
+++ b/content/sensu-go/5.16/guides/scale-event-storage.md
@@ -1,8 +1,8 @@
 ---
 title: "Scale Sensu Go with Enterprise Datastore"
-linkTitle: "Scaling with Enterprise datastore"
+linkTitle: "Scale with Enterprise Datastore"
 description: "Here’s how to scale your monitoring to thousands of events per second with Sensu."
-weight: 39
+weight: 160
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/securing-sensu.md
+++ b/content/sensu-go/5.16/guides/securing-sensu.md
@@ -1,7 +1,8 @@
 ---
-title: "Securing Sensu"
+title: "Secure Sensu"
+linkTitle: "Secure Sensu"
 description: "As with all software, it’s important to minimize any attack surface exposed by the software. Sensu is no different. In this guide, you’ll learn about the components that need to be secured (and how to do so)."
-weight: 1000
+weight: 170
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.16/guides/send-slack-alerts.md
@@ -1,8 +1,8 @@
 ---
-title: "How to send alerts to Slack with handlers"
-linkTitle: "Sending Slack Alerts"
+title: "Send Slack alerts with handlers"
+linkTitle: "Send Slack Alerts"
 description: "Here’s how to send alerts to Slack with Sensu handlers, which are actions executed by the Sensu backend on events. Handlers can be sent to your technology of choice (in this case, Slack) to alert you of incidents and help you resolve them faster. Learn how."
-weight: 30
+weight: 80
 version: "5.16"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.16/guides/systemd-logs.md
+++ b/content/sensu-go/5.16/guides/systemd-logs.md
@@ -1,9 +1,14 @@
 ---
-title: "Sensu service logging with systemd"
+title: "Log Sensu services with systemd"
+linkTitle: "Log Sensu Services"
 description: "By default, systems where systemd is the service manager do not write logs to /var/log/sensu/. This guide walks you through how to add log forwarding from journald to syslog, have rsyslog write logging data to disk, and set up log rotation of the newly created log files."
+weight: 60
 version: "5.16"
 product: "Sensu Go"
 platformContent: false
+menu:
+  sensu-go-5.16:
+    parent: guides
 ---
 
 By default, systems where systemd is the service manager do not write logs to `/var/log/sensu/` for the `sensu-agent` and the `sensu-backend` services. This guide walks you through how to add log forwarding from journald to syslog, have rsyslog write logging data to disk, and set up log rotation of the newly created log files.

--- a/content/sensu-go/5.16/guides/troubleshooting.md
+++ b/content/sensu-go/5.16/guides/troubleshooting.md
@@ -1,7 +1,8 @@
 ---
-title: "Troubleshooting"
+title: "Troubleshoot"
+linkTitle: "Troubleshoot"
 description: "Need to troubleshoot Sensu Go? Here’s how to look into errors, including service logging and the log levels you need to know about. Logs produced by Sensu services – i.e., sensu-backend and sensu-agent – are often the best source of truth when troubleshooting issues, so we recommend you start there."
-weight: 2000
+weight: 210
 version: "5.16"
 product: "Sensu Go"
 platformContent: true

--- a/content/sensu-go/5.16/guides/use-apikey-feature.md
+++ b/content/sensu-go/5.16/guides/use-apikey-feature.md
@@ -1,8 +1,8 @@
 ---
 title: "Use the API key feature"
-linkTitle: "Using API keys"
+linkTitle: "Use API keys"
 description: "In this guide, you'll learn how to use Sensu's API key feature for authentication."
-weight: 37
+weight: 180
 version: "5.16"
 product: "Sensu Go"
 platformContent: False


### PR DESCRIPTION
## Description
- Replaced gerunds in left-nav menu (e.g., changed "Using" to "Use")
- Removed "How to" in page titles and started with a verb instead (e.g., changed "How to monitor..." to "Monitor..."
- Rearranged nav order (after the "monitor" guides, which are the most popular guides for the last quarter according to Analytics) to try to group the guides

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1968
