### PR TITLE
Typo in API response filtering heading

### DIFF
--- a/content/sensu-go/5.17/api/overview.md
+++ b/content/sensu-go/5.17/api/overview.md
@@ -464,7 +464,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /highlight >}}
 
-#### Filter checks, entities, or entities by subscription
+#### Filter checks, entities, or events by subscription
 
 To list all checks that include the `linux` subscription:
 

--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -484,7 +484,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /highlight >}}
 
-#### Filter checks, entities, or entities by subscription
+#### Filter checks, entities, or events by subscription
 
 To list all checks that include the `linux` subscription:
 


### PR DESCRIPTION
## Description
Change heading in API overview `Filter checks, entities, or entities by subscription` to `Filter checks, entities, or events by subscription`

## Motivation and Context
Fix inadvertent duplicate in heading