### PR TITLE
Correct Ansible repo link and add docs link to config mgmt page

### DIFF
--- a/content/sensu-go/5.15/installation/configuration-management.md
+++ b/content/sensu-go/5.15/installation/configuration-management.md
@@ -24,13 +24,16 @@ Sensu has partnered with [Tailored Automation][7] to enhance the Puppet module w
 The [Chef][3] cookbook for Sensu can be found on the [GitHub][4]. Interested in more information on Sensu + Chef? Get some helpful resources [here][12].
 
 ### Ansible
-The [Ansible][5] role to deploy and manage Sensu Go can be found on [GitHub][6].
+The [Ansible][5] role to deploy and manage Sensu Go is available in the [Sensu-Go-Ansible GitHub repo][6].
+
+The [Sensu Go Ansible Collection documentation site][9] includes installation instructions, example playbooks, and module references.
 
 [1]: https://puppet.com/
 [2]: https://github.com/sensu/sensu-puppet
 [3]: https://www.chef.io/
 [4]: https://github.com/sensu/sensu-go-chef
 [5]: https://www.ansible.com/
-[6]: https://github.com/jaredledvina/sensu-go-ansible
+[6]: https://github.com/sensu/sensu-go-ansible
 [7]: https://tailoredautomation.io/
+[9]: https://sensu.github.io/sensu-go-ansible/
 [12]: http://monitoringlove.sensu.io/chef

--- a/content/sensu-go/5.16/installation/configuration-management.md
+++ b/content/sensu-go/5.16/installation/configuration-management.md
@@ -21,6 +21,8 @@ The configuration management tools listed here have well-defined Sensu modules t
 
 The [Ansible][5] role to deploy and manage Sensu Go is available in the [Sensu-Go-Ansible GitHub repo][6].
 
+The [Sensu Go Ansible Collection documentation site][9] includes installation instructions, example playbooks, and module references.
+
 ## Chef
 
 The [Chef][3] cookbook for Sensu is available in the [Sensu-Go-Chef GitHub repo][4].
@@ -39,6 +41,7 @@ Sensu partnered with [Tailored Automation][7] to enhance the Puppet module with 
 [3]: https://www.chef.io/
 [4]: https://github.com/sensu/sensu-go-chef
 [5]: https://www.ansible.com/
-[6]: https://github.com/jaredledvina/sensu-go-ansible
+[6]: https://github.com/sensu/sensu-go-ansible
 [7]: https://tailoredautomation.io/
 [8]: http://monitoringlove.sensu.io/chef
+[9]: https://sensu.github.io/sensu-go-ansible/

--- a/content/sensu-go/5.17/installation/configuration-management.md
+++ b/content/sensu-go/5.17/installation/configuration-management.md
@@ -21,6 +21,8 @@ The configuration management tools listed here have well-defined Sensu modules t
 
 The [Ansible][5] role to deploy and manage Sensu Go is available in the [Sensu-Go-Ansible GitHub repo][6].
 
+The [Sensu Go Ansible Collection documentation site][9] includes installation instructions, example playbooks, and module references.
+
 ## Chef
 
 The [Chef][3] cookbook for Sensu is available in the [Sensu-Go-Chef GitHub repo][4].
@@ -39,6 +41,7 @@ Sensu partnered with [Tailored Automation][7] to enhance the Puppet module with 
 [3]: https://www.chef.io/
 [4]: https://github.com/sensu/sensu-go-chef
 [5]: https://www.ansible.com/
-[6]: https://github.com/jaredledvina/sensu-go-ansible
+[6]: https://github.com/sensu/sensu-go-ansible
 [7]: https://tailoredautomation.io/
 [8]: http://monitoringlove.sensu.io/chef
+[9]: https://sensu.github.io/sensu-go-ansible/

--- a/content/sensu-go/5.18/installation/configuration-management.md
+++ b/content/sensu-go/5.18/installation/configuration-management.md
@@ -21,6 +21,8 @@ The configuration management tools listed here have well-defined Sensu modules t
 
 The [Ansible][5] role to deploy and manage Sensu Go is available in the [Sensu-Go-Ansible GitHub repo][6].
 
+The [Sensu Go Ansible Collection documentation site][9] includes installation instructions, example playbooks, and module references.
+
 ## Chef
 
 The [Chef][3] cookbook for Sensu is available in the [Sensu-Go-Chef GitHub repo][4].
@@ -39,6 +41,7 @@ Sensu partnered with [Tailored Automation][7] to enhance the Puppet module with 
 [3]: https://www.chef.io/
 [4]: https://github.com/sensu/sensu-go-chef
 [5]: https://www.ansible.com/
-[6]: https://github.com/jaredledvina/sensu-go-ansible
+[6]: https://github.com/sensu/sensu-go-ansible
 [7]: https://tailoredautomation.io/
 [8]: http://monitoringlove.sensu.io/chef
+[9]: https://sensu.github.io/sensu-go-ansible/


### PR DESCRIPTION
## Description
- Correct Ansible repo link to https://github.com/sensu/sensu-go-ansible
- Add link to Ansible collection docs site (https://sensu.github.io/sensu-go-ansible/index.html)

## Motivation and Context
Today's CR planning mtg discussion