### PR TITLE
Add release notes and document env var for Enterprise 3.7

### DIFF
--- a/content/sensu-enterprise/3.7/changelog.md
+++ b/content/sensu-enterprise/3.7/changelog.md
@@ -72,7 +72,7 @@ following improvements:
 
 Built on [Sensu Core 1.9.0][core-v1-9-0]:
 
-- **IMPROVEMENT**: You can now tune CMSInitiatingOccupancyFraction via an environment variable (e.g. `export CMS_OCCUPANCY_FRACTION="50"`).
+- **IMPROVEMENT**: You can now configure the threshold for Java CMSInitiatingOccupancyFraction garbage collection strategy via an environment variable (e.g. `export CMS_OCCUPANCY_FRACTION="50"`).
 
 ## Enterprise 3.6.2 Release Notes {#enterprise-v3-6-2}
 

--- a/content/sensu-enterprise/3.7/changelog.md
+++ b/content/sensu-enterprise/3.7/changelog.md
@@ -68,7 +68,6 @@ following improvements:
 
 ### CHANGES {#enterprise-v3-7-0-changes}
 
-
 Built on [Sensu Core 1.9.0][core-v1-9-0]:
 
 - **IMPROVEMENT**: You can now configure the threshold for Java CMSInitiatingOccupancyFraction garbage collection strategy via an environment variable (e.g. `export CMS_OCCUPANCY_FRACTION="50"`).

--- a/content/sensu-enterprise/3.7/changelog.md
+++ b/content/sensu-enterprise/3.7/changelog.md
@@ -70,7 +70,7 @@ following improvements:
 
 Built on [Sensu Core 1.9.0][core-v1-9-0]:
 
-- **IMPROVEMENT**: You can now configure the threshold for Java CMSInitiatingOccupancyFraction garbage collection strategy via an environment variable (e.g. `export CMS_OCCUPANCY_FRACTION="50"`).
+- **IMPROVEMENT**: You can now configure the Initiating Occupancy Fraction threshold for Java garbage collection via an environment variable (e.g. `export CMS_OCCUPANCY_FRACTION="50"`).
 
 ## Enterprise 3.6.2 Release Notes {#enterprise-v3-6-2}
 

--- a/content/sensu-enterprise/3.7/changelog.md
+++ b/content/sensu-enterprise/3.7/changelog.md
@@ -62,7 +62,7 @@ _NOTE: Sensu Enterprise is built on Sensu Core. Sensu Core changes are documente
 
 ## Enterprise 3.7.0 Release Notes {#enterprise-v3-7-0}
 
-**December 19, 2019** &mdash; Sensu Enterprise version 3.7.0 has been
+**January 7, 2020** &mdash; Sensu Enterprise version 3.7.0 has been
 released and is available for immediate download. Please note the
 following improvements:
 

--- a/content/sensu-enterprise/3.7/changelog.md
+++ b/content/sensu-enterprise/3.7/changelog.md
@@ -68,7 +68,6 @@ following improvements:
 
 ### CHANGES {#enterprise-v3-7-0-changes}
 
-- **BUGFIX**: Fixed Travis CI builds.
 
 Built on [Sensu Core 1.9.0][core-v1-9-0]:
 

--- a/content/sensu-enterprise/3.7/changelog.md
+++ b/content/sensu-enterprise/3.7/changelog.md
@@ -11,6 +11,7 @@ _NOTE: Sensu Enterprise is built on Sensu Core. Sensu Core changes are documente
 
 ## Releases
 
+- [Enterprise 3.7.0 Release Notes](#enterprise-v3-7-0)
 - [Enterprise 3.6.2 Release Notes](#enterprise-v3-6-2)
 - [Enterprise 3.6.1 Release Notes](#enterprise-v3-6-1)
 - [Enterprise 3.6.0 Release Notes](#enterprise-v3-6-0)
@@ -58,6 +59,20 @@ _NOTE: Sensu Enterprise is built on Sensu Core. Sensu Core changes are documente
 - [Enterprise 1.14.1 Release Notes](#enterprise-v1-14-1)
 - [Enterprise 1.14.0 Release Notes](#enterprise-v1-14-0)
 - [Enterprise 1.13.0 Release Notes](#enterprise-v1-13-0)
+
+## Enterprise 3.7.0 Release Notes {#enterprise-v3-7-0}
+
+**December 19, 2019** &mdash; Sensu Enterprise version 3.7.0 has been
+released and is available for immediate download. Please note the
+following improvements:
+
+### CHANGES {#enterprise-v3-7-0-changes}
+
+- **BUGFIX**: Fixed Travis CI builds.
+
+Built on [Sensu Core 1.9.0][core-v1-9-0]:
+
+- **IMPROVEMENT**: You can now tune CMSInitiatingOccupancyFraction via an environment variable (e.g. `export CMS_OCCUPANCY_FRACTION="50"`).
 
 ## Enterprise 3.6.2 Release Notes {#enterprise-v3-6-2}
 
@@ -953,3 +968,6 @@ This release includes potentially breaking, backwards-incompatible changes:
 <!-- 3.6 -->
 [core-v1-8-0]: /sensu-core/1.8/changelog/#core-v1-8-0
 [75]: https://account.sensu.io/support
+
+<!-- 3.7 -->
+[core-v1-9-0]: /sensu-core/1.9/changelog/#core-v1-9-0

--- a/content/sensu-enterprise/3.7/configuration.md
+++ b/content/sensu-enterprise/3.7/configuration.md
@@ -24,7 +24,7 @@ configuration honored by both Sensu Enterprise and Sensu Core, see the
 
 CMS_OCCUPANCY_FRACTION   | 
 -------------------------|-------
-description              | Tunes the CMSInitiatingOccupancyFraction.
+description              | Configures the Initiating Occupancy Fraction threshold for the Java [Concurrent Mark Sweep (CMS) garbage collector][2] used by Sensu Enterprise.
 type                     | String
 required                 | false
 default                  | `75`

--- a/content/sensu-enterprise/3.7/configuration.md
+++ b/content/sensu-enterprise/3.7/configuration.md
@@ -74,3 +74,4 @@ example         | {{< highlight shell >}}$ /opt/sensu/bin/sensu-enterprise -a
 {{< /highlight >}}
 
 [1]: /sensu-core/1.2/reference/configuration
+[2]: https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/cms.html

--- a/content/sensu-enterprise/3.7/configuration.md
+++ b/content/sensu-enterprise/3.7/configuration.md
@@ -18,9 +18,17 @@ sensu-enterprise service must be restarted before the new values can take effect
 
 ## Sensu Enterprise environment variables
 
-The Sensu Enterprise honors the following environment variables. For
+Sensu Enterprise honors the following environment variables. For
 configuration honored by both Sensu Enterprise and Sensu Core, see the
 [Sensu configuration reference documentation][1].
+
+CMS_OCCUPANCY_FRACTION   | 
+-------------------------|-------
+description              | Tunes the CMSInitiatingOccupancyFraction.
+type                     | String
+required                 | false
+default                  | `75`
+example                  | {{< highlight shell >}}CMS_OCCUPANCY_FRACTION="50"{{< /highlight >}}
 
 HEAP_SIZE    | 
 -------------|-------


### PR DESCRIPTION
## Description

- Adds 3.7.0 release notes
- Adds CMS_OCCUPANCY_FRACTION to https://docs.sensu.io/sensu-enterprise/3.7/configuration/#sensu-enterprise-environment-variables

## Motivation and Context
Support Enterprise 3.7.0 release

## Review Instructions
Need to confirm addition of env var
