### PR TITLE
Clarify and correct initialization content re: Docker

### DIFF
--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -88,16 +88,27 @@ sudo yum install sensu-go-backend
 You can configure the Sensu backend with `sensu-backend start` flags (recommended) or an `/etc/sensu/backend.yml` file.
 The Sensu backend requires the `state-dir` flag at minimum, but other useful configurations and templates are available.
 
+{{% notice note %}}
+**NOTE**: If you are using Docker, intitialization is included in this step when you start the backend rather than in [3. Initialization](#3-initialization).
+For details about intialization in Docker, see the [backend reference](../../reference/backend#initialization).
+{{% /notice %}}
+
 {{< language-toggle >}}
 
 {{< highlight Docker >}}
+# Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password
+# you want to use for your admin user credentials.
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
 -p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
+-e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
 {{< highlight "Docker Compose" >}}
+# Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password
+# you want to use for your admin user credentials.
 ---
 version: "3"
 services:
@@ -110,10 +121,14 @@ services:
     volumes:
     - "sensu-backend-data:/var/lib/sensu/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
+    environment:
+    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
+    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
 
 volumes:
   sensu-backend-data:
     driver: local
+
 {{< /highlight >}}
 
 {{< highlight "Ubuntu/Debian" >}}
@@ -144,43 +159,17 @@ For a complete list of configuration options, see the [backend reference][6].
 
 ### 3. Initialize
 
+{{% notice note %}}
+**NOTE**: If you are using Docker, you already completed intitialization in [2. Configure and start](#2-configure-and-start).
+Skip ahead to [4. Open the web UI](#4-open-the-web-ui) to continue the backend installation process.
+{{% /notice %}}
+
 **With the backend running**, run `sensu-backend init` to set up your Sensu administrator username and password.
 In this initialization step, you only need to set environment variables with a username and password string &mdash; no need for role-based access control (RBAC).
 
 Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use.
 
 {{< language-toggle >}}
-
-{{< highlight Docker >}}
-docker run \
--e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
--e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
---restart always \
---name sensu \
-sensu/sensu:latest \
-sensu-backend start
-{{< /highlight >}}
-
-{{< highlight "Docker Compose" >}}
----
-version: "3"
-services:
-  sensu-backend:
-    image: sensu/sensu:latest
-    ports:
-    - 3000:3000
-    - 8080:8080
-    - 8081:8081
-    volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
-    command: "sensu-backend start"
-    environment:
-    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
-    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
-volumes:
-  sensu-backend-data:
-    driver: local
-{{< /highlight >}}
 
 {{< highlight "Ubuntu/Debian" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME

--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -89,8 +89,8 @@ You can configure the Sensu backend with `sensu-backend start` flags (recommende
 The Sensu backend requires the `state-dir` flag at minimum, but other useful configurations and templates are available.
 
 {{% notice note %}}
-**NOTE**: If you are using Docker, intitialization is included in this step when you start the backend rather than in [3. Initialization](#3-initialization).
-For details about intialization in Docker, see the [backend reference](../../reference/backend#initialization).
+**NOTE**: If you are using Docker, intitialization is included in this step when you start the backend rather than in [3. Initialize](#3-initialize).
+For details about intialization in Docker, see the [backend reference](../../reference/backend#docker-initialization).
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -162,6 +162,7 @@ For a complete list of configuration options, see the [backend reference][6].
 {{% notice note %}}
 **NOTE**: If you are using Docker, you already completed intitialization in [2. Configure and start](#2-configure-and-start).
 Skip ahead to [4. Open the web UI](#4-open-the-web-ui) to continue the backend installation process.
+If you did not use environment variables to override the default admin credentials in step 2, skip ahead to [Install sensuctl](#install-sensuctl) so you can change your default admin password immediately.
 {{% /notice %}}
 
 **With the backend running**, run `sensu-backend init` to set up your Sensu administrator username and password.
@@ -193,7 +194,10 @@ The web UI provides a unified view of your monitoring events and user-friendly t
 After starting the Sensu backend, open the web UI by visiting http://localhost:3000.
 You may need to replace `localhost` with the hostname or IP address where the Sensu backend is running.
 
-To log in to the web UI, enter your Sensu user credentials (the username and password provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables).
+To log in to the web UI, enter your Sensu user credentials.
+If you are using Docker and you did not specify environment variables to override the default admin credentials, your user credentials are username `admin` and password `P@ssw0rd!`.
+Otherwise, your user credentials are the username and password you provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables.
+
 Select the ☰ icon to explore the web UI.
 
 ### 5. Make a request to the health API
@@ -269,9 +273,11 @@ sensuctl configure -n \
 Here, the `-n` flag triggers non-interactive mode.
 Run `sensuctl config view` to see your user profile.
 
-We recommend that you change the default admin password immediately: `sensuctl user change-password --interactive`.
-
 For more information about sensuctl, see the [quickstart][23] and [reference][4] docs.
+
+### Change default admin password
+
+If you are using Docker and you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process](#2-configure-and-start), we recommend that you change the default admin password immediately: `sensuctl user change-password --interactive`.
 
 ## Install Sensu agents
 

--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -277,7 +277,12 @@ For more information about sensuctl, see the [quickstart][23] and [reference][4]
 
 ### Change default admin password
 
-If you are using Docker and you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process](#2-configure-and-start), we recommend that you change the default admin password immediately: `sensuctl user change-password --interactive`.
+If you are using Docker and you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process](#2-configure-and-start), we recommend that you change the default admin password as soon as you have [installed sensuctl][19].
+Run:
+
+{{< highlight "shell" >}}
+sensuctl user change-password --interactive
+{{< /highlight >}}
 
 ## Install Sensu agents
 

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -54,7 +54,7 @@ For information about creating and managing checks, see:
 For a **new** installation, the backend database must be initialized by providing a username and password to be granted administrative privileges. Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during installation step [2. Configure and start][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you can set admin credentials during installation step [3. Initialization][25].
+- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during installation step [3. Initialization][25]. Sensu does not apply a default admin username or password for Ubuntu/Debian or RHEL/CentoOS installations.
 
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -51,8 +51,58 @@ For information about creating and managing checks, see:
 
 ## Initialization
 
-For a **new** installation, you must set up an administrator username and password.
-To do this, set environment variables as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
+For a **new** installation, you can set administrator credentials with environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`).
+
+- If you are using Docker, you can set admin credentials during installation step [2. Configure and start][24].
+- If you are using Ubuntu/Debian or RHEL/CentOS, you can set admin credentials during installation step [3. Initialization][25].
+
+This step bootstraps the first admin user account for your Sensu installation.
+This account will be granted the cluster admin role.
+
+If you do not include the environment variables to set administrator credentials, the backend will initialize with the default admin credentials (username `admin` and password `P@ssw0rd!`).
+
+### Docker initialization
+
+For Docker installations, set administrator credentials with environment variables when you [configure and start][24] the backend as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
+
+{{< language-toggle >}}
+
+{{< highlight Docker >}}
+docker run -v /var/lib/sensu:/var/lib/sensu \
+-d --name sensu-backend \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
+-e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
+{{< /highlight >}}
+
+{{< highlight "Docker Compose" >}}
+---
+version: "3"
+services:
+  sensu-backend:
+    image: sensu/sensu:latest
+    ports:
+    - 3000:3000
+    - 8080:8080
+    - 8081:8081
+    volumes:
+    - "sensu-backend-data:/var/lib/sensu/etcd"
+    command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
+    environment:
+    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
+    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+
+volumes:
+  sensu-backend-data:
+    driver: local
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+### Ubuntu/Debian or RHEL/CentOS initialization
+
+For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
 
 {{< highlight shell >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
@@ -73,12 +123,10 @@ Admin Username: YOUR_USERNAME
 Admin Password: YOUR_PASSWORD
 {{< /highlight >}}
 
-This initialization step bootstraps the first admin user account for your Sensu installation.
-This account will be granted the cluster admin role.
-
 {{% notice note %}}
 **NOTE**: If you are already using Sensu, you do not need to initialize.
 Your installation has already seeded the admin username and password you have set up.
+Running `sensu-backend init` on a previously initialized cluster has no effect &mdash; it will not change the admin credentials.
 {{% /notice %}}
 
 To see available initialization flags:
@@ -1210,3 +1258,5 @@ Here are some log rotate sample configurations:
 [21]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#dns-discovery
 [22]: #initialization
 [23]: #etcd-listen-client-urls
+[24]: ../../installation/install-sensu#2-configure-and-start
+[25]: ../../installation/install-sensu#3-initialization

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -99,7 +99,7 @@ volumes:
 
 {{< /language-toggle >}}
 
-If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] immediately.
+If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
 
 ### Ubuntu/Debian or RHEL/CentOS initialization
 

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -59,7 +59,6 @@ For a **new** installation, the backend database must be initialized by providin
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-If you do not include the environment variables to set administrator credentials, the backend will initialize with the default admin credentials (username `admin` and password `P@ssw0rd!`).
 
 ### Docker initialization
 

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -51,14 +51,14 @@ For information about creating and managing checks, see:
 
 ## Initialization
 
-For a **new** installation, the backend database must be initialized by providing a username and password to be granted administrative privileges. Although initialization is required for every new installation, the implementation differs depending on your method of installation:
+For a **new** installation, the backend database must be initialized by providing a username and password for the user to be granted administrative privileges.
+Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
-- If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during installation step [2. Configure and start][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during installation step [3. Initialization][25]. Sensu does not apply a default admin username or password for Ubuntu/Debian or RHEL/CentoOS installations.
+- If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
+- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25]. Sensu does not apply a default admin username or password for Ubuntu/Debian or RHEL/CentoOS installations.
 
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
-
 
 ### Docker initialization
 
@@ -98,6 +98,8 @@ volumes:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] immediately.
 
 ### Ubuntu/Debian or RHEL/CentOS initialization
 
@@ -1235,7 +1237,7 @@ Here are some log rotate sample configurations:
 {{< /highlight >}}
 
 [1]: ../../installation/install-sensu#install-the-sensu-backend
-[2]: https://github.com/etcd-io/etcd/blob/master/Documentation/docs.md
+[2]: https://etcd.io/docs
 [3]: ../../guides/monitor-server-resources/
 [4]: ../../guides/extract-metrics-with-checks/
 [5]: ../../reference/checks/
@@ -1252,10 +1254,11 @@ Here are some log rotate sample configurations:
 [16]: https://github.com/etcd-io/etcd/blob/master/Documentation/tuning.md#time-parameters
 [17]: ../../files/backend.yml
 [18]: https://golang.org/pkg/crypto/tls/#pkg-constants
-[19]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#discovery
-[20]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#etcd-discovery
-[21]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#dns-discovery
+[19]: https://etcd.io/docs/latest/op-guide/clustering/#discovery
+[20]: https://etcd.io/docs/latest/op-guide/clustering/#etcd-discovery
+[21]: https://etcd.io/docs/latest/op-guide/clustering/#dns-discovery
 [22]: #initialization
 [23]: #etcd-listen-client-urls
 [24]: ../../installation/install-sensu#2-configure-and-start
-[25]: ../../installation/install-sensu#3-initialization
+[25]: ../../installation/install-sensu#3-initialize
+[26]: ../../sensuctl/reference/#change-admin-user-s-password

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -53,7 +53,7 @@ For information about creating and managing checks, see:
 
 For a **new** installation, the backend database must be initialized by providing a username and password to be granted administrative privileges. Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
-- If you are using Docker, you can set admin credentials during installation step [2. Configure and start][24].
+- If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during installation step [2. Configure and start][24].
 - If you are using Ubuntu/Debian or RHEL/CentOS, you can set admin credentials during installation step [3. Initialization][25].
 
 This step bootstraps the first admin user account for your Sensu installation.

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -51,7 +51,7 @@ For information about creating and managing checks, see:
 
 ## Initialization
 
-For a **new** installation, you can set administrator credentials with environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`).
+For a **new** installation, the backend database must be initialized by providing a username and password to be granted administrative privileges. Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can set admin credentials during installation step [2. Configure and start][24].
 - If you are using Ubuntu/Debian or RHEL/CentOS, you can set admin credentials during installation step [3. Initialization][25].

--- a/content/sensu-go/5.18/reference/rbac.md
+++ b/content/sensu-go/5.18/reference/rbac.md
@@ -242,9 +242,9 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### Default users
 
-During the [Sensu backend installation][42] process, you can set administrator credentials to override the default credentials and a `default` namespace.
+During the [Sensu backend installation][42] process, you can set administrator credentials to override the default credentials and create a `default` namespace.
 
-This is the user that you can use to manage all aspects of Sensu and create new users.
+This is the admin user that you can use to manage all aspects of Sensu and create new users.
 
 | attribute | value |
 | --------- | ----- |
@@ -254,11 +254,7 @@ This is the user that you can use to manage all aspects of Sensu and create new 
 | cluster role   |  `cluster-admin` |
 | cluster role binding   | `cluster-admin	`  |
 
-Once authenticated, you can change the password for the admin user with the `change-password` command:
-
-{{< highlight shell >}}
-sensuctl user change-password
-{{< /highlight >}}
+Once authenticated, you can [change the admin user's password][45] with the `change-password` command.
 
 Sensu also includes an `agent` user, which is used internally by the Sensu agent.
 You can configure `agent` user credentials with the [`user` and `password` agent configuration flags][41].
@@ -1276,3 +1272,4 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [42]: ../../installation/install-sensu/#install-the-sensu-backend
 [43]: ../../installation/auth#ldap-authentication
 [44]: ../../installation/auth/#ad-authentication
+[45]: ../../sensuctl/reference/#change-admin-user-s-password

--- a/content/sensu-go/5.18/reference/rbac.md
+++ b/content/sensu-go/5.18/reference/rbac.md
@@ -242,7 +242,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### Default users
 
-During the [Sensu backend installation][42] process, you can set administrator credentials to override the default credentials and create a `default` namespace.
+During the [Sensu backend installation][42] process, you create an administrator username and password and a `default` namespace.
 
 This is the admin user that you can use to manage all aspects of Sensu and create new users.
 

--- a/content/sensu-go/5.18/reference/rbac.md
+++ b/content/sensu-go/5.18/reference/rbac.md
@@ -242,7 +242,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### Default users
 
-During the [Sensu backend installation][42] process, you can set administrator credentials to override the default credentials for a `default` namespace.
+During the [Sensu backend installation][42] process, you can set administrator credentials to override the default credentials and a `default` namespace.
 
 This is the user that you can use to manage all aspects of Sensu and create new users.
 

--- a/content/sensu-go/5.18/reference/rbac.md
+++ b/content/sensu-go/5.18/reference/rbac.md
@@ -254,7 +254,7 @@ This is the admin user that you can use to manage all aspects of Sensu and creat
 | cluster role   |  `cluster-admin` |
 | cluster role binding   | `cluster-admin	`  |
 
-Once authenticated, you can [change the admin user's password][45] with the `change-password` command.
+After you [configure sensuctl][26], you can [change the admin user's password][45] with the `change-password` command.
 
 Sensu also includes an `agent` user, which is used internally by the Sensu agent.
 You can configure `agent` user credentials with the [`user` and `password` agent configuration flags][41].

--- a/content/sensu-go/5.18/reference/rbac.md
+++ b/content/sensu-go/5.18/reference/rbac.md
@@ -242,7 +242,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### Default users
 
-When you install the Sensu backend, during the [initialization step][42], you create a username and password for a `default` namespace.
+During the [Sensu backend installation][42] process, you can set administrator credentials to override the default credentials for a `default` namespace.
 
 This is the user that you can use to manage all aspects of Sensu and create new users.
 
@@ -254,7 +254,7 @@ This is the user that you can use to manage all aspects of Sensu and create new 
 | cluster role   |  `cluster-admin` |
 | cluster role binding   | `cluster-admin	`  |
 
-Once authenticated, you can change the default password for the admin user with the `change-password` command:
+Once authenticated, you can change the password for the admin user with the `change-password` command:
 
 {{< highlight shell >}}
 sensuctl user change-password
@@ -1273,6 +1273,6 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [39]: ../../installation/auth/#ad-groups-prefix
 [40]: ../../reference/etcdreplicators/
 [41]: ../agent/#security-configuration-flags
-[42]: ../../installation/install-sensu/#3-initialize
+[42]: ../../installation/install-sensu/#install-the-sensu-backend
 [43]: ../../installation/auth#ldap-authentication
 [44]: ../../installation/auth/#ad-authentication

--- a/content/sensu-go/5.18/sensuctl/reference.md
+++ b/content/sensu-go/5.18/sensuctl/reference.md
@@ -64,7 +64,7 @@ For information about configuring the Sensu backend URL, see the [backend refere
 
 ### Username, password, and namespace
 
-During the [Sensu backend installation][40] process, you create an administrator username and password for a `default` namespace.
+During the [Sensu backend installation][40] process, you create an administrator username and password and a `default` namespace.
 
 Your ability to get, list, create, update, and delete resources with sensuctl depends on the permissions assigned to your Sensu user.
 For more information about configuring Sensu access control, see the [RBAC reference][1].

--- a/content/sensu-go/5.18/sensuctl/reference.md
+++ b/content/sensu-go/5.18/sensuctl/reference.md
@@ -76,7 +76,8 @@ If you are using Docker and you do not include the environment variables to set 
 
 #### Change admin user's password
 
-To change the admin user's password, run:
+After you have [installed and configured sensuctl][46], you can change the admin user's password.
+Run:
 
 {{< highlight shell >}}
 sensuctl user change-password --interactive
@@ -1075,3 +1076,4 @@ Flags are optional and apply only to the `delete` command.
 [43]: ../../reference/secrets-providers/
 [44]: ../../installation/auth#use-built-in-basic-authentication
 [45]: ../../installation/install-sensu/#2-configure-and-start
+[46]: #first-time-setup

--- a/content/sensu-go/5.18/sensuctl/reference.md
+++ b/content/sensu-go/5.18/sensuctl/reference.md
@@ -62,14 +62,16 @@ The default URL is `http://127.0.0.1:8080`.
 To connect to a [Sensu cluster][7], connect sensuctl to any single backend in the cluster.
 For information about configuring the Sensu backend URL, see the [backend reference][5].
 
-### Username, Password, and Namespace
+### Username, password, and namespace
 
-When you install the Sensu backend, during the [initialization step][40], you create a username and password for a `default` namespace.
+During the [Sensu backend installation][40] process, you create an administrator username and password for a `default` namespace.
+
 Your ability to get, list, create, update, and delete resources with sensuctl depends on the permissions assigned to your Sensu user.
 For more information about configuring Sensu access control, see the [RBAC reference][1].
 
 {{% notice note %}}
-**NOTE**: The `sensu-backend init` command for initialization runs automatically with a default username (`admin`) and password (`P@ssw0rd!`). You can specify a username and password with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables during [initialization](../../installation/install-sensu/#3-initialize) to override the defaults.
+**NOTE**: For a **new** installation, you can set administrator credentials with environment variables to override the default admin username and password during [initialization](../../reference/backend/#initialization).
+If you do not include the environment variables to set administrator credentials, the backend will initialize with the default username (`admin`) and password (`P@ssw0rd!`).
 {{% /notice %}} 
 
 ### Preferred output format
@@ -1059,7 +1061,7 @@ Flags are optional and apply only to the `delete` command.
 [36]: /images/sensu-influxdb-handler-namespace.png
 [37]: https://bonsai.sensu.io/assets/portertech/sensu-ec2-discovery
 [39]: #wrapped-json-format
-[40]: ../../installation/install-sensu/#3-initialize
+[40]: ../../installation/install-sensu/#install-the-sensu-backend
 [41]: ../../reference/secrets/
 [42]: ../../installation/auth/#ad-authentication
 [43]: ../../reference/secrets-providers/

--- a/content/sensu-go/5.18/sensuctl/reference.md
+++ b/content/sensu-go/5.18/sensuctl/reference.md
@@ -70,9 +70,17 @@ Your ability to get, list, create, update, and delete resources with sensuctl de
 For more information about configuring Sensu access control, see the [RBAC reference][1].
 
 {{% notice note %}}
-**NOTE**: For a **new** installation, you can set administrator credentials with environment variables to override the default admin username and password during [initialization](../../reference/backend/#initialization).
-If you do not include the environment variables to set administrator credentials, the backend will initialize with the default username (`admin`) and password (`P@ssw0rd!`).
+**NOTE**: For a **new** installation, you can set administrator credentials with environment variables during [initialization](../../reference/backend/#initialization).
+If you are using Docker and you do not include the environment variables to set administrator credentials, the backend will initialize with the default username (`admin`) and password (`P@ssw0rd!`).
 {{% /notice %}} 
+
+#### Change admin user's password
+
+To change the admin user's password, run:
+
+{{< highlight shell >}}
+sensuctl user change-password --interactive
+{{< /highlight >}}
 
 ### Preferred output format
 
@@ -1066,3 +1074,4 @@ Flags are optional and apply only to the `delete` command.
 [42]: ../../installation/auth/#ad-authentication
 [43]: ../../reference/secrets-providers/
 [44]: ../../installation/auth#use-built-in-basic-authentication
+[45]: ../../installation/install-sensu/#2-configure-and-start


### PR DESCRIPTION
## Description
- Updates code examples and instructions for Docker vs. Ubuntu/Debian and RHEL/CentOS in:
     - https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#2-configure-and-start
     - https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#3-initialize
- Clarifies when initialization happens for Docker vs. Ubuntu/Debian and RHEL/CentOS in:
     - https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#2-configure-and-start
     - https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#3-initialize
     - https://docs.sensu.io/sensu-go/latest/reference/backend/#initialization
- Adds minor link changes and language clarifications in:
     - https://docs.sensu.io/sensu-go/latest/sensuctl/reference/#username-password-and-namespace
     - https://docs.sensu.io/sensu-go/latest/reference/rbac/#default-users

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2224