### PR TITLE
Add proxy subscription to proxy entity definition

### DIFF
--- a/content/sensu-go/5.14/reference/entities.md
+++ b/content/sensu-go/5.14/reference/entities.md
@@ -94,7 +94,8 @@ spec:
   deregistration: {}
   entity_class: proxy
   last_seen: 0
-  subscriptions: []
+  subscriptions:
+  - proxy
   system:
     network:
       interfaces: null
@@ -117,7 +118,9 @@ spec:
     "deregistration": {},
     "entity_class": "proxy",
     "last_seen": 0,
-    "subscriptions": [],
+    "subscriptions": [
+      "proxy"
+    ],
     "system": {
       "network": {
         "interfaces": null
@@ -128,6 +131,8 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24]. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
 
 Then run `sensuctl create` to create the entity based on the definition.
 
@@ -320,7 +325,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | A list of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
 required     | false 
 type         | array 
 default      | The entity-specific subscription.
@@ -812,4 +817,5 @@ spec:
 [13]: ../checks/#proxy-requests
 [14]: ../../guides/monitor-external-resources/
 [15]: #proxy-entities
+[24]: ../checks#proxy-requests-attributes
 [50]: ../../dashboard/filtering#label-selectors

--- a/content/sensu-go/5.15/reference/entities.md
+++ b/content/sensu-go/5.15/reference/entities.md
@@ -94,7 +94,8 @@ spec:
   deregistration: {}
   entity_class: proxy
   last_seen: 0
-  subscriptions: []
+  subscriptions:
+  - proxy
   system:
     network:
       interfaces: null
@@ -117,7 +118,9 @@ spec:
     "deregistration": {},
     "entity_class": "proxy",
     "last_seen": 0,
-    "subscriptions": [],
+    "subscriptions": [
+      "proxy"
+    ],
     "system": {
       "network": {
         "interfaces": null
@@ -128,6 +131,8 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24]. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
 
 Then run `sensuctl create` to create the entity based on the definition.
 
@@ -320,7 +325,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | A list of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
 required     | false 
 type         | array 
 default      | The entity-specific subscription.
@@ -808,4 +813,5 @@ spec:
 [9]: ../../getting-started/enterprise
 [10]: https://sensu.io/contact
 [11]: https://blog.sensu.io/one-year-of-sensu-go
+[24]: ../checks#proxy-requests-attributes
 [50]: ../../dashboard/filtering#label-selectors

--- a/content/sensu-go/5.16/reference/entities.md
+++ b/content/sensu-go/5.16/reference/entities.md
@@ -91,7 +91,8 @@ spec:
   deregistration: {}
   entity_class: proxy
   last_seen: 0
-  subscriptions: []
+  subscriptions:
+  - proxy
   system:
     network:
       interfaces: null
@@ -114,7 +115,9 @@ spec:
     "deregistration": {},
     "entity_class": "proxy",
     "last_seen": 0,
-    "subscriptions": [],
+    "subscriptions": [
+      "proxy"
+    ],
     "system": {
       "network": {
         "interfaces": null
@@ -125,6 +128,8 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24]. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
 
 Then run `sensuctl create` to create the entity based on the definition:
 
@@ -360,7 +365,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.
@@ -814,4 +819,5 @@ spec:
 [20]: #annotations
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../rbac/
+[24]: ../checks#proxy-requests-attributes
 [50]: ../../dashboard/filtering#filter-with-label-selectors

--- a/content/sensu-go/5.17/reference/entities.md
+++ b/content/sensu-go/5.17/reference/entities.md
@@ -129,7 +129,7 @@ spec:
 
 {{< /language-toggle >}}
 
-_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24] . If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24]. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
 
 Then run `sensuctl create` to create the entity based on the definition:
 

--- a/content/sensu-go/5.17/reference/entities.md
+++ b/content/sensu-go/5.17/reference/entities.md
@@ -91,7 +91,8 @@ spec:
   deregistration: {}
   entity_class: proxy
   last_seen: 0
-  subscriptions: []
+  subscriptions:
+  - proxy
   system:
     network:
       interfaces: null
@@ -114,7 +115,9 @@ spec:
     "deregistration": {},
     "entity_class": "proxy",
     "last_seen": 0,
-    "subscriptions": [],
+    "subscriptions": [
+      "proxy"
+    ],
     "system": {
       "network": {
         "interfaces": null
@@ -125,6 +128,8 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** response filter labels. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the proxy check will fail to run._
 
 Then run `sensuctl create` to create the entity based on the definition:
 
@@ -360,7 +365,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** response filter labels with a proxy entity, the proxy entity definition must include the same subscriptions as the sensu-agent.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.

--- a/content/sensu-go/5.17/reference/entities.md
+++ b/content/sensu-go/5.17/reference/entities.md
@@ -820,3 +820,4 @@ spec:
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../rbac/
 [23]: ../../dashboard/filtering#filter-with-label-selectors
+[24]: ../checks#proxy-requests-attributes

--- a/content/sensu-go/5.17/reference/entities.md
+++ b/content/sensu-go/5.17/reference/entities.md
@@ -129,7 +129,7 @@ spec:
 
 {{< /language-toggle >}}
 
-_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** response filter labels. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the proxy check will fail to run._
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24] . If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
 
 Then run `sensuctl create` to create the entity based on the definition:
 
@@ -365,7 +365,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** response filter labels with a proxy entity, the proxy entity definition must include the same subscriptions as the sensu-agent.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.

--- a/content/sensu-go/5.18/reference/entities.md
+++ b/content/sensu-go/5.18/reference/entities.md
@@ -91,7 +91,8 @@ spec:
   deregistration: {}
   entity_class: proxy
   last_seen: 0
-  subscriptions: []
+  subscriptions:
+  - proxy
   system:
     network:
       interfaces: null
@@ -114,7 +115,9 @@ spec:
     "deregistration": {},
     "entity_class": "proxy",
     "last_seen": 0,
-    "subscriptions": [],
+    "subscriptions": [
+      "proxy"
+    ],
     "system": {
       "network": {
         "interfaces": null
@@ -125,6 +128,8 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+_**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes][24]. If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run._
 
 Then run `sensuctl create` to create the entity based on the definition:
 
@@ -360,7 +365,7 @@ example      | {{< highlight shell >}}"entity_class": "agent"{{< /highlight >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.
@@ -815,3 +820,4 @@ spec:
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../rbac/
 [23]: ../../dashboard/filtering#filter-with-label-selectors
+[24]: ../checks#proxy-requests-attributes


### PR DESCRIPTION
## Description
- Adds "proxy" subscription for proxy entity labels example
- Adds note under example and in "subscriptions" table to explain requirements for proxy entity subscriptions when using round robin scheduling and response filtering labels

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2197

## Review Instructions
@Blue0ctober I'm not sure I captured your meaning accurately -- what do you think?
