### PR TITLE
Fix missing word in federation guide description

### DIFF
--- a/content/sensu-go/5.15/guides/use-federation.md
+++ b/content/sensu-go/5.15/guides/use-federation.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-cluster visibility with federation"
 linkTitle: "Reaching Multi-cluster Visibility"
-description: "With Sensu's federation capabilities, you can access and manage resources across multiple clusters via the web UI and mirror changes in one cluster to follower clusters. In this guide, you'll learn how federate Sensu clusters."
+description: "With Sensu's federation capabilities, you can access and manage resources across multiple clusters via the web UI and mirror changes in one cluster to follower clusters. In this guide, you'll learn how to federate Sensu clusters."
 weight: 400
 version: "5.15"
 product: "Sensu Go"

--- a/content/sensu-go/5.16/guides/use-federation.md
+++ b/content/sensu-go/5.16/guides/use-federation.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-cluster visibility with federation"
 linkTitle: "Reach Multi-cluster Visibility"
-description: "With Sensu's federation capabilities, you can access and manage resources across multiple clusters via the web UI and mirror changes in one cluster to follower clusters. In this guide, you'll learn how federate Sensu clusters."
+description: "With Sensu's federation capabilities, you can access and manage resources across multiple clusters via the web UI and mirror changes in one cluster to follower clusters. In this guide, you'll learn how to federate Sensu clusters."
 weight: 220
 version: "5.16"
 product: "Sensu Go"


### PR DESCRIPTION
## Description
Change: "In this guide, you'll learn how federate Sensu clusters."
To: "In this guide, you'll learn how to federate Sensu clusters."