### PR TITLE
Add POST and PUT examples in hooks API doc

### DIFF
--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -27,8 +27,9 @@ The `/hooks` API endpoint provides HTTP GET access to [hook][1] data.
 The following example demonstrates a request to the `/hooks` API endpoint, resulting in a JSON array that contains [hook definitions][1].
 
 {{< highlight shell >}}
-curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks
--H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks \
+-H "Authorization: Bearer $SENSU_TOKEN" \
 [
   {
     "metadata": {
@@ -148,8 +149,9 @@ The `/hooks/:hook` API endpoint provides HTTP GET access to [hook data][1] for s
 In the following example, querying the `/hooks/:hook` API endpoint returns a JSON map that contains the requested [`:hook` definition][1] (in this example, for the `:hook` named `process-tree`).
 
 {{< highlight shell >}}
-curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree
--H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree \
+-H "Authorization: Bearer $SENSU_TOKEN" \
 
 {
   "metadata": {
@@ -245,8 +247,8 @@ The following example shows a request to the `/hooks/:hook` API endpoint to dele
 
 {{< highlight shell >}}
 curl -X DELETE \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -107,7 +107,7 @@ curl -X POST \
     "labels": null,
     "annotations": null
   },
-  "command": "ps aux",
+  "command": "ps -eo user,pid,cmd:50,%cpu --sort=-%cpu | head -n 6",
   "timeout": 10,
   "stdin": false
 }' \

--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -79,7 +79,7 @@ output         | {{< highlight shell >}}
       "name": "process-tree",
       "namespace": "default"
     },
-    "command": "ps aux",
+    "command": "ps -eo user,pid,cmd:50,%cpu --sort=-%cpu | head -n 6",
     "timeout": 10,
     "stdin": false,
     "runtime_assets": null

--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -27,18 +27,28 @@ The `/hooks` API endpoint provides HTTP GET access to [hook][1] data.
 The following example demonstrates a request to the `/hooks` API endpoint, resulting in a JSON array that contains [hook definitions][1].
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks -H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks
+-H "Authorization: Bearer $SENSU_TOKEN"
 [
   {
     "metadata": {
+      "name": "nginx-log",
+      "namespace": "default"
+    },
+    "command": "tail -n 100 /var/log/nginx/error.log",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
       "name": "process-tree",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "namespace": "default"
     },
     "command": "ps aux",
     "timeout": 10,
-    "stdin": false
+    "stdin": false,
+    "runtime_assets": null
   }
 ]
 {{< /highlight >}}
@@ -56,25 +66,23 @@ output         | {{< highlight shell >}}
 [
   {
     "metadata": {
-      "name": "process-tree",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
-    },
-    "command": "ps aux",
-    "timeout": 10,
-    "stdin": false
-  },
-  {
-    "metadata": {
       "name": "nginx-log",
-      "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "namespace": "default"
     },
     "command": "tail -n 100 /var/log/nginx/error.log",
     "timeout": 10,
-    "stdin": false
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "process-tree",
+      "namespace": "default"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
   }
 ]
 {{< /highlight >}}
@@ -82,6 +90,31 @@ output         | {{< highlight shell >}}
 ### `/hooks` (POST)
 
 The `/hooks` API endpoint provides HTTP POST access to create a hook.
+
+#### EXAMPLE {#hooks-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/hooks` API endpoint to create the hook `process-tree`.
+The request returns a successful HTTP `201 Created` response.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer $SENSU_TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "process-tree",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "command": "ps aux",
+  "timeout": 10,
+  "stdin": false
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks
+
+HTTP/1.1 201 Created
+{{< /highlight >}}
 
 #### API Specification {#hooks-post-specification}
 
@@ -102,7 +135,7 @@ payload         | {{< highlight shell >}}
   "stdin": false
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/hooks/:hook` API endpoint {#the-hookshook-api-endpoint}
 
@@ -115,7 +148,9 @@ The `/hooks/:hook` API endpoint provides HTTP GET access to [hook data][1] for s
 In the following example, querying the `/hooks/:hook` API endpoint returns a JSON map that contains the requested [`:hook` definition][1] (in this example, for the `:hook` named `process-tree`).
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree -H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree
+-H "Authorization: Bearer $SENSU_TOKEN"
+
 {
   "metadata": {
     "name": "process-tree",
@@ -155,24 +190,49 @@ output               | {{< highlight json >}}
 
 The `/hooks/:hook` API endpoint provides HTTP PUT access to create or update specific `:hook` definitions, by hook name.
 
+#### EXAMPLE {#hooks-post-example}
+
+In the following example, an HTTP PUT request is submitted to the `/hooks/:hook` API endpoint to create the hook `nginx-log`.
+The request returns a successful HTTP `201 Created` response.
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer $SENSU_TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "nginx-log",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "command": "tail -n 100 /var/log/nginx/error.log",
+  "timeout": 10,
+  "stdin": false
+  }' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/nginx-log
+
+HTTP/1.1 201 Created
+{{< /highlight >}}
+
 #### API Specification {#hookshook-put-specification}
 
 /hooks/:hook (PUT) | 
 ----------------|------
 description     | Creates or updates the specified Sensu hook.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/hooks/nginx-log
 payload         | {{< highlight shell >}}
 {
   "metadata": {
-    "name": "process-tree",
+    "name": "nginx-log",
     "namespace": "default",
     "labels": null,
     "annotations": null
   },
-  "command": "ps aux",
+  "command": "tail -n 100 /var/log/nginx/error.log",
   "timeout": 10,
   "stdin": false
-}
+  }
 {{< /highlight >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 

--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -45,7 +45,7 @@ curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks
       "name": "process-tree",
       "namespace": "default"
     },
-    "command": "ps aux",
+    "command": "ps -eo user,pid,cmd:50,%cpu --sort=-%cpu | head -n 6",
     "timeout": 10,
     "stdin": false,
     "runtime_assets": null


### PR DESCRIPTION
Add POST /hooks and PUT /hooks/:hook examples.

Epic #1452