### PR TITLE
Add Heroku app.json

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/boot

--- a/app.json
+++ b/app.json
@@ -1,0 +1,13 @@
+{
+    "name": "sensu-docs",
+    "description": "Documentation for Sensu Inc. software products",
+    "website": "https://docs.sensu.io",
+    "buildpacks": [
+        {
+            "url": ""heroku/nodejs""
+        },
+        {
+            "url": "https://github.com/sensu/heroku-buildpack-static"
+        }
+      ]
+}

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "website": "https://docs.sensu.io",
     "buildpacks": [
         {
-            "url": ""heroku/nodejs""
+            "url": "heroku/nodejs"
         },
         {
             "url": "https://github.com/sensu/heroku-buildpack-static"

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
             "url": "heroku/nodejs"
         },
         {
-            "url": "https://github.com/sensu/heroku-buildpack-static"
+            "url": "https://github.com/sensu/heroku-buildpack-static.git"
         }
       ]
 }


### PR DESCRIPTION
## Description

Adds app.json to repository root.

## Motivation and Context

In recent weeks we've been comparing Heroku and Netlify. With the merge of #2015 we have resolved some of the issues we thought would make us switch to Netlify, so we've decided to stick with Heroku.

One thing we really liked while evaluating Netlify was their deploy preview feature. Heroku has a similar capability (they call this Review Apps) but we aren't using it currently. Per the [review apps documentation](https://devcenter.heroku.com/articles/github-integration-review-apps) we need an app.json in the project.

## Review Instructions

Compare with [app.json Schema](https://devcenter.heroku.com/articles/app-json-schema).
