### PR TITLE
Implement redirects for 5.0-5.11 to "latest"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,54 +72,6 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     version = "5.12"
     platforms = []
 
-    [[params.products.sensu_go.versions]]
-    version = "5.11"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.10"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.9"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.8"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.7"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.6"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.5"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.4"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.3"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.2"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.1"
-    platforms = []
-
-    [[params.products.sensu_go.versions]]
-    version = "5.0"
-    platforms = []
-
   [params.products.sensu_core]
     identifier = "sensu-core"
     name = "Sensu Core"

--- a/static.json
+++ b/static.json
@@ -3,7 +3,7 @@
     "https_only": true,
     "error_page": "/404.html",
     "pattern_redirects": {
-      "~ ^/sensu-core/2\.0/?(.*)$": {
+      "~ ^/sensu-core/2.0/?(.*)$": {
           "url": "/sensu-go/5.0/$1",
           "status": 301
       },
@@ -27,11 +27,11 @@
             "url": "/sensu-go/latest/guides/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/5\.1[0-1]/?(?<=\/)(.*)$": {
+        "~ ^/sensu-go/5.1[0-1]/?(?<=\/)(.*)$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-go/5\.[0-9]/?(?<=\/)(.*)$": {
+        "~ ^/sensu-go/5.[0-9]/?(?<=\/)(.*)$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },

--- a/static.json
+++ b/static.json
@@ -27,10 +27,6 @@
             "url": "/sensu-go/latest/guides/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/latest/?(.*)$": {
-            "url": "/sensu-go/5.15/$1",
-            "status": 301
-        },
         "~ ^/sensu-go/5.0/?(.*)$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
@@ -81,6 +77,10 @@
         },
         "~ ^/plugins/latest/?(.*)$": {
             "url": "/plugins/1.0/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/latest/?(.*)$": {
+            "url": "/sensu-go/5.15/$1",
             "status": 301
         }
     }

--- a/static.json
+++ b/static.json
@@ -3,7 +3,7 @@
     "https_only": true,
     "error_page": "/404.html",
     "pattern_redirects": {
-      "~ ^/sensu-core/2.0/?(.*)$": {
+      "~ ^/sensu-core/2\.0/?(.*)$": {
           "url": "/sensu-go/5.0/$1",
           "status": 301
       },
@@ -27,51 +27,11 @@
             "url": "/sensu-go/latest/guides/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/5.0/?(.*)$": {
+        "~ ^/sensu-go/5\.1[0-1]/?(?<=\/)(.*)$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-go/5.1/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.2/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.3/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.4/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.5/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.6/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.7/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.8/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.9/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.10/?(.*)$": {
-            "url": "/sensu-go/latest/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.11/?(.*)$": {
+        "~ ^/sensu-go/5\.[0-9]/?(?<=\/)(.*)$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },

--- a/static.json
+++ b/static.json
@@ -31,6 +31,54 @@
             "url": "/sensu-go/5.15/$1",
             "status": 301
         },
+        "~ ^/sensu-go/5.0/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.1/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.2/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.3/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.4/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.5/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.6/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.7/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.8/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.9/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.10/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
+        "~ ^/sensu-go/5.11/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
         "~ ^/plugins/latest/?(.*)$": {
             "url": "/plugins/1.0/$1",
             "status": 301


### PR DESCRIPTION
## Description

Update static.json with rules which redirect requests for `/sensu-go/5.0` through `/sensu-go/5.11` to the relevant content in `latest`

## Motivation and Context

Closes https://github.com/sensu/sensu-docs/issues/1997

We need to archive documentation for Sensu Go 5.0 through 5.11 as these versions are no longer supported under our terms. 

## Review Instructions

Please test PR on sensu-docs-stage.herokuapp.com.