### PR TITLE
Add amd5, amd6, and amd7 do not include backend

### DIFF
--- a/content/sensu-go/5.14/installation/verify.md
+++ b/content/sensu-go/5.14/installation/verify.md
@@ -24,10 +24,12 @@ Sensu binary-only distributions for Linux are available for these architectures 
 | --- | --- |
 | `amd64` | [`.tar.gz`][14] \| [`.zip`][20]
 | `arm64` | [`.tar.gz`][15] \| [`.zip`][21]
-| `armv5` | [`.tar.gz`][16] \| [`.zip`][22]
-| `armv6` | [`.tar.gz`][17] \| [`.zip`][23]
-| `armv7` | [`.tar.gz`][18] \| [`.zip`][24]
+| `armv5` (agent and CLI) | [`.tar.gz`][16] \| [`.zip`][22]
+| `armv6` (agent and CLI) | [`.tar.gz`][17] \| [`.zip`][23]
+| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24]
 | `386` | [`.tar.gz`][19] \| [`.zip`][25]
+
+_**NOTE**: 32-bit systems cannot run the Sensu backend reliably, so `armv5`, `armv6`, and `armv7` packages include the agent and CLI only._
 
 For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 

--- a/content/sensu-go/5.15/installation/verify.md
+++ b/content/sensu-go/5.15/installation/verify.md
@@ -24,10 +24,12 @@ Sensu binary-only distributions for Linux are available for these architectures 
 | --- | --- |
 | `amd64` | [`.tar.gz`][14] \| [`.zip`][20]
 | `arm64` | [`.tar.gz`][15] \| [`.zip`][21]
-| `armv5` | [`.tar.gz`][16] \| [`.zip`][22]
-| `armv6` | [`.tar.gz`][17] \| [`.zip`][23]
-| `armv7` | [`.tar.gz`][18] \| [`.zip`][24]
+| `armv5` (agent and CLI) | [`.tar.gz`][16] \| [`.zip`][22]
+| `armv6` (agent and CLI) | [`.tar.gz`][17] \| [`.zip`][23]
+| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24]
 | `386` | [`.tar.gz`][19] \| [`.zip`][25]
+
+_**NOTE**: 32-bit systems cannot run the Sensu backend reliably, so `armv5`, `armv6`, and `armv7` packages include the agent and CLI only._
 
 For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 

--- a/content/sensu-go/5.16/installation/verify.md
+++ b/content/sensu-go/5.16/installation/verify.md
@@ -24,10 +24,12 @@ Sensu binary-only distributions for Linux are available for these architectures 
 | --- | --- |
 | `amd64` | [`.tar.gz`][14] \| [`.zip`][20]
 | `arm64` | [`.tar.gz`][15] \| [`.zip`][21]
-| `armv5` | [`.tar.gz`][16] \| [`.zip`][22]
-| `armv6` | [`.tar.gz`][17] \| [`.zip`][23]
-| `armv7` | [`.tar.gz`][18] \| [`.zip`][24]
+| `armv5` (agent and CLI) | [`.tar.gz`][16] \| [`.zip`][22]
+| `armv6` (agent and CLI) | [`.tar.gz`][17] \| [`.zip`][23]
+| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24]
 | `386` | [`.tar.gz`][19] \| [`.zip`][25]
+
+_**NOTE**: 32-bit systems cannot run the Sensu backend reliably, so `armv5`, `armv6`, and `armv7` packages include the agent and CLI only._
 
 For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 

--- a/content/sensu-go/5.17/installation/verify.md
+++ b/content/sensu-go/5.17/installation/verify.md
@@ -22,12 +22,14 @@ Sensu binary-only distributions for Linux are available for these architectures 
 
 | arch | format |
 | --- | --- |
-| `amd64` | [`.tar.gz`][14] \| [`.zip`][20]
+| `amd64` | [`.tar.gz`][14] \| [`.zip`][20] |
 | `arm64` | [`.tar.gz`][15] \| [`.zip`][21]
-| `armv5` | [`.tar.gz`][16] \| [`.zip`][22]
-| `armv6` | [`.tar.gz`][17] \| [`.zip`][23]
-| `armv7` | [`.tar.gz`][18] \| [`.zip`][24]
-| `386` | [`.tar.gz`][19] \| [`.zip`][25]
+| `armv5` (agent and CLI) | [`.tar.gz`][16] \| [`.zip`][22] |
+| `armv6` (agent and CLI) | [`.tar.gz`][17] \| [`.zip`][23] |
+| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24] |
+| `386` | [`.tar.gz`][19] \| [`.zip`][25] |
+
+_**NOTE**: 32-bit systems cannot run the Sensu backend reliably, so `armv5`, `armv6`, and `armv7` packages include the agent and CLI only._
 
 For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 


### PR DESCRIPTION
## Description
Adds in-table comment for amd5, amd6, and amd7 `(agent and CLI)` and note under table explaining why no backend binary for these systems.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2172
