### PR TITLE
Update "latest" product links and navigation styles

### DIFF
--- a/archived/sensu-go/5.0/api/_index.md
+++ b/archived/sensu-go/5.0/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.0/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.0/dashboard/_index.md
+++ b/archived/sensu-go/5.0/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.0/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.0/getting-started/_index.md
+++ b/archived/sensu-go/5.0/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.0/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.0/guides/_index.md
+++ b/archived/sensu-go/5.0/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.0/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.0/installation/_index.md
+++ b/archived/sensu-go/5.0/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.0/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.0/reference/_index.md
+++ b/archived/sensu-go/5.0/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.0/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.0/sensuctl/_index.md
+++ b/archived/sensu-go/5.0/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.0/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/api/_index.md
+++ b/archived/sensu-go/5.1/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.1/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/dashboard/_index.md
+++ b/archived/sensu-go/5.1/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.1/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/getting-started/_index.md
+++ b/archived/sensu-go/5.1/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.1/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/guides/_index.md
+++ b/archived/sensu-go/5.1/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.1/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/installation/_index.md
+++ b/archived/sensu-go/5.1/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.1/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/reference/_index.md
+++ b/archived/sensu-go/5.1/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.1/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.1/sensuctl/_index.md
+++ b/archived/sensu-go/5.1/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.1/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/api/_index.md
+++ b/archived/sensu-go/5.10/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.10/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/dashboard/_index.md
+++ b/archived/sensu-go/5.10/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.10/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/getting-started/_index.md
+++ b/archived/sensu-go/5.10/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.10/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/guides/_index.md
+++ b/archived/sensu-go/5.10/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.10/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/installation/_index.md
+++ b/archived/sensu-go/5.10/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.10/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/reference/_index.md
+++ b/archived/sensu-go/5.10/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.10/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.10/sensuctl/_index.md
+++ b/archived/sensu-go/5.10/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.10/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/api/_index.md
+++ b/archived/sensu-go/5.11/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.11/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/dashboard/_index.md
+++ b/archived/sensu-go/5.11/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.11/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/getting-started/_index.md
+++ b/archived/sensu-go/5.11/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.11/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/guides/_index.md
+++ b/archived/sensu-go/5.11/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.11/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/installation/_index.md
+++ b/archived/sensu-go/5.11/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.11/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/reference/_index.md
+++ b/archived/sensu-go/5.11/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.11/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.11/sensuctl/_index.md
+++ b/archived/sensu-go/5.11/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.11/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/api/_index.md
+++ b/archived/sensu-go/5.2/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.2/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/dashboard/_index.md
+++ b/archived/sensu-go/5.2/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.2/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/getting-started/_index.md
+++ b/archived/sensu-go/5.2/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.2/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/guides/_index.md
+++ b/archived/sensu-go/5.2/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.2/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/installation/_index.md
+++ b/archived/sensu-go/5.2/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.2/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/reference/_index.md
+++ b/archived/sensu-go/5.2/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.2/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.2/sensuctl/_index.md
+++ b/archived/sensu-go/5.2/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.2/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/api/_index.md
+++ b/archived/sensu-go/5.3/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.3/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/dashboard/_index.md
+++ b/archived/sensu-go/5.3/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.3/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/getting-started/_index.md
+++ b/archived/sensu-go/5.3/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.3/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/guides/_index.md
+++ b/archived/sensu-go/5.3/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.3/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/installation/_index.md
+++ b/archived/sensu-go/5.3/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.3/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/reference/_index.md
+++ b/archived/sensu-go/5.3/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.3/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.3/sensuctl/_index.md
+++ b/archived/sensu-go/5.3/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.3/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/api/_index.md
+++ b/archived/sensu-go/5.4/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.4/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/dashboard/_index.md
+++ b/archived/sensu-go/5.4/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.4/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/getting-started/_index.md
+++ b/archived/sensu-go/5.4/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.4/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/guides/_index.md
+++ b/archived/sensu-go/5.4/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.4/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/installation/_index.md
+++ b/archived/sensu-go/5.4/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.4/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/reference/_index.md
+++ b/archived/sensu-go/5.4/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.4/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.4/sensuctl/_index.md
+++ b/archived/sensu-go/5.4/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.4/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/api/_index.md
+++ b/archived/sensu-go/5.5/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.5/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/dashboard/_index.md
+++ b/archived/sensu-go/5.5/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.5/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/getting-started/_index.md
+++ b/archived/sensu-go/5.5/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.5/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/guides/_index.md
+++ b/archived/sensu-go/5.5/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.5/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/installation/_index.md
+++ b/archived/sensu-go/5.5/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.5/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/reference/_index.md
+++ b/archived/sensu-go/5.5/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.5/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.5/sensuctl/_index.md
+++ b/archived/sensu-go/5.5/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.5/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/api/_index.md
+++ b/archived/sensu-go/5.6/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.6/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/dashboard/_index.md
+++ b/archived/sensu-go/5.6/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.6/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/getting-started/_index.md
+++ b/archived/sensu-go/5.6/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.6/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/guides/_index.md
+++ b/archived/sensu-go/5.6/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.6/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/installation/_index.md
+++ b/archived/sensu-go/5.6/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.6/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/reference/_index.md
+++ b/archived/sensu-go/5.6/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.6/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.6/sensuctl/_index.md
+++ b/archived/sensu-go/5.6/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.6/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/api/_index.md
+++ b/archived/sensu-go/5.7/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.7/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/dashboard/_index.md
+++ b/archived/sensu-go/5.7/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.7/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/getting-started/_index.md
+++ b/archived/sensu-go/5.7/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.7/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/guides/_index.md
+++ b/archived/sensu-go/5.7/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.7/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/installation/_index.md
+++ b/archived/sensu-go/5.7/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.7/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/reference/_index.md
+++ b/archived/sensu-go/5.7/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.7/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.7/sensuctl/_index.md
+++ b/archived/sensu-go/5.7/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.7/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/api/_index.md
+++ b/archived/sensu-go/5.8/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.8/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/dashboard/_index.md
+++ b/archived/sensu-go/5.8/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.8/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/getting-started/_index.md
+++ b/archived/sensu-go/5.8/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.8/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/guides/_index.md
+++ b/archived/sensu-go/5.8/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.8/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/installation/_index.md
+++ b/archived/sensu-go/5.8/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.8/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/reference/_index.md
+++ b/archived/sensu-go/5.8/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.8/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.8/sensuctl/_index.md
+++ b/archived/sensu-go/5.8/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.8/sensuctl" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/api/_index.md
+++ b/archived/sensu-go/5.9/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.9/api" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/dashboard/_index.md
+++ b/archived/sensu-go/5.9/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.9/dashboard" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/getting-started/_index.md
+++ b/archived/sensu-go/5.9/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.9/getting-started" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/guides/_index.md
+++ b/archived/sensu-go/5.9/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.9/guides" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/installation/_index.md
+++ b/archived/sensu-go/5.9/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.9/installation" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/reference/_index.md
+++ b/archived/sensu-go/5.9/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.9/reference" >}}
+{{< directoryListing >}}

--- a/archived/sensu-go/5.9/sensuctl/_index.md
+++ b/archived/sensu-go/5.9/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.9/sensuctl" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/api/_index.md
+++ b/content/sensu-core/0.29/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/0.29/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/guides/_index.md
+++ b/content/sensu-core/0.29/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/0.29/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/installation/_index.md
+++ b/content/sensu-core/0.29/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/0.29/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/overview/_index.md
+++ b/content/sensu-core/0.29/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/0.29/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/platforms/_index.md
+++ b/content/sensu-core/0.29/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/0.29/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/quick-start/_index.md
+++ b/content/sensu-core/0.29/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/0.29/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/0.29/reference/_index.md
+++ b/content/sensu-core/0.29/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/0.29/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/api/_index.md
+++ b/content/sensu-core/1.0/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.0/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/guides/_index.md
+++ b/content/sensu-core/1.0/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.0/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/installation/_index.md
+++ b/content/sensu-core/1.0/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.0/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/overview/_index.md
+++ b/content/sensu-core/1.0/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.0/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/platforms/_index.md
+++ b/content/sensu-core/1.0/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.0/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/quick-start/_index.md
+++ b/content/sensu-core/1.0/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.0/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.0/reference/_index.md
+++ b/content/sensu-core/1.0/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.0/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/api/_index.md
+++ b/content/sensu-core/1.1/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.1/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/guides/_index.md
+++ b/content/sensu-core/1.1/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.1/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/installation/_index.md
+++ b/content/sensu-core/1.1/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.1/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/overview/_index.md
+++ b/content/sensu-core/1.1/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.1/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/platforms/_index.md
+++ b/content/sensu-core/1.1/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.1/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/quick-start/_index.md
+++ b/content/sensu-core/1.1/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.1/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.1/reference/_index.md
+++ b/content/sensu-core/1.1/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.1/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/api/_index.md
+++ b/content/sensu-core/1.2/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.2/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/guides/_index.md
+++ b/content/sensu-core/1.2/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.2/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/installation/_index.md
+++ b/content/sensu-core/1.2/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.2/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/overview/_index.md
+++ b/content/sensu-core/1.2/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.2/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/platforms/_index.md
+++ b/content/sensu-core/1.2/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.2/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/quick-start/_index.md
+++ b/content/sensu-core/1.2/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.2/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.2/reference/_index.md
+++ b/content/sensu-core/1.2/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.2/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/api/_index.md
+++ b/content/sensu-core/1.3/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.3/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/guides/_index.md
+++ b/content/sensu-core/1.3/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.3/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/installation/_index.md
+++ b/content/sensu-core/1.3/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.3/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/overview/_index.md
+++ b/content/sensu-core/1.3/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.3/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/platforms/_index.md
+++ b/content/sensu-core/1.3/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.3/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/quick-start/_index.md
+++ b/content/sensu-core/1.3/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.3/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.3/reference/_index.md
+++ b/content/sensu-core/1.3/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.3/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/api/_index.md
+++ b/content/sensu-core/1.4/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.4/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/guides/_index.md
+++ b/content/sensu-core/1.4/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.4/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/installation/_index.md
+++ b/content/sensu-core/1.4/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.4/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/overview/_index.md
+++ b/content/sensu-core/1.4/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.4/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/platforms/_index.md
+++ b/content/sensu-core/1.4/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.4/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/quick-start/_index.md
+++ b/content/sensu-core/1.4/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.4/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.4/reference/_index.md
+++ b/content/sensu-core/1.4/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.4/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/api/_index.md
+++ b/content/sensu-core/1.5/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.5/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/guides/_index.md
+++ b/content/sensu-core/1.5/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.5/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/installation/_index.md
+++ b/content/sensu-core/1.5/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.5/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/overview/_index.md
+++ b/content/sensu-core/1.5/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.5/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/platforms/_index.md
+++ b/content/sensu-core/1.5/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.5/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/quick-start/_index.md
+++ b/content/sensu-core/1.5/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.5/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.5/reference/_index.md
+++ b/content/sensu-core/1.5/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.5/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/api/_index.md
+++ b/content/sensu-core/1.6/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.6/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/guides/_index.md
+++ b/content/sensu-core/1.6/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.6/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/installation/_index.md
+++ b/content/sensu-core/1.6/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.6/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/overview/_index.md
+++ b/content/sensu-core/1.6/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.6/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/platforms/_index.md
+++ b/content/sensu-core/1.6/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.6/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/quick-start/_index.md
+++ b/content/sensu-core/1.6/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.6/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.6/reference/_index.md
+++ b/content/sensu-core/1.6/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.6/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/api/_index.md
+++ b/content/sensu-core/1.7/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.7/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/guides/_index.md
+++ b/content/sensu-core/1.7/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.7/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/installation/_index.md
+++ b/content/sensu-core/1.7/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.7/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/overview/_index.md
+++ b/content/sensu-core/1.7/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.7/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/platforms/_index.md
+++ b/content/sensu-core/1.7/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.7/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/quick-start/_index.md
+++ b/content/sensu-core/1.7/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.7/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.7/reference/_index.md
+++ b/content/sensu-core/1.7/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.7/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/api/_index.md
+++ b/content/sensu-core/1.8/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-core/1.8/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/guides/_index.md
+++ b/content/sensu-core/1.8/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-core/1.8/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/installation/_index.md
+++ b/content/sensu-core/1.8/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-core/1.8/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/overview/_index.md
+++ b/content/sensu-core/1.8/overview/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: overview
 ---
 
-{{< directoryListing "content/sensu-core/1.8/overview" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/platforms/_index.md
+++ b/content/sensu-core/1.8/platforms/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: platforms
 ---
 
-{{< directoryListing "content/sensu-core/1.8/platforms" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/quick-start/_index.md
+++ b/content/sensu-core/1.8/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-core/1.8/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-core/1.8/reference/_index.md
+++ b/content/sensu-core/1.8/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-core/1.8/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.10/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.10/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.10/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.10/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.10/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.10/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.11/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.11/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.11/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.11/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.11/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.11/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.12/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.12/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.12/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.12/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.12/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.12/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.13/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.13/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.13/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.13/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.13/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.13/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.14/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.14/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.14/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.14/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.14/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.14/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.15/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.15/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.15/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.15/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.15/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.15/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.16/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.16/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.16/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.16/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.16/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.16/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.9/api/_index.md
+++ b/content/sensu-enterprise-dashboard/2.9/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.9/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise-dashboard/2.9/rbac/_index.md
+++ b/content/sensu-enterprise-dashboard/2.9/rbac/_index.md
@@ -9,4 +9,4 @@ menu:
     identifier: rbac
 ---
 
-{{< directoryListing "content/sensu-enterprise-dashboard/2.9/rbac" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.6/filters/_index.md
+++ b/content/sensu-enterprise/2.6/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.6/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.6/guides/_index.md
+++ b/content/sensu-enterprise/2.6/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.6/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.6/installation/_index.md
+++ b/content/sensu-enterprise/2.6/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.6/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.6/integrations/_index.md
+++ b/content/sensu-enterprise/2.6/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.6/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.6/quick-start/_index.md
+++ b/content/sensu-enterprise/2.6/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.6/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.7/filters/_index.md
+++ b/content/sensu-enterprise/2.7/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.7/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.7/guides/_index.md
+++ b/content/sensu-enterprise/2.7/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.7/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.7/installation/_index.md
+++ b/content/sensu-enterprise/2.7/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.7/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.7/integrations/_index.md
+++ b/content/sensu-enterprise/2.7/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.7/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.7/quick-start/_index.md
+++ b/content/sensu-enterprise/2.7/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.7/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.8/filters/_index.md
+++ b/content/sensu-enterprise/2.8/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.8/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.8/guides/_index.md
+++ b/content/sensu-enterprise/2.8/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.8/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.8/installation/_index.md
+++ b/content/sensu-enterprise/2.8/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.8/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.8/integrations/_index.md
+++ b/content/sensu-enterprise/2.8/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.8/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/2.8/quick-start/_index.md
+++ b/content/sensu-enterprise/2.8/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/2.8/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.0/filters/_index.md
+++ b/content/sensu-enterprise/3.0/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.0/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.0/guides/_index.md
+++ b/content/sensu-enterprise/3.0/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.0/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.0/installation/_index.md
+++ b/content/sensu-enterprise/3.0/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.0/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.0/integrations/_index.md
+++ b/content/sensu-enterprise/3.0/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.0/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.0/quick-start/_index.md
+++ b/content/sensu-enterprise/3.0/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.0/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.1/filters/_index.md
+++ b/content/sensu-enterprise/3.1/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.1/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.1/guides/_index.md
+++ b/content/sensu-enterprise/3.1/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.1/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.1/installation/_index.md
+++ b/content/sensu-enterprise/3.1/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.1/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.1/integrations/_index.md
+++ b/content/sensu-enterprise/3.1/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.1/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.1/quick-start/_index.md
+++ b/content/sensu-enterprise/3.1/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.1/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.2/filters/_index.md
+++ b/content/sensu-enterprise/3.2/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.2/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.2/guides/_index.md
+++ b/content/sensu-enterprise/3.2/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.2/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.2/installation/_index.md
+++ b/content/sensu-enterprise/3.2/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.2/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.2/integrations/_index.md
+++ b/content/sensu-enterprise/3.2/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.2/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.2/quick-start/_index.md
+++ b/content/sensu-enterprise/3.2/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.2/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.3/filters/_index.md
+++ b/content/sensu-enterprise/3.3/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.3/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.3/guides/_index.md
+++ b/content/sensu-enterprise/3.3/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.3/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.3/installation/_index.md
+++ b/content/sensu-enterprise/3.3/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.3/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.3/integrations/_index.md
+++ b/content/sensu-enterprise/3.3/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.3/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.3/quick-start/_index.md
+++ b/content/sensu-enterprise/3.3/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.3/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.4/filters/_index.md
+++ b/content/sensu-enterprise/3.4/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.4/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.4/guides/_index.md
+++ b/content/sensu-enterprise/3.4/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.4/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.4/installation/_index.md
+++ b/content/sensu-enterprise/3.4/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.4/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.4/integrations/_index.md
+++ b/content/sensu-enterprise/3.4/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.4/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.4/quick-start/_index.md
+++ b/content/sensu-enterprise/3.4/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.4/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.5/filters/_index.md
+++ b/content/sensu-enterprise/3.5/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.5/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.5/guides/_index.md
+++ b/content/sensu-enterprise/3.5/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.5/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.5/installation/_index.md
+++ b/content/sensu-enterprise/3.5/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.5/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.5/integrations/_index.md
+++ b/content/sensu-enterprise/3.5/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.5/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.5/quick-start/_index.md
+++ b/content/sensu-enterprise/3.5/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.5/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.6/filters/_index.md
+++ b/content/sensu-enterprise/3.6/filters/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: filters
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.6/filters" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.6/guides/_index.md
+++ b/content/sensu-enterprise/3.6/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.6/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.6/installation/_index.md
+++ b/content/sensu-enterprise/3.6/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.6/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.6/integrations/_index.md
+++ b/content/sensu-enterprise/3.6/integrations/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: integrations
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.6/integrations" >}}
+{{< directoryListing >}}

--- a/content/sensu-enterprise/3.6/quick-start/_index.md
+++ b/content/sensu-enterprise/3.6/quick-start/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: quick-start
 ---
 
-{{< directoryListing "content/sensu-enterprise/3.6/quick-start" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/api/_index.md
+++ b/content/sensu-go/5.12/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.12/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/dashboard/_index.md
+++ b/content/sensu-go/5.12/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.12/dashboard" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/getting-started/_index.md
+++ b/content/sensu-go/5.12/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.12/getting-started" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/guides/_index.md
+++ b/content/sensu-go/5.12/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.12/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/installation/_index.md
+++ b/content/sensu-go/5.12/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.12/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/reference/_index.md
+++ b/content/sensu-go/5.12/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.12/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.12/sensuctl/_index.md
+++ b/content/sensu-go/5.12/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.12/sensuctl" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/api/_index.md
+++ b/content/sensu-go/5.13/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.13/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/dashboard/_index.md
+++ b/content/sensu-go/5.13/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.13/dashboard" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/getting-started/_index.md
+++ b/content/sensu-go/5.13/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.13/getting-started" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/guides/_index.md
+++ b/content/sensu-go/5.13/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.13/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/installation/_index.md
+++ b/content/sensu-go/5.13/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.13/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/reference/_index.md
+++ b/content/sensu-go/5.13/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.13/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.13/sensuctl/_index.md
+++ b/content/sensu-go/5.13/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.13/sensuctl" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/api/_index.md
+++ b/content/sensu-go/5.14/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.14/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/dashboard/_index.md
+++ b/content/sensu-go/5.14/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.14/dashboard" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/getting-started/_index.md
+++ b/content/sensu-go/5.14/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.14/getting-started" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/guides/_index.md
+++ b/content/sensu-go/5.14/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.14/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/installation/_index.md
+++ b/content/sensu-go/5.14/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.14/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/reference/_index.md
+++ b/content/sensu-go/5.14/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.14/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.14/sensuctl/_index.md
+++ b/content/sensu-go/5.14/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.14/sensuctl" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/api/_index.md
+++ b/content/sensu-go/5.15/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.15/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/dashboard/_index.md
+++ b/content/sensu-go/5.15/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.15/dashboard" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/getting-started/_index.md
+++ b/content/sensu-go/5.15/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.15/getting-started" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/guides/_index.md
+++ b/content/sensu-go/5.15/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.15/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/installation/_index.md
+++ b/content/sensu-go/5.15/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.15/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/reference/_index.md
+++ b/content/sensu-go/5.15/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.15/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.15/sensuctl/_index.md
+++ b/content/sensu-go/5.15/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.15/sensuctl" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/api/_index.md
+++ b/content/sensu-go/5.16/api/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/sensu-go/5.16/api" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/dashboard/_index.md
+++ b/content/sensu-go/5.16/dashboard/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: dashboard
 ---
 
-{{< directoryListing "content/sensu-go/5.16/dashboard" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/getting-started/_index.md
+++ b/content/sensu-go/5.16/getting-started/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/sensu-go/5.16/getting-started" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/guides/_index.md
+++ b/content/sensu-go/5.16/guides/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/sensu-go/5.16/guides" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/installation/_index.md
+++ b/content/sensu-go/5.16/installation/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: installation
 ---
 
-{{< directoryListing "content/sensu-go/5.16/installation" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/reference/_index.md
+++ b/content/sensu-go/5.16/reference/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/sensu-go/5.16/reference" >}}
+{{< directoryListing >}}

--- a/content/sensu-go/5.16/sensuctl/_index.md
+++ b/content/sensu-go/5.16/sensuctl/_index.md
@@ -10,4 +10,4 @@ menu:
     identifier: sensuctl
 ---
 
-{{< directoryListing "content/sensu-go/5.16/sensuctl" >}}
+{{< directoryListing >}}

--- a/content/uchiwa/1.0/api/_index.md
+++ b/content/uchiwa/1.0/api/_index.md
@@ -8,4 +8,4 @@ menu:
     identifier: api
 ---
 
-{{< directoryListing "content/uchiwa/1.0/api" >}}
+{{< directoryListing >}}

--- a/content/uchiwa/1.0/getting-started/_index.md
+++ b/content/uchiwa/1.0/getting-started/_index.md
@@ -8,4 +8,4 @@ menu:
     identifier: getting-started
 ---
 
-{{< directoryListing "content/uchiwa/1.0/getting-started" >}}
+{{< directoryListing >}}

--- a/content/uchiwa/1.0/guides/_index.md
+++ b/content/uchiwa/1.0/guides/_index.md
@@ -8,4 +8,4 @@ menu:
     identifier: guides
 ---
 
-{{< directoryListing "content/uchiwa/1.0/guides" >}}
+{{< directoryListing >}}

--- a/content/uchiwa/1.0/reference/_index.md
+++ b/content/uchiwa/1.0/reference/_index.md
@@ -8,4 +8,4 @@ menu:
     identifier: reference
 ---
 
-{{< directoryListing "content/uchiwa/1.0/reference" >}}
+{{< directoryListing >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,7 +15,7 @@
   <div class="product-grid">
     {{ range sort .Site.Params.Products "weight" }}
       {{ $.Scratch.Set "url" "" }}
-      {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
+      {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier (cond (eq $.Hugo.Environment "development") .latest "latest")) }}
       {{ $url := $.Scratch.Get "url" }}
       <a class="product-grid--product product-grid--product-{{ .identifier }}" href="{{ $url }}">
         <div class="product-grid--product--title">{{ .name }}</div>

--- a/layouts/partials/productVersionDropdown.html
+++ b/layouts/partials/productVersionDropdown.html
@@ -20,20 +20,18 @@
 
   <!-- Dropdown for versions -->
   <div class="dropdown dropdown--versions">
-    {{ if isset .Params "version" }}
-      {{ $display := .Params.version }}
-      <a>{{ $display }}<i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-    {{ else }}
-      {{ $display := "Version" }}
-      <a>{{ $display }}<i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-    {{ end }}
-    <div class="options">
-      <!-- Grab info for the current product from global -->
-      {{ $product := replace .Section "-" "_" }}
-      {{ $product_info := (index .Site.Params.products $product) }}
-      {{ $chopurl := split $.RelPermalink "/"}}
-      {{ $pageversion := .Params.version }}
+    <!-- Grab info for the current product from global -->
+    {{ $product := replace .Section "-" "_" }}
+    {{ $product_info := (index .Site.Params.products $product) }}
+    {{ $chopurl := split $.RelPermalink "/"}}
+    {{ $pageversion := string (.Params.version) }}
 
+    <a>
+      {{ cond (isset .Params "version") $pageversion "Version" }}
+      {{ if (eq $pageversion $product_info.latest) }}(latest)&nbsp;{{ end }}
+      <i class="fa fa-chevron-down" aria-hidden="true"></i>
+    </a>
+    <div class="options">
       {{ if not ($.Scratch.Get "versionList") }}
         {{ range $k, $v := $product_info.versions }}
           {{ $.Scratch.Add "versionList" (slice $v.version) }}
@@ -44,15 +42,13 @@
         <!-- Protects when $chopurl has nothing after 3 /'s'-->
         {{ if gt (len $chopurl) 3 }}
           {{ $endurl := after 3 $chopurl}}
-          {{ if ne $version "2.0" }}
-            {{ if ne $pageversion "2.0" }}
-              <a href="/{{ $.Section }}/{{ $version }}/{{delimit $endurl "/"}}">{{ $version }}</a>
-            {{ else }}
-              <a href="/{{ $.Section }}/{{ $version }}">{{ $version }}</a>
-            {{ end }}
+          {{ if and (ne $version "2.0") (ne $pageversion "2.0") }}
+            <a href="/{{ $.Section }}/{{ $version }}/{{delimit $endurl "/"}}">
           {{ else }}
-            <a href="/{{ $.Section }}/{{ $version }}">{{ $version }}</a>
+            <a href="/{{ $.Section }}/{{ $version }}">
           {{ end }}
+            {{ $version }} {{ if eq $version $product_info.latest }}(latest){{ end }}
+          </a>
         {{ end }}
       {{ end }}
     </div>

--- a/layouts/shortcodes/directoryListing.html
+++ b/layouts/shortcodes/directoryListing.html
@@ -1,5 +1,4 @@
-{{ $path := .Get 0 }}
-{{ $files := readDir $path }}
+{{ $files := readDir (path.Join "content" $.Page.File.Dir) }}
 
 <!-- Loop through all files in dir -->
 <ul>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-postcss": "^0.9.0",
     "grunt-sass": "^3.0.2",
     "node-sass": "^4.12.0",
-    "toml": "^2.3.2",
+    "toml": "^3.0.0",
     "yaml": "^0.3.0"
   },
   "scripts": {

--- a/static.json
+++ b/static.json
@@ -3,10 +3,10 @@
     "https_only": true,
     "error_page": "/404.html",
     "pattern_redirects": {
-      "~ ^/sensu-core/2.0/?(.*)$": {
-          "url": "/sensu-go/5.0/$1",
-          "status": 301
-      },
+        "~ ^/sensu-core/2.0/?(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 301
+        },
         "~ ^/sensu-core/latest/?(.*)$": {
             "url": "/sensu-core/1.8/$1",
             "status": 301
@@ -27,6 +27,10 @@
             "url": "/sensu-go/latest/guides/create-read-only-user",
             "status": 301
         },
+        "~ ^/sensu-go/5.15/?(?<=\/)(.*)$": {
+            "url": "/sensu-go/latest/$1",
+            "status": 302
+        },
         "~ ^/sensu-go/5.1[0-1]/?(?<=\/)(.*)$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
@@ -37,10 +41,6 @@
         },
         "~ ^/plugins/latest/?(.*)$": {
             "url": "/plugins/1.0/$1",
-            "status": 301
-        },
-        "~ ^/sensu-go/latest/?(.*)$": {
-            "url": "/sensu-go/5.15/$1",
             "status": 301
         }
     }

--- a/static.json
+++ b/static.json
@@ -27,15 +27,15 @@
             "url": "/sensu-go/latest/guides/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/5.15/?(?<=\/)(.*)$": {
+        "~ ^/sensu-go/5.15/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 302
         },
-        "~ ^/sensu-go/5.1[0-1]/?(?<=\/)(.*)$": {
+        "~ ^/sensu-go/5.1[0-1]/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-go/5.[0-9]/?(?<=\/)(.*)$": {
+        "~ ^/sensu-go/5.[0-9]/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },

--- a/static.json
+++ b/static.json
@@ -3,25 +3,25 @@
     "https_only": true,
     "error_page": "/404.html",
     "pattern_redirects": {
-        "~ ^/sensu-core/2.0/?(.*)$": {
+        "~ ^/sensu-core/1.8/?((?<=\/).*)?$": {
+            "url": "/sensu-core/latest/$1",
+            "status": 302
+        },
+        "~ ^/sensu-core/2.0/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-core/latest/?(.*)$": {
-            "url": "/sensu-core/1.8/$1",
-            "status": 301
+        "~ ^/uchiwa/1.0/?((?<=\/).*)?$": {
+            "url": "/uchiwa/latest/$1",
+            "status": 302
         },
-        "~ ^/uchiwa/latest/?(.*)$": {
-            "url": "/uchiwa/1.0/$1",
-            "status": 301
+        "~ ^/sensu-enterprise/3.6/?((?<=\/).*)?$": {
+            "url": "/sensu-enterprise/latest/$1",
+            "status": 302
         },
-        "~ ^/sensu-enterprise/latest/?(.*)$": {
-            "url": "/sensu-enterprise/3.6/$1",
-            "status": 301
-        },
-        "~ ^/sensu-enterprise-dashboard/latest/?(.*)$": {
-            "url": "/sensu-enterprise-dashboard/2.16/$1",
-            "status": 301
+        "~ ^/sensu-enterprise-dashboard/2.16/?((?<=\/).*)?$": {
+            "url": "/sensu-enterprise-dashboard/latest/$1",
+            "status": 302
         },
         "~ ^/sensu-go/latest/guides/create-a-ready-only-user$": {
             "url": "/sensu-go/latest/guides/create-read-only-user",
@@ -39,9 +39,9 @@
             "url": "/sensu-go/latest/$1",
             "status": 301
         },
-        "~ ^/plugins/latest/?(.*)$": {
-            "url": "/plugins/1.0/$1",
-            "status": 301
+        "~ ^/plugins/1.0/?((?<=\/).*)?$": {
+            "url": "/plugins/latest/$1",
+            "status": 302
         }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,10 +2871,10 @@ to-readable-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
   integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
 
-toml@^2.3.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.6.tgz#25b0866483a9722474895559088b436fd11f861b"
-  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
 tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
# Description
1. Makes `/latest/` the default URL for the latest version of Sensu Go.
  **Example:** Sensu Go 5.15 will appear at `/sensu-go/latest/` and `/sensu-go/5.15/etc` will redirect (302) to `/sensu-go/latest/etc`.
2. Updates the product version dropdown for all products, to explicitly show which product version is "latest" .
    <img width="426" alt="image" src="https://user-images.githubusercontent.com/4516305/70797686-4dc84000-1da5-11ea-890a-841f7067a2b6.png">
3. Updates the heroku-buildpack-static "postinstall" task to automatically deploy the latest version of Sensu Go to a `content/sensu-go/latest` directory. This allows Sensu Docs developers to keep their usual `content/sensu-go` child directories intact, while enabling us to deploy "latest" docs.
    <img width="501" alt="image" src="https://user-images.githubusercontent.com/4516305/70798046-389fe100-1da6-11ea-8edf-b86f583343c0.png">

## Motivation and Context

Closes #1845 

## Review Instructions

**Note:** The pattern redirect for the latest version of Sensu Go (defined in *static.json*) will need to be updated any time there is a new release.

