### PR TITLE
update drawer partial in theme to fix "Edit This Page"

### DIFF
--- a/layouts/partials/drawer.html
+++ b/layouts/partials/drawer.html
@@ -13,7 +13,7 @@
       <div class="drawer--footer">
         <iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-docs&type=star&count=true" frameborder="0" scrolling="0" width="170" height="20"></iframe>
         <a target="_blank" href="https://github.com/sensu/sensu-docs/issues/new?title=Docs%20Feedback&body=%3C!--Thanks%20for%20submitting%20feedback%20to%20the%20Sensu%20docs!--%3E%0A%0ALink%20to%20page%3A%20%0A%0A%23%23%23%20Feedback">Open a docs issue</a>
-        <a target="_blank" href="{{.Site.Params.repo_url}}/edit/master/content/{{.File.Path}}">Edit this page</a>
+        <a target="_blank" href="{{.Site.Params.repo_url}}/edit/master/content/{{replace .File.Path "latest" .Site.Params.products.sensu_go.latest}}">Edit this page</a>
         <a target="_blank" href="https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md">Read the contributing guide</a>
         <!-- Small section for Sensu links -->
         {{ if isset .Site.Params "author" }}


### PR DESCRIPTION
##  Description

Modify the `drawer` partial so that the "Edit this page" link will work when browsing the docs for the `latest` version.

## Motivation and Context

Closes #2200 

## Review Instructions

Needs to be reviewed via Heroku preview as local server doesn't set up the `latest` alias.

Edit: Github is currently showing that the branch has not been deployed, but Heroku disagrees. Preview app at https://sensu-docs-fix-edit-thi-dtrpmb.herokuapp.com/sensu-go/latest/
