### PR TITLE
Correct "balancing" typo in TOC of deploy guide for 5.18 and 5.17

### DIFF
--- a/content/sensu-go/5.17/guides/deploying.md
+++ b/content/sensu-go/5.17/guides/deploying.md
@@ -22,7 +22,7 @@ menu:
   - [Large-scale clustered deployment for multiple availability zones](#large-scale-clustered-deployment-for-multiple-availability-zones)
 - [Architecture considerations](#architecture-considerations)
   - [Networking](#networking)
-  - [Load blanacing](#load-balancing)
+  - [Load balancing](#load-balancing)
 
 This guide describes various deployment considerations and recommendations for a production-ready Sensu deployment, including details related to communication security and common deployment architectures.
 

--- a/content/sensu-go/5.18/guides/deploying.md
+++ b/content/sensu-go/5.18/guides/deploying.md
@@ -22,7 +22,7 @@ menu:
   - [Large-scale clustered deployment for multiple availability zones](#large-scale-clustered-deployment-for-multiple-availability-zones)
 - [Architecture considerations](#architecture-considerations)
   - [Networking](#networking)
-  - [Load blanacing](#load-balancing)
+  - [Load balancing](#load-balancing)
 
 This guide describes various deployment considerations and recommendations for a production-ready Sensu deployment, including details related to communication security and common deployment architectures.
 


### PR DESCRIPTION
## Description
Update typo in Deploy Sensu guide TOC

## Motivation and Context
Follows https://github.com/sensu/sensu-docs/pull/2276