### PR TITLE
Change agent to backend in secrets mgmt Vault certificate names and paths

### DIFF
--- a/content/sensu-go/5.17/guides/secrets-management.md
+++ b/content/sensu-go/5.17/guides/secrets-management.md
@@ -188,10 +188,10 @@ First, in your Vault, [enable and configure certificate authentication][33].
 For example, your Vault might be configured for certificate authentication like this:
 
 {{< highlight shell >}}
-vault write auth/cert/certs/sensu-agent \
-    display_name=sensu-agent \
-    policies=sensu-agent-policy \
-    certificate=@sensu-agent-vault.pem \
+vault write auth/cert/certs/sensu-backend \
+    display_name=sensu-backend \
+    policies=sensu-backend-policy \
+    certificate=@sensu-backend-vault.pem \
     ttl=3600
 {{< /highlight >}}
 
@@ -209,9 +209,9 @@ spec:
     version: v2
     tls:
       ca_cert: /path/to/your/ca.pem
-      client_cert: /etc/sensu/ssl/sensu-agent-vault.pem
-      client_key: /etc/sensu/ssl/sensu-agent-vault-key.pem
-      cname: sensu-agent.example.com
+      client_cert: /etc/sensu/ssl/sensu-backend-vault.pem
+      client_key: /etc/sensu/ssl/sensu-backend-vault-key.pem
+      cname: sensu-backend.example.com
     max_retries: 2
     timeout: 20s
     rate_limiter:

--- a/content/sensu-go/5.18/guides/secrets-management.md
+++ b/content/sensu-go/5.18/guides/secrets-management.md
@@ -197,10 +197,10 @@ First, in your Vault, [enable and configure certificate authentication][32].
 For example, your Vault might be configured for certificate authentication like this:
 
 {{< highlight shell >}}
-vault write auth/cert/certs/sensu-agent \
-    display_name=sensu-agent \
-    policies=sensu-agent-policy \
-    certificate=@sensu-agent-vault.pem \
+vault write auth/cert/certs/sensu-backend \
+    display_name=sensu-backend \
+    policies=sensu-backend-policy \
+    certificate=@sensu-backend-vault.pem \
     ttl=3600
 {{< /highlight >}}
 
@@ -218,9 +218,9 @@ spec:
     version: v2
     tls:
       ca_cert: /path/to/your/ca.pem
-      client_cert: /etc/sensu/ssl/sensu-agent-vault.pem
-      client_key: /etc/sensu/ssl/sensu-agent-vault-key.pem
-      cname: sensu-agent.example.com
+      client_cert: /etc/sensu/ssl/sensu-backend-vault.pem
+      client_key: /etc/sensu/ssl/sensu-backend-vault-key.pem
+      cname: sensu-backend.example.com
     max_retries: 2
     timeout: 20s
     rate_limiter:


### PR DESCRIPTION
## Description
In secrets management guide, in [Vault TLS certificate authentication](https://docs.sensu.io/sensu-go/latest/guides/secrets-management/#vault-tls-certificate-authentication) section examples, replace `agent` with `backend`.

## Motivation and Context
Closes #2264 