### PR TITLE
Update sha 512 to 256 and fix OS file name in verify.md

### DIFF
--- a/content/sensu-go/5.15/installation/verify.md
+++ b/content/sensu-go/5.15/installation/verify.md
@@ -37,10 +37,10 @@ For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.15.0/sensu-go_5.15.0_linux_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact.
+Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.15.0_linux_amd64.tar.gz
+sha256sum sensu-go_5.15.0_linux_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform.
@@ -100,10 +100,10 @@ For example, to download Sensu for macOS `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.15.0/sensu-go_5.15.0_darwin_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact.
+Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< highlight shell >}}
-shasum -a 512 sensu-go-5.15.0-darwin-amd64.tar.gz
+shasum -a 256 sensu-go_5.15.0_darwin_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform.
@@ -143,10 +143,10 @@ For example, to download Sensu for FreeBSD `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.15.0/sensu-go_5.15.0_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact.
+Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.15.0_freebsd_amd64.tar.gz
+sha256sum sensu-go_5.15.0_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform.

--- a/content/sensu-go/5.16/installation/verify.md
+++ b/content/sensu-go/5.16/installation/verify.md
@@ -37,10 +37,10 @@ For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.16.1/sensu-go_5.16.1_linux_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.16.1_linux_amd64.tar.gz
+sha256sum sensu-go_5.16.1_linux_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -100,10 +100,10 @@ For example, to download Sensu for macOS `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.16.1/sensu-go_5.16.1_darwin_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-shasum -a 512 sensu-go-5.16.1-darwin-amd64.tar.gz
+shasum -a 256 sensu-go_5.16.1_darwin_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -143,10 +143,10 @@ For example, to download Sensu for FreeBSD `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.16.1/sensu-go_5.16.1_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.16.1_freebsd_amd64.tar.gz
+sha256sum sensu-go_5.16.1_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -173,10 +173,10 @@ For example, to download Sensu for Solaris `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.16.1/sensu-go_5.16.1_solaris_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact.
+Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.16.1_solaris_amd64.tar.gz
+sha256sum sensu-go_5.16.1_solaris_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform.

--- a/content/sensu-go/5.17/installation/verify.md
+++ b/content/sensu-go/5.17/installation/verify.md
@@ -37,10 +37,10 @@ For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.2/sensu-go_5.17.2_linux_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.17.2_linux_amd64.tar.gz
+sha256sum sensu-go_5.17.2_linux_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -100,10 +100,10 @@ For example, to download Sensu for macOS `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.2/sensu-go_5.17.2_darwin_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-shasum -a 512 sensu-go-5.17.2-darwin-amd64.tar.gz
+shasum -a 256 sensu-go_5.17.2_darwin_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -143,10 +143,10 @@ For example, to download Sensu for FreeBSD `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.2/sensu-go_5.17.2_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.17.2_freebsd_amd64.tar.gz
+sha256sum sensu-go_5.17.2_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -173,10 +173,10 @@ For example, to download Sensu for Solaris `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.17.2/sensu-go_5.17.2_solaris_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact.
+Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.17.2_solaris_amd64.tar.gz
+sha256sum sensu-go_5.17.2_solaris_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform.

--- a/content/sensu-go/5.18/installation/verify.md
+++ b/content/sensu-go/5.18/installation/verify.md
@@ -39,10 +39,10 @@ For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.18.0/sensu-go_5.18.0_linux_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.18.0_linux_amd64.tar.gz
+sha256sum sensu-go_5.18.0_linux_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -102,10 +102,10 @@ For example, to download Sensu for macOS `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.18.0/sensu-go_5.18.0_darwin_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-shasum -a 512 sensu-go-5.18.0-darwin-amd64.tar.gz
+shasum -a 256 sensu-go_5.18.0_darwin_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -145,10 +145,10 @@ For example, to download Sensu for FreeBSD `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.18.0/sensu-go_5.18.0_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact:
+Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.18.0_freebsd_amd64.tar.gz
+sha256sum sensu-go_5.18.0_freebsd_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform:
@@ -175,10 +175,10 @@ For example, to download Sensu for Solaris `amd64` in `tar.gz` format:
 curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.18.0/sensu-go_5.18.0_solaris_amd64.tar.gz
 {{< /highlight >}}
 
-Generate a SHA-512 checksum for the downloaded artifact.
+Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< highlight shell >}}
-sha512sum sensu-go_5.18.0_solaris_amd64.tar.gz
+sha256sum sensu-go_5.18.0_solaris_amd64.tar.gz
 {{< /highlight >}}
 
 The result should match the checksum for your platform.


### PR DESCRIPTION
## Description
In verify.md for 5.15 through 5.18:
- Changes SHA-512 checksum references to SHA-256
- Changes `sensu-go-5.18.0-darwin-amd64.tar.gz` to `sensu-go_5.18.0_darwin_amd64.tar.gz`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2249