### PR TITLE
Change SENSU_TOKEN to SENSU_ACCESS_TOKEN in API examples

### DIFF
--- a/content/sensu-go/5.16/api/apikeys.md
+++ b/content/sensu-go/5.16/api/apikeys.md
@@ -27,9 +27,9 @@ The `/apikeys` GET endpoint retrieves all API keys.
 The following example demonstrates a request to the `/apikeys` API endpoint, resulting in a JSON array that contains all API keys.
 
 {{< highlight shell >}}
-curl -X GET
+curl -X GET \
 http://127.0.0.1:8080/api/core/v2/apikeys \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 
@@ -76,7 +76,7 @@ The request includes the API key definition in the request body and returns a su
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "admin"
@@ -112,7 +112,7 @@ In the following example, querying the `/apikeys/:apikey` API returns the reques
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -152,7 +152,7 @@ The following example shows a request to the `/apikeys/:apikey` API endpoint to 
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/assets.md
+++ b/content/sensu-go/5.16/api/assets.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/assets` API endpoint, resu
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/assets \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -130,7 +130,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "url": "https://github.com/sensu/sensu-slack-handler/releases/download/1.0.3/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
@@ -192,7 +192,7 @@ In the following example, querying the `/assets/:asset` API endpoint returns a J
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -257,7 +257,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "url": "https://github.com/sensu/sensu-slack-handler/releases/download/1.0.3/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
@@ -317,7 +317,7 @@ _**NOTE**: Deleting an asset does not remove the downloaded files from the asset
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/authproviders.md
+++ b/content/sensu-go/5.16/api/authproviders.md
@@ -32,7 +32,7 @@ In the following example, querying the `/authproviders` API endpoint returns the
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/authentication/v2/authproviders \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -144,7 +144,7 @@ In the following example, an HTTP GET request is submitted to the `/authprovider
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/authentication/v2/authproviders/openldap \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 
 HTTP/1.1 200 OK
@@ -249,7 +249,7 @@ In the following example, an HTTP PUT request is submitted to the `/authprovider
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "Type": "ldap",
@@ -325,7 +325,7 @@ The following example shows a request to the `/authproviders/:name` API endpoint
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/authproviders/openldap
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/checks.md
+++ b/content/sensu-go/5.16/api/checks.md
@@ -35,7 +35,7 @@ The following example demonstrates a request to the `/checks` API endpoint, resu
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/checks \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -123,7 +123,7 @@ The request includes the check definition in the request body and returns a succ
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "command": "check-cpu.sh -w 75 -c 90",
@@ -184,7 +184,7 @@ In the following example, querying the `/checks/:check` API endpoint returns a J
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/checks/check-cpu \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -266,7 +266,7 @@ In the following example, an HTTP PUT request is submitted to the `/checks/:chec
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "command": "check-cpu.sh -w 75 -c 90",
@@ -324,7 +324,7 @@ The following example shows a request to the `/checks/:check` API endpoint to de
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/checks/check-cpu
 
 HTTP/1.1 204 No Content
@@ -351,7 +351,7 @@ The request includes the check name in the request body and returns a successful
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "check": "check-cpu",
@@ -397,7 +397,7 @@ In the following example, an HTTP PUT request is submitted to the `/checks/:chec
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "critical": [
@@ -437,7 +437,7 @@ The following example shows a request to the `/checks/:check/hooks/:type/hook/:h
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/checks/check-cpu/hooks/critical/hook/process_tree 
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/cluster-role-bindings.md
+++ b/content/sensu-go/5.16/api/cluster-role-bindings.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/clusterrolebindings` API e
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/clusterrolebindings \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -122,7 +122,7 @@ The request includes the cluster role binding definition in the request body and
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "subjects": [
@@ -182,7 +182,7 @@ In the following example, querying the `/clusterrolebindings/:clusterrolebinding
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/clusterrolebindings/bob-binder \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -239,7 +239,7 @@ The request includes the cluster role binding definition in the request body and
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "subjects": [
@@ -296,7 +296,7 @@ The following example shows a request to the `/clusterrolebindings/:clusterroleb
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/clusterrolebindings/ops-binding
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/cluster-roles.md
+++ b/content/sensu-go/5.16/api/cluster-roles.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/clusterroles` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/clusterroles \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -131,7 +131,7 @@ The request includes the cluster role definition in the request body and returns
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -195,7 +195,7 @@ In the following example, querying the `/clusterroles/:clusterrole` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/clusterroles/global-event-reader \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -256,7 +256,7 @@ The request includes the cluster role definition in the request body and returns
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -318,7 +318,7 @@ The following example shows a request to the `/clusterroles/:clusterrole` API en
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/clusterroles/global-event-reader
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/cluster.md
+++ b/content/sensu-go/5.16/api/cluster.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/cluster/members` API endpo
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/cluster/members \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 
 HTTP/1.1 200 OK
 {
@@ -92,7 +92,7 @@ The `/cluster/members` API endpoint provides HTTP POST access to create a Sensu 
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/cluster/members?peer-addrs=http://127.0.0.1:2380
 
 HTTP/1.1 200 OK
@@ -136,7 +136,7 @@ The `/cluster/members/:member` API endpoint provides HTTP PUT access to create o
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/cluster/members/8927110dc66458af?peer-addrs=http://127.0.0.1:2380
 
 HTTP/1.1 200 OK
@@ -181,7 +181,7 @@ The following example shows a request to the `/cluster/members/:member` API endp
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/cluster/members/8927110dc66458af
 
 HTTP/1.1 204 No Content
@@ -208,7 +208,7 @@ The following example demonstrates a request to the `/cluster/id` API endpoint, 
 
 {{< highlight shell >}}
 curl -X GET \
- -H "Authorization: Bearer $SENSU_TOKEN" \
+ -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/cluster/id
 
 HTTP/1.1 200 OK

--- a/content/sensu-go/5.16/api/datastore.md
+++ b/content/sensu-go/5.16/api/datastore.md
@@ -28,7 +28,7 @@ The following example demonstrates a request to the `/provider` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/store/v1/provider
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 
 HTTP/1.1 200 OK
 [
@@ -92,7 +92,7 @@ output         | {{< highlight json >}}
 
 {{< highlight shell >}}
 curl -X GET \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/enterprise/store/v1/provider/my-postgres
 
 HTTP/1.1 200 OK
@@ -138,7 +138,7 @@ output         | {{< highlight json >}}
 {{< highlight shell >}}
 curl -X PUT \
 http://127.0.0.1:8080/api/enterprise/store/v1/provider/my-postgres \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -d '{
   "type": "PostgresConfig",
   "api_version": "store/v1",
@@ -187,7 +187,7 @@ The following example shows a request to the `/provider/:provider` API endpoint 
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/enterprise/store/v1/provider/my-postgres
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/entities.md
+++ b/content/sensu-go/5.16/api/entities.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/entities` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 [
   {
@@ -187,7 +187,7 @@ The request includes the entity definition in the request body and returns a suc
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "entity_class": "proxy",
@@ -246,7 +246,7 @@ In the following example, querying the `/entities/:entity` API endpoint returns 
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/sensu-centos \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 {
   "entity_class": "agent",
@@ -426,7 +426,7 @@ The request includes the updated entity definition in the request body and retur
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "entity_class": "proxy",
@@ -486,7 +486,7 @@ The following example shows a request to the `/entities/:entity` API endpoint to
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/server1 \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/events.md
+++ b/content/sensu-go/5.16/api/events.md
@@ -33,7 +33,7 @@ The following example demonstrates a request to the `/events` API endpoint, resu
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/events \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -183,7 +183,7 @@ The request includes information about the check and entity represented by the e
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -250,7 +250,7 @@ The request includes information about the check and entity represented by the e
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -320,7 +320,7 @@ In the following example, querying the `/events/:entity` API endpoint returns a 
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -487,7 +487,7 @@ In the following example, an HTTP GET request is submitted to the `/events/:enti
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/events/server1/server-health \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 
@@ -655,7 +655,7 @@ The event includes a status code of `1`, indicating a warning, and an output mes
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -740,7 +740,7 @@ The event includes a status code of `1`, indicating a warning, and an output mes
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -830,7 +830,7 @@ For more information about check attributes, see the [check specification][7].
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -858,7 +858,7 @@ For more information about these attributes and their available values, see the 
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -890,7 +890,7 @@ See the [events reference][9] and for more information about Sensu metric format
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 -d '{
   "entity": {
@@ -940,7 +940,7 @@ The following example shows a request to the `/events/:entity/:check` API endpoi
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/events/sensu-go-sandbox/check-cpu \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/federation.md
+++ b/content/sensu-go/5.16/api/federation.md
@@ -42,7 +42,7 @@ _**NOTE**: If you did not specify a [namespace][2] when you created a replicator
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 [
   {
     "api_version": "federation/v1",
@@ -106,7 +106,7 @@ The following example demonstrates a request to the `/etcd-replicators` API endp
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "api_version": "federation/v1",
@@ -172,7 +172,7 @@ _**NOTE**: If you did not specify a [namespace][2] when you created the replicat
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 {
   "api_version": "federation/v1",
   "type": "EtcdReplicator",
@@ -230,7 +230,7 @@ The following example demonstrates a request to the `/etcd-replicators/:etcd-rep
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "api_version": "federation/v1",
@@ -291,7 +291,7 @@ The following example shows a request to the `/etcd-replicators/:etcd-replicator
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator
 
 HTTP/1.1 204 No Content
@@ -318,7 +318,7 @@ The following example demonstrates a request to the `/clusters` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/clusters \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 
@@ -380,7 +380,7 @@ In the following example, querying the `/clusters/:cluster` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/federation/v1/clusters/us-west-2a \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 
@@ -437,7 +437,7 @@ The following example demonstrates a request to the `/clusters/:cluster` API end
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
     "type": "Cluster",
@@ -494,7 +494,7 @@ The following example shows a request to the `/clusters/:cluster` API endpoint t
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/enterprise/federation/v1/clusters/us-west-2a
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/api/filters.md
+++ b/content/sensu-go/5.16/api/filters.md
@@ -105,7 +105,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -210,7 +210,7 @@ The request returns a successful HTTP `200 OK` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -264,7 +264,7 @@ The following example shows a request to the `/filters/:filter` API endpoint to 
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/filters/development_filter \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/handlers.md
+++ b/content/sensu-go/5.16/api/handlers.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/handlers` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -131,7 +131,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -199,7 +199,7 @@ In the following example, querying the `/handlers/:handler` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -266,7 +266,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -332,7 +332,7 @@ The following example shows a request to the `/handlers/:handler` API endpoint t
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/slack \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/hooks.md
+++ b/content/sensu-go/5.16/api/hooks.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/hooks` API endpoint, resul
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -101,7 +101,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -153,7 +153,7 @@ In the following example, querying the `/hooks/:hook` API endpoint returns a JSO
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -202,7 +202,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -251,7 +251,7 @@ The following example shows a request to the `/hooks/:hook` API endpoint to dele
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/hooks/process-tree \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/license.md
+++ b/content/sensu-go/5.16/api/license.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/license` API endpoint, res
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 
 HTTP/1.1 200 OK
@@ -109,7 +109,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "type": "LicenseFile",
@@ -189,7 +189,7 @@ The following example shows a request to the `/license` API endpoint to delete t
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/enterprise/licensing/v2/license \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/mutators.md
+++ b/content/sensu-go/5.16/api/mutators.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/mutators` API endpoint, re
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -85,7 +85,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -139,7 +139,7 @@ In the following example, querying the `/mutators/:mutator` API endpoint returns
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -190,7 +190,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -241,7 +241,7 @@ The following example shows a request to the `/mutators/:mutator` API endpoint t
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/namespaces.md
+++ b/content/sensu-go/5.16/api/namespaces.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/namespaces` API endpoint, 
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -74,7 +74,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "name": "development"
@@ -110,7 +110,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "name": "development"
@@ -144,7 +144,7 @@ The following example shows a request to the `/namespaces/:namespace` API endpoi
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/development \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -170,7 +170,7 @@ The following example demonstrates a request to the `/user-namespaces` API endpo
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/user-namespaces \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [

--- a/content/sensu-go/5.16/api/overview.md
+++ b/content/sensu-go/5.16/api/overview.md
@@ -60,7 +60,7 @@ Beta APIs are more stable than alpha versions, but they offer similarly short-li
 
 With the exception of the [health API][5] and [metrics API][6], the Sensu API requires authentication using a JSON Web Token (JWT) access token.
 Use the [authentication API][12] and your Sensu username and password to generate access tokens and refresh tokens.
-The Sensu API docs use `$SENSU_TOKEN` to represent a valid access token in API requests.
+The Sensu API docs use `$SENSU_ACCESS_TOKEN` to represent a valid access token in API requests.
 
 ### Authentication quickstart
 
@@ -70,7 +70,7 @@ To set up a local API testing environment, save your Sensu credentials and token
 # Requires curl and jq
 export SENSU_USER=YOUR_USERNAME && SENSU_PASS=YOUR_PASSWORD
 
-export SENSU_TOKEN=`curl -XGET -u "$SENSU_USER:$SENSU_PASS" -s http://localhost:8080/auth | jq -r ".access_token"`
+export SENSU_ACCESS_TOKEN=`curl -X GET -u "$SENSU_USER:$SENSU_PASS" -s http://localhost:8080/auth | jq -r ".access_token"`
 {{< /highlight >}}
 
 ### Basic authentication using the authentication API
@@ -165,7 +165,7 @@ Similar to the `Bearer [token]` Authorization header, `Key [api-key]` will be ac
 For example, a JWT `Bearer [token]` Authorization header might be:
 
 {{< highlight shell >}}
-curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
 {{< /highlight >}}
 
 If you're using `Key [api-key]` to authenticate instead, the Authorization header might be:
@@ -207,7 +207,7 @@ You can request a paginated response with the `limit` and `continue` query param
 For example, the following request limits the response to a maximum of two objects:
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces?limit=2 -H "Authorization: Bearer $SENSU_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces?limit=2 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 {{< /highlight >}}
 
 The response includes the available objects up to the specified limit.
@@ -232,7 +232,7 @@ Sensu-Continue: L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA
 To request the next two available namespaces using the `Sensu-Continue` token included in the previous example's response:
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces?limit=2&continue=L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA -H "Authorization: Bearer $SENSU_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces?limit=2&continue=L2RlZmF1bHQvY2N4MWM2L2hlbGxvLXdvcmxkAA -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 {{< /highlight >}}
 
 If the request does not return a `Sensu-Continue` token, there are no further objects to return.
@@ -261,7 +261,7 @@ For example, to filter the response so that it only includes resources that have
 Include the `-G` flag so the request appends the data to the URL.
 
 {{< highlight shell >}}
-curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'labelSelector=region == "us-west-1"'
 {{< /highlight >}}
 
@@ -323,14 +323,14 @@ You can combine multiple statements separated with the logical operator `&&` (_A
 For example, the following cURL request looks up checks that are configured to be published **and** include the `slack` handler:
 
 {{< highlight shell >}}
-curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish == true && slack in check.handlers'
 {{< /highlight >}}
 
 In addition to selectors with multiple statements, you can use field and label selectors at the same time:
 
 {{< highlight shell >}}
-curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=slack in check.handlers' \
 --data-urlencode 'labelSelector=region != "us-west-1"'
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/role-bindings.md
+++ b/content/sensu-go/5.16/api/role-bindings.md
@@ -30,7 +30,7 @@ The following example demonstrates a request to the `/rolebindings` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -94,7 +94,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "name": "development"
@@ -143,7 +143,7 @@ In the following example, querying the `/rolebindings/:rolebinding` API endpoint
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings/readers-group-binding \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -202,7 +202,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "subjects": [
@@ -262,7 +262,7 @@ The following example shows a request to the `/rolebindings/:rolebinding` API en
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings/dev-binding \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/roles.md
+++ b/content/sensu-go/5.16/api/roles.md
@@ -29,7 +29,7 @@ The following example demonstrates a request to the `/roles` API endpoint, resul
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/roles \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -131,7 +131,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "rules": [
@@ -197,7 +197,7 @@ In the following example, querying the `/roles/:role` API endpoint returns a JSO
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -258,7 +258,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "rules": [
@@ -320,7 +320,7 @@ The following example shows a request to the `/roles/:role` API endpoint to dele
 {{< highlight shell >}}
 curl -X DELETE \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/roles/read-only \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}

--- a/content/sensu-go/5.16/api/silenced.md
+++ b/content/sensu-go/5.16/api/silenced.md
@@ -32,7 +32,7 @@ The following example demonstrates a request to the `/silenced` API endpoint, re
 
 {{< highlight shell >}}
 curl -X GET \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
 
 HTTP/1.1 200 OK
@@ -91,7 +91,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -147,7 +147,7 @@ Silencing entry names are generated from the combination of a subscription name 
 
 {{< highlight shell >}}
 curl -X GET \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced/linux:check-cpu
 
 HTTP/1.1 200 OK
@@ -201,7 +201,7 @@ The request returns a successful HTTP `201 Created` response.
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "metadata": {
@@ -254,7 +254,7 @@ In the following example, querying the `/silenced/:silenced` API endpoint to del
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced/linux:check-cpu
 
 HTTP/1.1 204 No Content
@@ -280,7 +280,7 @@ In the following example, querying the `silenced/subscriptions/:subscription` AP
 
 {{< highlight shell >}}
 curl -X GET \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced/subscriptions/linux
 
 HTTP/1.1 200 OK
@@ -340,7 +340,7 @@ In the following example, querying the `silenced/checks/:check` API endpoint ret
 
 {{< highlight shell >}}
 curl -X GET \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced/checks/check-cpu
 
 HTTP/1.1 200 OK

--- a/content/sensu-go/5.16/api/tessen.md
+++ b/content/sensu-go/5.16/api/tessen.md
@@ -29,7 +29,7 @@ The request returns an HTTP `200 OK` response and a JSON map that contains the a
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/tessen \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -63,7 +63,7 @@ The request returns an HTTP `200 OK` response and the resulting Tessen configura
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "opt_out": false

--- a/content/sensu-go/5.16/api/users.md
+++ b/content/sensu-go/5.16/api/users.md
@@ -39,7 +39,7 @@ The following example demonstrates a request to the `/users` API, resulting in a
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/users \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 [
@@ -98,7 +98,7 @@ The following example demonstrates a POST request to the `/users` API endpoint t
 
 {{< highlight shell >}}
 curl -X POST \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "alice",
@@ -145,7 +145,7 @@ In the following example, querying the `/users/:user` API returns a JSON map tha
 {{< highlight shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/users/alice \
--H "Authorization: Bearer $SENSU_TOKEN"
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
@@ -185,7 +185,7 @@ The following example demonstrates a PUT request to the `/users` API endpoint to
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "alice",
@@ -228,7 +228,7 @@ In the following example, an HTTP DELETE request is submitted to the `/users/:us
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/users/alice
 
 HTTP/1.1 204 No Content
@@ -254,7 +254,7 @@ In the following example, an HTTP PUT request is submitted to the `/users/:user/
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "alice",
@@ -292,7 +292,7 @@ In the following example, an HTTP PUT request is submitted to the `/users/:user/
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 http://127.0.0.1:8080/api/core/v2/users/alice/reinstate
 
@@ -319,7 +319,7 @@ In the following example, an HTTP DELETE request is submitted to the `/users/:us
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/users/alice/groups
 
 HTTP/1.1 204 No Content
@@ -345,7 +345,7 @@ In the following example, an HTTP PUT request is submitted to the `/users/:user/
 
 {{< highlight shell >}}
 curl -X PUT \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/users/alice/groups/ops
 
 HTTP/1.1 201 Created
@@ -369,7 +369,7 @@ In the following example, an HTTP DELETE request is submitted to the `/users/:us
 
 {{< highlight shell >}}
 curl -X DELETE \
--H "Authorization: Bearer $SENSU_TOKEN" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 http://127.0.0.1:8080/api/core/v2/users/alice/groups/ops
 
 HTTP/1.1 204 No Content

--- a/content/sensu-go/5.16/guides/use-apikey-feature.md
+++ b/content/sensu-go/5.16/guides/use-apikey-feature.md
@@ -32,7 +32,7 @@ Similar to the `Bearer [token]` Authorization header, `Key [api-key]` will be ac
 For example, a JWT `Bearer [token]` Authorization header might be:
 
 {{< highlight shell >}}
-curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
 {{< /highlight >}}
 
 If you're using `Key [api-key]` to authenticate instead, the Authorization header might be:

--- a/content/sensu-go/5.16/reference/license.md
+++ b/content/sensu-go/5.16/reference/license.md
@@ -63,7 +63,7 @@ Both agent and proxy entities count toward the overall entity limit.
 To see your current entity count, use any `/api/core` or `/api/enterprise` [API request][9]. For example:
 
 {{< highlight shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Bearer $SENSU_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 {{< /highlight >}}
 
 Your current entity count and limit are listed as response headers:


### PR DESCRIPTION
## Description
In API examples, replaces SENSU_TOKEN with SENSU_ACCESS_TOKEN

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2096