### PR TITLE
Correcting link for windows agent

### DIFF
--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -321,10 +321,10 @@ sudo yum install sensu-go-agent
 
 {{< highlight "Windows" >}}
 # Download the Sensu agent for Windows amd64
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.8521_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x64.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.9112_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x64.msi"
 
 # Or for Windows 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.8521_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x86.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.9112_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x86.msi"
 
 # Install the Sensu agent
 msiexec.exe /i $env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x64.msi /qn

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -321,13 +321,13 @@ sudo yum install sensu-go-agent
 
 {{< highlight "Windows" >}}
 # Download the Sensu agent for Windows amd64
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.9112_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x64.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.9112_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.9112_en-US.x64.msi"
 
 # Or for Windows 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.9112_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x86.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.0/sensu-go-agent_5.17.0.9112_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_5.17.0.9112_en-US.x86.msi"
 
 # Install the Sensu agent
-msiexec.exe /i $env:userprofile\sensu-go-agent_5.17.0.8521_en-US.x64.msi /qn
+msiexec.exe /i $env:userprofile\sensu-go-agent_5.17.0.9112_en-US.x64.msi /qn
 
 # Or via Chocolatey
 choco install sensu-agent


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
the version number used for the download of Windows agent is not valid. It's referring to 5.17.0.8521 when it should be 5.17.0.9112.
As consequence the link provided in the documentation is not working (AccessDenied)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
Allowing to download the windows agent by providing a working link

## Review Instructions
<!--- Optional -->
