### PR TITLE
Correct links and button text on last page of Katacoda scenarios

### DIFF
--- a/content/sensu-go/5.16/guides/up-running-tutorial.md
+++ b/content/sensu-go/5.16/guides/up-running-tutorial.md
@@ -23,8 +23,8 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/up-and-running"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/guides/email-handler/"
-    data-katacoda-ctatext="Up and running with Sensu Go tutorial"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>

--- a/content/sensu-go/5.16/learn/learn-in-15.md
+++ b/content/sensu-go/5.16/learn/learn-in-15.md
@@ -21,7 +21,7 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/sandbox"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-go/"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
     data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>

--- a/content/sensu-go/5.16/learn/up-and-running.md
+++ b/content/sensu-go/5.16/learn/up-and-running.md
@@ -21,8 +21,8 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/up-and-running"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-go/"
-    data-katacoda-ctatext="Up and running with Sensu Go tutorial"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>

--- a/content/sensu-go/5.17/guides/up-running-tutorial.md
+++ b/content/sensu-go/5.17/guides/up-running-tutorial.md
@@ -22,8 +22,8 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/up-and-running"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/guides/email-handler/"
-    data-katacoda-ctatext="Up and running with Sensu Go tutorial"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>

--- a/content/sensu-go/5.17/learn/learn-in-15.md
+++ b/content/sensu-go/5.17/learn/learn-in-15.md
@@ -21,7 +21,7 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/sandbox"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-go/"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
     data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>

--- a/content/sensu-go/5.17/learn/up-and-running.md
+++ b/content/sensu-go/5.17/learn/up-and-running.md
@@ -21,8 +21,8 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/up-and-running"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-go/"
-    data-katacoda-ctatext="Up and running with Sensu Go tutorial"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>

--- a/content/sensu-go/5.18/guides/up-running-tutorial.md
+++ b/content/sensu-go/5.18/guides/up-running-tutorial.md
@@ -22,8 +22,8 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/up-and-running"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/guides/email-handler/"
-    data-katacoda-ctatext="Up and running with Sensu Go tutorial"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>

--- a/content/sensu-go/5.18/learn/learn-in-15.md
+++ b/content/sensu-go/5.18/learn/learn-in-15.md
@@ -21,7 +21,7 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/sandbox"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-go/"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
     data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>

--- a/content/sensu-go/5.18/learn/up-and-running.md
+++ b/content/sensu-go/5.18/learn/up-and-running.md
@@ -21,8 +21,8 @@ s.parentNode.insertBefore(b, s);})();
 <div id="katacoda-scenario-1"
     data-katacoda-id="sensu/up-and-running"
     data-katacoda-color="2c3458"
-    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-go/"
-    data-katacoda-ctatext="Up and running with Sensu Go tutorial"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>


### PR DESCRIPTION
## Description
Corrects last page button text and link to https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/ in all Katacoda scenarios

## Motivation and Context
Scenarios linked to different places and used text that did not match the linked pages.
