### PR TITLE
Add sensuctl prune to sensuctl reference doc

### DIFF
--- a/content/sensu-go/5.19/sensuctl/reference.md
+++ b/content/sensu-go/5.19/sensuctl/reference.md
@@ -20,8 +20,7 @@ menu:
 - [Update resources](#update-resources)
 - [Export resources](#export-resources)
 - [Manage resources](#manage-resources)
-  - [Subcommands](#subcommands)
-- [Prune resources](#prune-resources) (alpha feature)
+  - [Subcommands](#subcommands): [sensuctl check](#sensuctl-check) | [sensuctl cluster](#sensuctl-cluster) | [sensuctl event](#sensuctl-event) | [sensuctl namespace](#sensuctl-namespace) | [sensuctl user](#sensuctl-user) | [sensuctl prune](#sensuctl-prune) (alpha feature)
 - [Response filtering](#response-filtering) (commercial feature)
 - [Time formats](#time-formats)
 - [Shell auto-completion](#shell-auto-completion)
@@ -649,38 +648,28 @@ See the [RBAC reference][21] for information about using access control with nam
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
-## Prune resources
+#### sensuctl prune
 
 {{% notice important %}}
 **IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
 {{% /notice %}}
 
-The `sensuctl prune` command allows you to delete resources that do not appear in your configuration from a file, URL, or STDIN.
-For example, you can use `sensuctl prune` to prune resources that were created by a specific user or that include a specific label selector.
+**COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features][30].
 
-`sensuctl prune` will only prune resources that were created with `sensuctl create` or that have the following label:
+The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
+For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-{{< language-toggle >}}
+`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+This means you can only use `sensuctl prune` for delete resources that were created with sensuctl.
 
-{{< highlight yml >}}
-labels:
-  sensu.io/managed_by: sensuctl
-{{< /highlight >}}
+The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
+For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
 
-{{< highlight json >}}
-"labels": {
-  "sensu.io/managed_by": "sensuctl"
-}
-{{< /highlight >}}
-
-{{< /language-toggle >}}
-
-Sensu automatically adds the `sensu.io/managed_by: sensuctl` label to all resources created with sensuctl.
-
-### sensuctl prune usage
+##### sensuctl prune usage
 
 {{< highlight shell >}}
-sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... [-f [FILE] -f [URL] -f [STDIN] [-r] ... ] [flags]
+sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... [-f [FILE] -f [URL] -f [STDIN] [-r] ... ] [--NAMESPACE] [flags]
 {{< /highlight >}}
 
 In this example `sensuctl prune` command:
@@ -689,6 +678,8 @@ In this example `sensuctl prune` command:
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE], [URL], or [STDIN] with the name of the file, URL, or STDIN where you want to apply the pruning.
 - Replace [flags] with the flags you want to use, if any.
+- Replace [--NAMESPACE] with the namespace where you want to apply pruning.
+To prune all namespaces, omit the namespace qualifier from your command.
 
 Use a comma separator to prune more than one resource in a single command.
 
@@ -698,7 +689,7 @@ For example, to prune checks and assets from the file `checks.yaml` for the `dev
 sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
 {{< /highlight >}}
 
-### sensuctl prune flags
+##### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
 The following table describes the command-specific flags.
@@ -713,7 +704,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-### sensuctl prune resource types
+##### sensuctl prune resource types
 
 The table below lists supported `sensuctl prune` resource types.
 
@@ -742,7 +733,7 @@ None | `secrets/v1.Secret`
 `tessen` | `core/v2.TessenConfig`
 `users` | `core/v2.User`
 
-### sensuctl prune examples
+##### sensuctl prune examples
 
 `sensuctl prune` supports pruning resources by their synonyms or fully qualified names:
 

--- a/content/sensu-go/5.19/sensuctl/reference.md
+++ b/content/sensu-go/5.19/sensuctl/reference.md
@@ -669,17 +669,17 @@ For example, to prune resources in the `dev` namespace, the current user who sen
 ##### sensuctl prune usage
 
 {{< highlight shell >}}
-sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... [-f [FILE] -f [URL] -f [STDIN] [-r] ... ] [--NAMESPACE] [flags]
+sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... -f [FILE or URL] [-r] ... ] [--NAMESPACE] [flags]
 {{< /highlight >}}
 
 In this example `sensuctl prune` command:
 
 - Replace [RESOURCE TYPE] with the [synonym or fully qualified name][48] of the resource you want to prune.
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
-- Replace [FILE], [URL], or [STDIN] with the name of the file, URL, or STDIN where you want to apply the pruning.
+- Replace [FILE or URL] with the name of the file or the URL where you want to apply the pruning.
 - Replace [flags] with the flags you want to use, if any.
 - Replace [--NAMESPACE] with the namespace where you want to apply pruning.
-To prune all namespaces, omit the namespace qualifier from your command.
+If you omit the namespace qualifier, the command defaults to the current configured namespace.
 
 Use a comma separator to prune more than one resource in a single command.
 
@@ -697,6 +697,7 @@ The following table describes the command-specific flags.
 | Flag | Function and important notes
 | ---- | ----------------------------
 `-a` or `--all-users` | Prunes resources created by all users. Mutually exclusive with the `--users` flag. Defaults to false.
+`-c` or `--cluster-wide` | Prunes any cluster-wide (non-namespaced) resources that are not defined in the configuration. Defaults to false.
 `-d` or `--dry-run` | Prints the resources that will be pruned but does not actually delete them. Defaults to false.
 `-f` or `--file` | Files, URLs, or directories to prune resources from. Strings.
 `-h` or `--help` | Help for the prune command.

--- a/content/sensu-go/5.19/sensuctl/reference.md
+++ b/content/sensu-go/5.19/sensuctl/reference.md
@@ -21,8 +21,8 @@ menu:
 - [Export resources](#export-resources)
 - [Manage resources](#manage-resources)
   - [Subcommands](#subcommands)
-- [Prune resources](#prune-resources) (experimental feature)
-- [Response filtering](#response-filtering)
+- [Prune resources](#prune-resources) (alpha feature)
+- [Response filtering](#response-filtering) (commercial feature)
 - [Time formats](#time-formats)
 - [Shell auto-completion](#shell-auto-completion)
 - [Environment variables](#environment-variables)
@@ -652,26 +652,41 @@ See the [RBAC reference][22] for information about local user management with se
 ## Prune resources
 
 {{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is experimental and under testing for Sensu Go 5.19.0.
-We may remove this feature from 5.19.0 and future releases.
+**IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
 {{% /notice %}}
-
-**COMMERCIAL FEATURE**: Access `sensuctl prune` in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][30].
 
 The `sensuctl prune` command allows you to delete resources that do not appear in your configuration from a file, URL, or STDIN.
 For example, you can use `sensuctl prune` to prune resources that were created by a specific user or that include a specific label selector.
 
+`sensuctl prune` will only prune resources that were created with `sensuctl create` or that have the following label:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+labels:
+  sensu.io/managed_by: sensuctl
+{{< /highlight >}}
+
+{{< highlight json >}}
+"labels": {
+  "sensu.io/managed_by": "sensuctl"
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+Sensu automatically adds the `sensu.io/managed_by: sensuctl` label to all resources created with sensuctl.
+
 ### sensuctl prune usage
 
 {{< highlight shell >}}
-sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... [-f [FILE] -f [URL] -f [URL] [-r] ... ] [flags]
+sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... [-f [FILE] -f [URL] -f [STDIN] [-r] ... ] [flags]
 {{< /highlight >}}
 
 In this example `sensuctl prune` command:
 
 - Replace [RESOURCE TYPE] with the [synonym or fully qualified name][48] of the resource you want to prune.
-If you do not specify any resource types, `sensuctl prune` defaults to all types except events and entities.
+You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE], [URL], or [STDIN] with the name of the file, URL, or STDIN where you want to apply the pruning.
 - Replace [flags] with the flags you want to use, if any.
 
@@ -686,12 +701,17 @@ sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,op
 ### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
+The following table describes the command-specific flags.
 
-The `sensuctl prune` flags have a few important characteristics:
-
-- `--all-users` defaults to false and overrides the `--users` flag.
-- `--dry-run` defaults to false.
-- `--users` defaults to the currently configured sensuctl user.
+| Flag | Function and important notes
+| ---- | ----------------------------
+`-a` or `--all-users` | Prunes resources created by all users. Mutually exclusive with the `--users` flag. Defaults to false.
+`-d` or `--dry-run` | Prints the resources that will be pruned but does not actually delete them. Defaults to false.
+`-f` or `--file` | Files, URLs, or directories to prune resources from. Strings.
+`-h` or `--help` | Help for the prune command.
+`--label-selector` | Prunes only resources that match the specified labels (comma-separated strings). Labels are a [commercial feature][30].
+`-r` or `--recursive` | Prune command will follow subdirectories.
+`-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
 ### sensuctl prune resource types
 

--- a/content/sensu-go/5.19/sensuctl/reference.md
+++ b/content/sensu-go/5.19/sensuctl/reference.md
@@ -661,7 +661,7 @@ The `sensuctl prune` subcommand allows you to delete resources that do not appea
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
-This means you can only use `sensuctl prune` for delete resources that were created with sensuctl.
+This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.

--- a/content/sensu-go/5.19/sensuctl/reference.md
+++ b/content/sensu-go/5.19/sensuctl/reference.md
@@ -21,7 +21,8 @@ menu:
 - [Export resources](#export-resources)
 - [Manage resources](#manage-resources)
   - [Subcommands](#subcommands)
-- [Response filtering](#response-filtering) (commercial feature)
+- [Prune resources](#prune-resources) (experimental feature)
+- [Response filtering](#response-filtering)
 - [Time formats](#time-formats)
 - [Shell auto-completion](#shell-auto-completion)
 - [Environment variables](#environment-variables)
@@ -648,6 +649,97 @@ See the [RBAC reference][21] for information about using access control with nam
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
+## Prune resources
+
+{{% notice important %}}
+**IMPORTANT**: `sensuctl prune` is experimental and under testing for Sensu Go 5.19.0.
+We may remove this feature from 5.19.0 and future releases.
+{{% /notice %}}
+
+**COMMERCIAL FEATURE**: Access `sensuctl prune` in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features][30].
+
+The `sensuctl prune` command allows you to delete resources that do not appear in your configuration from a file, URL, or STDIN.
+For example, you can use `sensuctl prune` to prune resources that were created by a specific user or that include a specific label selector.
+
+### sensuctl prune usage
+
+{{< highlight shell >}}
+sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... [-f [FILE] -f [URL] -f [URL] [-r] ... ] [flags]
+{{< /highlight >}}
+
+In this example `sensuctl prune` command:
+
+- Replace [RESOURCE TYPE] with the [synonym or fully qualified name][48] of the resource you want to prune.
+If you do not specify any resource types, `sensuctl prune` defaults to all types except events and entities.
+- Replace [FILE], [URL], or [STDIN] with the name of the file, URL, or STDIN where you want to apply the pruning.
+- Replace [flags] with the flags you want to use, if any.
+
+Use a comma separator to prune more than one resource in a single command.
+
+For example, to prune checks and assets from the file `checks.yaml` for the `dev` namespace and the `admin` and `ops` users:
+
+{{< highlight shell >}}
+sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
+{{< /highlight >}}
+
+### sensuctl prune flags
+
+Run `sensuctl prune -h` to view command-specific and global flags.
+
+The `sensuctl prune` flags have a few important characteristics:
+
+- `--all-users` defaults to false and overrides the `--users` flag.
+- `--dry-run` defaults to false.
+- `--users` defaults to the currently configured sensuctl user.
+
+### sensuctl prune resource types
+
+The table below lists supported `sensuctl prune` resource types.
+
+Synonym | Fully qualified name 
+--------------------|---
+None | `authentication/v2.Provider`
+None | `licensing/v2.LicenseFile`
+None | `store/v1.PostgresConfig`
+None | `federation/v1.EtcdReplicator`
+None | `secrets/v1.Provider`
+None | `secrets/v1.Secret`
+`apikey` | `core/v2.APIKey`
+`assets` | `core/v2.Asset`
+`checks` | `core/v2.CheckConfig`
+`clusterroles` | `core/v2.ClusterRole`
+`clusterrolebindings` | `core/v2.ClusterRoleBinding`
+`entities` | `core/v2.Entity`
+`filters` | `core/v2.EventFilter`
+`handlers` | `core/v2.Handler`
+`hooks` | `core/v2.Hook`
+`mutators` | `core/v2.Mutator`
+`namespaces` | `core/v2.Namespace`
+`roles` | `core/v2.Role`
+`rolebindings` | `core/v2.RoleBinding`
+`silenced` | `core/v2.Silenced`
+`tessen` | `core/v2.TessenConfig`
+`users` | `core/v2.User`
+
+### sensuctl prune examples
+
+`sensuctl prune` supports pruning resources by their synonyms or fully qualified names:
+
+{{< highlight shell >}}
+sensuctl prune checks,entities
+{{< /highlight >}}
+
+{{< highlight shell >}}
+sensuctl prune core/v2.CheckConfig,core/v2.Entity
+{{< /highlight >}}
+
+Use the `all` qualifier to prune all supported resources:
+
+{{< highlight shell >}}
+sensuctl prune all
+{{< /highlight >}}
+
 ## Response filtering
 
 **COMMERCIAL FEATURE**: Access sensuctl response filters in the packaged Sensu Go distribution.
@@ -1125,3 +1217,4 @@ Flags are optional and apply only to the `delete` command.
 [45]: ../../installation/install-sensu/#2-configure-and-start
 [46]: #first-time-setup
 [47]: ../../api/overview/#operators
+[48]: #sensuctl-prune-resource-types


### PR DESCRIPTION
## Description
Adds documentation for `sensuctl prune` command in the sensuctl reference doc.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2296

## Review Instructions
One question about the   `-u, --users` flag: In the command help, it says the default is admin. The issue says the default is the current configured sensuctl user. I'm not sure which is correct.
