### PR TITLE
Use 'latest' as default version for Algolia search

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -183,7 +183,7 @@
         apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
         indexName: 'sensu',
         inputSelector: '#desktop-search', 
-        algoliaOptions: { 'facetFilters': [[{{ if isset .Page.Params "product" }}'tags:{{ .Section }}'{{ else }}'tags:sensu-go','tags:plugins', 'tags:sensu-core', 'tags:sensu-enterprise', 'tags:sensu-enterprise-dashboard', 'tags:uchiwa'{{end}}], [{{ if isset .Page.Params "product" }}'version:{{ .Page.Params.version }}'{{ else }}'version:5.16','version:1.0','version:2.16','version:1.9','version:3.6'{{end}}]]},
+        algoliaOptions: { 'facetFilters': [[{{ if isset .Page.Params "product" }}'tags:{{ .Section }}'{{ else }}'tags:sensu-go','tags:plugins', 'tags:sensu-core', 'tags:sensu-enterprise', 'tags:sensu-enterprise-dashboard', 'tags:uchiwa'{{end}}], [{{ if isset .Page.Params "product" }}'version:{{ .Page.Params.version }}'{{ else }}'version:latest'{{end}}]]},
         debug: false
       }
       docsearch(options);


### PR DESCRIPTION
## Description

Update Algolia JS parameters to use 'latest' as default search version

## Motivation and Context

Closes #2018

## Review Instructions

¯\_(ツ)_/¯ 