### PR TITLE
Add POST and PUT examples in handlers API doc

### DIFF
--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -27,9 +27,9 @@ The `/handlers` API endpoint provides HTTP GET access to [handler][1] data.
 The following example demonstrates a request to the `/handlers` API endpoint, resulting in a JSON array that contains [handler definitions][1].
 
 {{< highlight shell >}}
-curl -X GET
-http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
--H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers \
+-H "Authorization: Bearer $SENSU_TOKEN" \
 [
   {
     "metadata": {
@@ -195,8 +195,9 @@ The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data]
 In the following example, querying the `/handlers/:handler` API endpoint returns a JSON map that contains the requested [`:handler` definition][1] (in this example, for the `:handler` named `slack`).
 
 {{< highlight shell >}}
-curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack
--H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack \
+-H "Authorization: Bearer $SENSU_TOKEN" \
 {
   "metadata": {
     "name": "slack",
@@ -326,8 +327,8 @@ The following example shows a request to the `/handlers/:handler` API endpoint t
 
 {{< highlight shell >}}
 curl -X DELETE \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -113,7 +113,7 @@ output         | {{< highlight shell >}}
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     ],
-    "runtime_assets": null
+    "runtime_assets": ["sensu/sensu-slack-handler"]
   }
 ]
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -46,7 +46,7 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
       "INFLUXDB_USER=sensu",
       "INFLUXDB_PASSWORD=password"
     ],
-    "runtime_assets": null
+    "runtime_assets": ["sensu/sensu-influxdb-handler"]
   },
   {
     "metadata": {

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -278,7 +278,7 @@ curl -X PUT \
   ],
   "filters": [],
   "handlers": [],
-  "runtime_assets": [],
+  "runtime_assets": ["sensu/sensu-influxdb-handler"],
   "timeout": 0,
   "type": "pipe"
 }' \

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -64,7 +64,7 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     ],
-    "runtime_assets": null
+    "runtime_assets": ["sensu/sensu-influxdb-handler"]
   }
 ]
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -95,7 +95,7 @@ output         | {{< highlight shell >}}
       "INFLUXDB_USER=sensu",
       "INFLUXDB_PASSWORD=password"
     ],
-    "runtime_assets": null
+    "runtime_assets": ["sensu/sensu-influxdb-handler"]
   },
   {
     "metadata": {

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -122,7 +122,7 @@ output         | {{< highlight shell >}}
 
 The `/handlers` API endpoint provides HTTP POST access to create a handler.
 
-#### EXAMPLE {#filters-post-example}
+#### EXAMPLE {#handlers-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/handlers` API endpoint to create the event handler `influx-db`.
 The request returns a successful HTTP `201 Created` response.


### PR DESCRIPTION
Add POST /handlers and PUT /handlers/:handler examples.

Epic #1452