### PR TITLE
Add 5.18 release notes

### DIFF
--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -7,6 +7,7 @@ version: "5.18"
 menu: "sensu-go-5.18"
 ---
 
+- [5.18.0 release notes](#5-18-0-release-notes)
 - [5.17.2 release notes](#5-17-2-release-notes)
 - [5.17.1 release notes](#5-17-1-release-notes)
 - [5.17.0 release notes](#5-17-0-release-notes)
@@ -52,6 +53,28 @@ PATCH versions include backward-compatible bug fixes.
 Read the [upgrade guide][1] for information about upgrading to the latest version of Sensu Go.
 
 ---
+
+## 5.18.0 release notes
+
+**February 24, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download.
+**PLACEHOLDER FOR RELEASE SUMMARY**
+
+See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
+
+**IMPROVEMENTS:**
+
+- The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
+- Proxy entities are now automatically created when events are published with an entity that does not exist.
+- Supported Bonsai asset versions are now prefixed with the letter `v` (for example, `v1.2.0`).
+- The version API now retrieves the Sensu agent version for the Sensu instance.
+- Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
+- Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
+- Updated Go version from 1.13.5 to 1.13.7.
+
+**FIXES:**
+
+- ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
+- Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
 
 ## 5.17.2 release notes
 
@@ -1048,7 +1071,11 @@ To get started with Sensu Go:
 [107]: /sensu-go/5.17/dashboard/overview
 [108]: /sensu-go/5.17/api/secrets
 [109]: /sensu-go/5.17/reference/backend/#initialization
-[110]: https://docs.sensu.io/sensu-go/5.17/api/overview/#field-selector
-[111]: https://docs.sensu.io/sensu-go/5.17/reference/rbac/#cluster-wide-resource-types
-[112]: https://docs.sensu.io/sensu-go/5.17/api/events/#events-post
-[113]: https://docs.sensu.io/sensu-go/5.17/sensuctl/reference/#list-commands
+[110]: /sensu-go/5.17/api/overview/#field-selector
+[111]: /sensu-go/5.17/reference/rbac/#cluster-wide-resource-types
+[112]: /sensu-go/5.17/api/events/#events-post
+[113]: /sensu-go/5.17/sensuctl/reference/#list-commands
+[114]: /sensu-go/5.18/api/events/#events-post
+[115]: /sensu-go/5.18/getting-started/enterprise/
+[116]: /sensu-go/5.18/api/overview/#label-selector
+[117]: /sensu-go/5.18/api/overview/#field-selector

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -64,7 +64,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 **IMPROVEMENTS:**
 
 - The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
-- Proxy entities are now automatically created when events are published with an entity that does not exist.
+- If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Supported Bonsai asset versions are now prefixed with the letter `v` (for example, `v1.2.0`).
 - The version API now retrieves the Sensu agent version for the Sensu instance.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
@@ -1079,3 +1079,4 @@ To get started with Sensu Go:
 [115]: /sensu-go/5.18/getting-started/enterprise/
 [116]: /sensu-go/5.18/api/overview/#label-selector
 [117]: /sensu-go/5.18/api/overview/#field-selector
+[118]: /sensu-go/5.18/api/events#events-post

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -75,7 +75,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
-
+- Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 ## 5.17.2 release notes
 
 **February 19, 2020** &mdash; The latest release of Sensu Go, version 5.17.2, is now available for download.

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -67,6 +67,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 - If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
 - The version API now retrieves the Sensu agent version for the Sensu instance.
+- In the [web UI][119], annotations that contain URLs are now clickable links.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
 - Updated Go version from 1.13.5 to 1.13.7.
@@ -1080,3 +1081,4 @@ To get started with Sensu Go:
 [116]: /sensu-go/5.18/api/overview/#label-selector
 [117]: /sensu-go/5.18/api/overview/#field-selector
 [118]: /sensu-go/5.18/api/events#events-post
+[119]: /sensu-go/5.18/dashboard/overview

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -76,10 +76,10 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
-- Fixed a bug that prevented [API response filtering][120] from working properly for the silenced API.
+- Fixed a bug that prevented [API response filtering][119] from working properly for the silenced API.
 - Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 - Sensuctl now supports the `http_proxy`, `https_proxy`, and `no_proxy` environment variables.
-- The [`auth/test` endpoint][121] now returns the correct error messages.
+- The [`auth/test` endpoint][120] now returns the correct error messages.
 
 ## 5.17.2 release notes
 
@@ -1085,5 +1085,5 @@ To get started with Sensu Go:
 [116]: /sensu-go/5.18/api/overview/#label-selector
 [117]: /sensu-go/5.18/api/overview/#field-selector
 [118]: /sensu-go/5.18/api/events#events-post
-[120]: /sensu-go/5.18/api/overview/#response-filtering
-[121]: /sensu-go/5.18/api/auth/#the-authtest-api-endpoint
+[119]: /sensu-go/5.18/api/overview/#response-filtering
+[120]: /sensu-go/5.18/api/auth/#the-authtest-api-endpoint

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -56,8 +56,7 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 ## 5.18.0 release notes
 
-**February 25, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download.
-**PLACEHOLDER FOR RELEASE SUMMARY**
+**February 25, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download. This release delivers a number of improvements to the overall Sensu Go experience. From automatic proxy entity creation to unique Sensu event IDs, it’s now much easier to use and troubleshoot your monitoring event pipelines! If you’re working behind an HTTP proxy, you can now easily manage remote Sensu Go clusters, as sensuctl now honours proxy environment variables (e.g. HTTPS_PROXY). This release includes a number of fixes for usability bugs, making for the most polished release of Sensu Go yet, so go ahead and give it a download!
 
 See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -67,7 +67,6 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 - If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
 - The version API now retrieves the Sensu agent version for the Sensu instance.
-- In the [web UI][119], annotations that contain URLs are now clickable links.
 - Log messages now indicate which filter dropped an event.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
@@ -1086,6 +1085,5 @@ To get started with Sensu Go:
 [116]: /sensu-go/5.18/api/overview/#label-selector
 [117]: /sensu-go/5.18/api/overview/#field-selector
 [118]: /sensu-go/5.18/api/events#events-post
-[119]: /sensu-go/5.18/dashboard/overview
 [120]: /sensu-go/5.18/api/overview/#response-filtering
 [121]: /sensu-go/5.18/api/auth/#the-authtest-api-endpoint

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -65,7 +65,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
 - If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
-- Supported Bonsai asset versions are now prefixed with the letter `v` (for example, `v1.2.0`).
+- Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
 - The version API now retrieves the Sensu agent version for the Sensu instance.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -56,7 +56,11 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 ## 5.18.0 release notes
 
-**February 25, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download. This release delivers a number of improvements to the overall Sensu Go experience. From automatic proxy entity creation to unique Sensu event IDs, it’s now much easier to use and troubleshoot your monitoring event pipelines! If you’re working behind an HTTP proxy, you can now easily manage remote Sensu Go clusters, as sensuctl now honours proxy environment variables (e.g. HTTPS_PROXY). This release includes a number of fixes for usability bugs, making for the most polished release of Sensu Go yet, so go ahead and give it a download!
+**February 25, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download.
+This release delivers a number of improvements to the overall Sensu Go experience.
+From automatic proxy entity creation to unique Sensu event IDs, it’s now much easier to use and troubleshoot your monitoring event pipelines!
+If you’re working behind an HTTP proxy, you can now manage remote Sensu Go clusters, as sensuctl now honors proxy environment variables (e.g. HTTPS_PROXY).
+This release also includes a number of fixes for usability bugs, making for the most polished release of Sensu Go yet, so go ahead and give it a download!
 
 See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -76,6 +76,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
+- Fixed a bug that prevented [API response filtering][120] from working properly for the silenced API.
 - Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 ## 5.17.2 release notes
 
@@ -1082,3 +1083,4 @@ To get started with Sensu Go:
 [117]: /sensu-go/5.18/api/overview/#field-selector
 [118]: /sensu-go/5.18/api/events#events-post
 [119]: /sensu-go/5.18/dashboard/overview
+[120]: /sensu-go/5.18/api/overview/#response-filtering

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -56,7 +56,7 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 ## 5.18.0 release notes
 
-**February 24, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download.
+**February 25, 2020** &mdash; The latest release of Sensu Go, version 5.18.0, is now available for download.
 **PLACEHOLDER FOR RELEASE SUMMARY**
 
 See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
@@ -68,6 +68,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
 - The version API now retrieves the Sensu agent version for the Sensu instance.
 - In the [web UI][119], annotations that contain URLs are now clickable links.
+- Log messages now indicate which filter dropped an event.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
 - Updated Go version from 1.13.5 to 1.13.7.
@@ -78,6 +79,9 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
 - Fixed a bug that prevented [API response filtering][120] from working properly for the silenced API.
 - Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
+- Sensuctl now supports the `http_proxy`, `https_proxy`, and `no_proxy` environment variables.
+- The [`auth/test` endpoint][121] now returns the correct error messages.
+
 ## 5.17.2 release notes
 
 **February 19, 2020** &mdash; The latest release of Sensu Go, version 5.17.2, is now available for download.
@@ -1084,3 +1088,4 @@ To get started with Sensu Go:
 [118]: /sensu-go/5.18/api/events#events-post
 [119]: /sensu-go/5.18/dashboard/overview
 [120]: /sensu-go/5.18/api/overview/#response-filtering
+[121]: /sensu-go/5.18/api/auth/#the-authtest-api-endpoint


### PR DESCRIPTION
## Description
Adds release notes for 5.18.

## Motivation and Context
Support 5.18 release.

## Review Instructions
A couple questions:
- Is something new supported for the `GET /silenced` endpoint? We already list this as available for API filtering (see https://docs.sensu.io/sensu-go/latest/api/silenced/#silenced-get-specification and https://docs.sensu.io/sensu-go/latest/api/overview/#field-selector).
- I'm not sure I have this correct: `The version API now retrieves the Sensu agent version for the Sensu instance.` The responses to my requests to `GET /version` using a local devel installation do not include the agent version.
