### PR TITLE
Remove POST entities/entity endpoint from API doc

### DIFF
--- a/content/sensu-go/5.13/api/entities.md
+++ b/content/sensu-go/5.13/api/entities.md
@@ -13,7 +13,6 @@ menu:
 	- [`/entities` (POST)](#entities-post)
 - [The `/entities/:entity` API endpoint](#the-entitiesentity-api-endpoint)
 	- [`/entities/:entity` (GET)](#entitiesentity-get)
-  - [`/entities/:entity` (POST)](#entitiesentity-post)
   - [`/entities/:entity` (PUT)](#entitiesentity-put)
   - [`/entities/:entity` (DELETE)](#entitiesentity-delete)
 
@@ -346,33 +345,6 @@ output               | {{< highlight json >}}
   }
 }
 {{< /highlight >}}
-
-### `/entities/:entity` (POST) {#entitiesentity-post}
-
-#### API Specification {#entitiesentity-post-specification}
-
-/entities/:entity (POST) | 
-----------------|------
-description     | Create or update a Sensu entity.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
-payload         | {{< highlight shell >}}
-{
-  "entity_class": "proxy",
-  "subscriptions": [
-    "web"
-  ],
-  "deregister": false,
-  "deregistration": {},
-  "metadata": {
-    "name": "sensu-centos",
-    "labels": null,
-    "annotations": null
-  }
-}
-{{< /highlight >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-
-Note that when an event is created via an HTTP POST request, the event will use the namespace in the request URL.
 
 ### `/entities/:entity` (PUT) {#entitiesentity-put}
 

--- a/content/sensu-go/5.14/api/entities.md
+++ b/content/sensu-go/5.14/api/entities.md
@@ -13,7 +13,6 @@ menu:
 	- [`/entities` (POST)](#entities-post)
 - [The `/entities/:entity` API endpoint](#the-entitiesentity-api-endpoint)
 	- [`/entities/:entity` (GET)](#entitiesentity-get)
-  - [`/entities/:entity` (POST)](#entitiesentity-post)
   - [`/entities/:entity` (PUT)](#entitiesentity-put)
   - [`/entities/:entity` (DELETE)](#entitiesentity-delete)
 
@@ -351,34 +350,6 @@ output               | {{< highlight json >}}
   }
 }
 {{< /highlight >}}
-
-### `/entities/:entity` (POST) {#entitiesentity-post}
-
-#### API Specification {#entitiesentity-post-specification}
-
-/entities/:entity (POST) | 
-----------------|------
-description     | Create or update a Sensu entity.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
-payload         | {{< highlight shell >}}
-{
-  "entity_class": "proxy",
-  "sensu_agent_version": "1.0.0",
-  "subscriptions": [
-    "web"
-  ],
-  "deregister": false,
-  "deregistration": {},
-  "metadata": {
-    "name": "sensu-centos",
-    "labels": null,
-    "annotations": null
-  }
-}
-{{< /highlight >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-
-Note that when an event is created via an HTTP POST request, the event will use the namespace in the request URL.
 
 ### `/entities/:entity` (PUT) {#entitiesentity-put}
 

--- a/content/sensu-go/5.15/api/entities.md
+++ b/content/sensu-go/5.15/api/entities.md
@@ -13,7 +13,6 @@ menu:
 	- [`/entities` (POST)](#entities-post)
 - [The `/entities/:entity` API endpoint](#the-entitiesentity-api-endpoint)
 	- [`/entities/:entity` (GET)](#entitiesentity-get)
-  - [`/entities/:entity` (POST)](#entitiesentity-post)
   - [`/entities/:entity` (PUT)](#entitiesentity-put)
   - [`/entities/:entity` (DELETE)](#entitiesentity-delete)
 
@@ -351,34 +350,6 @@ output               | {{< highlight json >}}
   }
 }
 {{< /highlight >}}
-
-### `/entities/:entity` (POST) {#entitiesentity-post}
-
-#### API Specification {#entitiesentity-post-specification}
-
-/entities/:entity (POST) | 
-----------------|------
-description     | Create or update a Sensu entity.
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
-payload         | {{< highlight shell >}}
-{
-  "entity_class": "proxy",
-  "sensu_agent_version": "1.0.0",
-  "subscriptions": [
-    "web"
-  ],
-  "deregister": false,
-  "deregistration": {},
-  "metadata": {
-    "name": "sensu-centos",
-    "labels": null,
-    "annotations": null
-  }
-}
-{{< /highlight >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-
-Note that when an event is created via an HTTP POST request, the event will use the namespace in the request URL.
 
 ### `/entities/:entity` (PUT) {#entitiesentity-put}
 

--- a/content/sensu-go/5.16/api/entities.md
+++ b/content/sensu-go/5.16/api/entities.md
@@ -13,7 +13,6 @@ menu:
 	- [`/entities` (POST)](#entities-post)
 - [The `/entities/:entity` API endpoint](#the-entitiesentity-api-endpoint)
 	- [`/entities/:entity` (GET)](#entitiesentity-get)
-  - [`/entities/:entity` (POST)](#entitiesentity-post)
   - [`/entities/:entity` (PUT)](#entitiesentity-put)
   - [`/entities/:entity` (DELETE)](#entitiesentity-delete)
 
@@ -389,34 +388,6 @@ output               | {{< highlight json >}}
   }
 }
 {{< /highlight >}}
-
-### `/entities/:entity` (POST) {#entitiesentity-post}
-
-The `/entities/:entity` API endpoint provides HTTP POST access to create or update the specified Sensu entity.
-
-#### API Specification {#entitiesentity-post-specification}
-
-/entities/:entity (POST) | 
-----------------|------
-description     | Creates or updates the specified Sensu entity. _**NOTE**: When you create an entity via an HTTP POST request, the entity will use the namespace in the request URL._
-example URL     | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
-payload         | {{< highlight shell >}}
-{
-  "entity_class": "proxy",
-  "sensu_agent_version": "1.0.0",
-  "subscriptions": [
-    "web"
-  ],
-  "deregister": false,
-  "deregistration": {},
-  "metadata": {
-    "name": "sensu-centos",
-    "labels": null,
-    "annotations": null
-  }
-}
-{{< /highlight >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ### `/entities/:entity` (PUT) {#entitiesentity-put}
 


### PR DESCRIPTION
## Description
Eng confirms POST entities/entity is not a valid call (https://sensu.slack.com/archives/C60EEQFH8/p1579012111340500). Removes endpoint from 5.13-5.16 Entity API doc.

## Motivation and Context
Closes #2097 
