### PR TITLE
Update 5.16.0 and 5.17.0 release notes; propagate init changes to 5.17

### DIFF
--- a/content/sensu-go/5.16/release-notes.md
+++ b/content/sensu-go/5.16/release-notes.md
@@ -80,7 +80,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- The backend is no longer seeded with a default admin username and password.
+- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -88,16 +88,25 @@ sudo yum install sensu-go-backend
 You can configure the Sensu backend with `sensu-backend start` flags (recommended) or an `/etc/sensu/backend.yml` file.
 The Sensu backend requires the `state-dir` flag at minimum, but other useful configurations and templates are available.
 
+_**NOTE**: If you are using Docker, intitialization is included in this step when you start the backend rather than in [3. Initialize][37].
+For details about intialization in Docker, see the [backend reference][38]._
+
 {{< language-toggle >}}
 
 {{< highlight Docker >}}
+# Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password
+# you want to use for your admin user credentials.
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
 -p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
+-e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
 {{< highlight "Docker Compose" >}}
+# Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password
+# you want to use for your admin user credentials.
 ---
 version: "3"
 services:
@@ -110,10 +119,14 @@ services:
     volumes:
     - "sensu-backend-data:/var/lib/sensu/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
+    environment:
+    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
+    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
 
 volumes:
   sensu-backend-data:
     driver: local
+
 {{< /highlight >}}
 
 {{< highlight "Ubuntu/Debian" >}}
@@ -144,43 +157,16 @@ For a complete list of configuration options, see the [backend reference][6].
 
 ### 3. Initialize
 
+_**NOTE**: If you are using Docker, you already completed intitialization in [2. Configure and start][39].
+Skip ahead to [4. Open the web UI][36] to continue the backend installation process.
+If you did not use environment variables to override the default admin credentials in step 2, skip ahead to [Install sensuctl][19] so you can change your default admin password immediately._
+
 **With the backend running**, run `sensu-backend init` to set up your Sensu administrator username and password.
 In this initialization step, you only need to set environment variables with a username and password string &mdash; no need for role-based access control (RBAC).
 
 Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use.
 
 {{< language-toggle >}}
-
-{{< highlight Docker >}}
-docker run \
--e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
--e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
---restart always \
---name sensu \
-sensu/sensu:latest \
-sensu-backend start
-{{< /highlight >}}
-
-{{< highlight "Docker Compose" >}}
----
-version: "3"
-services:
-  sensu-backend:
-    image: sensu/sensu:latest
-    ports:
-    - 3000:3000
-    - 8080:8080
-    - 8081:8081
-    volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
-    command: "sensu-backend start"
-    environment:
-    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
-    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
-volumes:
-  sensu-backend-data:
-    driver: local
-{{< /highlight >}}
 
 {{< highlight "Ubuntu/Debian" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
@@ -204,8 +190,9 @@ The web UI provides a unified view of your monitoring events and user-friendly t
 After starting the Sensu backend, open the web UI by visiting http://localhost:3000.
 You may need to replace `localhost` with the hostname or IP address where the Sensu backend is running.
 
-To log in to the web UI, enter your Sensu user credentials (the username and password provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables).
-Select the ☰ icon to explore the web UI.
+To log in to the web UI, enter your Sensu user credentials.
+If you are using Docker and you did not specify environment variables to override the default admin credentials, your user credentials are username `admin` and password `P@ssw0rd!`.
+Otherwise, your user credentials are the username and password you provided with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables.
 
 ### 5. Make a request to the health API
 
@@ -280,9 +267,16 @@ sensuctl configure -n \
 Here, the `-n` flag triggers non-interactive mode.
 Run `sensuctl config view` to see your user profile.
 
-We recommend that you change the default admin password immediately: `sensuctl user change-password --interactive`.
-
 For more information about sensuctl, see the [quickstart][23] and [reference][4] docs.
+
+### Change default admin password
+
+If you are using Docker and you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process](#2-configure-and-start), we recommend that you change the default admin password as soon as you have [installed sensuctl][19].
+Run:
+
+{{< highlight "shell" >}}
+sensuctl user change-password --interactive
+{{< /highlight >}}
 
 ## Install Sensu agents
 
@@ -474,3 +468,6 @@ Now that you've installed Sensu, here are some resources to help continue your j
 [34]: https://account.sensu.io/
 [35]: ../../api/health/
 [36]: #4-open-the-web-ui
+[37]: #3-initialize
+[38]: ../../reference/backend#docker-initialization
+[39]: #2-configure-and-start

--- a/content/sensu-go/5.17/reference/backend.md
+++ b/content/sensu-go/5.17/reference/backend.md
@@ -51,8 +51,59 @@ For information about creating and managing checks, see:
 
 ## Initialization
 
-For a **new** installation, you must set up an administrator username and password.
-To do this, set environment variables as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
+For a **new** installation, the backend database must be initialized by providing a username and password for the user to be granted administrative privileges.
+Although initialization is required for every new installation, the implementation differs depending on your method of installation:
+
+- If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
+- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25]. Sensu does not apply a default admin username or password for Ubuntu/Debian or RHEL/CentoOS installations.
+
+This step bootstraps the first admin user account for your Sensu installation.
+This account will be granted the cluster admin role.
+
+### Docker initialization
+
+For Docker installations, set administrator credentials with environment variables when you [configure and start][24] the backend as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
+
+{{< language-toggle >}}
+
+{{< highlight Docker >}}
+docker run -v /var/lib/sensu:/var/lib/sensu \
+-d --name sensu-backend \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
+-e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
+{{< /highlight >}}
+
+{{< highlight "Docker Compose" >}}
+---
+version: "3"
+services:
+  sensu-backend:
+    image: sensu/sensu:latest
+    ports:
+    - 3000:3000
+    - 8080:8080
+    - 8081:8081
+    volumes:
+    - "sensu-backend-data:/var/lib/sensu/etcd"
+    command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
+    environment:
+    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
+    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+
+volumes:
+  sensu-backend-data:
+    driver: local
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
+
+### Ubuntu/Debian or RHEL/CentOS initialization
+
+For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:
 
 {{< highlight shell >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
@@ -74,7 +125,7 @@ Admin Password: YOUR_PASSWORD
 This initialization step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-_**NOTE**: If you are already using Sensu, you do not need to initialize. Your installation has already seeded the admin username and password you have set up._
+_**NOTE**: If you are already using Sensu, you do not need to initialize. Your installation has already seeded the admin username and password you have set up. Running `sensu-backend init` on a previously initialized cluster has no effect &mdash; it will not change the admin credentials._
 
 To see available initialization flags:
 
@@ -1151,7 +1202,7 @@ Here are some log rotate sample configurations:
 {{< /highlight >}}
 
 [1]: ../../installation/install-sensu#install-the-sensu-backend
-[2]: https://github.com/etcd-io/etcd/blob/master/Documentation/docs.md
+[2]: https://etcd.io/docs
 [3]: ../../guides/monitor-server-resources/
 [4]: ../../guides/extract-metrics-with-checks/
 [5]: ../../reference/checks/
@@ -1168,8 +1219,11 @@ Here are some log rotate sample configurations:
 [16]: https://github.com/etcd-io/etcd/blob/master/Documentation/tuning.md#time-parameters
 [17]: ../../files/backend.yml
 [18]: https://golang.org/pkg/crypto/tls/#pkg-constants
-[19]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#discovery
-[20]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#etcd-discovery
-[21]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#dns-discovery
+[19]: https://etcd.io/docs/latest/op-guide/clustering/#discovery
+[20]: https://etcd.io/docs/latest/op-guide/clustering/#etcd-discovery
+[21]: https://etcd.io/docs/latest/op-guide/clustering/#dns-discovery
 [22]: #initialization
 [23]: #etcd-listen-client-urls
+[24]: ../../installation/install-sensu#2-configure-and-start
+[25]: ../../installation/install-sensu#3-initialize
+[26]: ../../sensuctl/reference/#change-admin-user-s-password

--- a/content/sensu-go/5.17/reference/rbac.md
+++ b/content/sensu-go/5.17/reference/rbac.md
@@ -238,9 +238,9 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### Default users
 
-When you install the Sensu backend, during the [initialization step][42], you create a username and password for a `default` namespace.
+During the [Sensu backend installation][42] process, you create an administrator username and password and a `default` namespace.
 
-This is the user that you can use to manage all aspects of Sensu and create new users.
+This is the admin user that you can use to manage all aspects of Sensu and create new users.
 
 | attribute | value |
 | --------- | ----- |
@@ -250,11 +250,7 @@ This is the user that you can use to manage all aspects of Sensu and create new 
 | cluster role   |  `cluster-admin` |
 | cluster role binding   | `cluster-admin	`  |
 
-Once authenticated, you can change the default password for the admin user with the `change-password` command:
-
-{{< highlight shell >}}
-sensuctl user change-password
-{{< /highlight >}}
+After you [configure sensuctl][26], you can [change the admin user's password][45] with the `change-password` command.
 
 Sensu also includes an `agent` user, which is used internally by the Sensu agent.
 You can configure `agent` user credentials with the [`user` and `password` agent configuration flags][41].
@@ -1261,6 +1257,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [39]: ../../installation/auth/#ad-groups-prefix
 [40]: ../../reference/etcdreplicators/
 [41]: ../agent/#security-configuration-flags
-[42]: ../../installation/install-sensu/#3-initialize
+[42]: ../../installation/install-sensu/#install-the-sensu-backend
 [43]: ../../installation/auth#ldap-authentication
 [44]: ../../installation/auth/#ad-authentication
+[45]: ../../sensuctl/reference/#change-admin-user-s-password

--- a/content/sensu-go/5.17/release-notes.md
+++ b/content/sensu-go/5.17/release-notes.md
@@ -103,7 +103,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][106]) Upgraded the size of the events auto-incremented ID in the PostgreSQL store to a 64-bit variant, which allows you to store many more events and avoids exhausting the sequence.
-- ([Commercial feature][106]) Initialization via [`sensu-backend init`][109] is now implemented for Docker.
+- ([Commercial feature][106]) [Initialization][109] via `sensu-backend init` is now implemented for Docker.
 - ([Commercial feature][106]) UPN binding support has been re-introduced via the `default_upn_domain` configuration attribute.
 - In the [web UI][107], labels that contain URLs are now clickable links.
 - Added `event.entity.name` as a supported field for the [`fieldSelector`][110] query parameter.
@@ -152,7 +152,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- The backend is no longer seeded with a default admin username and password.
+- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1047,7 +1047,7 @@ To get started with Sensu Go:
 [106]: /sensu-go/5.17/getting-started/enterprise/
 [107]: /sensu-go/5.17/dashboard/overview
 [108]: /sensu-go/5.17/api/secrets
-[109]: /sensu-go/5.17/reference/backend/#initialization
+[109]: /sensu-go/5.17/reference/backend/#docker-initialization
 [110]: https://docs.sensu.io/sensu-go/5.17/api/overview/#field-selector
 [111]: https://docs.sensu.io/sensu-go/5.17/reference/rbac/#cluster-wide-resource-types
 [112]: https://docs.sensu.io/sensu-go/5.17/api/events/#events-post

--- a/content/sensu-go/5.17/sensuctl/reference.md
+++ b/content/sensu-go/5.17/sensuctl/reference.md
@@ -62,13 +62,23 @@ The default URL is `http://127.0.0.1:8080`.
 To connect to a [Sensu cluster][7], connect sensuctl to any single backend in the cluster.
 For information about configuring the Sensu backend URL, see the [backend reference][5].
 
-### Username, Password, and Namespace
+### Username, password, and namespace
 
-When you install the Sensu backend, during the [initialization step][40], you create a username and password for a `default` namespace.
+During the [Sensu backend installation][40] process, you create an administrator username and password and a `default` namespace.
 Your ability to get, list, create, update, and delete resources with sensuctl depends on the permissions assigned to your Sensu user.
 For more information about configuring Sensu access control, see the [RBAC reference][1].
 
-_**NOTE**: The `sensu-backend init` command for initialization runs automatically with a default username (`admin`) and password (`P@ssw0rd!`). You can specify a username and password with the `SENSU_BACKEND_CLUSTER_ADMIN_USERNAME` and `SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD` environment variables during [initialization][40] to override the defaults._ 
+_**NOTE**: For a **new** installation, you can set administrator credentials with environment variables during [initialization][47].
+If you are using Docker and you do not include the environment variables to set administrator credentials, the backend will initialize with the default username (`admin`) and password (`P@ssw0rd!`)._
+
+#### Change admin user's password
+
+After you have [installed and configured sensuctl][46], you can change the admin user's password.
+Run:
+
+{{< highlight shell >}}
+sensuctl user change-password --interactive
+{{< /highlight >}}
 
 ### Preferred output format
 
@@ -1045,8 +1055,11 @@ Flags are optional and apply only to the `delete` command.
 [37]: https://bonsai.sensu.io/assets/portertech/sensu-ec2-discovery
 [38]: #environment-variables
 [39]: #wrapped-json-format
-[40]: ../../installation/install-sensu/#3-initialize
+[40]: ../../installation/install-sensu/#install-the-sensu-backend
 [41]: ../../reference/secrets/
 [42]: ../../installation/auth/#ad-authentication
 [43]: ../../reference/secrets-providers/
 [44]: ../../installation/auth#use-built-in-basic-authentication
+[45]: ../../installation/install-sensu/#2-configure-and-start
+[46]: #first-time-setup
+[47]: ../../reference/backend/#initialization

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -134,7 +134,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][106]) Upgraded the size of the events auto-incremented ID in the PostgreSQL store to a 64-bit variant, which allows you to store many more events and avoids exhausting the sequence.
-- ([Commercial feature][106]) Initialization via [`sensu-backend init`][109] is now implemented for Docker.
+- ([Commercial feature][106]) [Initialization][109] via `sensu-backend init` is now implemented for Docker.
 - ([Commercial feature][106]) UPN binding support has been re-introduced via the `default_upn_domain` configuration attribute.
 - In the [web UI][107], labels that contain URLs are now clickable links.
 - Added `event.entity.name` as a supported field for the [`fieldSelector`][110] query parameter.
@@ -183,7 +183,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- The backend is no longer seeded with a default admin username and password.
+- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1080,7 +1080,7 @@ To get started with Sensu Go:
 [106]: /sensu-go/5.17/getting-started/enterprise/
 [107]: /sensu-go/5.17/dashboard/overview
 [108]: /sensu-go/5.17/api/secrets
-[109]: /sensu-go/5.17/reference/backend/#initialization
+[109]: /sensu-go/5.17/reference/backend/#docker-initialization
 [110]: /sensu-go/5.17/api/overview/#field-selector
 [111]: /sensu-go/5.17/reference/rbac/#cluster-wide-resource-types
 [112]: /sensu-go/5.17/api/events/#events-post


### PR DESCRIPTION
## Description
- Updates descriptions associated with `sensu-backend init` in the 5.16.0 and 5.17.0 release notes.
- Propagates changes from https://github.com/sensu/sensu-docs/pull/2229 into 5.17 docs.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2240 and then some