### PR TITLE
Add field selector filtering examples for silenced to API overview

### DIFF
--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -484,7 +484,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /highlight >}}
 
-#### Filter checks, entities, or entities by subscription
+#### Filter checks, entities, or events by subscription
 
 To list all checks that include the `linux` subscription:
 

--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -507,6 +507,65 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 --data-urlencode 'fieldSelector=linux in event.entity.subscriptions'
 {{< /highlight >}}
 
+#### Filter silenced resources and silences
+
+**Filter silenced resources by namespace**
+
+To list all silenced resources for a particular namespace (in this example, the `default` namespace):
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=silenced.namespace == "default"'
+{{< /highlight >}}
+
+Likewise, to list all silenced resources *except* those in the `default` namespace:
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=silenced.namespace != "default"'
+{{< /highlight >}}
+
+**Filter silences by creator**
+
+To list all silences created by the user `alice`:
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=silenced.creator == "alice"'
+{{< /highlight >}}
+
+To list all silences that were not created by the `admin` user:
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=silenced.creator == "admin"'
+{{< /highlight >}}
+
+**Filter silences by silence subscription**
+
+To retrieve silences with a specific subscription (in this example, `linux`):
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=silenced.subscription == "linux"'
+{{< /highlight >}}
+
+Another way to make the same request is:
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=linux in silenced.subscription'
+{{< /highlight >}}
+
+**Filter silenced resources by expiration**
+
+To list all silenced resources that expire only when a matching check resolves:
+
+{{< highlight shell >}}
+curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector=silenced.expire_on_resolve == true'
+{{< /highlight >}}
+
 
 [1]: ../../sensuctl/reference#preferred-output-format
 [2]: ../../installation/install-sensu#install-sensuctl

--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -538,7 +538,7 @@ To list all silences that were not created by the `admin` user:
 
 {{< highlight shell >}}
 curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
---data-urlencode 'fieldSelector=silenced.creator == "admin"'
+--data-urlencode 'fieldSelector=silenced.creator != "admin"'
 {{< /highlight >}}
 
 **Filter silences by silence subscription**

--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -557,6 +557,11 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 --data-urlencode 'fieldSelector=linux in silenced.subscription'
 {{< /highlight >}}
 
+{{% notice note %}}
+**NOTE**: For this field selector, `subscription` means the subscription specified for the silence.
+In other words, this filter retrieves **silences** with a particular subscription, not silenced resources with a particular subscription.
+{{% /notice %}}
+
 **Filter silenced resources by expiration**
 
 To list all silenced resources that expire only when a matching check resolves:

--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -559,7 +559,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 
 {{% notice note %}}
 **NOTE**: For this field selector, `subscription` means the subscription specified for the silence.
-In other words, this filter retrieves **silences** with a particular subscription, not silenced resources with a particular subscription.
+In other words, this filter retrieves **silences** with a particular subscription, not silenced entities or checks with a matching subscription.
 {{% /notice %}}
 
 **Filter silenced resources by expiration**


### PR DESCRIPTION
## Description
Adds examples for API response filtering with silenced field selectors.

## Motivation and Context
Partially addresses https://github.com/sensu/sensu-docs/issues/2170. Waiting for resolution of https://github.com/sensu/sensu-go/issues/3552 to complete #2170 .