### PR TITLE
Fix annotations example in description table

### DIFF
--- a/content/sensu-go/5.13/reference/checks.md
+++ b/content/sensu-go/5.13/reference/checks.md
@@ -678,7 +678,7 @@ description  | Non-identifying metadata to include with event data, which can be
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
-example      | {{< highlight shell >}} "annotations": {
+example      | {{< highlight shell >}}"annotations": {
   "managed-by": "ops",
   "playbook": "www.example.url"
 }{{< /highlight >}}

--- a/content/sensu-go/5.14/reference/checks.md
+++ b/content/sensu-go/5.14/reference/checks.md
@@ -671,7 +671,7 @@ description  | Non-identifying metadata to include with event data, which can be
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
-example      | {{< highlight shell >}} "annotations": {
+example      | {{< highlight shell >}}"annotations": {
   "managed-by": "ops",
   "playbook": "www.example.url"
 }{{< /highlight >}}

--- a/content/sensu-go/5.15/reference/checks.md
+++ b/content/sensu-go/5.15/reference/checks.md
@@ -754,7 +754,7 @@ description  | Non-identifying metadata to include with event data, which can be
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
-example      | {{< highlight shell >}} "annotations": {
+example      | {{< highlight shell >}}"annotations": {
   "managed-by": "ops",
   "playbook": "www.example.url"
 }{{< /highlight >}}

--- a/content/sensu-go/5.16/reference/checks.md
+++ b/content/sensu-go/5.16/reference/checks.md
@@ -543,7 +543,7 @@ description  | Non-identifying metadata to include with event data that you can 
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
-example      | {{< highlight shell >}} "annotations": {
+example      | {{< highlight shell >}}"annotations": {
   "managed-by": "ops",
   "playbook": "www.example.url"
 }{{< /highlight >}}


### PR DESCRIPTION
## Description
In checks reference pages, the annotations example in the description table had an extra space that was throwing off the formatting.
