### PR TITLE
Add event_id to Events API and reference doc

### DIFF
--- a/content/sensu-go/5.18/api/events.md
+++ b/content/sensu-go/5.18/api/events.md
@@ -38,6 +38,7 @@ HTTP/1.1 200 OK
 [
   {
     "timestamp": 1542667666,
+    "event_id": "caaf2c38-2afb-4f96-89b3-8ca5c3e6f449",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -112,6 +113,7 @@ output         | {{< highlight shell >}}
 [
   {
     "timestamp": 1542667666,
+    "event_id": "caaf2c38-2afb-4f96-89b3-8ca5c3e6f449",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -207,7 +209,7 @@ curl -X POST \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/events
 
 HTTP/1.1 200 OK
-{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{"timestamp":1552582569,"event_id":"caaf2c38-2afb-4f96-89b3-8ca5c3e6f449","entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
 {{< /highlight >}}
 
 #### API Specification {#events-post-specification}
@@ -258,6 +260,7 @@ HTTP/1.1 200 OK
 [
   {
     "timestamp": 1543871497,
+    "event_id": "a68906e0-7c5c-49f0-8424-59a71d3ecfe2",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -303,6 +306,7 @@ HTTP/1.1 200 OK
   },
   {
     "timestamp": 1543871524,
+    "event_id": "095c37e8-1cb4-4d10-91e9-0bdd55a4f35b",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -361,6 +365,7 @@ output               | {{< highlight json >}}
 [
   {
     "timestamp": 1543871524,
+    "event_id": "095c37e8-1cb4-4d10-91e9-0bdd55a4f35b",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -425,6 +430,7 @@ HTTP/1.1 200 OK
 
 {
     "timestamp": 1577724113,
+    "event_id": "cf3c9fc0-023a-497a-aaf4-880dbd490332",
     "entity": {
         "entity_class": "proxy",
         "system": {
@@ -507,6 +513,7 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< highlight json >}}
 {
     "timestamp": 1577724113,
+    "event_id": "cf3c9fc0-023a-497a-aaf4-880dbd490332",
     "entity": {
         "entity_class": "proxy",
         "system": {
@@ -616,7 +623,7 @@ _**NOTE**: A namespace is not required to create the event. The event will use t
 
 {{< highlight shell >}}
 HTTP/1.1 200 OK
-{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{"timestamp":1552582569,"event_id":"15feeae0-e114-410a-b3e3-e757b04d92ec","entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
 {{< /highlight >}}
 
 You can use sensuctl or the [Sensu dashboard][4] to see the event:
@@ -701,7 +708,7 @@ _**NOTE**: A namespace is not required to create the event. The event will use t
 
 {{< highlight shell >}}
 HTTP/1.1 200 OK
-{"timestamp":1552582569,"entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{"timestamp":1552582569,"event_id":15feeae0-e114-410a-b3e3-e757b04d92ec,entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
 {{< /highlight >}}
 
 You can use sensuctl or the [Sensu dashboard][4] to see the event:

--- a/content/sensu-go/5.18/api/events.md
+++ b/content/sensu-go/5.18/api/events.md
@@ -113,7 +113,7 @@ output         | {{< highlight shell >}}
 [
   {
     "timestamp": 1542667666,
-    "event_id": "caaf2c38-2afb-4f96-89b3-8ca5c3e6f449",
+    "id": "caaf2c38-2afb-4f96-89b3-8ca5c3e6f449",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -209,7 +209,7 @@ curl -X POST \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/events
 
 HTTP/1.1 200 OK
-{"timestamp":1552582569,"event_id":"caaf2c38-2afb-4f96-89b3-8ca5c3e6f449","entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{"timestamp":1552582569,"id":"caaf2c38-2afb-4f96-89b3-8ca5c3e6f449","entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","state":"failing","status":2,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
 {{< /highlight >}}
 
 #### API Specification {#events-post-specification}
@@ -260,7 +260,7 @@ HTTP/1.1 200 OK
 [
   {
     "timestamp": 1543871497,
-    "event_id": "a68906e0-7c5c-49f0-8424-59a71d3ecfe2",
+    "id": "a68906e0-7c5c-49f0-8424-59a71d3ecfe2",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -306,7 +306,7 @@ HTTP/1.1 200 OK
   },
   {
     "timestamp": 1543871524,
-    "event_id": "095c37e8-1cb4-4d10-91e9-0bdd55a4f35b",
+    "id": "095c37e8-1cb4-4d10-91e9-0bdd55a4f35b",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -365,7 +365,7 @@ output               | {{< highlight json >}}
 [
   {
     "timestamp": 1543871524,
-    "event_id": "095c37e8-1cb4-4d10-91e9-0bdd55a4f35b",
+    "id": "095c37e8-1cb4-4d10-91e9-0bdd55a4f35b",
     "entity": {
       "entity_class": "agent",
       "system": {
@@ -430,7 +430,7 @@ HTTP/1.1 200 OK
 
 {
     "timestamp": 1577724113,
-    "event_id": "cf3c9fc0-023a-497a-aaf4-880dbd490332",
+    "id": "cf3c9fc0-023a-497a-aaf4-880dbd490332",
     "entity": {
         "entity_class": "proxy",
         "system": {
@@ -513,7 +513,7 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< highlight json >}}
 {
     "timestamp": 1577724113,
-    "event_id": "cf3c9fc0-023a-497a-aaf4-880dbd490332",
+    "id": "cf3c9fc0-023a-497a-aaf4-880dbd490332",
     "entity": {
         "entity_class": "proxy",
         "system": {
@@ -623,7 +623,7 @@ _**NOTE**: A namespace is not required to create the event. The event will use t
 
 {{< highlight shell >}}
 HTTP/1.1 200 OK
-{"timestamp":1552582569,"event_id":"15feeae0-e114-410a-b3e3-e757b04d92ec","entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{"timestamp":1552582569,"id":"15feeae0-e114-410a-b3e3-e757b04d92ec","entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
 {{< /highlight >}}
 
 You can use sensuctl or the [Sensu dashboard][4] to see the event:
@@ -708,7 +708,7 @@ _**NOTE**: A namespace is not required to create the event. The event will use t
 
 {{< highlight shell >}}
 HTTP/1.1 200 OK
-{"timestamp":1552582569,"event_id":15feeae0-e114-410a-b3e3-e757b04d92ec,entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
+{"timestamp":1552582569,"id":15feeae0-e114-410a-b3e3-e757b04d92ec,entity":{"entity_class":"proxy","system":{"network":{"interfaces":null}},"subscriptions":null,"last_seen":0,"deregister":false,"deregistration":{},"metadata":{"name":"server1","namespace":"default"}},"check":{"handlers":["slack"],"high_flap_threshold":0,"interval":60,"low_flap_threshold":0,"publish":false,"runtime_assets":null,"subscriptions":[],"proxy_entity_name":"","check_hooks":null,"stdin":false,"subdue":null,"ttl":0,"timeout":0,"round_robin":false,"executed":0,"history":null,"issued":0,"output":"Server error","status":1,"total_state_change":0,"last_ok":0,"occurrences":0,"occurrences_watermark":0,"output_metric_format":"","output_metric_handlers":null,"env_vars":null,"metadata":{"name":"server-health"}},"metadata":{}}
 {{< /highlight >}}
 
 You can use sensuctl or the [Sensu dashboard][4] to see the event:

--- a/content/sensu-go/5.18/api/events.md
+++ b/content/sensu-go/5.18/api/events.md
@@ -38,7 +38,7 @@ HTTP/1.1 200 OK
 [
   {
     "timestamp": 1542667666,
-    "event_id": "caaf2c38-2afb-4f96-89b3-8ca5c3e6f449",
+    "id": "caaf2c38-2afb-4f96-89b3-8ca5c3e6f449",
     "entity": {
       "entity_class": "agent",
       "system": {

--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -143,6 +143,8 @@ Sensu events contain:
   - Metric points in [Sensu metric format][22]
 - `timestamp`
   - Time that the event occurred in seconds since the Unix epoch
+- `event_id`
+  - Universally unique identifier (UUID) for the event
 
 ## Use event data
 
@@ -331,7 +333,8 @@ example      | {{< highlight shell >}}
       }
     ]
   },
-  "timestamp": 1552506033
+  "timestamp": 1552506033,
+  "event_id": "431a0085-96da-4521-863f-c38b480701e9"
 }
 {{< /highlight >}}
 
@@ -354,6 +357,13 @@ required     | false
 type         | Integer
 default      | Time that the event occurred
 example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
+
+event_id     |      |
+-------------|------
+description  | Universally unique identifier (UUID) for the event.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"event_id": "431a0085-96da-4521-863f-c38b480701e9"{{< /highlight >}}
 
 |entity      |      |
 -------------|------
@@ -787,6 +797,7 @@ spec:
       platform_version: 7.4.1708
     user: agent
   timestamp: 1552594758
+  event_id: 3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f
 {{< /highlight >}}
 
 {{< highlight json >}}
@@ -900,7 +911,8 @@ spec:
       },
       "user": "agent"
     },
-    "timestamp": 1552594758
+    "timestamp": 1552594758,
+    "event_id": "3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f"
   }
 }
 {{< /highlight >}}
@@ -1010,6 +1022,7 @@ spec:
       timestamp: 1552506033
       value: 0.004
   timestamp: 1552506033
+  event_id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /highlight >}}
 
 {{< highlight json >}}
@@ -1139,7 +1152,8 @@ spec:
         }
       ]
     },
-    "timestamp": 1552506033
+    "timestamp": 1552506033,
+    "event_id": "431a0085-96da-4521-863f-c38b480701e9"
   }
 }
 {{< /highlight >}}
@@ -1208,6 +1222,7 @@ spec:
       timestamp: 1552506033
       value: 0.004
   timestamp: 1552506033
+  event_id: 47ea07cd-1e50-4897-9e6d-09cd39ec5180
 {{< /highlight >}}
 
 {{< highlight json >}}
@@ -1289,7 +1304,8 @@ spec:
         }
       ]
     },
-    "timestamp": 1552506033
+    "timestamp": 1552506033,
+    "event_id": "47ea07cd-1e50-4897-9e6d-09cd39ec5180"
   }
 }
 {{< /highlight >}}


### PR DESCRIPTION
## Description
- Adds `event_id` field in Events API doc
- Adds `event_id` field in examples and description table in Events reference doc

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2188

## Review Instructions
I am not sure if I have the `event_id` in the correct position in either doc -- I couldn't seem to generate an event that included it using my local installation.

It seems a little confusing that the timestamp is shown at the top of the responses in the API doc but at the bottom of the spec in the reference examples. I'm not sure if either is incorrect (and maybe out of scope for this PR).
