### PR TITLE
Add solaris info in Installation docs

### DIFF
--- a/content/sensu-go/5.16/installation/platforms.md
+++ b/content/sensu-go/5.16/installation/platforms.md
@@ -99,6 +99,7 @@ Docker images containing the Sensu backend and Sensu agent are available for Lin
 | Linux              | {{< check >}}      | {{< check >}}     | {{< check >}}      | {{< check >}}      | {{< check >}}     | {{< check >}}    |
 | Windows            | {{< check >}}      |         |         |         |        | {{< check >}}    |
 | macOS              | {{< check >}}      |         |         |         |        |       |
+| Solaris            | {{< check >}}      |         |         |         |        |       |
 
 ## Building from source
 

--- a/content/sensu-go/5.16/installation/verify.md
+++ b/content/sensu-go/5.16/installation/verify.md
@@ -12,7 +12,7 @@ menu:
     parent: installation
 ---
 
-In addition to [packages][1], Sensu binary-only distributions are available for Linux, Windows (agent and CLI only), and macOS (CLI only).
+In addition to [packages][1], Sensu binary-only distributions are available for Linux, Windows (agent and CLI only), macOS (CLI only), and Solaris.
 
 {{< platformBlock "Linux" >}}
 


### PR DESCRIPTION
## Description
I left Solaris out in a couple places where it needed to be mentioned to close #2011 

## Motivation and Context
Additional changes based on #2011 
