### PR TITLE
Add CentOS/RHEL 8 as a supported platform

### DIFF
--- a/content/sensu-go/5.14/installation/platforms.md
+++ b/content/sensu-go/5.14/installation/platforms.md
@@ -33,6 +33,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |--------------------|---------|---|---|---|
 | CentOS/RHEL 6      | {{< check >}}      |
 | CentOS/RHEL 7      | {{< check >}}      |
+| CentOS/RHEL 8      | {{< check >}}      |
 | Ubuntu 14.04       | {{< check >}}      |
 | Ubuntu 16.04       | {{< check >}}      |
 | Ubuntu 18.04       | {{< check >}}      |
@@ -48,6 +49,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |--------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6      | {{< check >}}      |
 | CentOS/RHEL 7      | {{< check >}}      |
+| CentOS/RHEL 8      | {{< check >}}      |
 | Ubuntu 14.04       | {{< check >}}      |
 | Ubuntu 16.04       | {{< check >}}      |
 | Ubuntu 18.04       | {{< check >}}      |
@@ -65,6 +67,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |--------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6      | {{< check >}}      |
 | CentOS/RHEL 7      | {{< check >}}      |
+| CentOS/RHEL 8      | {{< check >}}      |
 | Ubuntu 14.04       | {{< check >}}      |
 | Ubuntu 16.04       | {{< check >}}      |
 | Ubuntu 18.04       | {{< check >}}      |

--- a/content/sensu-go/5.15/installation/platforms.md
+++ b/content/sensu-go/5.15/installation/platforms.md
@@ -33,6 +33,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |--------------------|---------|---|---|---|
 | CentOS/RHEL 6      | {{< check >}}      |
 | CentOS/RHEL 7      | {{< check >}}      |
+| CentOS/RHEL 8      | {{< check >}}      |
 | Ubuntu 14.04       | {{< check >}}      |
 | Ubuntu 16.04       | {{< check >}}      |
 | Ubuntu 18.04       | {{< check >}}      |
@@ -48,6 +49,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |--------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6      | {{< check >}}      |
 | CentOS/RHEL 7      | {{< check >}}      |
+| CentOS/RHEL 8      | {{< check >}}      |
 | Ubuntu 14.04       | {{< check >}}      |
 | Ubuntu 16.04       | {{< check >}}      |
 | Ubuntu 18.04       | {{< check >}}      |
@@ -65,6 +67,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |--------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6      | {{< check >}}      |
 | CentOS/RHEL 7      | {{< check >}}      |
+| CentOS/RHEL 8      | {{< check >}}      |
 | Ubuntu 14.04       | {{< check >}}      |
 | Ubuntu 16.04       | {{< check >}}      |
 | Ubuntu 18.04       | {{< check >}}      |

--- a/content/sensu-go/5.16/installation/platforms.md
+++ b/content/sensu-go/5.16/installation/platforms.md
@@ -33,6 +33,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |----------------------|---------|---|---|---|
 | CentOS/RHEL 6        | {{< check >}}      |
 | CentOS/RHEL 7        | {{< check >}}      |
+| CentOS/RHEL 8        | {{< check >}}      |
 | Ubuntu 14.04         | {{< check >}}      |
 | Ubuntu 16.04         | {{< check >}}      |
 | Ubuntu 18.04         | {{< check >}}      |
@@ -48,6 +49,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |----------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6        | {{< check >}}      |
 | CentOS/RHEL 7        | {{< check >}}      |
+| CentOS/RHEL 8        | {{< check >}}      |
 | Ubuntu 14.04         | {{< check >}}      |
 | Ubuntu 16.04         | {{< check >}}      |
 | Ubuntu 18.04         | {{< check >}}      |
@@ -65,6 +67,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |----------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6        | {{< check >}}      |
 | CentOS/RHEL 7        | {{< check >}}      |
+| CentOS/RHEL 8        | {{< check >}}      |
 | Ubuntu 14.04         | {{< check >}}      |
 | Ubuntu 16.04         | {{< check >}}      |
 | Ubuntu 18.04         | {{< check >}}      |

--- a/content/sensu-go/5.17/installation/platforms.md
+++ b/content/sensu-go/5.17/installation/platforms.md
@@ -33,6 +33,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |----------------------|---------|---|---|---|
 | CentOS/RHEL 6        | {{< check >}}      |
 | CentOS/RHEL 7        | {{< check >}}      |
+| CentOS/RHEL 8        | {{< check >}}      |
 | Ubuntu 14.04         | {{< check >}}      |
 | Ubuntu 16.04         | {{< check >}}      |
 | Ubuntu 18.04         | {{< check >}}      |
@@ -48,6 +49,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |----------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6        | {{< check >}}      |
 | CentOS/RHEL 7        | {{< check >}}      |
+| CentOS/RHEL 8        | {{< check >}}      |
 | Ubuntu 14.04         | {{< check >}}      |
 | Ubuntu 16.04         | {{< check >}}      |
 | Ubuntu 18.04         | {{< check >}}      |
@@ -65,6 +67,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 |----------------------|---------|-------|---|---|---|---|
 | CentOS/RHEL 6        | {{< check >}}      |
 | CentOS/RHEL 7        | {{< check >}}      |
+| CentOS/RHEL 8        | {{< check >}}      |
 | Ubuntu 14.04         | {{< check >}}      |
 | Ubuntu 16.04         | {{< check >}}      |
 | Ubuntu 18.04         | {{< check >}}      |


### PR DESCRIPTION
## Description
Lists CentOS/RHEL 8 as a supported platform for 5.14 through 5.17.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2151
