### PR TITLE
Add reason key-value pair to examples in silencing API doc

### DIFF
--- a/content/sensu-go/5.15/api/silenced.md
+++ b/content/sensu-go/5.15/api/silenced.md
@@ -47,6 +47,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -75,6 +76,7 @@ output         | {{< highlight shell >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -98,6 +100,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -132,6 +135,7 @@ HTTP/1.1 200 OK
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -156,6 +160,7 @@ output               | {{< highlight json >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -180,6 +185,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -238,6 +244,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -265,6 +272,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -298,6 +306,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }
@@ -325,6 +334,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }

--- a/content/sensu-go/5.16/api/silenced.md
+++ b/content/sensu-go/5.16/api/silenced.md
@@ -47,6 +47,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -75,6 +76,7 @@ output         | {{< highlight shell >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -104,6 +106,7 @@ curl -X POST \
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }' \
@@ -129,6 +132,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -162,6 +166,7 @@ HTTP/1.1 200 OK
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -186,6 +191,7 @@ output               | {{< highlight json >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -214,6 +220,7 @@ curl -X PUT \
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }' \
@@ -239,6 +246,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -296,6 +304,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -323,6 +332,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -356,6 +366,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }
@@ -383,6 +394,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }

--- a/content/sensu-go/5.17/api/silenced.md
+++ b/content/sensu-go/5.17/api/silenced.md
@@ -47,6 +47,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -75,6 +76,7 @@ output         | {{< highlight shell >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -104,6 +106,7 @@ curl -X POST \
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }' \
@@ -129,6 +132,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -162,6 +166,7 @@ HTTP/1.1 200 OK
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -186,6 +191,7 @@ output               | {{< highlight json >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -214,6 +220,7 @@ curl -X PUT \
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }' \
@@ -239,6 +246,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -296,6 +304,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -323,6 +332,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -356,6 +366,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }
@@ -383,6 +394,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }

--- a/content/sensu-go/5.18/api/silenced.md
+++ b/content/sensu-go/5.18/api/silenced.md
@@ -47,6 +47,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -75,6 +76,7 @@ output         | {{< highlight shell >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -104,6 +106,7 @@ curl -X POST \
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }' \
@@ -129,6 +132,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -162,6 +166,7 @@ HTTP/1.1 200 OK
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -186,6 +191,7 @@ output               | {{< highlight json >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -214,6 +220,7 @@ curl -X PUT \
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }' \
@@ -239,6 +246,7 @@ payload         | {{< highlight shell >}}
   "expire": -1,
   "expire_on_resolve": false,
   "creator": "admin",
+  "reason": "reason for silence",
   "subscription": "linux",
   "begin": 1542671205
 }
@@ -296,6 +304,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -323,6 +332,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "subscription": "linux",
     "begin": 1542671205
   }
@@ -356,6 +366,7 @@ HTTP/1.1 200 OK
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }
@@ -383,6 +394,7 @@ output               | {{< highlight json >}}
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
+    "reason": "reason for silence",
     "check": "linux",
     "begin": 1542671205
   }


### PR DESCRIPTION
## Description
Adds `reason` key-value pair to examples in silencing API documentation to match spec in silencing reference.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2269