### PR TITLE
Replace sample-app.md with sensu-k8s-quick-start in sandbox page

### DIFF
--- a/content/sensu-go/5.13/getting-started/sandbox.md
+++ b/content/sensu-go/5.13/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - [Start here](../learn-sensu): Building your first monitoring workflow
 
 ### Container monitoring
-- [Container and application monitoring with Sensu](../sample-app): Monitoring a sample app on Kubernetes
+- [Container and application monitoring with Sensu](https://github.com/sensu/sensu-k8s-quick-start): Get started with Sensu Go on Kubernetes
 
 ### Metrics
 - [Sensu + Prometheus](../prometheus-metrics): Collecting Prometheus metrics with Sensu

--- a/content/sensu-go/5.14/getting-started/sandbox.md
+++ b/content/sensu-go/5.14/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - [Start here](../learn-sensu): Building your first monitoring workflow
 
 ### Container monitoring
-- [Container and application monitoring with Sensu](../sample-app): Monitoring a sample app on Kubernetes
+- [Container and application monitoring with Sensu](https://github.com/sensu/sensu-k8s-quick-start): Get started with Sensu Go on Kubernetes
 
 ### Metrics
 - [Sensu + Prometheus](../prometheus-metrics): Collecting Prometheus metrics with Sensu

--- a/content/sensu-go/5.15/getting-started/sandbox.md
+++ b/content/sensu-go/5.15/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - [Start here](../learn-sensu): Building your first monitoring workflow
 
 ### Container monitoring
-- [Container and application monitoring with Sensu](../sample-app): Monitoring a sample app on Kubernetes
+- [Container and application monitoring with Sensu](https://github.com/sensu/sensu-k8s-quick-start): Get started with Sensu Go on Kubernetes
 
 ### Metrics
 - [Sensu + Prometheus](../prometheus-metrics): Collecting Prometheus metrics with Sensu

--- a/content/sensu-go/5.16/getting-started/sandbox.md
+++ b/content/sensu-go/5.16/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - Download the Sensu sandbox and [build your first monitoring workflow][1]
 
 ## Monitor containers and applications
-- [Deploy a sample app with Kubernetes and monitor it with Sensu][2]
+- [Deploy a Sensu Go cluster and example app in Kubernetes and monitor the app with Sensu][2]
 
 ## Collect metrics
 - [Collect Prometheus metrics with Sensu][3]
@@ -25,6 +25,6 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - Use the [Sensu translator][4] to translate check configurations from Sensu Core 1.x to Sensu Go
 
 [1]: ../learn-sensu/
-[2]: ../sample-app/
+[2]: https://github.com/sensu/sensu-k8s-quick-start
 [3]: ../prometheus-metrics/
 [4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/5.16/getting-started/sandbox.md
+++ b/content/sensu-go/5.16/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - Download the Sensu sandbox and [build your first monitoring workflow][1]
 
 ## Monitor containers and applications
-- [Deploy a Sensu Go cluster and example app in Kubernetes and monitor the app with Sensu][2]
+- [Deploy a Sensu Go cluster and example app with Kubernetes and monitor the app with Sensu][2]
 
 ## Collect metrics
 - [Collect Prometheus metrics with Sensu][3]

--- a/content/sensu-go/5.17/getting-started/sandbox.md
+++ b/content/sensu-go/5.17/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - Download the Sensu sandbox and [build your first monitoring workflow][1]
 
 ## Monitor containers and applications
-- [Deploy a sample app with Kubernetes and monitor it with Sensu][2]
+- [Deploy a Sensu Go cluster and example app in Kubernetes and monitor the app with Sensu][2]
 
 ## Collect metrics
 - [Collect Prometheus metrics with Sensu][3]
@@ -25,6 +25,6 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - Use the [Sensu translator][4] to translate check configurations from Sensu Core 1.x to Sensu Go
 
 [1]: ../learn-sensu/
-[2]: ../sample-app/
+[2]: https://github.com/sensu/sensu-k8s-quick-start
 [3]: ../prometheus-metrics/
 [4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/5.17/getting-started/sandbox.md
+++ b/content/sensu-go/5.17/getting-started/sandbox.md
@@ -16,7 +16,7 @@ Welcome to the Sensu sandbox! The sandbox is the best place to get started with 
 - Download the Sensu sandbox and [build your first monitoring workflow][1]
 
 ## Monitor containers and applications
-- [Deploy a Sensu Go cluster and example app in Kubernetes and monitor the app with Sensu][2]
+- [Deploy a Sensu Go cluster and example app with Kubernetes and monitor the app with Sensu][2]
 
 ## Collect metrics
 - [Collect Prometheus metrics with Sensu][3]


### PR DESCRIPTION
## Description
Replaces reference to sample-app.md in Sandbox page with link to https://github.com/sensu/sensu-k8s-quick-start

## Motivation and Context
Developer Advocates prefer https://github.com/sensu/sensu-k8s-quick-start as the entry point for trying Sensu on K8s.

## Review Instructions
See https://github.com/sensu/sensu-docs/issues/2027 for partial context for this change.

This PR does not remove the sample-app.md doc from the repo. It only replaces all links to sample-app.md with links to https://github.com/sensu/sensu-k8s-quick-start.
