### PR TITLE
Update UPN note in installation/auth

### DIFF
--- a/content/sensu-go/5.17/installation/auth.md
+++ b/content/sensu-go/5.17/installation/auth.md
@@ -971,7 +971,7 @@ example      | {{< highlight shell >}}
 
 | default_upn_domain |     |
 -------------|------
-description  | Enables UPN authentication when set. The default UPN suffix that will be appended to the username when a domain is not specified during login (for example, `user` becomes `user@defaultdomain.xyz`). _**WARNING**: When using UPN authentication, users must re-authenticate to apply any changes made to group membership on the AD server since their last authentication. To ensure group membership updates are reflected without re-authentication, specify a binding account or enable anonymous binding._
+description  | Enables UPN authentication when set. The default UPN suffix that will be appended to the username when a domain is not specified during login (for example, `user` becomes `user@defaultdomain.xyz`). _**WARNING**: When using UPN authentication, users must re-authenticate to apply any changes to group membership on the AD server since their last authentication. For example, if you remove a user from a group with administrator permissions for the current session (such as a terminated employee), Sensu will not apply the change until the user logs out and tries to start a new session. Likewise, under UPN, users cannot be forced to log out of Sensu. To apply group membership updates without re-authentication, specify a binding account or enable anonymous binding._
 required     | false
 type         | String
 example      | {{< highlight shell >}}


### PR DESCRIPTION
## Description
Updates warning in `default_upn_domain` description to give an example of how group membership changes work under UPN, such as in the case of a terminated employee.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2129

## Review Question
I'm not sure whether we should include the context you listed in the issue -- it seems like the log info could be useful.
