### PR TITLE
Add "backend must be running" to sensu-backend init instructions

### DIFF
--- a/content/sensu-go/5.16/installation/install-sensu.md
+++ b/content/sensu-go/5.16/installation/install-sensu.md
@@ -146,7 +146,7 @@ For a complete list of configuration options, see the [backend reference][6].
 
 _**NOTE**: If you are using Docker, skip this step and continue with [4. Open the web UI][36]. The `sensu-backend init` command is not implemented for Docker._
 
-Run `sensu-backend init` to set up your Sensu administrator username and password.
+**With the backend running**, run `sensu-backend init` to set up your Sensu administrator username and password.
 In this initialization step, you only need to set environment variables with a username and password string &mdash; no need for role-based access control (RBAC).
 
 Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:

--- a/content/sensu-go/5.16/reference/backend.md
+++ b/content/sensu-go/5.16/reference/backend.md
@@ -51,7 +51,7 @@ For information about creating and managing checks, see:
 
 ## Initialization
 
-Before you start the Sensu backend on a **new** installation, you must set up an administrator username and password.
+For a **new** installation, you must set up an administrator username and password.
 To do this, set environment variables as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
 
 {{< highlight shell >}}
@@ -59,6 +59,8 @@ export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
 sensu-backend init
 {{< /highlight >}}
+
+_**NOTE**: Make sure the Sensu backend is running before you run `sensu-backend init`._
 
 You can also run the `sensu-backend init` command in interactive mode if you prefer to respond to prompts for your username and password:
 


### PR DESCRIPTION
## Description
Specify that the backend must be running for `sensu-backend init` to work.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2035