### PR TITLE
Minor formatting changes in API doc curl examples

### DIFF
--- a/content/sensu-go/5.16/api/authproviders.md
+++ b/content/sensu-go/5.16/api/authproviders.md
@@ -32,7 +32,7 @@ In the following example, querying the `/authproviders` API endpoint returns the
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/authentication/v2/authproviders \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -145,7 +145,7 @@ In the following example, an HTTP GET request is submitted to the `/authprovider
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/authentication/v2/authproviders/openldap \
 -H "Authorization: Bearer $SENSU_TOKEN" \
--H 'Content-Type: application/json' \
+-H 'Content-Type: application/json'
 
 HTTP/1.1 200 OK
 -d '{

--- a/content/sensu-go/5.16/api/cluster-roles.md
+++ b/content/sensu-go/5.16/api/cluster-roles.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/clusterroles` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/clusterroles \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -195,7 +195,7 @@ In the following example, querying the `/clusterroles/:clusterrole` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/clusterroles/global-event-reader \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 {

--- a/content/sensu-go/5.16/api/federation.md
+++ b/content/sensu-go/5.16/api/federation.md
@@ -42,7 +42,7 @@ _**NOTE**: If you did not specify a [namespace][2] when you created a replicator
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 [
   {
     "api_version": "federation/v1",
@@ -172,7 +172,7 @@ _**NOTE**: If you did not specify a [namespace][2] when you created the replicat
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 {
   "api_version": "federation/v1",
   "type": "EtcdReplicator",
@@ -318,7 +318,7 @@ The following example demonstrates a request to the `/clusters` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/clusters \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 
@@ -380,7 +380,7 @@ In the following example, querying the `/clusters/:cluster` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/clusters/us-west-2a \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 

--- a/content/sensu-go/5.16/api/filters.md
+++ b/content/sensu-go/5.16/api/filters.md
@@ -29,7 +29,9 @@ The following example demonstrates a request to the `/filters` API endpoint, res
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/filters \
--H "Authorization: Bearer $TOKEN" \
+-H "Authorization: Bearer $TOKEN"
+
+HTTP/1.1 200 OK
 [
   {
     "metadata": {
@@ -159,8 +161,9 @@ In the following example, querying the `/filters/:filter` API endpoint returns a
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/filters/state_change_only \
--H "Authorization: Bearer $TOKEN" \
+-H "Authorization: Bearer $TOKEN"
 
+HTTP/1.1 200 OK
 {
   "metadata": {
     "name": "state_change_only",
@@ -261,7 +264,7 @@ The following example shows a request to the `/filters/:filter` API endpoint to 
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/filters/development_filter \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -29,7 +29,9 @@ The following example demonstrates a request to the `/handlers` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
+
+HTTP/1.1 200 OK
 [
   {
     "metadata": {
@@ -197,7 +199,9 @@ In the following example, querying the `/handlers/:handler` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
+
+HTTP/1.1 200 OK
 {
   "metadata": {
     "name": "slack",
@@ -328,7 +332,7 @@ The following example shows a request to the `/handlers/:handler` API endpoint t
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -29,7 +29,9 @@ The following example demonstrates a request to the `/hooks` API endpoint, resul
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
+
+HTTP/1.1 200 OK
 [
   {
     "metadata": {
@@ -151,8 +153,9 @@ In the following example, querying the `/hooks/:hook` API endpoint returns a JSO
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
+HTTP/1.1 200 OK
 {
   "metadata": {
     "name": "process-tree",
@@ -248,7 +251,7 @@ The following example shows a request to the `/hooks/:hook` API endpoint to dele
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/license.md
+++ b/content/sensu-go/5.16/api/license.md
@@ -31,7 +31,9 @@ curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
 -H "Authorization: Bearer $SENSU_TOKEN" \
 -H 'Content-Type: application/json'
--d '{
+
+HTTP/1.1 200 OK
+{
   "type": "LicenseFile",
   "api_version": "licensing/v2",
   "metadata": {},
@@ -56,7 +58,7 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
     "signature": "XXXXXXXXXX",
     "metadata": {}
   }
-}'
+}
 {{< /highlight >}}
 
 #### API Specification {#license-get-specification}
@@ -108,7 +110,7 @@ The request returns a successful HTTP `201 Created` response.
 {{< highlight shell >}}
 curl -X PUT \
 -H "Authorization: Bearer $SENSU_TOKEN" \
--H 'Content-Type: application/json'
+-H 'Content-Type: application/json' \
 -d '{
   "type": "LicenseFile",
   "api_version": "licensing/v2",

--- a/content/sensu-go/5.16/api/mutators.md
+++ b/content/sensu-go/5.16/api/mutators.md
@@ -29,7 +29,9 @@ The following example demonstrates a request to the `/mutators` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
+
+HTTP/1.1 200 OK
 [
   {
     "metadata": {
@@ -137,7 +139,9 @@ In the following example, querying the `/mutators/:mutator` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
+
+HTTP/1.1 200 OK
 {
   "metadata": {
     "name": "example-mutator",

--- a/content/sensu-go/5.16/api/namespaces.md
+++ b/content/sensu-go/5.16/api/namespaces.md
@@ -30,7 +30,9 @@ The following example demonstrates a request to the `/namespaces` API endpoint, 
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
+
+HTTP/1.1 200 OK
 [
   {
     "name": "default"
@@ -142,7 +144,7 @@ The following example shows a request to the `/namespaces/:namespace` API endpoi
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/development \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -168,8 +170,9 @@ The following example demonstrates a request to the `/user-namespaces` API endpo
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/user-namespaces \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
+HTTP/1.1 200 OK
 [
   {
     "name": "default"

--- a/content/sensu-go/5.16/api/role-bindings.md
+++ b/content/sensu-go/5.16/api/role-bindings.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/rolebindings` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -143,7 +143,7 @@ In the following example, querying the `/rolebindings/:rolebinding` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings/readers-group-binding \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -262,7 +262,7 @@ The following example shows a request to the `/rolebindings/:rolebinding` API en
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings/dev-binding \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/roles.md
+++ b/content/sensu-go/5.16/api/roles.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/roles` API endpoint, resul
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/roles \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -197,7 +197,7 @@ In the following example, querying the `/roles/:role` API endpoint returns a JSO
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -320,7 +320,7 @@ The following example shows a request to the `/roles/:role` API endpoint to dele
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/silenced.md
+++ b/content/sensu-go/5.16/api/silenced.md
@@ -339,7 +339,8 @@ The `/silenced/checks/:check` API endpoint provides HTTP GET access to [silencin
 In the following example, querying the `silenced/checks/:check` API endpoint returns a JSON array that contains the requested [silences][1] for the given check (in this example, for the `check-cpu` check).
 
 {{< highlight shell >}}
-curl -H "Authorization: Bearer $SENSU_TOKEN" \
+curl -X GET \
+-H "Authorization: Bearer $SENSU_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced/checks/check-cpu
 
 HTTP/1.1 200 OK


### PR DESCRIPTION
- Remove \ from last line of curl commands
- Add HTTP/1.1 200 OK in GET calls