### PR TITLE
Add secrets reference

### DIFF
--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -166,7 +166,7 @@ spec:
 
 {{< /language-toggle >}}
 
-Secrets that target a HashiCorp Vault are configured as shown in the following example:
+Configure secrets that target a HashiCorp Vault as shown in the following example:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -18,7 +18,7 @@ menu:
 For more information, see [Get started with commercial features][1].
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
-Use secrets to obtain secrets from one or more external secrets management providers, refer to external secrets, and comsume secrets via backend [environment variables][5].
+Use secrets to obtain secrets from one or more external secrets management providers, refer to external secrets, and consume secrets via backend [environment variables][5].
 
 Only Sensu backends have access to request secrets from a [secret provider][7].
 Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -1,7 +1,7 @@
 ---
 title: "Secrets"
 linkTitle: "Secrets"
-description: "Sensu's secrets management capability allows you to avoid exposing secrets in your Sensu configuration. Read the reference to obtain secrets from one or more external secrets management providers and use sensuctl to manage secrets."
+description: "Sensu's secrets management feature allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration. Read the reference to obtain secrets from one or more external secrets providers and use sensuctl to manage secrets."
 weight: 145
 version: "5.17"
 product: "Sensu Go"
@@ -19,9 +19,9 @@ menu:
 For more information, see [Get started with commercial features][1].
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
-When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via backend [environment variables][5].
+When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
-Only Sensu backends have access to request secrets from a [secret provider][7].
+Only Sensu backends have access to request secrets from a [secrets provider][7].
 Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.
 Secrets provided via a "lease" with a "lease duration" are deleted from Sensu's in-memory cache after the configured number of seconds, prompting the Sensu backend to request the secret again.
 
@@ -29,7 +29,7 @@ Secrets are only transmitted over a TLS websocket connection.
 Unencrypted connections must not transmit privileged information.
 For agent-side resources, enable TLS/mTLS.
 
-Secrets are only exposed to Sensu services like environment variables and are automatically redacted from all logs, the API, and the Sensu dashboard.
+Sensu only exposes secrets to Sensu services like environment variables and automatically redacts secrets from all logs, the API, and the dashboard.
  
 ## Secret specification
 
@@ -44,7 +44,7 @@ example      | {{< highlight shell >}}"type": "Secret"{{< /highlight >}}
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For secrets configuration in this version of Sensu, the `api_version` should always be `secrets/v1`.
+description  | Top-level attribute that specifies the Sensu API group and version. For secrets configuration in this version of Sensu, the api_version should always be `secrets/v1`.
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | String
 example      | {{< highlight shell >}}"api_version": "secrets/v1"{{< /highlight >}}
@@ -77,7 +77,7 @@ example      | {{< highlight shell >}}
 
 name         |      |
 -------------|------
-description  | The name for the secret that is used internally by Sensu.
+description  | Name for the secret that is used internally by Sensu.
 required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "sensu-ansible-token"{{< /highlight >}}
@@ -93,21 +93,21 @@ example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
 
 id           | 
 -------------|------ 
-description  | The identifying key for the provider to retrieve the secret.
+description  | Identifying key for the provider to retrieve the secret.
 required     | true
 type         | String
 example      | {{< highlight shell >}}"id": "secret/ansible#token"{{< /highlight >}}
 
 provider     | 
 -------------|------ 
-description  | The name of the Sensu provider with the secret.
+description  | Name of the provider with the secret.
 required     | true
 type         | String
-example      | {{< highlight shell >}}"provider": "ansible_vault"{{< /highlight >}}
+example      | {{< highlight shell >}}"provider": "vault"{{< /highlight >}}
 
 ## Secret configuration
 
-Use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
+You can use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
 To manage secrets configuration with sensuctl, configure sensuctl as the default [`admin` user][6].
 
 The [standard sensuctl subcommands][4] are available for secrets (list, info, and delete).
@@ -179,7 +179,7 @@ metadata:
   namespace: default
 spec:
   id: 'secret/database#password'
-  provider: ansible_vault
+  provider: vault
 {{< /highlight >}}
 
 {{< highlight json >}}
@@ -199,9 +199,9 @@ spec:
 
 {{< /language-toggle >}}
 
-The id value for secrets that target a HashiCorp Vault must start with the name of the secret's path in Vault.
-The [Vault dev server][10] is preconfigured with the secret keyspace already set up.
-This is convenient for learning and getting started with Vault secrets management, so this example and our guide to [Secrets management][11] use the secret/ path for the id value.
+The `id` value for secrets that target a HashiCorp Vault must start with the name of the secret's path in Vault.
+The [Vault dev server][10] is preconfigured with the `secret` keyspace already set up.
+This is convenient for learning and getting started with Vault secrets management, so this example and our guide to [Secrets management][11] use the `secret/` path for the `id` value.
 In this example, the name of the secret is `database`.
 The `database` secret contains a value called `password`, which is the password to our database.
 

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -12,7 +12,7 @@ menu:
 - [Secret specification](#secret-specification)
   - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
 - [Secret configuration](#secret-configuration)
-- [Secret payload examples](#secret-payload-examples)
+- [Secret examples](#secret-examples)
 
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
@@ -131,7 +131,7 @@ To delete a secret:
 sensuctl secret delete SECRET_NAME
 {{< /highlight >}}
 
-## Secret payload examples
+## Secret examples
 
 A secret resource definition refers to a secrets `id` and a secrets `provider`.
 Read the [secrets provider reference][7] for the provider specification.

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -1,5 +1,6 @@
 ---
 title: "Secrets"
+linkTitle: "Secrets"
 description: "Sensu's secrets management capability allows you to avoid exposing secrets in your Sensu configuration. Read the reference to obtain secrets from one or more external secrets management providers and use sensuctl to manage secrets."
 weight: 145
 version: "5.17"

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -131,6 +131,7 @@ sensuctl secret delete SECRET_NAME
 {{< /highlight >}}
 
 `SECRET_NAME` is the value specified in the secret's `name` [metadata attribute][12].
+
 ## Secret examples
 
 A secret resource definition refers to a secrets `id` and a secrets `provider`.

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -1,0 +1,173 @@
+---
+title: "Secrets"
+description: "Sensu's secrets management capability allows you to avoid exposing secrets in your Sensu configuration. Read the reference to obtain secrets from one or more external secrets management providers and use sensuctl to manage secrets."
+weight: 145
+version: "5.17"
+product: "Sensu Go"
+menu: 
+  sensu-go-5.17:
+    parent: reference
+---
+
+- [Secret specification](#secret-specification)
+  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
+- [Secret configuration](#secret-configuration)
+- [Secret payload example](#secret-payload-example)
+
+**COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features][1].
+
+Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
+Use secrets to obtain secrets from one or more external secrets management providers, refer to external secrets, and comsume secrets via backend [environment variables][5].
+
+Only Sensu backends have access to request secrets from a [secret provider][7].
+Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.
+Secrets provided via a "lease" with a "lease duration" are deleted from Sensu's in-memory cache after the configured number of seconds, prompting the Sensu backend to request the secret again.
+
+Secrets are only transmitted over a TLS websocket connection.
+Unencrypted connections must not transmit privileged information.
+For agent-side resources, enable TLS/mTLS.
+
+Secrets are only exposed to Sensu services like environment variables and are automatically redacted from all logs, the API, and the Sensu dashboard.
+ 
+## Secret specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For secrets configuration, the type should always be `Secret`.
+required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< highlight shell >}}"type": "Secret"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. For secrets configuration in this version of Sensu, the `api_version` should always be `secrets/v1`.
+required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< highlight shell >}}"api_version": "secrets/v1"{{< /highlight >}}
+
+metadata     |      |
+-------------|------
+description  | Top-level scope that contains the secret's `name` and `namespace`.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"metadata": {
+  "name": "sensu-ansible-token",
+  "namespace": "default"
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes secrets configuration [spec attributes][12].
+required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"spec": {
+  "id": "ANSIBLE_TOKEN",
+  "provider": "ansible_vault"
+}
+{{< /highlight >}}
+
+### Metadata attributes
+
+name         |      |
+-------------|------
+description  | The name for the secret that is used internally by Sensu.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "sensu-ansible-token"{{< /highlight >}}
+
+namespace    |      |
+-------------|------
+description  | Provider name used internally by Sensu.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
+
+### Spec attributes
+
+id           | 
+-------------|------ 
+description  | The identifying key for the provider to retrieve the secret.
+required     | true
+type         | String
+default      | `false`
+example      | {{< highlight shell >}}"id": "ANSIBLE_TOKEN"{{< /highlight >}}
+
+provider     | 
+-------------|------ 
+description  | The name of the provider with the secret.
+required     | true
+type         | String
+default      | `false`
+example      | {{< highlight shell >}}"provider": "ansible_vault"{{< /highlight >}}
+
+## Secret configuration
+
+Use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
+To manage secrets configuration with sensuctl, configure sensuctl as the default [`admin` user][6].
+
+The [standard sensuctl subcommands][4] are available for secrets (list, info, and delete).
+
+To list all secrets:
+
+{{< highlight shell >}}
+sensuctl secret list
+{{< /highlight >}}
+
+To see a secret's status:
+
+{{< highlight shell >}}
+sensuctl secret info SECRET_NAME
+{{< /highlight >}}
+
+To delete a secret:
+
+{{< highlight shell >}}
+sensuctl secret delete SECRET_NAME
+{{< /highlight >}}
+
+## Secret payload example
+
+A secret resource definition refers to a secrets `id` and a secrets `provider`.
+Read the [secrets provider reference][7] for the provider specification.
+
+{{< highlight json >}}
+{
+  "type": "Secret",
+  "api_version": "secrets/v1",
+  "metadata": {
+    "name": "sensu-ansible-token",
+    "namespace": "default"
+  },
+  "spec": {
+    "id": "ANSIBLE_TOKEN",
+    "provider": "ansible_vault"
+  }
+}
+{{< /highlight >}}
+
+{{< highlight yaml >}}
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: sensu-ansible-token
+  namespace: default
+spec:
+  id: ANSIBLE_TOKEN
+  provider: ansible_vault
+{{< /highlight >}}
+
+
+[1]: ../../getting-started/enterprise/
+[2]: ../../api/secrets/
+[3]: ../../sensuctl/reference/
+[4]: ../../sensuctl/reference/#subcommands
+[5]: ..//backend/#configuration-via-environment-variables
+[6]: ../rbac#default-users
+[7]: ../secret-providers/

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -212,7 +212,7 @@ The `website` secret contains a value called `database`, which is the password t
 [2]: ../../api/secrets/
 [3]: ../../sensuctl/reference/
 [4]: ../../sensuctl/reference/#subcommands
-[5]: ..//backend/#configuration-via-environment-variables
+[5]: ../backend/#configuration-via-environment-variables
 [6]: ../rbac#default-users
 [7]: ../secret-providers/
 [8]: #spec-attributes

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -12,7 +12,7 @@ menu:
 - [Secret specification](#secret-specification)
   - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
 - [Secret configuration](#secret-configuration)
-- [Secret payload example](#secret-payload-example)
+- [Secret payload examples](#secret-payload-examples)
 
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -85,10 +85,6 @@ example      | {{< highlight shell >}}"name": "sensu-ansible-token"{{< /highligh
 namespace    |      |
 -------------|------
 description  | [Sensu RBAC namespace][9] that the secret belongs to.
---
-
-
-.
 required     | true
 type         | String
 example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
@@ -100,15 +96,13 @@ id           |
 description  | The identifying key for the provider to retrieve the secret.
 required     | true
 type         | String
-default      | `false`
 example      | {{< highlight shell >}}"id": "secret/ansible#token"{{< /highlight >}}
 
 provider     | 
 -------------|------ 
-description  | The name of the provider with the secret.
+description  | The name of the Sensu provider with the secret.
 required     | true
 type         | String
-default      | `false`
 example      | {{< highlight shell >}}"provider": "ansible_vault"{{< /highlight >}}
 
 ## Secret configuration

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -215,4 +215,4 @@ The `database` secret contains a value called `password`, which is the password 
 [8]: #spec-attributes
 [9]: ../../reference/rbac/#namespaces
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
-[11]: ../../guides/secrets-management-vault/
+[11]: ../../guides/secrets-management/

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -209,7 +209,7 @@ The `database` secret contains a value called `password`, which is the password 
 [4]: ../../sensuctl/reference/#subcommands
 [5]: ../backend/#configuration-via-environment-variables
 [6]: ../rbac#default-users
-[7]: ../secret-providers/
+[7]: ../secrets-providers/
 [8]: #spec-attributes
 [9]: ../../reference/rbac/#namespaces
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -179,7 +179,7 @@ metadata:
   name: sensu-ansible-token
   namespace: default
 spec:
-  id: ANSIBLE_TOKEN
+  id: secret/website#database
   provider: ansible_vault
 {{< /highlight >}}
 

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -130,6 +130,7 @@ To delete a secret:
 sensuctl secret delete SECRET_NAME
 {{< /highlight >}}
 
+`SECRET_NAME` is the value specified in the secret's `name` [metadata attribute][12].
 ## Secret examples
 
 A secret resource definition refers to a secrets `id` and a secrets `provider`.
@@ -216,3 +217,4 @@ The `database` secret contains a value called `password`, which is the password 
 [9]: ../../reference/rbac/#namespaces
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../../guides/secrets-management/
+[12]: #metadata-attributes

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -62,7 +62,7 @@ example      | {{< highlight shell >}}
 
 spec         | 
 -------------|------
-description  | Top-level map that includes secrets configuration [spec attributes][12].
+description  | Top-level map that includes secrets configuration [spec attributes][8].
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
@@ -211,3 +211,4 @@ The `website` secret contains a value called `database`, which is the password t
 [5]: ..//backend/#configuration-via-environment-variables
 [6]: ../rbac#default-users
 [7]: ../secret-providers/
+[8]: #spec-attributes

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -19,7 +19,7 @@ menu:
 For more information, see [Get started with commercial features][1].
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
-When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via backend [environment variables][5].
+When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via backend [environment variables][5].
 
 Only Sensu backends have access to request secrets from a [secret provider][7].
 Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -19,7 +19,7 @@ menu:
 For more information, see [Get started with commercial features][1].
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
-Use secrets to obtain secrets from one or more external secrets management providers, refer to external secrets, and consume secrets via backend [environment variables][5].
+When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via backend [environment variables][5].
 
 Only Sensu backends have access to request secrets from a [secret provider][7].
 Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -83,7 +83,11 @@ example      | {{< highlight shell >}}"name": "sensu-ansible-token"{{< /highligh
 
 namespace    |      |
 -------------|------
-description  | Provider name used internally by Sensu.
+description  | [Sensu RBAC namespace][9] that the secret belongs to.
+--
+
+
+.
 required     | true
 type         | String
 example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
@@ -212,3 +216,4 @@ The `website` secret contains a value called `database`, which is the password t
 [6]: ../rbac#default-users
 [7]: ../secret-providers/
 [8]: #spec-attributes
+[9]: ../../reference/rbac/#namespaces

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -69,7 +69,7 @@ type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "spec": {
   "id": "ANSIBLE_TOKEN",
-  "provider": "ansible_vault"
+  "provider": "env"
 }
 {{< /highlight >}}
 
@@ -175,10 +175,10 @@ Secrets that target a HashiCorp Vault always have an `id` as shown in the follow
 type: Secret
 api_version: secrets/v1
 metadata:
-  name: sensu-ansible-token
+  name: sensu-ansible
   namespace: default
 spec:
-  id: 'secret/website#database'
+  id: 'secret/database#password'
   provider: ansible_vault
 {{< /highlight >}}
 
@@ -187,11 +187,11 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "database",
+    "name": "sensu-ansible",
     "namespace": "default"
   },
   "spec": {
-    "id": "secret/website#database",
+    "id": "secret/database#password",
     "provider": "vault"
   }
 }
@@ -200,8 +200,8 @@ spec:
 {{< /language-toggle >}}
 
 Secrets that target a HashiCorp Vault must start with the word `secret`.
-In this example, the name of the secret is `website`.
-The `website` secret contains a value called `database`, which is the password to our database.
+In this example, the name of the secret is `database`.
+The `database` secret contains a value called `password`, which is the password to our database.
 
 [1]: ../../getting-started/enterprise/
 [2]: ../../api/secrets/

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -96,7 +96,7 @@ description  | The identifying key for the provider to retrieve the secret.
 required     | true
 type         | String
 default      | `false`
-example      | {{< highlight shell >}}"id": "ANSIBLE_TOKEN"{{< /highlight >}}
+example      | {{< highlight shell >}}"id": "secret/ansible#token"{{< /highlight >}}
 
 provider     | 
 -------------|------ 

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -212,3 +212,5 @@ The `database` secret contains a value called `password`, which is the password 
 [7]: ../secret-providers/
 [8]: #spec-attributes
 [9]: ../../reference/rbac/#namespaces
+[10]: https://learn.hashicorp.com/vault/getting-started/dev-server
+[11]: ../../guides/secrets-management-vault/

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -199,7 +199,9 @@ spec:
 
 {{< /language-toggle >}}
 
-Secrets that target a HashiCorp Vault must start with the word `secret`.
+The id value for secrets that target a HashiCorp Vault must start with the name of the secret's path in Vault.
+The [Vault dev server][10] is preconfigured with the secret keyspace already set up.
+This is convenient for learning and getting started with Vault secrets management, so this example and our guide to [Secrets management][11] use the secret/ path for the id value.
 In this example, the name of the secret is `database`.
 The `database` secret contains a value called `password`, which is the password to our database.
 

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -166,7 +166,7 @@ spec:
 
 {{< /language-toggle >}}
 
-Secrets that target a HashiCorp Vault always have an `id` as shown in the following example:
+Secrets that target a HashiCorp Vault are configured as shown in the following example:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -131,10 +131,24 @@ To delete a secret:
 sensuctl secret delete SECRET_NAME
 {{< /highlight >}}
 
-## Secret payload example
+## Secret payload examples
 
 A secret resource definition refers to a secrets `id` and a secrets `provider`.
 Read the [secrets provider reference][7] for the provider specification.
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: sensu-ansible-token
+  namespace: default
+spec:
+  id: ANSIBLE_TOKEN
+  provider: env
+{{< /highlight >}}
 
 {{< highlight json >}}
 {
@@ -146,12 +160,18 @@ Read the [secrets provider reference][7] for the provider specification.
   },
   "spec": {
     "id": "ANSIBLE_TOKEN",
-    "provider": "ansible_vault"
+    "provider": "env"
   }
 }
 {{< /highlight >}}
 
-{{< highlight yaml >}}
+{{< /language-toggle >}}
+
+Secrets that target a HashiCorp Vault always have an `id` as shown in the following example:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
 ---
 type: Secret
 api_version: secrets/v1
@@ -163,6 +183,26 @@ spec:
   provider: ansible_vault
 {{< /highlight >}}
 
+{{< highlight json >}}
+{
+  "type": "Secret",
+  "api_version": "secrets/v1",
+  "metadata": {
+    "name": "database",
+    "namespace": "default"
+  },
+  "spec": {
+    "id": "secret/website#database",
+    "provider": "vault"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+Secrets that target a HashiCorp Vault must start with the word `secret`.
+In this example, the name of the secret is `website`.
+The `website` secret contains a value called `database`, which is the password to our database.
 
 [1]: ../../getting-started/enterprise/
 [2]: ../../api/secrets/

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -178,7 +178,7 @@ metadata:
   name: sensu-ansible-token
   namespace: default
 spec:
-  id: secret/website#database
+  id: 'secret/website#database'
   provider: ansible_vault
 {{< /highlight >}}
 


### PR DESCRIPTION
## Description
Adds secrets reference doc, with spec for Secret datatype and sensuctl command information.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2113
