### PR TITLE
Add created_by field to API docs and references

### DIFF
--- a/content/sensu-go/5.19/api/apikeys.md
+++ b/content/sensu-go/5.19/api/apikeys.md
@@ -36,7 +36,8 @@ HTTP/1.1 200 OK
 [
   {
     "metadata": {
-      "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b"
+      "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
+      "created_by": "admin"
     },
     "username": "admin",
     "created_at": 1570640363
@@ -57,7 +58,8 @@ output         | {{< highlight shell >}}
 [
   {
     "metadata": {
-      "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b"
+      "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
+      "created_by": "admin"
     },
     "username": "admin",
     "created_at": 1570640363
@@ -117,7 +119,8 @@ http://127.0.0.1:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b \
 HTTP/1.1 200 OK
 {
   "metadata": {
-    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b"
+    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
+    "created_by": "admin"
   },
   "username": "admin",
   "created_at": 1570640363
@@ -135,7 +138,8 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (N
 output               | {{< highlight json >}}
 {
   "metadata": {
-    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b"
+    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
+    "created_by": "admin"
   },
   "username": "admin",
   "created_at": 1570640363

--- a/content/sensu-go/5.19/api/assets.md
+++ b/content/sensu-go/5.19/api/assets.md
@@ -44,7 +44,8 @@ HTTP/1.1 200 OK
     "builds": null,
     "metadata": {
       "name": "sensu-influxdb-handler",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "headers": {
       "Authorization": "Bearer $TOKEN",
@@ -61,7 +62,8 @@ HTTP/1.1 200 OK
     "builds": null,
     "metadata": {
       "name": "sensu-slack-handler",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "headers": {
       "Authorization": "Bearer $TOKEN",
@@ -93,7 +95,8 @@ output         | {{< highlight shell >}}
     "builds": null,
     "metadata": {
       "name": "sensu-influxdb-handler",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "headers": {
       "Authorization": "Bearer $TOKEN",
@@ -110,7 +113,8 @@ output         | {{< highlight shell >}}
     "builds": null,
     "metadata": {
       "name": "sensu-slack-handler",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "headers": {
       "Authorization": "Bearer $TOKEN",
@@ -207,7 +211,8 @@ HTTP/1.1 200 OK
     "builds": null,
     "metadata": {
       "name": "sensu-slack-handler",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "headers": {
       "Authorization": "Bearer $TOKEN",
@@ -237,7 +242,8 @@ output               | {{< highlight json >}}
     "builds": null,
     "metadata": {
       "name": "sensu-slack-handler",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "headers": {
       "Authorization": "Bearer $TOKEN",

--- a/content/sensu-go/5.19/api/checks.md
+++ b/content/sensu-go/5.19/api/checks.md
@@ -64,7 +64,8 @@ HTTP/1.1 200 OK
     "env_vars": null,
     "metadata": {
       "name": "check-email",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]
@@ -107,7 +108,8 @@ output         | {{< highlight shell >}}
     "env_vars": null,
     "metadata": {
       "name": "check-email",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]
@@ -213,7 +215,8 @@ HTTP/1.1 200 OK
   "env_vars": null,
   "metadata": {
     "name": "check-cpu",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}
@@ -252,7 +255,8 @@ output               | {{< highlight json >}}
   "env_vars": null,
   "metadata": {
     "name": "check-cpu",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.19/api/cluster-role-bindings.md
+++ b/content/sensu-go/5.19/api/cluster-role-bindings.md
@@ -46,7 +46,8 @@ HTTP/1.1 200 OK
       "name": "cluster-admin"
     },
     "metadata": {
-      "name": "cluster-admin"
+      "name": "cluster-admin",
+      "created_by": "admin"
     }
   },
   {
@@ -61,7 +62,8 @@ HTTP/1.1 200 OK
       "name": "system:agent"
     },
     "metadata": {
-      "name": "system:agent"
+      "name": "system:agent",
+      "created_by": "admin"
     }
   }
 ]
@@ -91,7 +93,8 @@ output         | {{< highlight shell >}}
       "name": "cluster-admin"
     },
     "metadata": {
-      "name": "cluster-admin"
+      "name": "cluster-admin",
+      "created_by": "admin"
     }
   },
   {
@@ -198,7 +201,8 @@ HTTP/1.1 200 OK
     "name": "cluster-admin"
   },
   "metadata": {
-    "name": "bob-binder"
+    "name": "bob-binder",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}
@@ -224,7 +228,8 @@ output               | {{< highlight json >}}
     "name": "cluster-admin"
   },
   "metadata": {
-    "name": "bob-binder"
+    "name": "bob-binder",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.19/api/cluster-roles.md
+++ b/content/sensu-go/5.19/api/cluster-roles.md
@@ -84,7 +84,8 @@ HTTP/1.1 200 OK
       }
     ],
     "metadata": {
-      "name": "cluster-admin"
+      "name": "cluster-admin",
+      "created_by": "admin"
     }
   }
 ]
@@ -115,7 +116,8 @@ output         | {{< highlight shell >}}
       }
     ],
     "metadata": {
-      "name": "cluster-admin"
+      "name": "cluster-admin",
+      "created_by": "admin"
     }
   }
 ]
@@ -201,7 +203,8 @@ http://127.0.0.1:8080/api/core/v2/clusterroles/global-event-reader \
 HTTP/1.1 200 OK
 {
   "metadata": {
-    "name": "global-event-reader"
+    "name": "global-event-reader",
+    "created_by": "admin"
   },
   "rules": [
     {
@@ -229,7 +232,8 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< highlight json >}}
 {
   "metadata": {
-    "name": "global-event-reader"
+    "name": "global-event-reader",
+    "created_by": "admin"
   },
   "rules": [
     {

--- a/content/sensu-go/5.19/api/datastore.md
+++ b/content/sensu-go/5.19/api/datastore.md
@@ -35,7 +35,10 @@ HTTP/1.1 200 OK
   {
     "type": "PostgresConfig",
     "api_version": "store/v1",
-    "metadata": {},
+    "metadata": {
+      "name": "my-other-postgres",
+      "created_by": "admin"
+    },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/otherdbname",
       "pool_size": 20
@@ -44,7 +47,10 @@ HTTP/1.1 200 OK
   {
     "type": "PostgresConfig",
     "api_version": "store/v1",
-    "metadata": {},
+    "metadata": {
+      "name": "my-postgres",
+      "created_by": "admin"
+    },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/dbname",
       "pool_size": 20
@@ -66,7 +72,10 @@ output         | {{< highlight json >}}
   {
     "type": "PostgresConfig",
     "api_version": "store/v1",
-    "metadata": {},
+    "metadata": {
+      "name": "my-postgres",
+      "created_by": "admin"
+    },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/otherdbname",
       "pool_size": 20
@@ -75,7 +84,10 @@ output         | {{< highlight json >}}
   {
     "type": "PostgresConfig",
     "api_version": "store/v1",
-    "metadata": {},
+    "metadata": {
+      "name": "my-postgres",
+      "created_by": "admin"
+    },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/dbname",
       "pool_size": 20
@@ -100,7 +112,8 @@ HTTP/1.1 200 OK
   "type": "PostgresConfig",
   "api_version": "store/v1",
   "metadata": {
-    "name": "my-postgres"
+    "name": "my-postgres",
+    "created_by": "admin"
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",
@@ -122,7 +135,8 @@ output         | {{< highlight json >}}
   "type": "PostgresConfig",
   "api_version": "store/v1",
   "metadata": {
-    "name": "my-postgres"
+    "name": "my-postgres",
+    "created_by": "admin"
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",

--- a/content/sensu-go/5.19/api/entities.md
+++ b/content/sensu-go/5.19/api/entities.md
@@ -92,6 +92,7 @@ HTTP/1.1 200 OK
     "metadata": {
       "name": "sensu-centos",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     }
@@ -170,6 +171,7 @@ output         | {{< highlight shell >}}
     "metadata": {
       "name": "sensu-centos",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     }
@@ -310,6 +312,7 @@ HTTP/1.1 200 OK
   "metadata": {
     "name": "sensu-centos",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   }
@@ -384,6 +387,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "sensu-centos",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   }

--- a/content/sensu-go/5.19/api/events.md
+++ b/content/sensu-go/5.19/api/events.md
@@ -53,6 +53,7 @@ HTTP/1.1 200 OK
       "metadata": {
         "name": "check-nginx",
         "namespace": "default",
+        "created_by": "admin",
         "labels": null,
         "annotations": null
       }
@@ -91,6 +92,7 @@ HTTP/1.1 200 OK
       "metadata": {
         "name": "check-nginx",
         "namespace": "default",
+        "created_by": "admin",
         "labels": null,
         "annotations": null
       }
@@ -128,6 +130,7 @@ output         | {{< highlight shell >}}
       "metadata": {
         "name": "check-nginx",
         "namespace": "default",
+        "created_by": "admin",
         "labels": null,
         "annotations": null
       }
@@ -166,6 +169,7 @@ output         | {{< highlight shell >}}
       "metadata": {
         "name": "check-nginx",
         "namespace": "default",
+        "created_by": "admin",
         "labels": null,
         "annotations": null
       }
@@ -275,7 +279,8 @@ HTTP/1.1 200 OK
       "last_seen": 1543858763,
       "metadata": {
         "name": "sensu-go-sandbox",
-        "namespace": "default"
+        "namespace": "default",
+        "created_by": "admin"
       }
     },
     "check": {
@@ -297,7 +302,8 @@ HTTP/1.1 200 OK
       "occurrences": 1,
       "metadata": {
         "name": "check-cpu",
-        "namespace": "default"
+        "namespace": "default",
+        "created_by": "admin"
       }
     },
     "metadata": {
@@ -321,7 +327,8 @@ HTTP/1.1 200 OK
       "last_seen": 1543871523,
       "metadata": {
         "name": "sensu-go-sandbox",
-        "namespace": "default"
+        "namespace": "default",
+        "created_by": "admin"
       }
     },
     "check": {
@@ -344,7 +351,8 @@ HTTP/1.1 200 OK
       "occurrences": 1,
       "metadata": {
         "name": "keepalive",
-        "namespace": "default"
+        "namespace": "default",
+        "created_by": "admin"
       }
     },
     "metadata": {}
@@ -380,7 +388,8 @@ output               | {{< highlight json >}}
       "last_seen": 1543871523,
       "metadata": {
         "name": "sensu-go-sandbox",
-        "namespace": "default"
+        "namespace": "default",
+        "created_by": "admin"
       }
     },
     "check": {
@@ -403,7 +412,8 @@ output               | {{< highlight json >}}
       "occurrences": 1,
       "metadata": {
         "name": "keepalive",
-        "namespace": "default"
+        "namespace": "default",
+        "created_by": "admin"
       }
     },
     "metadata": {}
@@ -444,7 +454,8 @@ HTTP/1.1 200 OK
         "deregistration": {},
         "metadata": {
             "name": "server1",
-            "namespace": "default"
+            "namespace": "default",
+            "created_by": "admin"
         },
         "sensu_agent_version": ""
     },
@@ -493,7 +504,8 @@ HTTP/1.1 200 OK
         "env_vars": null,
         "metadata": {
             "name": "server-health",
-            "namespace": "default"
+            "namespace": "default",
+            "created_by": "admin"
         }
     },
     "metadata": {}
@@ -527,7 +539,8 @@ output               | {{< highlight json >}}
         "deregistration": {},
         "metadata": {
             "name": "server1",
-            "namespace": "default"
+            "namespace": "default",
+            "created_by": "admin"
         },
         "sensu_agent_version": ""
     },
@@ -576,7 +589,8 @@ output               | {{< highlight json >}}
         "env_vars": null,
         "metadata": {
             "name": "server-health",
-            "namespace": "default"
+            "namespace": "default",
+            "created_by": "admin"
         }
     },
     "metadata": {}

--- a/content/sensu-go/5.19/api/federation.md
+++ b/content/sensu-go/5.19/api/federation.md
@@ -48,7 +48,8 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
     "api_version": "federation/v1",
     "type": "EtcdReplicator",
     "metadata": {
-      "name": "my_replicator"
+      "name": "my_replicator",
+      "created_by": "admin"
     },
     "spec": {
       "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
@@ -80,7 +81,8 @@ output         | {{< highlight shell >}}
     "api_version": "federation/v1",
     "type": "EtcdReplicator",
     "metadata": {
-      "name": "my_replicator"
+      "name": "my_replicator",
+      "created_by": "admin"
     },
     "spec": {
       "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
@@ -182,7 +184,8 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicato
   "api_version": "federation/v1",
   "type": "EtcdReplicator",
   "metadata": {
-    "name": "my_replicator"
+    "name": "my_replicator",
+    "created_by": "admin"
   },
   "spec": {
     "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
@@ -212,7 +215,8 @@ output               | {{< highlight json >}}
   "api_version": "federation/v1",
   "type": "EtcdReplicator",
   "metadata": {
-    "name": "my_replicator"
+    "name": "my_replicator",
+    "created_by": "admin"
   },
   "spec": {
     "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
@@ -334,7 +338,8 @@ HTTP/1.1 200 OK
         "type": "Cluster",
         "api_version": "federation/v1",
         "metadata": {
-            "name": "us-west-2a"
+            "name": "us-west-2a",
+            "created_by": "admin"
         },
         "spec": {
             "api_urls": [
@@ -361,7 +366,8 @@ output         | {{< highlight shell >}}
         "type": "Cluster",
         "api_version": "federation/v1",
         "metadata": {
-            "name": "us-west-2a"
+            "name": "us-west-2a",
+            "created_by": "admin"
         },
         "spec": {
             "api_urls": [
@@ -395,7 +401,8 @@ HTTP/1.1 200 OK
   "type": "Cluster",
   "api_version": "federation/v1",
   "metadata": {
-      "name": "us-west-2a"
+      "name": "us-west-2a",
+      "created_by": "admin"
   },
   "spec": {
       "api_urls": [
@@ -420,7 +427,8 @@ output               | {{< highlight json >}}
     "type": "Cluster",
     "api_version": "federation/v1",
     "metadata": {
-        "name": "us-west-2a"
+        "name": "us-west-2a",
+        "created_by": "admin"
     },
     "spec": {
         "api_urls": [

--- a/content/sensu-go/5.19/api/filters.md
+++ b/content/sensu-go/5.19/api/filters.md
@@ -36,7 +36,8 @@ HTTP/1.1 200 OK
   {
     "metadata": {
       "name": "development_filter",
-       "namespace": "default"
+       "namespace": "default",
+       "created_by": "admin"
     },
     "action": "deny",
     "expressions": [
@@ -73,7 +74,8 @@ output         | {{< highlight shell >}}
   {
     "metadata": {
       "name": "development_filter",
-       "namespace": "default"
+       "namespace": "default",
+       "created_by": "admin"
     },
     "action": "deny",
     "expressions": [
@@ -168,7 +170,8 @@ HTTP/1.1 200 OK
 {
   "metadata": {
     "name": "state_change_only",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   },
   "action": "allow",
   "expressions": [
@@ -190,7 +193,8 @@ output               | {{< highlight json >}}
 {
   "metadata": {
     "name": "state_change_only",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   },
   "action": "allow",
   "expressions": [

--- a/content/sensu-go/5.19/api/handlers.md
+++ b/content/sensu-go/5.19/api/handlers.md
@@ -36,7 +36,8 @@ HTTP/1.1 200 OK
   {
     "metadata": {
       "name": "influx-db",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "type": "pipe",
     "command": "sensu-influxdb-handler -d sensu",
@@ -53,7 +54,8 @@ HTTP/1.1 200 OK
   {
     "metadata": {
       "name": "slack",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "type": "pipe",
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -86,7 +88,8 @@ output         | {{< highlight shell >}}
   {
     "metadata": {
       "name": "influx-db",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "type": "pipe",
     "command": "sensu-influxdb-handler -d sensu",
@@ -207,6 +210,7 @@ HTTP/1.1 200 OK
   "metadata": {
     "name": "slack",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },
@@ -238,6 +242,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "slack",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },

--- a/content/sensu-go/5.19/api/hooks.md
+++ b/content/sensu-go/5.19/api/hooks.md
@@ -36,7 +36,8 @@ HTTP/1.1 200 OK
   {
     "metadata": {
       "name": "nginx-log",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "command": "tail -n 100 /var/log/nginx/error.log",
     "timeout": 10,
@@ -46,7 +47,8 @@ HTTP/1.1 200 OK
   {
     "metadata": {
       "name": "process-tree",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "command": "ps -eo user,pid,cmd:50,%cpu --sort=-%cpu | head -n 6",
     "timeout": 10,
@@ -71,7 +73,8 @@ output         | {{< highlight shell >}}
   {
     "metadata": {
       "name": "nginx-log",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "command": "tail -n 100 /var/log/nginx/error.log",
     "timeout": 10,
@@ -81,7 +84,8 @@ output         | {{< highlight shell >}}
   {
     "metadata": {
       "name": "process-tree",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "command": "ps -eo user,pid,cmd:50,%cpu --sort=-%cpu | head -n 6",
     "timeout": 10,
@@ -161,6 +165,7 @@ HTTP/1.1 200 OK
   "metadata": {
     "name": "process-tree",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },
@@ -183,6 +188,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "process-tree",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },

--- a/content/sensu-go/5.19/api/mutators.md
+++ b/content/sensu-go/5.19/api/mutators.md
@@ -37,6 +37,7 @@ HTTP/1.1 200 OK
     "metadata": {
       "name": "example-mutator",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -64,6 +65,7 @@ output         | {{< highlight shell >}}
     "metadata": {
       "name": "example-mutator",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -147,6 +149,7 @@ HTTP/1.1 200 OK
   "metadata": {
     "name": "example-mutator",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },
@@ -170,6 +173,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "example-mutator",
     "namespace": "default",
+    "created_by" "admin",
     "labels": null,
     "annotations": null
   },

--- a/content/sensu-go/5.19/api/mutators.md
+++ b/content/sensu-go/5.19/api/mutators.md
@@ -173,7 +173,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "example-mutator",
     "namespace": "default",
-    "created_by" "admin",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },

--- a/content/sensu-go/5.19/api/overview.md
+++ b/content/sensu-go/5.19/api/overview.md
@@ -204,7 +204,8 @@ HTTP/1.1 200 OK
     ],
     "metadata": {
       "name": "check-cpu",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]

--- a/content/sensu-go/5.19/api/role-bindings.md
+++ b/content/sensu-go/5.19/api/role-bindings.md
@@ -47,7 +47,8 @@ HTTP/1.1 200 OK
     },
     "metadata": {
       "name": "readers-group-binding",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]
@@ -78,7 +79,8 @@ output         | {{< highlight shell >}}
     },
     "metadata": {
       "name": "readers-group-binding",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]
@@ -160,7 +162,8 @@ HTTP/1.1 200 OK
   },
   "metadata": {
     "name": "readers-group-binding",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}
@@ -187,7 +190,8 @@ output               | {{< highlight json >}}
   },
   "metadata": {
     "name": "readers-group-binding",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.19/api/roles.md
+++ b/content/sensu-go/5.19/api/roles.md
@@ -48,7 +48,8 @@ HTTP/1.1 200 OK
     ],
     "metadata": {
       "name": "event-reader",
-      "namespace": "default"
+      "namespace": "default",
+      :created_by": "admin"
     }
   },
   {
@@ -65,7 +66,8 @@ HTTP/1.1 200 OK
     ],
     "metadata": {
       "name": "read-only",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]
@@ -98,7 +100,8 @@ output         | {{< highlight shell >}}
     ],
     "metadata": {
       "name": "event-reader",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   },
   {
@@ -115,7 +118,8 @@ output         | {{< highlight shell >}}
     ],
     "metadata": {
       "name": "read-only",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     }
   }
 ]
@@ -215,7 +219,8 @@ HTTP/1.1 200 OK
   ],
   "metadata": {
     "name": "read-only",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}
@@ -243,7 +248,8 @@ output               | {{< highlight json >}}
   ],
   "metadata": {
     "name": "read-only",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   }
 }
 {{< /highlight >}}

--- a/content/sensu-go/5.19/api/secrets.md
+++ b/content/sensu-go/5.19/api/secrets.md
@@ -43,7 +43,8 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
     "type": "VaultProvider",
     "api_version": "secrets/v1",
     "metadata": {
-      "name": "my_vault"
+      "name": "my_vault",
+      "created_by": "admin"
     },
     "spec": {
       "client": {
@@ -85,7 +86,8 @@ output         | {{< highlight shell >}}
     "type": "VaultProvider",
     "api_version": "secrets/v1",
     "metadata": {
-      "name": "my_vault"
+      "name": "my_vault",
+      "created_by": "admin"
     },
     "spec": {
       "client": {
@@ -125,7 +127,8 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers/my_vault \
   "type": "VaultProvider",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "my_vault"
+    "name": "my_vault",
+    "created_by": "admin"
   },
   "spec": {
     "client": {
@@ -159,7 +162,8 @@ output               | {{< highlight json >}}
   "type": "VaultProvider",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "my_vault"
+    "name": "my_vault",
+    "created_by": "admin"
   },
   "spec": {
     "client": {
@@ -299,7 +303,8 @@ HTTP/1.1 200 OK
     "api_version": "secrets/v1",
     "metadata": {
       "name": "sensu-ansible-token",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "spec": {
       "id": "secret/ansible#token",
@@ -325,7 +330,8 @@ output         | {{< highlight shell >}}
     "api_version": "secrets/v1",
     "metadata": {
       "name": "sensu-ansible-token",
-      "namespace": "default"
+      "namespace": "default",
+      "created_by": "admin"
     },
     "spec": {
       "id": "secret/ansible#token",
@@ -356,7 +362,8 @@ HTTP/1.1 200 OK
   "api_version": "secrets/v1",
   "metadata": {
     "name": "sensu-ansible-token",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   },
   "spec": {
     "id": "secret/ansible#token",
@@ -379,7 +386,8 @@ output               | {{< highlight json >}}
   "api_version": "secrets/v1",
   "metadata": {
     "name": "sensu-ansible-token",
-    "namespace": "default"
+    "namespace": "default",
+    "created_by": "admin"
   },
   "spec": {
     "id": "secret/ansible#token",

--- a/content/sensu-go/5.19/api/silenced.md
+++ b/content/sensu-go/5.19/api/silenced.md
@@ -188,7 +188,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "linux:check-cpu",
     "namespace": "default",
-    "created_by" "admin",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },

--- a/content/sensu-go/5.19/api/silenced.md
+++ b/content/sensu-go/5.19/api/silenced.md
@@ -41,6 +41,7 @@ HTTP/1.1 200 OK
     "metadata": {
       "name": "linux:check-cpu",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -70,6 +71,7 @@ output         | {{< highlight shell >}}
     "metadata": {
       "name": "linux:check-cpu",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -160,6 +162,7 @@ HTTP/1.1 200 OK
   "metadata": {
     "name": "linux:check-cpu",
     "namespace": "default",
+    "created_by": "admin",
     "labels": null,
     "annotations": null
   },
@@ -185,6 +188,7 @@ output               | {{< highlight json >}}
   "metadata": {
     "name": "linux:check-cpu",
     "namespace": "default",
+    "created_by" "admin",
     "labels": null,
     "annotations": null
   },
@@ -298,6 +302,7 @@ HTTP/1.1 200 OK
     "metadata": {
       "name": "linux:check-cpu",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -326,6 +331,7 @@ output               | {{< highlight json >}}
     "metadata": {
       "name": "linux:check-cpu",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -360,6 +366,7 @@ HTTP/1.1 200 OK
     "metadata": {
       "name": "linux:check-cpu",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },
@@ -388,6 +395,7 @@ output               | {{< highlight json >}}
     "metadata": {
       "name": "linux:check-cpu",
       "namespace": "default",
+      "created_by": "admin",
       "labels": null,
       "annotations": null
     },

--- a/content/sensu-go/5.19/reference/apikeys.md
+++ b/content/sensu-go/5.19/reference/apikeys.md
@@ -88,11 +88,12 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the API key, including the `name`. The `metadata` map is always at the top level of the API key definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.
+description  | Top-level collection of metadata about the API key, including `name` and `created_by`. The `metadata` map is always at the top level of the API key definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"metadata": {
-  "name": "19803eb8-36a6-4203-a225-28ec4e9f4444"
+  "name": "19803eb8-36a6-4203-a225-28ec4e9f4444",
+  "created_by": "admin"
 }{{< /highlight >}}
 
 spec         | 
@@ -114,6 +115,13 @@ description  | Unique string used to identify the API key. Sensu randomly genera
 required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "19803eb8-36a6-4203-a225-28ec4e9f4444"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the API key or last updated the API key. Sensu automatically populates the `created_by` field when the API key is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 ### Spec attributes
 

--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -437,7 +437,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu_linux_amd64",
-    "namespace": "default"
+    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -513,7 +513,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu",
-    "namespace": "default"
+    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -611,7 +611,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-email-handler",
-    "namespace": default,
+    "namespace": default
   },
   "spec": {
     "builds": [
@@ -631,7 +631,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "prometheus_collector",
-    "namespace": "default",
+    "namespace": "default"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",

--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -200,12 +200,13 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the asset, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the asset definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][5] for details.
+description  | Top-level collection of metadata about the asset, including `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the asset definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][5] for details.
 required     | Required for asset definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][11].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"metadata": {
   "name": "check_script",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -273,6 +274,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the asset or last updated the asset. Sensu automatically populates the `created_by` field when the asset is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------
@@ -429,7 +437,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu_linux_amd64",
-    "namespace": "default",
+    "namespace": "default"
     "labels": {
       "origin": "bonsai"
     },
@@ -505,7 +513,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu",
-    "namespace": "default",
+    "namespace": "default"
     "labels": {
       "origin": "bonsai"
     },
@@ -570,6 +578,7 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-prometheus-collector
+  namespace: default
 spec:
   builds:
   - url: https://assets.bonsai.sensu.io/ef812286f59de36a40e51178024b81c69666e1b7/sensu-prometheus-collector_1.1.6_linux_amd64.tar.gz
@@ -601,7 +610,8 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-email-handler"
+    "name": "sensu-email-handler",
+    "namespace": default,
   },
   "spec": {
     "builds": [
@@ -621,7 +631,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "prometheus_collector",
-    "namespace": "default"
+    "namespace": "default",
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",

--- a/content/sensu-go/5.19/reference/checks.md
+++ b/content/sensu-go/5.19/reference/checks.md
@@ -497,12 +497,13 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the check, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][25] for details.
+description  | Top-level collection of metadata about the check, including `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][25] for details.
 required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"metadata": {
   "name": "collect-metrics",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -541,6 +542,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the check or last updated the check. Sensu automatically populates the `created_by` field when the check is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------

--- a/content/sensu-go/5.19/reference/datastore.md
+++ b/content/sensu-go/5.19/reference/datastore.md
@@ -127,12 +127,13 @@ example      | {{< highlight shell >}}api_version: store/v1{{< /highlight >}}
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the PostgreSQL datastore `name`.
+description  | Top-level scope that contains the PostgreSQL datastore `name` and `created_by` field.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 metadata:
   name: my-postgres
+  created_by: admin
 {{< /highlight >}}
 
 spec         |      |
@@ -154,6 +155,13 @@ description  | PostgreSQL datastore name used internally by Sensu.
 required     | true
 type         | String
 example      | {{< highlight shell >}}name: my-postgres{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the datastore or last updated the datastore. Sensu automatically populates the `created_by` field when the datastore is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}created_by: admin{{< /highlight >}}
 
 #### Spec attributes
 

--- a/content/sensu-go/5.19/reference/entities.md
+++ b/content/sensu-go/5.19/reference/entities.md
@@ -229,13 +229,14 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the entity, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the entity definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][8] for details.
+description  | Top-level collection of metadata about the entity, including `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the entity definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][8] for details.
 required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "webserver01",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -332,6 +333,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the entity or last updated the entity. Sensu automatically populates the `created_by` field when the entity is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------

--- a/content/sensu-go/5.19/reference/etcdreplicators.md
+++ b/content/sensu-go/5.19/reference/etcdreplicators.md
@@ -79,12 +79,13 @@ example      | {{< highlight shell >}}api_version: federation/v1{{< /highlight >
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the replicator `name`. Namespace is not supported in the metadata because etcd replicators are cluster-wide resources.
+description  | Top-level scope that contains the replicator `name` and `created_by` value. Namespace is not supported in the metadata because etcd replicators are cluster-wide resources.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 metadata:
   name: my_replicator
+  created_by: admin
 {{< /highlight >}}
 
 spec         |      |
@@ -112,6 +113,13 @@ description  | Replicator name used internally by Sensu.
 required     | true
 type         | String
 example      | {{< highlight shell >}}name: my_replicator{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the replicator or last updated the replicator. Sensu automatically populates the `created_by` field when the replicator is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}created_by: admin{{< /highlight >}}
 
 #### Spec attributes
 

--- a/content/sensu-go/5.19/reference/events.md
+++ b/content/sensu-go/5.19/reference/events.md
@@ -202,11 +202,12 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level scope that contains the event `namespace`. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes][29] for details.
+description  | Top-level scope that contains the event `namespace` and `created_by` field. The `metadata` map is always at the top level of the check definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope.  See the [metadata attributes][29] for details.
 required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"metadata": {
-  "namespace": "default"
+  "namespace": "default",
+  "created_by": "admin"
 }{{< /highlight >}}
 
 spec         | 
@@ -349,6 +350,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 ### Spec attributes
 

--- a/content/sensu-go/5.19/reference/filters.md
+++ b/content/sensu-go/5.19/reference/filters.md
@@ -395,13 +395,14 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the event filter, including the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the filter definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][11] for details.
+description  | Top-level collection of metadata about the event filter, including `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the filter definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][11] for details.
 required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "filter-weekdays-only",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -442,6 +443,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the filter or last updated the filter. Sensu automatically populates the `created_by` field when the filter is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------

--- a/content/sensu-go/5.19/reference/handlers.md
+++ b/content/sensu-go/5.19/reference/handlers.md
@@ -120,13 +120,14 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the handler that includes the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the handler definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][8] for details.
+description  | Top-level collection of metadata about the handler that includes `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the handler definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][8] for details.
 required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "handler-slack",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -171,6 +172,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the handler or last updated the handler. Sensu automatically populates the `created_by` field when the handler is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------

--- a/content/sensu-go/5.19/reference/hooks.md
+++ b/content/sensu-go/5.19/reference/hooks.md
@@ -90,13 +90,14 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the hook that includes the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the hook definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][2] for details.
+description  | Top-level collection of metadata about the hook that includes `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the hook definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][2] for details.
 required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "process_tree",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -135,6 +136,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the hook or last updated the hook. Sensu automatically populates the `created_by` field when the hook is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------

--- a/content/sensu-go/5.19/reference/mutators.md
+++ b/content/sensu-go/5.19/reference/mutators.md
@@ -118,13 +118,14 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the mutator that includes the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the mutator definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See the [metadata attributes reference][2] for details.
+description  | Top-level collection of metadata about the mutator that includes `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the mutator definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See the [metadata attributes reference][2] for details.
 required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "example-mutator",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   },
@@ -164,6 +165,13 @@ required     | false
 type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the mutator or last updated the mutator. Sensu automatically populates the `created_by` field when the mutator is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 | labels     |      |
 -------------|------

--- a/content/sensu-go/5.19/reference/secrets-providers.md
+++ b/content/sensu-go/5.19/reference/secrets-providers.md
@@ -61,12 +61,13 @@ example      | {{< highlight shell >}}"api_version": "secrets/v1"{{< /highlight 
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the secrets provider `name`. Namespace is not supported in the metadata because secrets providers are cluster-wide resources.
+description  | Top-level scope that contains the secrets provider `name` and `created_by` field. Namespace is not supported in the metadata because secrets providers are cluster-wide resources.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
-  "name": "vault"
+  "name": "vault",
+  "created_by": "admin"
 }
 {{< /highlight >}}
 
@@ -102,6 +103,13 @@ description  | Provider name used internally by Sensu.
 required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "vault"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the secrets provider or last updated the secrets provider. Sensu automatically populates the `created_by` field when the secrets provider is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 ### Spec attributes
 

--- a/content/sensu-go/5.19/reference/secrets.md
+++ b/content/sensu-go/5.19/reference/secrets.md
@@ -55,13 +55,14 @@ example      | {{< highlight shell >}}"api_version": "secrets/v1"{{< /highlight 
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the secret's `name` and `namespace`.
+description  | Top-level scope that contains the secret's `name` and `namespace` as well as the `created_by` field.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "sensu-ansible-token",
-  "namespace": "default"
+  "namespace": "default",
+  "created_by": "admin"
 }
 {{< /highlight >}}
 
@@ -92,6 +93,13 @@ description  | [Sensu RBAC namespace][9] that the secret belongs to.
 required     | true
 type         | String
 example      | {{< highlight shell >}}"namespace": "default"{{< /highlight >}}
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the secret or last updated the secret. Sensu automatically populates the `created_by` field when the secret is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 ### Spec attributes
 

--- a/content/sensu-go/5.19/reference/silencing.md
+++ b/content/sensu-go/5.19/reference/silencing.md
@@ -64,13 +64,14 @@ example      | {{< highlight shell >}}"api_version": "core/v2"{{< /highlight >}}
 
 metadata     | 
 -------------|------
-description  | Top-level collection of metadata about the silencing entry that includes the `name` and `namespace` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the silencing entry definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][3] for details.
+description  | Top-level collection of metadata about the silencing entry that includes `name`, `namespace`, and `created_by` as well as custom `labels` and `annotations`. The `metadata` map is always at the top level of the silencing entry definition. This means that in `wrapped-json` and `yaml` formats, the `metadata` scope occurs outside the `spec` scope. See [metadata attributes][3] for details.
 required     | Required for silencing entry definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "appserver:mysql_status",
   "namespace": "default",
+  "created_by": "admin",
   "labels": {
     "region": "us-west-1"
   }
@@ -110,6 +111,13 @@ type         | String
 default      | `default`
 example      | {{< highlight shell >}}"namespace": "production"{{< /highlight >}}
 
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the silence or last updated the silence. Sensu automatically populates the `created_by` field when the silence is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
+
 | labels     |      |
 -------------|------
 description  | Custom attributes to include with event data that you can use for response and dashboard view filtering.<br><br>If you include labels in your event data, you can filter [API responses][6], [sensuctl responses][7], and [dashboard views][9] based on them. In other words, labels allow you to create meaningful groupings for your data.<br><br>Limit labels to metadata you need to use for response filtering. For complex, non-identifying metadata that you will *not* need to use in response filtering, use annotations rather than labels.
@@ -140,7 +148,6 @@ description  | Name of the check the entry should match.
 required     | true, unless `subscription` is provided
 type         | String
 example      | {{< highlight shell >}}"check": "haproxy_status"{{< /highlight >}}
-
 
 subscription | 
 -------------|------ 


### PR DESCRIPTION
## Description
- Adds `created_by` to metadata object in GET examples in API docs
- Adds `created_by` to metadata and spec tables in references

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2243