### PR TITLE
Add release notes for 5.18.1 release

### DIFF
--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -7,6 +7,7 @@ version: "5.18"
 menu: "sensu-go-5.18"
 ---
 
+- [5.18.1 release notes](#5-18-1-release-notes)
 - [5.18.0 release notes](#5-18-0-release-notes)
 - [5.17.2 release notes](#5-17-2-release-notes)
 - [5.17.1 release notes](#5-17-1-release-notes)
@@ -53,6 +54,20 @@ PATCH versions include backward-compatible bug fixes.
 Read the [upgrade guide][1] for information about upgrading to the latest version of Sensu Go.
 
 ---
+
+## 5.18.1 release notes
+
+**March 9, 2020** &mdash; The latest release of Sensu Go, version 5.18.1, is now available for download.
+
+**RELEASE SUMMARY NEEDED**
+
+See the [upgrade guide][1] to upgrade Sensu to version 5.18.1.
+
+**FIXES:**
+
+- Fixed a bug where OIDC login could result in a nil pointer panic.
+- Changed to using the gRPC client (rather than the embedded etcd client) to improve reliability and avoid nil pointer panics triggered by shutting down the embedded etcd client.
+- Changed the cache resource struct alignment to 64-bit to support 32-bit systems.
 
 ## 5.18.0 release notes
 

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -57,7 +57,7 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 ## 5.18.1 release notes
 
-**March 9, 2020** &mdash; The latest release of Sensu Go, version 5.18.1, is now available for download.
+**March 10, 2020** &mdash; The latest release of Sensu Go, version 5.18.1, is now available for download.
 
 **RELEASE SUMMARY NEEDED**
 

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -70,7 +70,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.1.
 - Changed to using the gRPC client (rather than the embedded etcd client) to improve reliability and avoid nil pointer panics triggered by shutting down the embedded etcd client.
 - The Sensu backend no longer hangs indefinitely if a file lock for the asset manager cannot be obtained. Instead, the backend returns an error after 60 seconds.
 - Fixed a bug that caused sensu-backend to restart when agents disconnected.
-- Changed the `Resource` struct alignment in the store cache to 64-bit to support 32-bit systems.
+- Fixed a bug where the backend would panic on some 32 bit systems.
 
 ## 5.18.0 release notes
 

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -65,9 +65,12 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.1.
 
 **FIXES:**
 
-- Fixed a bug where OIDC login could result in a nil pointer panic.
+- ([Commercial feature][121]) Fixed a bug that caused SQL migrations to fail on PostgreSQL 12.
+- ([Commercial feature][121]) Fixed a bug where OIDC login could result in a nil pointer panic.
 - Changed to using the gRPC client (rather than the embedded etcd client) to improve reliability and avoid nil pointer panics triggered by shutting down the embedded etcd client.
-- Changed the cache resource struct alignment to 64-bit to support 32-bit systems.
+- The Sensu backend no longer hangs indefinitely if a file lock for the asset manager cannot be obtained. Instead, the backend returns an error after 60 seconds.
+- Fixed a bug that caused sensu-backend to restart when agents disconnected.
+- Changed the `Resource` struct alignment in the store cache to 64-bit to support 32-bit systems.
 
 ## 5.18.0 release notes
 
@@ -1107,3 +1110,4 @@ To get started with Sensu Go:
 [118]: /sensu-go/5.18/api/events#events-post
 [119]: /sensu-go/5.18/api/overview/#response-filtering
 [120]: /sensu-go/5.18/api/auth/#the-authtest-api-endpoint
+[121]: /sensu-go/5.18/getting-started/enterprise/

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -58,8 +58,8 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 ## 5.18.1 release notes
 
 **March 10, 2020** &mdash; The latest release of Sensu Go, version 5.18.1, is now available for download.
-
-This release fixes bugs that caused SQL migration failure on PostgreSQL 12, nil pointer panic due to OICD login, and sensu-backend restart upon agent disconnection. It also includes a reliability improvement &emdash; a change to use the gRPC client rather than the embedded etcd client.
+This release fixes bugs that caused SQL migration failure on PostgreSQL 12, nil pointer panic due to OICD login, and sensu-backend restart upon agent disconnection.
+It also includes a reliability improvement &emdash; a change to use the gRPC client rather than the embedded etcd client.
 See the [upgrade guide][1] to upgrade Sensu to version 5.18.1.
 
 **FIXES:**

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -70,7 +70,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.18.1.
 - Changed to using the gRPC client (rather than the embedded etcd client) to improve reliability and avoid nil pointer panics triggered by shutting down the embedded etcd client.
 - The Sensu backend no longer hangs indefinitely if a file lock for the asset manager cannot be obtained. Instead, the backend returns an error after 60 seconds.
 - Fixed a bug that caused sensu-backend to restart when agents disconnected.
-- Fixed a bug where the backend would panic on some 32 bit systems.
+- Fixed a bug where the backend would panic on some 32-bit systems.
 
 ## 5.18.0 release notes
 

--- a/content/sensu-go/5.18/release-notes.md
+++ b/content/sensu-go/5.18/release-notes.md
@@ -59,8 +59,7 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 **March 10, 2020** &mdash; The latest release of Sensu Go, version 5.18.1, is now available for download.
 
-**RELEASE SUMMARY NEEDED**
-
+This release fixes bugs that caused SQL migration failure on PostgreSQL 12, nil pointer panic due to OICD login, and sensu-backend restart upon agent disconnection. It also includes a reliability improvement &emdash; a change to use the gRPC client rather than the embedded etcd client.
 See the [upgrade guide][1] to upgrade Sensu to version 5.18.1.
 
 **FIXES:**


### PR DESCRIPTION
## Description
Adds release notes for 5.18.1 release.

~The sensu-go and sensu-enterprise-go repo changelogs do not yet specify which changes apply for 5.18.1, so these updates reflect my best guesses as of now based on reviewing the release/5.18 branches and PRs.~

~I can draft the release summary once I'm sure I have the correct fixes listed.~

Release 5.18.1 contents approved and release summary drafted.

## Motivation and Context
Support 5.18.1 release