### PR TITLE
Add missing fieldSelector= in 2 examples in API overview

### DIFF
--- a/content/sensu-go/5.17/api/overview.md
+++ b/content/sensu-go/5.17/api/overview.md
@@ -369,14 +369,14 @@ For example, to retrieve checks with a `linux` subscription:
 
 {{< highlight shell >}}
 curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
---data-urlencode 'linux in check.subscriptions'
+--data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /highlight >}}
 
 To retrieve checks that do not use the `slack` handler:
 
 {{< highlight shell >}}
 curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
---data-urlencode 'slack notin check.handlers'
+--data-urlencode 'fieldSelector=slack notin check.handlers'
 {{< /highlight >}}
 
 The `in` and `notin` operators have two important conditions:

--- a/content/sensu-go/5.18/api/overview.md
+++ b/content/sensu-go/5.18/api/overview.md
@@ -373,14 +373,14 @@ For example, to retrieve checks with a `linux` subscription:
 
 {{< highlight shell >}}
 curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
---data-urlencode 'linux in check.subscriptions'
+--data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /highlight >}}
 
 To retrieve checks that do not use the `slack` handler:
 
 {{< highlight shell >}}
 curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
---data-urlencode 'slack notin check.handlers'
+--data-urlencode 'fieldSelector=slack notin check.handlers'
 {{< /highlight >}}
 
 The `in` and `notin` operators have two important conditions:


### PR DESCRIPTION
## Description
Two of the examples for API response filtering were missing `fieldSelector=` in the filter statement.