### PR TITLE
Incorporate Vault TLS instructions in secrets mgmt guide

### DIFF
--- a/content/sensu-go/5.17/guides/secrets-management.md
+++ b/content/sensu-go/5.17/guides/secrets-management.md
@@ -16,8 +16,7 @@ menu:
   - [Create your backend environment variable](#create-your-backend-environment-variable)
   - [Create your Env secret](#create-your-env-secret)
 - [Use HashiCorp Vault for secrets management](#use-hashicorp-vault-for-secrets-management)
-  - [Retrieve your Vault root token](#retrieve-your-vault-root-token)
-  - [Create your Vault secrets provider](#create-your-vault-secrets-provider)
+  - [Configure your Vault authentication method (token or TLS)](#configure-your-vault-authentication-method-token-or-tls)
   - [Create your Vault secret](#create-your-vault-secret)
 - [Add a handler](#add-a-handler)
   - [Register the PagerDuty handler asset](#register-the-pagerduty-handler-asset)
@@ -119,7 +118,15 @@ This section explains how to use [HashiCorp Vault][1] as your external [secrets 
 
 _**NOTE**: You will need to set up [HashiCorp Vault][15] to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server][32], which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
 
-### Retrieve your Vault root token
+### Configure your Vault authentication method (token or TLS)
+
+If you use [HashiCorp Vault][1] as your external [secrets provider][2], you can authenticate via the HashiCorp Vault integration's [token][3] or [transport layer security (TLS) certificate][4] authentication method.
+
+#### Vault token authentication
+
+Follow the steps in this section to use HashiCorp Vault as your external [secrets provider][2] to authenticate with the HashiCorp Vault integration's [token auth method][3].
+
+##### Retrieve your Vault root token
 
 _**NOTE**: The examples in this guide use the `Root Token` for the the [Vault dev server][18], which gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
 
@@ -140,7 +147,7 @@ You will use it next to create your Vault secrets provider.
 Leave the Vault dev server running.
 Because you aren't using TLS, you will need to set `VAULT_ADDR=http://127.0.0.1:8200` in your shell environment.
 
-### Create your Vault secrets provider
+##### Create your Vault secrets provider
 
 _**NOTE**: In Vault's dev server, TLS is not enabled, so you won't be able to use certificate-based authentication._
 
@@ -168,6 +175,53 @@ spec:
       burst: 100
 EOF
 {{< /highlight >}}
+
+To continue, skip ahead to [create your Vault secret][29].
+
+#### Vault TLS certificate authentication
+
+This section explains how use HashiCorp Vault as your external [secrets provider][2] to authenticate with the HashiCorp Vault integration's [TLS certificate auth method][4].
+
+_**NOTE**: You will need to set up [HashiCorp Vault][15] in production to use TLS certificate-based authentication. In Vault's dev server, TLS is not enabled. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
+
+First, in your Vault, [enable and configure certificate authentication][33].
+For example, your Vault might be configured for certificate authentication like this:
+
+{{< highlight shell >}}
+vault write auth/cert/certs/sensu-agent \
+    display_name=sensu-agent \
+    policies=sensu-agent-policy \
+    certificate=@sensu-agent-vault.pem \
+    ttl=3600
+{{< /highlight >}}
+
+Second, configure your `VaultProvider` in Sensu: 
+
+{{< highlight yaml >}}
+---
+type: VaultProvider
+api_version: secrets/v1
+metadata:
+  name: vault
+spec:
+  client:
+    address: https://vault.example.com:8200
+    version: v2
+    tls:
+      ca_cert: /path/to/your/ca.pem
+      client_cert: /etc/sensu/ssl/sensu-agent-vault.pem
+      client_key: /etc/sensu/ssl/sensu-agent-vault-key.pem
+      cname: sensu-agent.example.com
+    max_retries: 2
+    timeout: 20s
+    rate_limiter:
+      limit: 10
+      burst: 100
+{{< /highlight >}}
+
+The certificate you specify for `tls.client_cert` should be the same certificate you configured in your Vault for certificate authentication.
+
+Next, [create your Vault secret][29].
 
 ### Create your Vault secret
 

--- a/content/sensu-go/5.18/guides/secrets-management.md
+++ b/content/sensu-go/5.18/guides/secrets-management.md
@@ -16,8 +16,7 @@ menu:
   - [Create your backend environment variable](#create-your-backend-environment-variable)
   - [Create your Env secret](#create-your-env-secret)
 - [Use HashiCorp Vault for secrets management](#use-hashicorp-vault-for-secrets-management)
-  - [Retrieve your Vault root token](#retrieve-your-vault-root-token)
-  - [Create your Vault secrets provider](#create-your-vault-secrets-provider)
+  - [Configure your Vault authentication method (token or TLS)](#configure-your-vault-authentication-method-token-or-tls)
   - [Create your Vault secret](#create-your-vault-secret)
 - [Add a handler](#add-a-handler)
   - [Register the PagerDuty handler asset](#register-the-pagerduty-handler-asset)
@@ -119,9 +118,17 @@ This section explains how to use [HashiCorp Vault][1] as your external [secrets 
 
 _**NOTE**: You will need to set up [HashiCorp Vault][15] to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server][32], which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
 
-### Retrieve your Vault root token
+### Configure your Vault authentication method (token or TLS)
 
-_**NOTE**: The examples in this guide use the `Root Token` for the the [Vault dev server][18], which gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
+If you use [HashiCorp Vault][1] as your external [secrets provider][2], you can authenticate via the HashiCorp Vault integration's [token][3] or [transport layer security (TLS) certificate][4] authentication method.
+
+#### Vault token authentication
+
+Follow the steps in this section to use HashiCorp Vault as your external [secrets provider][2] to authenticate with the HashiCorp Vault integration's [token auth method][3].
+
+##### Retrieve your Vault root token
+
+_**NOTE**: The examples in this section use the `Root Token` for the the [Vault dev server][18], which gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
 
 To retrieve your Vault root token:
 
@@ -140,7 +147,7 @@ You will use it next to create your Vault secrets provider.
 Leave the Vault dev server running.
 Because you aren't using TLS, you will need to set `VAULT_ADDR=http://127.0.0.1:8200` in your shell environment.
 
-### Create your Vault secrets provider
+##### Create your Vault secrets provider
 
 _**NOTE**: In Vault's dev server, TLS is not enabled, so you won't be able to use certificate-based authentication._
 
@@ -168,6 +175,51 @@ spec:
       burst: 100
 EOF
 {{< /highlight >}}
+
+To continue, skip ahead to [create your Vault secret][29].
+
+#### Vault TLS certificate authentication
+
+This section explains how use HashiCorp Vault as your external [secrets provider][2] to authenticate with the HashiCorp Vault integration's [TLS certificate auth method][4].
+
+First, in your Vault, [enable and configure certificate authentication][33].
+For example, your Vault might be configured for certificate authentication like this:
+
+{{< highlight shell >}}
+vault write auth/cert/certs/sensu-agent \
+    display_name=sensu-agent \
+    policies=sensu-agent-policy \
+    certificate=@sensu-agent-vault.pem \
+    ttl=3600
+{{< /highlight >}}
+
+Second, configure your `VaultProvider` in Sensu: 
+
+{{< highlight yaml >}}
+---
+type: VaultProvider
+api_version: secrets/v1
+metadata:
+  name: vault
+spec:
+  client:
+    address: https://vault.example.com:8200
+    version: v2
+    tls:
+      ca_cert: /path/to/your/ca.pem
+      client_cert: /etc/sensu/ssl/sensu-agent-vault.pem
+      client_key: /etc/sensu/ssl/sensu-agent-vault-key.pem
+      cname: sensu-agent.example.com
+    max_retries: 2
+    timeout: 20s
+    rate_limiter:
+      limit: 10
+      burst: 100
+{{< /highlight >}}
+
+The certificate you specify for `tls.client_cert` should be the same certificate you configured in your Vault for certificate authentication.
+
+Next, [create your Vault secret][29].
 
 ### Create your Vault secret
 
@@ -289,3 +341,4 @@ Read the [secrets][9] or [secrets providers][10] reference for in-depth secrets 
 [30]: #retrieve-your-pagerduty-integration-key
 [31]: https://www.pagerduty.com/
 [32]: https://www.vaultproject.io/docs/concepts/dev-server/
+[33]: https://www.vaultproject.io/docs/auth/cert/#configuration

--- a/content/sensu-go/5.18/guides/secrets-management.md
+++ b/content/sensu-go/5.18/guides/secrets-management.md
@@ -189,7 +189,9 @@ To continue, skip ahead to [create your Vault secret][29].
 
 This section explains how use HashiCorp Vault as your external [secrets provider][2] to authenticate with the HashiCorp Vault integration's [TLS certificate auth method][4].
 
-_**NOTE**: You will need to set up [HashiCorp Vault][15] in production to use TLS certificate-based authentication. In Vault's dev server, TLS is not enabled. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
+{{% notice note %}}
+**NOTE**: You will need to set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) in production to use TLS certificate-based authentication. In Vault's dev server, TLS is not enabled. Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.
+{{% /notice %}}
 
 First, in your Vault, [enable and configure certificate authentication][33].
 For example, your Vault might be configured for certificate authentication like this:

--- a/content/sensu-go/5.18/guides/secrets-management.md
+++ b/content/sensu-go/5.18/guides/secrets-management.md
@@ -116,7 +116,7 @@ Skip to the [add a handler][19] section, where you'll use your `pagerduty_key` s
 
 This section explains how to use [HashiCorp Vault][1] as your external [secrets provider][2] to authenticate via the HashiCorp Vault integration's [token auth method][3] or [TLS certificate auth method][4].
 
-_**NOTE**: You will need to set up [HashiCorp Vault][15] to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server][32], which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
+_**NOTE**: You will need to set up [HashiCorp Vault][15] to use `VaultProvider` secrets management in production. The examples in the [Vault token authentication][34] section of this guide use the [Vault dev server][32], which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
 
 ### Configure your Vault authentication method (token or TLS)
 
@@ -149,8 +149,6 @@ Because you aren't using TLS, you will need to set `VAULT_ADDR=http://127.0.0.1:
 
 ##### Create your Vault secrets provider
 
-_**NOTE**: In Vault's dev server, TLS is not enabled, so you won't be able to use certificate-based authentication._
-
 Use `sensuctl create` to create your secrets provider, `vault`.
 In the code below, replace `ROOT_TOKEN` with the `Root Token` value for your Vault dev server.
 Then, run:
@@ -181,6 +179,8 @@ To continue, skip ahead to [create your Vault secret][29].
 #### Vault TLS certificate authentication
 
 This section explains how use HashiCorp Vault as your external [secrets provider][2] to authenticate with the HashiCorp Vault integration's [TLS certificate auth method][4].
+
+_**NOTE**: You will need to set up [HashiCorp Vault][15] in production to use TLS certificate-based authentication. In Vault's dev server, TLS is not enabled. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
 
 First, in your Vault, [enable and configure certificate authentication][33].
 For example, your Vault might be configured for certificate authentication like this:
@@ -342,3 +342,4 @@ Read the [secrets][9] or [secrets providers][10] reference for in-depth secrets 
 [31]: https://www.pagerduty.com/
 [32]: https://www.vaultproject.io/docs/concepts/dev-server/
 [33]: https://www.vaultproject.io/docs/auth/cert/#configuration
+[34]: #vault-token-authentication


### PR DESCRIPTION
## Description
Incorporates section about using Vault TLS auth (instead of token auth) in the secrets management guide.

Based on [draft content](https://docs.google.com/document/d/1ysCZgd7gf4grTLhNa4p6l1ckK9fsIgNX_h7fpGf8hXE/edit?disco=AAAAJH8a2M0) from @nixwiz .

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2199