### PR TITLE
Add examples with secrets to checks, handlers, and mutators references

### DIFF
--- a/content/sensu-go/5.17/reference/checks.md
+++ b/content/sensu-go/5.17/reference/checks.md
@@ -17,7 +17,7 @@ menu:
 - [Check token substitution](#check-token-substitution)
 - [Check hooks](#check-hooks)
 - [Check specification](#check-specification)
-	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Proxy requests attributes](#proxy-requests-attributes) | [Check output truncation attributes](#check-output-truncation-attributes)
+	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Proxy requests attributes](#proxy-requests-attributes) | [Check output truncation attributes](#check-output-truncation-attributes) | [`secrets` attributes](#secrets-attributes)
 - [Examples](#examples)
 
 Checks work with Sensu agents to produce monitoring events automatically.
@@ -725,7 +725,23 @@ example      | {{< highlight shell >}}"round_robin": true{{< /highlight >}}
 description  | Check subdues are not yet implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
 example      | {{< highlight shell >}}"subdue": null{{< /highlight >}}
 
-### Proxy requests attributes
+secrets        | 
+---------------|------
+description    | Array of the name/secret pairs to use with command execution.
+required       | false
+type           | Array
+example        | {{< highlight shell >}}"secrets": [
+  {
+    "name": "ANSIBLE_HOST",
+    "secret": "sensu-ansible-host"
+  },
+  {
+    "name": "ANSIBLE_TOKEN",
+    "secret": "sensu-ansible-token"
+  }
+]{{< /highlight >}}
+
+#### Proxy requests attributes
 
 |entity_attributes| |
 -------------|------
@@ -752,7 +768,7 @@ required     | Required if `splay` attribute is set to `true`
 type         | Integer
 example      | {{< highlight shell >}}"splay_coverage": 90{{< /highlight >}}
 
-### Check output truncation attributes
+#### Check output truncation attributes
 
 |max_output_size  | |
 -------------|-------
@@ -767,6 +783,22 @@ description  | If `true`, discard check output after extracting metrics. No chec
 required     | false
 type         | Boolean
 example      | {{< highlight shell >}}"discard_output": true{{< /highlight >}}
+
+#### `secrets` attributes
+
+name         | 
+-------------|------
+description  | Name of the [secret][56] defined in the executable command.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "ANSIBLE_HOST"{{< /highlight >}}
+
+secret       | 
+-------------|------
+description  | Name of the Sensu secret resource that defines how to retrieve the [secret][56].
+required     | true
+type         | String
+example      | {{< highlight shell >}}"secret": "sensu-ansible-host"{{< /highlight >}}
 
 ## Examples
 

--- a/content/sensu-go/5.17/reference/checks.md
+++ b/content/sensu-go/5.17/reference/checks.md
@@ -896,6 +896,50 @@ spec:
 
 {{< /language-toggle >}}
 
+### Check with secret
+
+Learn more about secrets management for your Sensu configuration in the [secrets][56] and [secrets providers][57] references.
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: ping-github-api
+  namespace: default
+spec:
+  check_hooks: null
+  command: ping-github-api.sh $GITHUB_TOKEN
+  secrets:
+  - name: GITHUB_TOKEN
+    secret: github-token-vault
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ping-github-api",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "ping-github-api.sh $GITHUB_TOKEN",
+    "secrets": [
+      {
+        "name": "GITHUB_TOKEN",
+        "secret": "github-token-vault"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
 [1]: #subscription-checks
 [2]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [3]: https://en.wikipedia.org/wiki/Standard_streams
@@ -948,3 +992,5 @@ spec:
 [53]: https://regex101.com/r/zo9mQU/2
 [54]: ../../api/overview#response-filtering
 [55]: ../../sensuctl/reference#response-filters
+[56]: ../../reference/secrets/
+[57]: ../../reference/secrets-providers/

--- a/content/sensu-go/5.17/reference/handlers.md
+++ b/content/sensu-go/5.17/reference/handlers.md
@@ -15,7 +15,7 @@ menu:
 - [Handler sets](#handler-sets)
 - [Keepalive event handlers](#keepalive-event-handlers)
 - [Handler specification](#handler-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`socket` attributes](#socket-attributes)
+  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`socket` attributes](#socket-attributes) | [`secrets` attributes](#secrets-attributes)
 - [Examples](#handler-examples)
 
 Handlers are actions the Sensu backend executes on events.
@@ -171,7 +171,7 @@ example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}
 
 | labels     |      |
 -------------|------
-description  | Custom attributes you can use to create meaningful collections that you can select with [API response filtering][11] and [sensuctl response filtering][12]. Overusing labels can affect Sensu's internal performance, so we recommend moving complex, non-identifying metadata to annotations.
+description  | Custom attributes you can use to create meaningful collections that you can select with [API response filtering][10] and [sensuctl response filtering][11]. Overusing labels can affect Sensu's internal performance, so we recommend moving complex, non-identifying metadata to annotations.
 required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
@@ -182,7 +182,7 @@ example      | {{< highlight shell >}}"labels": {
 
 | annotations |     |
 -------------|------
-description  | Non-identifying metadata that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][11] or [sensuctl response filtering][12], and annotations do not affect Sensu's internal performance.
+description  | Non-identifying metadata that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10] or [sensuctl response filtering][11], and annotations do not affect Sensu's internal performance.
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
@@ -258,7 +258,23 @@ required       | false
 type           | Array
 example        | {{< highlight shell >}}"runtime_assets": ["ruby-2.5.0"]{{< /highlight >}}
 
-### `socket` attributes
+secrets        | 
+---------------|------
+description    | Array of the name/secret pairs to use with command execution.
+required       | false
+type           | Array
+example        | {{< highlight shell >}}"secrets": [
+  {
+    "name": "ANSIBLE_HOST",
+    "secret": "sensu-ansible-host"
+  },
+  {
+    "name": "ANSIBLE_TOKEN",
+    "secret": "sensu-ansible-token"
+  }
+]{{< /highlight >}}
+
+#### `socket` attributes
 
 host         | 
 -------------|------
@@ -273,6 +289,22 @@ description  | Socket port to connect to.
 required     | true
 type         | Integer
 example      | {{< highlight shell >}}"port": 4242{{< /highlight >}}
+
+#### `secrets` attributes
+
+name         | 
+-------------|------
+description  | Name of the [secret][20] defined in the executable command.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "ANSIBLE_HOST"{{< /highlight >}}
+
+secret       | 
+-------------|------
+description  | Name of the Sensu secret resource that defines how to retrieve the [secret][20].
+required     | true
+type         | String
+example      | {{< highlight shell >}}"secret": "sensu-ansible-host"{{< /highlight >}}
 
 ## Handler examples
 

--- a/content/sensu-go/5.17/reference/handlers.md
+++ b/content/sensu-go/5.17/reference/handlers.md
@@ -519,6 +519,56 @@ spec:
 
 {{< /language-toggle >}}
 
+### Handler with secret
+
+Learn more about secrets management for your Sensu configuration in the [secrets][20] and [secrets providers][21] references.
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+---
+type: Handler 
+api_version: core/v2 
+metadata:
+  name: ansible-tower
+  namespace: ops
+spec: 
+  type: pipe
+  command: sensu-ansible-handler -h $ANSIBLE_HOST -t $ANSIBLE_TOKEN
+  secrets:
+  - name: ANSIBLE_HOST
+    secret: sensu-ansible-host
+  - name: ANSIBLE_TOKEN
+    secret: sensu-ansible-token
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ansible-tower",
+    "namespace": "ops"
+  },
+  "spec": {
+    "type": "pipe",
+    "command": "sensu-ansible-handler -h $ANSIBLE_HOST -t $ANSIBLE_TOKEN",
+    "secrets": [
+      {
+        "name": "ANSIBLE_HOST",
+        "secret": "sensu-ansible-host"
+      },
+      {
+        "name": "ANSIBLE_TOKEN",
+        "secret": "sensu-ansible-token"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
 [1]: ../checks/
 [2]: https://en.wikipedia.org/wiki/Standard_streams
 [3]: ../events/
@@ -537,4 +587,6 @@ spec:
 [16]: https://bonsai.sensu.io/
 [18]: https://regex101.com/r/zo9mQU/2
 [19]: ../agent/#keepalive-handlers-flag
+[20]: ../../reference/secrets/
+[21]: ../../reference/secrets-providers/
 [23]: ../../guides/install-check-executables-with-assets

--- a/content/sensu-go/5.17/reference/mutators.md
+++ b/content/sensu-go/5.17/reference/mutators.md
@@ -13,7 +13,7 @@ menu:
 - [Commands](#commands)
 - [Built-in mutators](#built-in-mutators)
 - [Mutator specification](#mutator-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
+  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`secrets` attributes](#secrets-attributes)
 - [Examples](#examples)
 
 Handlers can specify a mutator to execute and transform event data before any handlers are applied.
@@ -100,15 +100,15 @@ Mutators:
 
 type         | 
 -------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][sc] resource type. Mutators should always be type `Mutator`.
-required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | String
 example      | {{< highlight shell >}}"type": "Mutator"{{< /highlight >}}
 
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For mutators in this version of Sensu, the `api_version` should always be `core/v2`.
-required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][sc].
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | String
 example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
@@ -192,13 +192,6 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"command": "/etc/sensu/plugins/mutated.go"{{</highlight>}}
 
-env_vars      | 
--------------|------
-description  | Array of environment variables to use with command execution.
-required     | false
-type         | Array
-example      | {{< highlight shell >}}"env_vars": ["RUBY_VERSION=2.5.0"]{{< /highlight >}}
-
 timeout      | 
 -------------|------ 
 description  | Mutator execution duration timeout (hard stop). In seconds.
@@ -206,12 +199,51 @@ required     | false
 type         | integer 
 example      | {{< highlight shell >}}"timeout": 30{{</highlight>}}
 
+env_vars      | 
+-------------|------
+description  | Array of environment variables to use with command execution.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"env_vars": ["RUBY_VERSION=2.5.0"]{{< /highlight >}}
+
 runtime_assets | 
 ---------------|------
 description    | Array of [Sensu assets][1] (by their names) required at runtime for execution of the `command`.
 required       | false
 type           | Array
 example        | {{< highlight shell >}}"runtime_assets": ["ruby-2.5.0"]{{< /highlight >}}
+
+secrets        | 
+---------------|------
+description    | Array of the name/secret pairs to use with command execution.
+required       | false
+type           | Array
+example        | {{< highlight shell >}}"secrets": [
+  {
+    "name": "ANSIBLE_HOST",
+    "secret": "sensu-ansible-host"
+  },
+  {
+    "name": "ANSIBLE_TOKEN",
+    "secret": "sensu-ansible-token"
+  }
+]{{< /highlight >}}
+
+#### `secrets` attributes
+
+name         | 
+-------------|------
+description  | Name of the [secret][10] defined in the executable command.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "ANSIBLE_HOST"{{< /highlight >}}
+
+secret       | 
+-------------|------
+description  | Name of the Sensu secret resource that defines how to retrieve the [secret][10].
+required     | true
+type         | String
+example      | {{< highlight shell >}}"secret": "sensu-ansible-host"{{< /highlight >}}
 
 ## Examples
 

--- a/content/sensu-go/5.17/reference/mutators.md
+++ b/content/sensu-go/5.17/reference/mutators.md
@@ -287,6 +287,55 @@ spec:
 
 {{< /language-toggle >}}
 
+### Mutator with secret
+
+Learn more about secrets management for your Sensu configuration in the [secrets][10] and [secrets providers][11] references.
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+---
+type: Mutator 
+api_version: core/v2 
+metadata:
+  name: ansible-tower
+  namespace: ops
+spec: 
+  command: sensu-ansible-mutator -h $ANSIBLE_HOST -t $ANSIBLE_TOKEN
+  secrets:
+  - name: ANSIBLE_HOST
+    secret: sensu-ansible-host
+  - name: ANSIBLE_TOKEN
+    secret: sensu-ansible-token
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Mutator",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ansible-tower",
+    "namespace": "ops"
+  },
+  "spec": {
+    "command": "sensu-ansible-mutator -h $ANSIBLE_HOST -t $ANSIBLE_TOKEN",
+    "secrets": [
+      {
+        "name": "ANSIBLE_HOST",
+        "secret": "sensu-ansible-host"
+      },
+      {
+        "name": "ANSIBLE_TOKEN",
+        "secret": "sensu-ansible-token"
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+
 [1]: ../assets/
 [2]: #metadata-attributes
 [3]: ../rbac#namespaces
@@ -296,3 +345,5 @@ spec:
 [7]: https://regex101.com/r/zo9mQU/2
 [8]: ../../api/overview#response-filtering
 [9]: ../../sensuctl/reference#response-filters
+[10]: ../../reference/secrets/
+[11]: ../../reference/secrets-providers/


### PR DESCRIPTION
## Description
Adds an example that includes a secrets resource in each of the checks, handlers, and mutators references. Examples are provided in the issue (https://github.com/sensu/sensu-docs/issues/2119).

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2119