### PR TITLE
Add release version and build number update script

### DIFF
--- a/scripts/update-sensu-version.sh
+++ b/scripts/update-sensu-version.sh
@@ -30,7 +30,7 @@ find_and_replace() {
     ;;
   "Darwin")
     sed -i '' "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
-    sed -i '' "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    sed -i '' "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
     ;;
   *)
     echo "Unsupported platform"

--- a/scripts/update-sensu-version.sh
+++ b/scripts/update-sensu-version.sh
@@ -25,7 +25,7 @@ find_and_replace() {
 
   case $(uname) in
   "Linux")
-    sed -i "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    sed -i "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
     sed -i "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
     ;;
   "Darwin")

--- a/scripts/update-sensu-version.sh
+++ b/scripts/update-sensu-version.sh
@@ -29,7 +29,7 @@ find_and_replace() {
     sed -i "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
     ;;
   "Darwin")
-    sed -i '' "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    sed -i '' "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
     sed -i '' "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
     ;;
   *)

--- a/scripts/update-sensu-version.sh
+++ b/scripts/update-sensu-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+
+REQUIRED_ARGS=4
+PROVIDED_ARGS=$#
+OLD_SENSU_VERSION=$1
+OLD_SENSU_BUILD=$2
+NEW_SENSU_VERSION=$3
+NEW_SENSU_BUILD=$4
+
+
+check_args() {
+  if [ "$REQUIRED_ARGS" != "$PROVIDED_ARGS" ];
+  then
+    echo "\nERROR: too few arguments. Please provide exactly four arguments:\n"
+    echo "  - The old Sensu version number (the version you wish to replace)"
+    echo "  - The old Sensu build number (the build you wish to replace)"
+    echo "  - The new Sensu version number"
+    echo "  - The new Sensu build number\n"
+    exit 1
+  fi
+  return 0
+}
+
+find_and_replace() {
+
+  case $(uname) in
+  "Linux")
+    sed -i "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    sed -i "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    ;;
+  "Darwin")
+    sed -i '' "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    sed -i '' "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    ;;
+  *)
+    echo "Unsupported platform"
+  esac
+}
+
+check_args
+echo "Updating Sensu version from ${OLD_SENSU_VERSION} (build ${OLD_SENSU_BUILD}) to ${NEW_SENSU_VERSION} (build ${NEW_SENSU_BUILD})"
+find_and_replace

--- a/scripts/update-sensu-version.sh
+++ b/scripts/update-sensu-version.sh
@@ -26,7 +26,7 @@ find_and_replace() {
   case $(uname) in
   "Linux")
     sed -i "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
-    sed -i "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md
+    sed -i "s/${OLD_SENSU_BUILD}/${NEW_SENSU_BUILD}/g" content/sensu-go/${NEW_SENSU_VERSION}/installation/install-sensu.md content/sensu-go/${NEW_SENSU_VERSION}/installation/verify.md
     ;;
   "Darwin")
     sed -i '' "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/5.18/installation/install-sensu.md content/sensu-go/5.18/installation/verify.md


### PR DESCRIPTION
## Description
Script to update version and build numbers in docs. Based on https://github.com/sensu/website/blob/master/scripts/update-sensu-version.sh.

## Motivation and Context
Automates release-related updates for version and build numbers in the docs.

## Review Instructions
There is probably a more elegant way to handle the file paths in lines 28, 29, 32, and 33.
