### PR TITLE
Replace default `--name string` example in agent ref

### DIFF
--- a/content/sensu-go/5.14/reference/agent.md
+++ b/content/sensu-go/5.14/reference/agent.md
@@ -715,7 +715,7 @@ Flags:
       --keepalive-timeout uint32        number of seconds until agent is considered dead by backend (default 120)
       --labels stringToString           entity labels map (default [])
       --log-level string                logging level [panic, fatal, error, warn, info, debug] (default "warn")
-      --name string                     agent name (defaults to hostname) (default "sensu-go-sandbox")
+      --name string                     agent name (defaults to hostname) (default "my-hostname")
       --namespace string                agent namespace (default "default")
       --password string                 agent password (default "P@ssw0rd!")
       --redact string                   comma-delimited customized list of fields to redact

--- a/content/sensu-go/5.15/reference/agent.md
+++ b/content/sensu-go/5.15/reference/agent.md
@@ -715,7 +715,7 @@ Flags:
       --keepalive-timeout uint32        number of seconds until agent is considered dead by backend (default 120)
       --labels stringToString           entity labels map (default [])
       --log-level string                logging level [panic, fatal, error, warn, info, debug] (default "warn")
-      --name string                     agent name (defaults to hostname) (default "sensu-go-sandbox")
+      --name string                     agent name (defaults to hostname) (default "my-hostname")
       --namespace string                agent namespace (default "default")
       --password string                 agent password (default "P@ssw0rd!")
       --redact string                   comma-delimited customized list of fields to redact

--- a/content/sensu-go/5.16/reference/agent.md
+++ b/content/sensu-go/5.16/reference/agent.md
@@ -729,7 +729,7 @@ Flags:
       --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
       --labels stringToString                 entity labels map (default [])
       --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "warn")
-      --name string                           agent name (defaults to hostname) (default "sensu-go-sandbox")
+      --name string                           agent name (defaults to hostname) (default "my-hostname")
       --namespace string                      agent namespace (default "default")
       --password string                       agent password (default "P@ssw0rd!")
       --redact string                         comma-delimited customized list of fields to redact

--- a/content/sensu-go/5.17/reference/agent.md
+++ b/content/sensu-go/5.17/reference/agent.md
@@ -733,7 +733,7 @@ Flags:
       --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
       --labels stringToString                 entity labels map (default [])
       --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "warn")
-      --name string                           agent name (defaults to hostname) (default "sensu-go-sandbox")
+      --name string                           agent name (defaults to hostname) (default "my-hostname")
       --namespace string                      agent namespace (default "default")
       --password string                       agent password (default "P@ssw0rd!")
       --redact string                         comma-delimited customized list of fields to redact


### PR DESCRIPTION
## Description
Changes `sensu-go-sandbox` to `my-hostname` in
`--name string agent name (defaults to hostname) (default "sensu-go-sandbox")`
in agent reference.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2165