### PR TITLE
Add global meta tag for Algolia Docsearch

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,6 +22,10 @@
     <meta name="author" content="{{ . }}">
     {{ end }}
 
+    {{ if isset .Page.Params "product" }}
+      <meta name="docsearch:version" content="{{ .Page.Params.version }}" />
+    {{ end}}
+
     <meta name="twitter:card" content="summary">
     <meta property="og:url" content="{{ .Permalink }}">
     <meta property="og:site_name" content="Sensu Docs">


### PR DESCRIPTION
## Description

Adds a `"docsearch:version"` [global meta tag](https://community.algolia.com/docsearch/required-configuration.html#introduces-global-information-as-meta-tags) to the document `<head>`.

Updates #2018

## Motivation and Context

Decouples current product versions from the document markup.

## Review Instructions

Lines 52-54 should also be removed from the [Docsearch config](https://github.com/algolia/docsearch-configs/blob/a43d72b0d351f5c65324f36f24bad7d8b3185180/configs/sensu.json#L52-L54).