### PR TITLE
Correct some out of date info about the datastore

### DIFF
--- a/content/sensu-go/5.15/reference/datastore.md
+++ b/content/sensu-go/5.15/reference/datastore.md
@@ -77,7 +77,6 @@ With the `PostgresConfig` resource definition saved to a file (for example: post
 sensuctl create --file postgres.yml
 {{< /highlight >}}
 
-At this time, there is no supported method for viewing a `PostgresConfig` resource.
 To update your Sensu PostgreSQL configuration, repeat the `sensuctl create` process shown above.
 You can expect to see PostgreSQL status updates and error messages in the [Sensu backend logs][2] at the `warn` and `error` log levels, respectively.
 

--- a/content/sensu-go/5.16/reference/datastore.md
+++ b/content/sensu-go/5.16/reference/datastore.md
@@ -77,7 +77,6 @@ With the `PostgresConfig` resource definition saved to a file (for example: post
 sensuctl create --file postgres.yml
 {{< /highlight >}}
 
-At this time, there is no supported method for viewing a `PostgresConfig` resource.
 To update your Sensu PostgreSQL configuration, repeat the `sensuctl create` process shown above.
 You can expect to see PostgreSQL status updates and error messages in the [Sensu backend logs][2] at the `warn` and `error` log levels, respectively.
 


### PR DESCRIPTION
## Description
PostgresConfig can now be retrieved with `sensuctl dump`, so I've removed the line that says it's not possible.

## Motivation and Context
Noticed this while reading the docs.