### PR TITLE
Remove extraneous namespace notes in Federation API doc

### DIFF
--- a/content/sensu-go/5.15/api/federation.md
+++ b/content/sensu-go/5.15/api/federation.md
@@ -36,8 +36,6 @@ The `/etcd-replicators` endpoint provides HTTP GET access to a list of replicato
 
 The following example demonstrates a request to the `/etcd-replicators` endpoint, resulting in a list of replicators.
 
-_**NOTE**: If you did not specify a [namespace][2] when you created a replicator, the response will not include a `namespace` key-value pair._
-
 {{< highlight shell >}}
 curl http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators -H "Authorization: Bearer $SENSU_TOKEN"
 [
@@ -122,6 +120,8 @@ response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad 
 
 ## The `/etcd-replicators/:etcd-replicator` endpoint {#the-etcd-replicatorsetcd-replicator-endpoint}
 
+_**NOTE**: The etcd-replicators datatype is only accessible for users who have a cluster role that permits access to replication resources._
+
 ### `/etcd-replicators/:etcd-replicator` (GET) {#etcd-replicatorsetcd-replicator-get}
 
 The `/etcd-replicators/:etcd-replicator` endpoint provides HTTP GET access to data for a specific `:etcd-replicator`, by replicator `name`.
@@ -129,8 +129,6 @@ The `/etcd-replicators/:etcd-replicator` endpoint provides HTTP GET access to da
 #### EXAMPLE {#etcd-replicatorsetcd-replicator-get-example}
 
 In the following example, querying the `/etcd-replicators/:etcd-replicator` endpoint returns a JSON Map containing the requested `:etcd-replicator`.
-
-_**NOTE**: If you did not specify a [namespace][2] when you created the replicator, the response will not include a `namespace` key-value pair._
 
 {{< highlight shell >}}
 curl http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator -H "Authorization: Bearer $SENSU_TOKEN"

--- a/content/sensu-go/5.16/api/federation.md
+++ b/content/sensu-go/5.16/api/federation.md
@@ -66,7 +66,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
 
 /etcd-replicators (GET)  | 
 ---------------|------
-description    | Returns the list of replicators. _**NOTE**: If you did not specify a [namespace][2] when you created a replicator, the response will not include a `namespace` key-value pair._
+description    | Returns the list of replicators.
 example url    | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -158,6 +158,8 @@ response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad 
 
 ## The `/etcd-replicators/:etcd-replicator` API endpoint {#the-etcd-replicatorsetcd-replicator-endpoint}
 
+_**NOTE**: The etcd-replicators datatype is only accessible for users who have a cluster role that permits access to replication resources._
+
 ### `/etcd-replicators/:etcd-replicator` (GET) {#etcd-replicatorsetcd-replicator-get}
 
 The `/etcd-replicators/:etcd-replicator` API endpoint provides HTTP GET access to data for a specific `:etcd-replicator`, by replicator name.
@@ -193,7 +195,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicato
 
 /etcd-replicators/:etcd-replicator (GET) | 
 ---------------------|------
-description          | Returns the specified replicator. _**NOTE**: If you did not specify a [namespace][2] when you created the replicator, the response will not include a `namespace` key-value pair._
+description          | Returns the specified replicator.
 example url          | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/5.17/api/federation.md
+++ b/content/sensu-go/5.17/api/federation.md
@@ -66,7 +66,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
 
 /etcd-replicators (GET)  | 
 ---------------|------
-description    | Returns the list of replicators. _**NOTE**: If you did not specify a [namespace][2] when you created a replicator, the response will not include a `namespace` key-value pair._
+description    | Returns the list of replicators.
 example url    | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -133,7 +133,7 @@ HTTP/1.1 200 OK
 
 /etcd-replicators (POST) | 
 ----------------|------
-description     | Creates a new replicator (if none exists). _**NOTE**: If you do not specify a [namespace][2] when you create a replicator, all namespaces for the given resource are replicated._
+description     | Creates a new replicator (if none exists).
 example URL     | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 payload         | {{< highlight shell >}}
 {
@@ -157,6 +157,8 @@ payload         | {{< highlight shell >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/etcd-replicators/:etcd-replicator` API endpoint {#the-etcd-replicatorsetcd-replicator-endpoint}
+
+_**NOTE**: The etcd-replicators datatype is only accessible for users who have a cluster role that permits access to replication resources._
 
 ### `/etcd-replicators/:etcd-replicator` (GET) {#etcd-replicatorsetcd-replicator-get}
 
@@ -193,7 +195,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicato
 
 /etcd-replicators/:etcd-replicator (GET) | 
 ---------------------|------
-description          | Returns the specified replicator. _**NOTE**: If you did not specify a [namespace][2] when you created the replicator, the response will not include a `namespace` key-value pair._
+description          | Returns the specified replicator.
 example url          | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/5.18/api/federation.md
+++ b/content/sensu-go/5.18/api/federation.md
@@ -68,9 +68,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
 
 /etcd-replicators (GET)  | 
 ---------------|------
-description    | Returns the list of replicators. {{% notice note %}}
-**NOTE**: If you did not specify a [namespace](../../reference/etcdreplicators#namespace-attribute) when you created a replicator, the response will not include a `namespace` key-value pair.
-{{% /notice %}}
+description    | Returns the list of replicators.
 example url    | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -139,9 +137,7 @@ HTTP/1.1 200 OK
 
 /etcd-replicators (POST) | 
 ----------------|------
-description     | Creates a new replicator (if none exists). {{% notice note %}}
-**NOTE**: If you do not specify a [namespace](../../reference/etcdreplicators#namespace-attribute) when you create a replicator, all namespaces for the given resource are replicated.
-{{% /notice %}}
+description     | Creates a new replicator (if none exists).
 example URL     | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 payload         | {{< highlight shell >}}
 {
@@ -165,6 +161,10 @@ payload         | {{< highlight shell >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/etcd-replicators/:etcd-replicator` API endpoint {#the-etcd-replicatorsetcd-replicator-endpoint}
+
+{{% notice note %}}
+**NOTE**: The etcd-replicators datatype is only accessible for users who have a cluster role that permits access to replication resources.
+{{% /notice %}}
 
 ### `/etcd-replicators/:etcd-replicator` (GET) {#etcd-replicatorsetcd-replicator-get}
 
@@ -201,9 +201,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicato
 
 /etcd-replicators/:etcd-replicator (GET) | 
 ---------------------|------
-description          | Returns the specified replicator. {{% notice note %}}
-**NOTE**: If you did not specify a [namespace](../../reference/etcdreplicators#namespace-attribute) when you created the replicator, the response will not include a `namespace` key-value pair.
-{{% /notice %}}
+description          | Returns the specified replicator.
 example url          | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/5.19/api/federation.md
+++ b/content/sensu-go/5.19/api/federation.md
@@ -69,9 +69,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators \
 
 /etcd-replicators (GET)  | 
 ---------------|------
-description    | Returns the list of replicators. {{% notice note %}}
-**NOTE**: If you did not specify a [namespace](../../reference/etcdreplicators#namespace-attribute) when you created a replicator, the response will not include a `namespace` key-value pair.
-{{% /notice %}}
+description    | Returns the list of replicators.
 example url    | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -141,9 +139,7 @@ HTTP/1.1 200 OK
 
 /etcd-replicators (POST) | 
 ----------------|------
-description     | Creates a new replicator (if none exists). {{% notice note %}}
-**NOTE**: If you do not specify a [namespace](../../reference/etcdreplicators#namespace-attribute) when you create a replicator, all namespaces for the given resource are replicated.
-{{% /notice %}}
+description     | Creates a new replicator (if none exists).
 example URL     | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators
 payload         | {{< highlight shell >}}
 {
@@ -167,6 +163,10 @@ payload         | {{< highlight shell >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## The `/etcd-replicators/:etcd-replicator` API endpoint {#the-etcd-replicatorsetcd-replicator-endpoint}
+
+{{% notice note %}}
+**NOTE**: The etcd-replicators datatype is only accessible for users who have a cluster role that permits access to replication resources.
+{{% /notice %}}
 
 ### `/etcd-replicators/:etcd-replicator` (GET) {#etcd-replicatorsetcd-replicator-get}
 
@@ -204,9 +204,7 @@ http://127.0.0.1:8080/api/enterprise/federation/v1/etcd-replicators/my_replicato
 
 /etcd-replicators/:etcd-replicator (GET) | 
 ---------------------|------
-description          | Returns the specified replicator. {{% notice note %}}
-**NOTE**: If you did not specify a [namespace](../../reference/etcdreplicators#namespace-attribute) when you created the replicator, the response will not include a `namespace` key-value pair.
-{{% /notice %}}
+description          | Returns the specified replicator.
 example url          | http://hostname:8080/api/enterprise/federation/v1/etcd-replicators/my_replicator
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>


### PR DESCRIPTION
## Description
Removes notes specifying that etcd replicator API call responses do not include namespaces if namespace is not specified (all resources at the global level will omit the namespace key-value pair).

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2239