### PR TITLE
Add append flag to tee commands for agent and backend files

### DIFF
--- a/content/sensu-go/5.15/reference/backend.md
+++ b/content/sensu-go/5.15/reference/backend.md
@@ -928,12 +928,12 @@ In the following example, the `api-listen-address` flag is configured as an envi
 {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/default/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/sysconfig/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 

--- a/content/sensu-go/5.16/reference/backend.md
+++ b/content/sensu-go/5.16/reference/backend.md
@@ -1064,12 +1064,12 @@ In this example, the `api-listen-address` flag is configured as an environment v
 {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/default/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/sysconfig/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 

--- a/content/sensu-go/5.17/reference/backend.md
+++ b/content/sensu-go/5.17/reference/backend.md
@@ -1064,12 +1064,12 @@ In this example, the `api-listen-address` flag is configured as an environment v
 {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/default/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/sysconfig/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a/etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -1064,12 +1064,12 @@ In this example, the `api-listen-address` flag is configured as an environment v
 {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/default/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee /etc/sysconfig/sensu-backend
+$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 


### PR DESCRIPTION
## Description
Adds the append (`-a`) flag after `tee` in every command for updating agent and backend files.

## Motivation and Context
In some of our code examples, we use `tee` with an `append` flag. This could cause problems if someone copies and pastes the example as-is and they have an existing Sensu installation configured.

## Review Instructions
Edgar, I know you specifically mentioned the agent and backend yaml files, but should we also add the `a` flag to any of these other examples in the docs?

- `sha512sum sensu-go-hello-world-0.0.1.tar.gz | tee sha512sum.txt` (second code example under [Package the assets](https://docs.sensu.io/sensu-go/latest/reference/assets/#package-the-asset) in asset reference)
- `tee sensu-backend-$(date +%Y-%m-%d).log` (code examples in [Narrow your search to a specific timeframe](https://docs.sensu.io/sensu-go/latest/guides/troubleshooting/#narrow-your-search-to-a-specific-timeframe) section in troubleshooting guide)
- `sudo tee /etc/yum.repos.d/influxdb.repo` (first code example under [Install and configure InfluxDB](https://docs.sensu.io/sensu-go/latest/getting-started/prometheus-metrics/#install-and-configure-influxdb) in Prometheus metrics exercise in sandbox)