### PR TITLE
Add `offline: false` indicator in frontmatter for supported versions page

### DIFF
--- a/content/sensu-go/5.14/getting-started/versions.md
+++ b/content/sensu-go/5.14/getting-started/versions.md
@@ -4,6 +4,7 @@ linkTitle: "Supported Versions"
 description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
 version: "5.14"
 weight: 10
+offline: false
 product: "Sensu Go"
 menu:
   sensu-go-5.14:

--- a/content/sensu-go/5.15/getting-started/versions.md
+++ b/content/sensu-go/5.15/getting-started/versions.md
@@ -4,6 +4,7 @@ linkTitle: "Supported Versions"
 description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read the doc to learn about supported versions of Sensu."
 version: "5.15"
 weight: 10
+offline: false
 product: "Sensu Go"
 menu:
   sensu-go-5.15:

--- a/content/sensu-go/5.16/getting-started/versions.md
+++ b/content/sensu-go/5.16/getting-started/versions.md
@@ -4,6 +4,7 @@ linkTitle: "Supported Versions"
 description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read this article to learn about supported versions of Sensu."
 version: "5.16"
 weight: 60
+offline: false
 product: "Sensu Go"
 menu:
   sensu-go-5.16:

--- a/content/sensu-go/5.17/getting-started/versions.md
+++ b/content/sensu-go/5.17/getting-started/versions.md
@@ -4,6 +4,7 @@ linkTitle: "Supported Versions"
 description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read this article to learn about supported versions of Sensu."
 version: "5.17"
 weight: 60
+offline: false
 product: "Sensu Go"
 menu:
   sensu-go-5.17:


### PR DESCRIPTION
## Description
Adds `offline: false` indicator in frontmatter for versions.md pages for 5.14 through 5.17.

## Motivation and Context
Exclude versions.md from offline layout so it will not be included during PDF generation. Eliminates the need to manually delete versions page when creating offline docs.