### PR TITLE
Fix offline docs formatting issues

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,6 +116,32 @@ module.exports = function(grunt) {
       });
   });
 
+  grunt.registerTask("hugo-build-offline", function() {
+    const done = this.async();
+    const toml = require('toml');
+    const config = toml.parse(grunt.file.read('config.toml'));
+    const latestProducts = Object.entries(config.params.products).map(([key, product]) => ({
+      identifier: product.identifier,
+      latest: product.latest
+    }));
+
+    grunt.log.writeln("Running hugo build");
+    grunt.util.spawn(
+      {
+        cmd: "hugo",
+        args: ['--layoutDir=offline'],
+      },
+      function(error, result, code) {
+        if (code == 0) {
+          grunt.log.ok("Successfully built site");
+        } else {
+          grunt.fail.fatal(error);
+        }
+        done();
+      }
+    );
+  });
+
   grunt.registerTask("hugo-server", function() {
     const done = this.async();
     const args = process.argv.slice(3).filter(a => a !== '--color'); // fetch given arguments
@@ -153,6 +179,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask("default", ["env", "hugo-version", "sass:dist", "postcss:dist", "hugo-build",]);
+  grunt.registerTask("build-offline", ["env", "hugo-version", "sass:dist", "postcss:dist", "hugo-build-offline",]);
   grunt.registerTask("server", ["env", "hugo-version", "sass:develop", "postcss:develop", "concurrent:target"]);
   grunt.registerTask("hugo-version", ["env", "print-hugo-version",]);
 };

--- a/content/sensu-go/5.14/getting-started/tutorial.md
+++ b/content/sensu-go/5.14/getting-started/tutorial.md
@@ -5,6 +5,7 @@ version: "5.14"
 weight: 3
 product: "Sensu Go"
 layout: "katacoda-wide"
+offline: false
 menu:
   sensu-go-5.14:
     parent: getting-started

--- a/content/sensu-go/5.15/getting-started/tutorial.md
+++ b/content/sensu-go/5.15/getting-started/tutorial.md
@@ -5,6 +5,7 @@ version: "5.15"
 weight: 3
 product: "Sensu Go"
 layout: "katacoda-wide"
+offline: false
 menu:
   sensu-go-5.15:
     parent: getting-started

--- a/content/sensu-go/5.16/getting-started/tutorial.md
+++ b/content/sensu-go/5.16/getting-started/tutorial.md
@@ -5,6 +5,7 @@ version: "5.16"
 weight: 30
 product: "Sensu Go"
 layout: "katacoda-wide"
+offline: false
 menu:
   sensu-go-5.16:
     parent: getting-started

--- a/content/sensu-go/5.16/guides/up-running-tutorial.md
+++ b/content/sensu-go/5.16/guides/up-running-tutorial.md
@@ -5,6 +5,7 @@ version: "5.16"
 product: "Sensu Go"
 layout: "katacoda-wide"
 platformContent: false
+offline: false
 ---
 
 <!-- begin tracking -->

--- a/content/sensu-go/5.17/getting-started/tutorial.md
+++ b/content/sensu-go/5.17/getting-started/tutorial.md
@@ -5,6 +5,7 @@ version: "5.17"
 weight: 30
 product: "Sensu Go"
 layout: "katacoda-wide"
+offline: false
 menu:
   sensu-go-5.17:
     parent: getting-started

--- a/content/sensu-go/5.17/guides/up-running-tutorial.md
+++ b/content/sensu-go/5.17/guides/up-running-tutorial.md
@@ -5,6 +5,7 @@ version: "5.17"
 product: "Sensu Go"
 layout: "katacoda-wide"
 platformContent: false
+offline: false
 ---
 <!-- begin tracking -->
 <script> !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments); },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js', a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script'); // Insert Twitter Pixel ID and Standard Event data below twq('init','o1043'); twq('track','PageView');

--- a/offline/_default/product-versions.html
+++ b/offline/_default/product-versions.html
@@ -1,9 +1,9 @@
 {{ partial "head" . }}
   <h1>{{ .Title }} {{ if .Draft }} (Draft){{ end }}</h1>
   <h2>Versions</h2>
+  {{ $product := replace .Section "-" "_" }}
+  {{ $product_info := (index .Site.Params.products $product) }}
   {{ if not ($.Scratch.Get "versionList") }}
-    {{ $product := replace .Section "-" "_" }}
-    {{ $product_info := (index .Site.Params.products $product) }}
     {{ range $k, $v := $product_info.versions }}
       {{ $.Scratch.Add "versionList" (slice $v.version) }}
     {{ end }}

--- a/offline/_default/single.html
+++ b/offline/_default/single.html
@@ -1,5 +1,7 @@
 {{ partial "head" . }}
   <h1>{{ .Title }} {{ if .Draft }} (Draft){{ end }}</h1>
   {{ partial "toc" . }}
-  {{ .Content }}
+  <div class="article">
+    {{ .Content }}
+  </div>
 {{ partial "footer" . }}

--- a/offline/partials/head.html
+++ b/offline/partials/head.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>{{ .Title }}{{ if not .IsHome }} - {{ .Site.Title }}{{ end }}</title>
+    <title>{{ .Title }}</title>
     {{ hugo.Generator }}
     <link rel="stylesheet" href="{{ "/stylesheets/offline.css" | absURL }}">
   </head>

--- a/offline/partials/toc.html
+++ b/offline/partials/toc.html
@@ -1,65 +1,67 @@
-<div id="toc">
-  <h2>Contents</h2>
-  {{ range .Sections }}
-    {{ $section := replace . "-" "_" }}
-    {{ $product_info := (index .Site.Params.products $section) }}
-    {{ $.Scratch.Add "version" .Params.version }}
-    {{ if (eq .Params.version "latest") }}
-      {{ $.Scratch.Set "version" $product_info.latest }}
-    {{ end }}
-    {{ $version := $.Scratch.Get "version" }}
+{{ if .Sections }}
+  <div id="toc">
+    <h2>Contents</h2>
+    {{ range .Sections }}
+      {{ $section := replace . "-" "_" }}
+      {{ $product_info := (index .Site.Params.products $section) }}
+      {{ $.Scratch.Add "version" .Params.version }}
+      {{ if (eq .Params.version "latest") }}
+        {{ $.Scratch.Set "version" $product_info.latest }}
+      {{ end }}
+      {{ $version := $.Scratch.Get "version" }}
 
-    <!-- loop through all menus, but only care if they're for our current section -->
-    {{ range $k, $v := .Site.Menus }}
-      {{ if and (ne $k "main") (in $k $.Section) }}
+      <!-- loop through all menus, but only care if they're for our current section -->
+      {{ range $k, $v := .Site.Menus }}
+        {{ if and (ne $k "main") (in $k $.Section) }}
 
-        <!-- special case for sensu enterprise dash -->
-        {{ if not (and (in $k "sensu-enterprise-dashboard") (eq $.Section "sensu-enterprise")) }}
+          <!-- special case for sensu enterprise dash -->
+          {{ if not (and (in $k "sensu-enterprise-dashboard") (eq $.Section "sensu-enterprise")) }}
 
-          <!-- check if we're looking at the section index, or a sub section -->
-          {{ if ne (strings.TrimSuffix $version $k) $k }}
-            {{ $niceName := $.Params.product }}
+            <!-- check if we're looking at the section index, or a sub section -->
+            {{ if ne (strings.TrimSuffix $version $k) $k }}
+              {{ $niceName := $.Params.product }}
 
-            <!-- Loop through the menus pages -->
-            {{ range $y, $x := sort $v "Weight" }}
+              <!-- Loop through the menus pages -->
+              {{ range $y, $x := sort $v "Weight" }}
 
-              <ul>
-              <!-- if the menu has a child menu -->
-              {{ if .HasChildren }}
-                {{ if (in $k $version) }}
-                  {{ $niceName := replace $x.Name "-" " " }}
-                  {{ $niceName := title $niceName }}
+                <ul>
+                <!-- if the menu has a child menu -->
+                {{ if .HasChildren }}
+                  {{ if (in $k $version) }}
+                    {{ $niceName := replace $x.Name "-" " " }}
+                    {{ $niceName := title $niceName }}
 
-                  <li>
-                    <span class="strong">
-                      {{ if or (eq $niceName "Api") (eq $niceName "Rbac") }}
-                        {{ upper $niceName }}
-                      <!-- render the title normally if not API -->
-                      {{ else }}
-                        {{ $niceName }}
-                      {{ end }}
-                    </span>
-                    <ul>
-                      <!-- Loop through the child menu's pages -->
-                      {{ range where .Children.ByWeight ".Page.Params.offline" "!=" false }}
-                        {{ if not (eq (lower .Parent) (lower .Name)) }}
-                          <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+                    <li>
+                      <span class="strong">
+                        {{ if or (eq $niceName "Api") (eq $niceName "Rbac") }}
+                          {{ upper $niceName }}
+                        <!-- render the title normally if not API -->
+                        {{ else }}
+                          {{ $niceName }}
                         {{ end }}
-                      {{ end }}
-                    </ul>
-                  </li>
+                      </span>
+                      <ul>
+                        <!-- Loop through the child menu's pages -->
+                        {{ range where .Children.ByWeight ".Page.Params.offline" "!=" false }}
+                          {{ if not (eq (lower .Parent) (lower .Name)) }}
+                            <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+                          {{ end }}
+                        {{ end }}
+                      </ul>
+                    </li>
+                  {{ end }}
+                <!-- No children, this is top level menu items -->
+                {{ else }}
+                  {{ if not (eq $.Params.product $x.Name) }}
+                  <li><a class="strong" href="{{ .URL | absURL }}">{{ $x.Name }}</a></li>
+                  {{ end }}
                 {{ end }}
-              <!-- No children, this is top level menu items -->
-              {{ else }}
-                {{ if not (eq $.Params.product $x.Name) }}
-                <li><a class="strong" href="{{ .URL | absURL }}">{{ $x.Name }}</a></li>
-                {{ end }}
+                </ul>
               {{ end }}
-              </ul>
             {{ end }}
           {{ end }}
         {{ end }}
       {{ end }}
     {{ end }}
-  {{ end }}
-</div>
+  </div>
+{{ end }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "yaml": "^0.3.0"
   },
   "scripts": {
-    "build-offline": "grunt default --layoutDir=offline",
+    "build-offline": "grunt build-offline",
     "postinstall": "grunt",
     "server": "grunt server",
     "hugo-version": "grunt hugo-version",

--- a/static/stylesheets/scss/offline.scss
+++ b/static/stylesheets/scss/offline.scss
@@ -45,6 +45,10 @@ table {
   }
 }
 
+.article {
+  border: none;
+}
+
 .language-toggle {
   p + & {
     margin-top: 4rem;


### PR DESCRIPTION
## Description

Updates offline docs templates and styles to resolve the following issues:

- [x] PDF is not picking up bullet formatting or indention in lists and TOCs
- [x] PDF bookmarks list includes "Sensu Docs" as part of each page title
- [x] PDF prints "Contents" after the heading (just before the TOC) on the first page of each docs article

## Motivation and Context

Updates #1806