### PR TITLE
Specify secrets mgmt is implemented for checks, handlers, and mutators in secrets and secrets providers references

### DIFF
--- a/content/sensu-go/5.17/reference/secrets-providers.md
+++ b/content/sensu-go/5.17/reference/secrets-providers.md
@@ -21,6 +21,8 @@ For more information, see [Get started with commercial features][1].
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
+_**NOTE**: Secrets management is implemented for [checks][18], [handlers][19], and [mutators][20]._
+
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
 Secrets are only transmitted over a TLS websocket connection.
 Unencrypted connections must not transmit privileged information.
@@ -318,3 +320,6 @@ spec: {}
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes
+[18]: ../checks/#check-with-secret
+[19]: ../handlers/#handler-with-secret
+[20]: ../mutators/#mutator-with-secret

--- a/content/sensu-go/5.17/reference/secrets.md
+++ b/content/sensu-go/5.17/reference/secrets.md
@@ -21,6 +21,8 @@ For more information, see [Get started with commercial features][1].
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
+_**NOTE**: Secrets management is implemented for [checks][13], [handlers][14], and [mutators][15]._
+
 Only Sensu backends have access to request secrets from a [secrets provider][7].
 Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.
 Secrets provided via a "lease" with a "lease duration" are deleted from Sensu's in-memory cache after the configured number of seconds, prompting the Sensu backend to request the secret again.
@@ -219,3 +221,6 @@ The `database` secret contains a key called `password`, and its value is the pas
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../../guides/secrets-management/
 [12]: #metadata-attributes
+[13]: ../checks/#check-with-secret
+[14]: ../handlers/#handler-with-secret
+[15]: ../mutators/#mutator-with-secret

--- a/content/sensu-go/5.18/reference/secrets-providers.md
+++ b/content/sensu-go/5.18/reference/secrets-providers.md
@@ -21,6 +21,10 @@ For more information, see [Get started with commercial features][1].
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
+{{% notice note %}}
+**NOTE**: Secrets management is implemented for [checks](../checks/#check-with-secret), [handlers](../handlers/#handler-with-secret), and [mutators](../mutators/#mutator-with-secret).
+{{% /notice %}}
+
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
 Secrets are only transmitted over a TLS websocket connection.
 Unencrypted connections must not transmit privileged information.

--- a/content/sensu-go/5.18/reference/secrets.md
+++ b/content/sensu-go/5.18/reference/secrets.md
@@ -21,6 +21,10 @@ For more information, see [Get started with commercial features][1].
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (e.g. a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
+{{% notice note %}}
+**NOTE**: Secrets management is implemented for [checks](../checks/#check-with-secret), [handlers](../handlers/#handler-with-secret), and [mutators](../mutators/#mutator-with-secret).
+{{% /notice %}}
+
 Only Sensu backends have access to request secrets from a [secrets provider][7].
 Sensu backends cache fetched secrets in memory, with no persistence to a Sensu datastore or file on disk.
 Secrets provided via a "lease" with a "lease duration" are deleted from Sensu's in-memory cache after the configured number of seconds, prompting the Sensu backend to request the secret again.


### PR DESCRIPTION
## Description
Adds note to specify that secrets management is implemented for checks, handlers, and mutators in the introductions of the secrets and secrets providers references.

## Motivation and Context
Need to state the implemented resources in the docs (not just in the release notes).
