### PR TITLE
Fix keepalive-warning-timeout table

### DIFF
--- a/content/sensu-go/5.16/reference/agent.md
+++ b/content/sensu-go/5.16/reference/agent.md
@@ -1000,7 +1000,7 @@ sensu-agent start --keepalive-interval 30
 keepalive-interval: 30{{< /highlight >}}
 
 
- | keepalive-warning-timeout |      |
+| keepalive-warning-timeout |      |
 --------------------|------
 description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.
 type                | Integer


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Removes an extra space that causes the `keepalive-warning-timeout` table to be broken.

## Motivation and Context
So the table renders properly.

## Review Instructions
Before:
<img width="916" alt="Screen Shot 2019-12-11 at 11 34 32 AM" src="https://user-images.githubusercontent.com/19964713/70653950-4587cd80-1c0a-11ea-98bd-ccd0661649f6.png">

After:
<img width="889" alt="Screen Shot 2019-12-11 at 11 34 17 AM" src="https://user-images.githubusercontent.com/19964713/70653969-4caedb80-1c0a-11ea-884b-9aaf42b2cf60.png">
