### PR TITLE
Add info about automatic proxy entity in events API and reference doc

### DIFF
--- a/content/sensu-go/5.18/api/events.md
+++ b/content/sensu-go/5.18/api/events.md
@@ -214,7 +214,7 @@ HTTP/1.1 200 OK
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< highlight shell >}}
 {

--- a/content/sensu-go/5.18/api/events.md
+++ b/content/sensu-go/5.18/api/events.md
@@ -214,7 +214,7 @@ HTTP/1.1 200 OK
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< highlight shell >}}
 {

--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -68,6 +68,8 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
+If you use the events API to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+
 ## Manage events
 
 You can manage events using the [Sensu dashboard][15], [events API][16], and [sensuctl][17] command line tool.
@@ -357,7 +359,7 @@ example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
 
 |entity      |      |
 -------------|------
-description  | [Entity attributes][2] from the originating entity (agent or proxy).
+description  | [Entity attributes][2] from the originating entity (agent or proxy). If you use the [events API][35] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 type         | Map
 required     | true
 example      | {{< highlight shell >}}
@@ -1329,3 +1331,4 @@ spec:
 [32]: #history-attributes
 [33]: ../checks#spec-attributes
 [34]: #points-attributes
+[35]: ../../api/events#events-post

--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -68,7 +68,7 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
-If you use the events API to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 
 ## Manage events
 
@@ -359,7 +359,7 @@ example      | {{< highlight shell >}}"timestamp": 1522099512{{< /highlight >}}
 
 |entity      |      |
 -------------|------
-description  | [Entity attributes][2] from the originating entity (agent or proxy). If you use the [events API][35] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description  | [Entity attributes][2] from the originating entity (agent or proxy). If you use the [events API][35] to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 type         | Map
 required     | true
 example      | {{< highlight shell >}}


### PR DESCRIPTION
## Description
- Adds automatic proxy entity creation when events are published without an entity using the events API in events API and reference doc.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2190

## Review Instructions
I looked through the guides but didn't see an obvious place to add this information. I also looked through the Core docs (probably too briefly) but didn't find this info there. @cwjohnston are you aware of a place in the Go guides that might need to include a note about the auto proxy entity creation?