### PR TITLE
Add LibCType, VMSystem, VMRole, and CloudProvider fields in Entity.System

### DIFF
--- a/content/sensu-go/5.19/api/entities.md
+++ b/content/sensu-go/5.19/api/entities.md
@@ -69,7 +69,11 @@ HTTP/1.1 200 OK
           }
         ]
       },
-      "arch": "amd64"
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "kvm",
+      "vm_role": "host",
+      "cloud_provider": ""
     },
     "subscriptions": [
       "entity:sensu-centos"
@@ -147,7 +151,11 @@ output         | {{< highlight shell >}}
           }
         ]
       },
-      "arch": "amd64"
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "kvm",
+      "vm_role": "host",
+      "cloud_provider": ""
     },
     "subscriptions": [
       "entity:sensu-centos"
@@ -287,7 +295,11 @@ HTTP/1.1 200 OK
         }
       ]
     },
-    "arch": "amd64"
+    "arch": "amd64",
+    "libc_type": "glibc",
+    "vm_system": "kvm",
+    "vm_role": "host",
+    "cloud_provider": ""
   },
   "subscriptions": [
     "entity:sensu-centos"
@@ -361,7 +373,11 @@ output               | {{< highlight json >}}
         }
       ]
     },
-    "arch": "amd64"
+    "arch": "amd64",
+    "libc_type": "glibc",
+    "vm_system": "kvm",
+    "vm_role": "host",
+    "cloud_provider": ""
   },
   "subscriptions": [
     "entity:sensu-centos"

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -745,6 +745,7 @@ Flags:
   -c, --config-file string                    path to sensu-agent config file
       --deregister                            ephemeral agent
       --deregistration-handler string         deregistration handler that should process the entity deregistration event.
+      --detect-cloud-provider                 enable cloud provider detection mechanisms
       --disable-assets                        disable check assets on this agent
       --disable-api                           disable the Agent HTTP API
       --disable-sockets                       disable the Agent TCP and UDP event sockets
@@ -1030,6 +1031,19 @@ sensu-agent start --deregistration-handler deregister
 
 # /etc/sensu/agent.yml example
 deregistration-handler: "deregister"{{< /highlight >}}
+
+
+| detect-cloud-provider  |      |
+-------------------------|------
+description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this flag is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
+type                     | Boolean
+default                  | `false`
+environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
+example                  | {{< highlight shell >}}# Command line example
+sensu-agent start --detect-cloud-provider false
+
+# /etc/sensu/agent.yml example
+detect-cloud-provider: "false"{{< /highlight >}}
 
 
 ### Keepalive configuration flags

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -1032,6 +1032,8 @@ sensu-agent start --deregistration-handler deregister
 # /etc/sensu/agent.yml example
 deregistration-handler: "deregister"{{< /highlight >}}
 
+<a name="detect-cloud-provider-flag"></a>
+
 
 | detect-cloud-provider  |      |
 -------------------------|------

--- a/content/sensu-go/5.19/reference/entities.md
+++ b/content/sensu-go/5.19/reference/entities.md
@@ -293,7 +293,11 @@ example      | {{< highlight shell >}}
           }
         ]
       },
-      "arch": "amd64"
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "kvm",
+      "vm_role": "host",
+      "cloud_provider": ""
     },
     "subscriptions": [
       "entity:webserver01"
@@ -384,6 +388,10 @@ example      | {{< language-toggle >}}
 {{< highlight yml >}}
 system:
   arch: amd64
+  libc_type: glibc
+  vm_system: kvm
+  vm_role: host
+  cloud_provider: null
   hostname: example-hostname
   network:
     interfaces:
@@ -429,7 +437,11 @@ system:
         }
       ]
     },
-    "arch": "amd64"
+    "arch": "amd64",
+    "libc_type": "glibc",
+    "vm_system": "kvm",
+    "vm_role": "host",
+    "cloud_provider": ""
   }
 }{{< /highlight >}}
 
@@ -441,7 +453,6 @@ description  | Timestamp the entity was last seen. In seconds since the Unix epo
 required     | false 
 type         | Integer 
 example      | {{< highlight shell >}}"last_seen": 1522798317 {{< /highlight >}}
-
 
 deregister   | 
 -------------|------ 
@@ -593,6 +604,37 @@ required     | false
 type         | String 
 example      | {{< highlight shell >}}"arch": "amd64" {{< /highlight >}}
 
+libc_type    | 
+-------------|------ 
+description  | Entity's libc type. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< highlight shell >}}"libc_type": "glibc" {{< /highlight >}}
+
+vm_system    | 
+-------------|------ 
+description  | Entity's virtual machine system. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< highlight shell >}}"vm_system": "kvm" {{< /highlight >}}
+
+vm_role      | 
+-------------|------ 
+description  | Entity's virtual machine role. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< highlight shell >}}"vm_role": "host" {{< /highlight >}}
+
+cloud_provider | 
+---------------|------ 
+description    | . Automatically populated upon agent startup if the `--detect-cloud-provider` flag is set. {{% notice note %}}
+**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
+{{% /notice %}}
+required       | false 
+type           | String 
+example        | {{< highlight shell >}}"cloud_provider": "" {{< /highlight >}}
+
+
 ### Network attributes
 
 network_interface         | 
@@ -704,6 +746,10 @@ spec:
   - entity:webserver01
   system:
     arch: amd64
+    libc_type: glibc
+    vm_system: kvm
+    vm_role: host
+    cloud_provider: null
     hostname: sensu2-centos
     network:
       interfaces:
@@ -774,7 +820,11 @@ spec:
           }
         ]
       },
-      "arch": "amd64"
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "kvm",
+      "vm_role": "host",
+      "cloud_provider": ""
     },
     "subscriptions": [
       "entity:webserver01"

--- a/content/sensu-go/5.19/reference/entities.md
+++ b/content/sensu-go/5.19/reference/entities.md
@@ -627,7 +627,7 @@ example      | {{< highlight shell >}}"vm_role": "host" {{< /highlight >}}
 
 cloud_provider | 
 ---------------|------ 
-description    | . Automatically populated upon agent startup if the `--detect-cloud-provider` flag is set. {{% notice note %}}
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. {{% notice note %}}
 **NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
 {{% /notice %}}
 required       | false 
@@ -874,3 +874,4 @@ spec:
 [22]: ../rbac/
 [23]: ../../dashboard/filtering#filter-with-label-selectors
 [24]: ../checks#proxy-requests-attributes
+[25]: ../agent/#detect-cloud-provider-flag


### PR DESCRIPTION
## Description
- Add libc_type, vm_system, vm_role, and cloud_provider key-value pairs in Entity API doc and reference
- Add description tables for each field in System attributes section of Entity reference
- Add --enable-cloud-provider flag in Agent reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2285