### PR TITLE
Add POST and PUT examples in mutators API doc

### DIFF
--- a/content/sensu-go/5.16/api/mutators.md
+++ b/content/sensu-go/5.16/api/mutators.md
@@ -27,8 +27,8 @@ The `/mutators` API endpoint provides HTTP GET access to [mutator][1] data.
 The following example demonstrates a request to the `/mutators` API endpoint, resulting in a JSON array that contains [mutator definitions][1].
 
 {{< highlight shell >}}
-curl -X GET
-http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators
+curl -X GET \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators \
 -H "Authorization: Bearer $SENSU_TOKEN"
 [
   {
@@ -135,7 +135,8 @@ The `/mutators/:mutator` API endpoint provides HTTP GET access to [mutator data]
 In the following example, querying the `/mutators/:mutator` API endpoint returns a JSON map that contains the requested [`:mutator` definition][1] (in this example, for the `:mutator` named `example-mutator`).
 
 {{< highlight shell >}}
-curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator
+curl -X GET \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator \
 -H "Authorization: Bearer $SENSU_TOKEN"
 {
   "metadata": {

--- a/content/sensu-go/5.16/api/mutators.md
+++ b/content/sensu-go/5.16/api/mutators.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/mutators` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_TOKEN" \
 [
   {
     "metadata": {
@@ -137,7 +137,7 @@ In the following example, querying the `/mutators/:mutator` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_TOKEN" \
 {
   "metadata": {
     "name": "example-mutator",
@@ -236,8 +236,8 @@ The following example shows a request to the `/mutators/:mutator` API endpoint t
 
 {{< highlight shell >}}
 curl -X DELETE \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator \
 -H "Authorization: Bearer $SENSU_TOKEN" \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/mutators.md
+++ b/content/sensu-go/5.16/api/mutators.md
@@ -27,7 +27,9 @@ The `/mutators` API endpoint provides HTTP GET access to [mutator][1] data.
 The following example demonstrates a request to the `/mutators` API endpoint, resulting in a JSON array that contains [mutator definitions][1].
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators -H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators
+-H "Authorization: Bearer $SENSU_TOKEN"
 [
   {
     "metadata": {
@@ -74,6 +76,32 @@ output         | {{< highlight shell >}}
 
 The `/mutators` API endpoint provides HTTP POST access to create mutators.
 
+#### EXAMPLE {#mutators-post-example}
+
+In the following example, an HTTP POST request is submitted to the `/mutators` API endpoint to create the mutator `example-mutator`.
+The request returns a successful HTTP `201 Created` response.
+
+{{< highlight shell >}}
+curl -X POST \
+-H "Authorization: Bearer $SENSU_TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "example-mutator",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "command": "example_mutator.go",
+  "timeout": 0,
+  "env_vars": [],
+  "runtime_assets": []
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators
+
+HTTP/1.1 201 Created
+{{< /highlight >}}
+
 #### API Specification {#mutators-post-specification}
 
 /mutators (POST) | 
@@ -94,7 +122,7 @@ payload         | {{< highlight shell >}}
   "runtime_assets": []
 }
 {{< /highlight >}}
-response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/mutators/:mutator` API endpoint {#the-mutatorsmutator-api-endpoint}
 
@@ -107,7 +135,8 @@ The `/mutators/:mutator` API endpoint provides HTTP GET access to [mutator data]
 In the following example, querying the `/mutators/:mutator` API endpoint returns a JSON map that contains the requested [`:mutator` definition][1] (in this example, for the `:mutator` named `example-mutator`).
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator -H "Authorization: Bearer $SENSU_TOKEN"
+curl -X GET http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator
+-H "Authorization: Bearer $SENSU_TOKEN"
 {
   "metadata": {
     "name": "example-mutator",
@@ -148,6 +177,32 @@ output               | {{< highlight json >}}
 ### `/mutators/:mutator` (PUT) {#mutatorsmutator-put}
 
 The `/mutators/:mutator` API endpoint provides HTTP PUT access to [mutator data][1] to create or update specific `:mutator` definitions, by mutator name.
+
+#### EXAMPLE {#mutatorsmutator-put-example}
+
+In the following example, an HTTP PUT request is submitted to the `/mutators/:mutator` API endpoint to create the mutator `example-mutator`.
+The request returns a successful HTTP `201 Created` response.
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer $SENSU_TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "example-mutator",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "command": "example_mutator.go",
+  "timeout": 0,
+  "env_vars": [],
+  "runtime_assets": []
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator
+
+HTTP/1.1 201 Created
+{{< /highlight >}}
 
 #### API Specification {#mutatorsmutator-put-specification}
 


### PR DESCRIPTION
Add POST /mutators and PUT /mutators/:mutator examples.

Epic #1452