### PR TITLE
Remove gerund from menu title

### DIFF
--- a/content/sensu-go/5.16/guides/use-federation.md
+++ b/content/sensu-go/5.16/guides/use-federation.md
@@ -1,8 +1,8 @@
 ---
 title: "Multi-cluster visibility with federation"
-linkTitle: "Reaching Multi-cluster Visibility"
+linkTitle: "Reach Multi-cluster Visibility"
 description: "With Sensu's federation capabilities, you can access and manage resources across multiple clusters via the web UI and mirror changes in one cluster to follower clusters. In this guide, you'll learn how federate Sensu clusters."
-weight: 400
+weight: 220
 version: "5.16"
 product: "Sensu Go"
 platformContent: False


### PR DESCRIPTION
## Description
Removes gerund from menu title for federation guide (reaching --> reach)