### PR TITLE
Add metadata attributes to Events reference TOC

### DIFF
--- a/content/sensu-go/5.15/reference/events.md
+++ b/content/sensu-go/5.15/reference/events.md
@@ -22,6 +22,7 @@ menu:
   - [Occurrences](#occurrences-and-occurrences-watermark)
 - [Events specification](#events-specification)
 	- [Top-level attributes](#top-level-attributes)
+  - [Metadata attributes](#metadata-attributes)
 	- [Spec attributes](#spec-attributes)
 	- [Check attributes](#check-attributes)
 	- [Metric attributes](#metric-attributes)

--- a/content/sensu-go/5.16/reference/events.md
+++ b/content/sensu-go/5.16/reference/events.md
@@ -20,7 +20,7 @@ menu:
 - [Use event data](#use-event-data)
   - [Occurrences](#occurrences-and-occurrences-watermark)
 - [Events specification](#events-specification)
-	- [Top-level attributes](#top-level-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
+	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
 - [Examples](#examples)
 
 An event is a generic container used by Sensu to provide context to checks and metrics.

--- a/content/sensu-go/5.17/reference/events.md
+++ b/content/sensu-go/5.17/reference/events.md
@@ -20,7 +20,7 @@ menu:
 - [Use event data](#use-event-data)
   - [Occurrences](#occurrences-and-occurrences-watermark)
 - [Events specification](#events-specification)
-	- [Top-level attributes](#top-level-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
+	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
 - [Examples](#examples)
 
 An event is a generic container used by Sensu to provide context to checks and metrics.

--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -20,7 +20,7 @@ menu:
 - [Use event data](#use-event-data)
   - [Occurrences](#occurrences-and-occurrences-watermark)
 - [Events specification](#events-specification)
-	- [Top-level attributes](#top-level-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
+	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
 - [Examples](#examples)
 
 An event is a generic container used by Sensu to provide context to checks and metrics.

--- a/content/sensu-go/5.19/reference/events.md
+++ b/content/sensu-go/5.19/reference/events.md
@@ -20,7 +20,7 @@ menu:
 - [Use event data](#use-event-data)
   - [Occurrences](#occurrences-and-occurrences-watermark)
 - [Events specification](#events-specification)
-	- [Top-level attributes](#top-level-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
+	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
 - [Examples](#examples)
 
 An event is a generic container used by Sensu to provide context to checks and metrics.


### PR DESCRIPTION
## Description
Adds "Metadata attributes" TOC item and link in Events reference for 5.15 through 5.19

## Motivation and Context
Found while planning 5.19 docs work