### PR TITLE
Add event.entity.name supported for fieldSelector

### DIFF
--- a/content/sensu-go/5.17/api/overview.md
+++ b/content/sensu-go/5.17/api/overview.md
@@ -285,7 +285,7 @@ Here's the list of available fields:
 | ClusterRole | `clusterrole.name` |
 | ClusterRoleBinding | `clusterrolebinding.name` `clusterrolebinding.role_ref.name` `clusterrolebinding.role_ref.type`|
 | Entity | `entity.name` `entity.namespace` `entity.deregister` `entity.entity_class` `entity.subscriptions` |
-| Event | `event.name` `event.namespace` `event.check.handlers` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.subscriptions` |
+| Event | `event.name` `event.namespace` `event.check.handlers` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
 | Extension | `extension.name` `extension.namespace` |
 | Filter | `filter.name` `filter.namespace` `filter.action` `filter.runtime_assets` |
 | Handler | `handler.name` `handler.namespace` `handler.filters` `handler.handlers` `handler.mutator` `handler.type`| 


### PR DESCRIPTION
## Description
Add `event.entity.name` as a supported field for `fieldSelector` filtering

## Motivation and Context
Final 5.17 [Go changelog](https://github.com/sensu/sensu-go/blob/master/CHANGELOG.md#5170---2020-01-28) lists this change.
