### PR TITLE
Add sensu-backend-init for Docker and remove notes

### DIFF
--- a/content/sensu-go/5.17/getting-started/sample-app.md
+++ b/content/sensu-go/5.17/getting-started/sample-app.md
@@ -115,8 +115,6 @@ Use Sensu role-based access control (RBAC) to create a `demo` namespace and a `d
 
 When you installed the Sensu backend, during the [initialization step][14], you created an admin username and password for a `default` namespace. Use that username and password to configure sensuctl in this step.
 
-_**NOTE**: If you're using Docker, the username is `admin` and the password is `P@ssw0rd!`._
-
 {{< highlight shell >}}
 sensuctl configure
 ? Sensu Backend URL: http://sensu.local

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -154,7 +154,7 @@ Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you w
 {{< highlight Docker >}}
 docker run \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
--e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=`YOUR_PASSWORD' \
+-e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
 --restart always \
 --name sensu \
 sensu/sensu:latest \

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -175,8 +175,8 @@ services:
     - "sensu-backend-data:/var/lib/sensu/etcd"
     command: "sensu-backend start"
     environment:
-    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME
-    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD
+    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
+    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
 volumes:
   sensu-backend-data:
     driver: local

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -204,7 +204,7 @@ The web UI provides a unified view of your monitoring events and user-friendly t
 After starting the Sensu backend, open the web UI by visiting http://localhost:3000.
 You may need to replace `localhost` with the hostname or IP address where the Sensu backend is running.
 
-To log in to the web UI, enter your Sensu user credentials (the user ID and password you provided with the (the user ID and password provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables).
+To log in to the web UI, enter your Sensu user credentials (the username and password provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables).
 Select the ☰ icon to explore the web UI.
 
 ### 5. Make a request to the health API

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -144,18 +144,42 @@ For a complete list of configuration options, see the [backend reference][6].
 
 ### 3. Initialize
 
-_**NOTE**: If you are using Docker, skip this step and continue with [4. Open the web UI][36]. The `sensu-backend init` command is not implemented for Docker._
-
 **With the backend running**, run `sensu-backend init` to set up your Sensu administrator username and password.
 In this initialization step, you only need to set environment variables with a username and password string &mdash; no need for role-based access control (RBAC).
 
-Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
+Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use.
 
-{{< highlight shell >}}
+{{< language-toggle >}}
+
+{{< highlight Docker >}}
+docker run \
+-e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
+-e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=`YOUR_PASSWORD' \
+--restart always \
+--name sensu \
+sensu/sensu:latest \
+sensu-backend start \
+sensu-backend init
+{{< /highlight >}}
+
+{{< highlight "Docker Compose" >}}
+---
+NEEDED
+{{< /highlight >}}
+
+{{< highlight "Ubuntu/Debian" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
 sensu-backend init
 {{< /highlight >}}
+
+{{< highlight "RHEL/CentOS" >}}
+export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
+export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+sensu-backend init
+{{< /highlight >}}
+
+{{< /language-toggle >}}
 
 For details about `sensu-backend init`, see the [backend reference][30].
 
@@ -165,7 +189,7 @@ The web UI provides a unified view of your monitoring events and user-friendly t
 After starting the Sensu backend, open the web UI by visiting http://localhost:3000.
 You may need to replace `localhost` with the hostname or IP address where the Sensu backend is running.
 
-To log in to the web UI, enter your Sensu user credentials (the user ID and password you provided with `sensu-backend init`, or `admin` and `P@ssw0rd!` if you're using Docker).
+To log in to the web UI, enter your Sensu user credentials (the user ID and password you provided with `sensu-backend init`).
 Select the ☰ icon to explore the web UI.
 
 ### 5. Make a request to the health API

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -164,7 +164,6 @@ sensu-backend init
 
 {{< highlight "Docker Compose" >}}
 ---
----
 version: "3"
 services:
   sensu-backend:

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -164,7 +164,21 @@ sensu-backend init
 
 {{< highlight "Docker Compose" >}}
 ---
-NEEDED
+---
+version: "3"
+services:
+  sensu-backend:
+    image: sensu/sensu:latest
+    ports:
+    - 3000:3000
+    - 8080:8080
+    - 8081:8081
+    volumes:
+    - "sensu-backend-data:/var/lib/sensu/etcd"
+    command: "sensu-backend-init -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD"
+volumes:
+  sensu-backend-data:
+    driver: local
 {{< /highlight >}}
 
 {{< highlight "Ubuntu/Debian" >}}

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -158,8 +158,7 @@ docker run \
 --restart always \
 --name sensu \
 sensu/sensu:latest \
-sensu-backend start \
-sensu-backend init
+sensu-backend start
 {{< /highlight >}}
 
 {{< highlight "Docker Compose" >}}
@@ -174,7 +173,10 @@ services:
     - 8081:8081
     volumes:
     - "sensu-backend-data:/var/lib/sensu/etcd"
-    command: "sensu-backend-init -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD"
+    command: "sensu-backend start"
+    environment:
+    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME
+    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD
 volumes:
   sensu-backend-data:
     driver: local
@@ -202,7 +204,7 @@ The web UI provides a unified view of your monitoring events and user-friendly t
 After starting the Sensu backend, open the web UI by visiting http://localhost:3000.
 You may need to replace `localhost` with the hostname or IP address where the Sensu backend is running.
 
-To log in to the web UI, enter your Sensu user credentials (the user ID and password you provided with `sensu-backend init`).
+To log in to the web UI, enter your Sensu user credentials (the user ID and password you provided with the (the user ID and password provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables).
 Select the ☰ icon to explore the web UI.
 
 ### 5. Make a request to the health API

--- a/content/sensu-go/5.17/reference/rbac.md
+++ b/content/sensu-go/5.17/reference/rbac.md
@@ -240,8 +240,6 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 When you install the Sensu backend, during the [initialization step][42], you create a username and password for a `default` namespace.
 
-_**NOTE**: If you are using Docker, the `sensu-backend init` command runs automatically with a default username (`admin`) and password (`P@ssw0rd!`). You do not need to create a username and password for the `default` namespace if you are using Docker._
-
 This is the user that you can use to manage all aspects of Sensu and create new users.
 
 | attribute | value |

--- a/content/sensu-go/5.17/sensuctl/quickstart.md
+++ b/content/sensu-go/5.17/sensuctl/quickstart.md
@@ -20,8 +20,6 @@ sensuctl configure
 ? Password: YOUR_PASSWORD
 {{< /highlight >}}
 
-_**NOTE**: If you are using Docker, the default username is `admin` and the password is `P@ssw0rd!`._
-
 ### Create resources from a file that contains JSON resource definitions
 
 {{< highlight shell >}}

--- a/content/sensu-go/5.17/sensuctl/reference.md
+++ b/content/sensu-go/5.17/sensuctl/reference.md
@@ -53,8 +53,6 @@ When prompted, type the [Sensu backend URL][9] and your [Sensu access credential
 ? Preferred output format: tabular
 {{< /highlight >}}
 
-_**NOTE**: If you are using Docker, the default username is `admin` and the password is `P@ssw0rd!`._
-
 ### Sensu backend URL
 
 The Sensu backend URL is the HTTP or HTTPS URL where sensuctl can connect to the Sensu backend server.
@@ -68,8 +66,6 @@ For information about configuring the Sensu backend URL, see the [backend refere
 When you install the Sensu backend, during the [initialization step][40], you create a username and password for a `default` namespace.
 Your ability to get, list, create, update, and delete resources with sensuctl depends on the permissions assigned to your Sensu user.
 For more information about configuring Sensu access control, see the [RBAC reference][1].
-
-_**NOTE**: If you are using Docker, the `sensu-backend init` command for initialization runs automatically with a default username (`admin`) and password (`P@ssw0rd!`) for Docker. You do not need to create a username and password for the `default` namespace if you are using Docker._
 
 ### Preferred output format
 
@@ -89,8 +85,6 @@ Run `sensuctl configure` non-interactively by adding the `-n` (`--non-interactiv
 {{< highlight shell >}}
 sensuctl configure -n --url http://127.0.0.1:8080 --username YOUR_USERNAME --password YOUR_PASSWORD --format tabular
 {{< /highlight >}}
-
-_**NOTE**: If you are using Docker, the default username is `admin` and the password is `P@ssw0rd!`._
 
 ## Get help
 

--- a/content/sensu-go/5.17/sensuctl/reference.md
+++ b/content/sensu-go/5.17/sensuctl/reference.md
@@ -67,6 +67,8 @@ When you install the Sensu backend, during the [initialization step][40], you cr
 Your ability to get, list, create, update, and delete resources with sensuctl depends on the permissions assigned to your Sensu user.
 For more information about configuring Sensu access control, see the [RBAC reference][1].
 
+_**NOTE**: The `sensu-backend init` command for initialization runs automatically with a default username (`admin`) and password (`P@ssw0rd!`). You can specify a username and password with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables during [initialization][40] to override the defaults._ 
+
 ### Preferred output format
 
 Sensuctl supports the following output formats:


### PR DESCRIPTION
## Description

- Adds `sensu-backend-init` step for Docker in Install Sensu initialize step
- Removes notes about Docker still using the default username and password because `sensu-backend-init` is not implemented for Docker

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2028

## Review Instructions
Need to confirm my guess at the Docker Compose init (see tab placeholder in https://github.com/sensu/sensu-docs/pull/2124/files#diff-e43dde491c2c004c5dc46a0c7787ae33)