### PR TITLE
Typo fix: blanacing to balancing

### DIFF
--- a/content/sensu-go/5.15/guides/deploying.md
+++ b/content/sensu-go/5.15/guides/deploying.md
@@ -22,7 +22,7 @@ menu:
   - [Large-scale clustered deployment for multiple availability zones](#large-scale-clustered-deployment-for-multiple-availability-zones)
 - [Architecture considerations](#architecture-considerations)
   - [Networking](#networking)
-  - [Load blanacing](#load-balancing)
+  - [Load balancing](#load-balancing)
 
 This guide describes various deployment considerations and recommendations for a production-ready Sensu deployment, including details related to communication security and common deployment architectures.
 

--- a/content/sensu-go/5.16/guides/deploying.md
+++ b/content/sensu-go/5.16/guides/deploying.md
@@ -22,7 +22,7 @@ menu:
   - [Large-scale clustered deployment for multiple availability zones](#large-scale-clustered-deployment-for-multiple-availability-zones)
 - [Architecture considerations](#architecture-considerations)
   - [Networking](#networking)
-  - [Load blanacing](#load-balancing)
+  - [Load balancing](#load-balancing)
 
 This guide describes various deployment considerations and recommendations for a production-ready Sensu deployment, including details related to communication security and common deployment architectures.
 


### PR DESCRIPTION
## Description

Fixes a typo from blanacing to balancing in docs

## Motivation and Context
- Improves readability

## Review Instructions
Should be nil