### PR TITLE
Add PagerDuty scenario to Learn page and next steps in relevant guides

### DIFF
--- a/content/sensu-go/5.18/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.18/guides/install-check-executables-with-assets.md
@@ -141,6 +141,9 @@ Read these resources for more information about using assets in Sensu:
 - [Asset format specification][14]
 - [Share assets on Bonsai][15]
 
+You can also try our interactive tutorial to [send critical alerts to your PagerDuty account][8].
+
+
 [1]: ../../reference/assets/
 [2]: #create-an-asset
 [3]: https://bonsai.sensu.io
@@ -148,6 +151,7 @@ Read these resources for more information about using assets in Sensu:
 [5]: ../../reference/assets/#metadata-attributes
 [6]: ../../sensuctl/reference/#install-asset-definitions
 [7]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
+[8]: ../../learn/sensu-pagerduty/
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
 [11]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
 [12]: ../../getting-started/enterprise/

--- a/content/sensu-go/5.18/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.18/guides/send-slack-alerts.md
@@ -97,6 +97,9 @@ Whenever an event is being handled, a log entry is added with the message `"hand
 
 Now that you know how to apply a handler to a check and take action on events, read the [handlers reference][8] for in-depth handler documentation and check out the [Reduce alert fatigue][9] guide.
 
+You can also try our interactive tutorial and learn how to [send Sensu Go alerts to your PagerDuty account][11].
+
+
 [1]: ../../reference/events/
 [2]: ../monitor-server-resources/
 [3]: https://github.com/sensu/slack-handler
@@ -107,6 +110,7 @@ Now that you know how to apply a handler to a check and take action on events, r
 [8]: ../../reference/handlers/
 [9]: ../reduce-alert-fatigue/
 [10]: ../../sensuctl/reference/#install-asset-definitions
+[11]: ../../learn/sensu-pagerduty/
 [12]: https://slack.com/get-started#create
 [13]: ../../reference/assets
 [14]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler

--- a/content/sensu-go/5.18/learn/learn-sensu-go.md
+++ b/content/sensu-go/5.18/learn/learn-sensu-go.md
@@ -12,6 +12,7 @@ menu:
 
 - [Learn Sensu in 15 minutes](#learn-sensu-in-15-minutes)
 - [Up and running with Sensu Go](#up-and-running-with-sensu-go)
+- [Send Sensu Go alerts to PagerDuty](#send-sensu-go-alerts-to-pagerduty)
 
 Sensu is the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
 
@@ -37,5 +38,18 @@ When you complete this tutorial, your system will have both the Sensu backend an
 
 [Launch **Up and running with Sensu Go**][2].
 
+## Send Sensu Go alerts to PagerDuty
+
+When you complete this interactive tutorial, your Sensu Go backend will be configured with a handler that will send critical alerts to your PagerDuty account.
+In this scenario, you will:
+
+- Add a Sensu Nagios Foundation asset.
+- Add the PagerDuty asset and create a handler that uses your PagerDuty API key.
+- Send an alert for a Sensu Go event to PagerDuty.
+
+[Launch **Send Sensu Go alerts to PagerDuty**][3].
+
+
 [1]: ../learn-in-15/
 [2]: ../up-and-running/
+[3]: ../sensu-pagerduty

--- a/content/sensu-go/5.18/learn/sensu-pagerduty.md
+++ b/content/sensu-go/5.18/learn/sensu-pagerduty.md
@@ -1,0 +1,31 @@
+---
+title: "Interactive Tutorial: Send Sensu Go alerts to PagerDuty"
+linkTitle: "Send Sensu Go alerts to PagerDuty"
+description: "See Sensu Go's monitoring event pipeline in action, using PagerDuty to view Sensu alerts."
+version: "5.18"
+product: "Sensu Go"
+layout: "katacoda-wide"
+---
+<!-- begin tracking -->
+<script> !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments); },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js', a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script'); // Insert Twitter Pixel ID and Standard Event data below twq('init','o1043'); twq('track','PageView');
+</script> <script type="text/javascript"> _linkedin_partner_id = "409770"; window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || []; window._linkedin_data_partner_ids.push(_linkedin_partner_id); </script><script type="text/javascript">
+(function(){var s = document.getElementsByTagName("script")[0];
+var b = document.createElement("script");
+b.type = "text/javascript";b.async = true;
+b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+s.parentNode.insertBefore(b, s);})();
+</script>
+<!-- end tracking -->
+
+<script src="//katacoda.com/embed.js"></script>
+<div id="katacoda-scenario-1"
+    data-katacoda-id="sensu/sensu-pagerduty"
+    data-katacoda-color="2c3458"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
+    style="height: 800px; padding-top: 10px;" 
+></div>
+<br><br>
+[**<-- Back to Learn Sensu Go with interactive training**][1]
+
+[1]: ../learn-sensu-go/

--- a/content/sensu-go/5.19/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.19/guides/install-check-executables-with-assets.md
@@ -141,6 +141,9 @@ Read these resources for more information about using assets in Sensu:
 - [Asset format specification][14]
 - [Share assets on Bonsai][15]
 
+You can also try our interactive tutorial to [send critical alerts to your PagerDuty account][8].
+
+
 [1]: ../../reference/assets/
 [2]: #create-an-asset
 [3]: https://bonsai.sensu.io
@@ -148,6 +151,7 @@ Read these resources for more information about using assets in Sensu:
 [5]: ../../reference/assets/#metadata-attributes
 [6]: ../../sensuctl/reference/#install-asset-definitions
 [7]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
+[8]: ../../learn/sensu-pagerduty/
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
 [11]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
 [12]: ../../getting-started/enterprise/

--- a/content/sensu-go/5.19/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.19/guides/send-slack-alerts.md
@@ -97,6 +97,9 @@ Whenever an event is being handled, a log entry is added with the message `"hand
 
 Now that you know how to apply a handler to a check and take action on events, read the [handlers reference][8] for in-depth handler documentation and check out the [Reduce alert fatigue][9] guide.
 
+You can also try our interactive tutorial and learn how to [send Sensu Go alerts to your PagerDuty account][11].
+
+
 [1]: ../../reference/events/
 [2]: ../monitor-server-resources/
 [3]: https://github.com/sensu/slack-handler
@@ -107,6 +110,7 @@ Now that you know how to apply a handler to a check and take action on events, r
 [8]: ../../reference/handlers/
 [9]: ../reduce-alert-fatigue/
 [10]: ../../sensuctl/reference/#install-asset-definitions
+[11]: ../../learn/sensu-pagerduty/
 [12]: https://slack.com/get-started#create
 [13]: ../../reference/assets
 [14]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler

--- a/content/sensu-go/5.19/learn/learn-sensu-go.md
+++ b/content/sensu-go/5.19/learn/learn-sensu-go.md
@@ -12,6 +12,7 @@ menu:
 
 - [Learn Sensu in 15 minutes](#learn-sensu-in-15-minutes)
 - [Up and running with Sensu Go](#up-and-running-with-sensu-go)
+- [Send Sensu Go alerts to PagerDuty](#send-sensu-go-alerts-to-pagerduty)
 
 Sensu is the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
 
@@ -37,5 +38,18 @@ When you complete this tutorial, your system will have both the Sensu backend an
 
 [Launch **Up and running with Sensu Go**][2].
 
+## Send Sensu Go alerts to PagerDuty
+
+When you complete this interactive tutorial, your Sensu Go backend will be configured with a handler that will send critical alerts to your PagerDuty account.
+In this scenario, you will:
+
+- Add a Sensu Nagios Foundation asset.
+- Add the PagerDuty asset and create a handler that uses your PagerDuty API key.
+- Send an alert for a Sensu Go event to PagerDuty.
+
+[Launch **Send Sensu Go alerts to PagerDuty**][3].
+
+
 [1]: ../learn-in-15/
 [2]: ../up-and-running/
+[3]: ../sensu-pagerduty

--- a/content/sensu-go/5.19/learn/sensu-pagerduty.md
+++ b/content/sensu-go/5.19/learn/sensu-pagerduty.md
@@ -1,0 +1,31 @@
+---
+title: "Interactive Tutorial: Send Sensu Go alerts to PagerDuty"
+linkTitle: "Send Sensu Go alerts to PagerDuty"
+description: "See Sensu Go's monitoring event pipeline in action, using PagerDuty to view Sensu alerts."
+version: "5.19"
+product: "Sensu Go"
+layout: "katacoda-wide"
+---
+<!-- begin tracking -->
+<script> !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments); },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js', a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script'); // Insert Twitter Pixel ID and Standard Event data below twq('init','o1043'); twq('track','PageView');
+</script> <script type="text/javascript"> _linkedin_partner_id = "409770"; window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || []; window._linkedin_data_partner_ids.push(_linkedin_partner_id); </script><script type="text/javascript">
+(function(){var s = document.getElementsByTagName("script")[0];
+var b = document.createElement("script");
+b.type = "text/javascript";b.async = true;
+b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+s.parentNode.insertBefore(b, s);})();
+</script>
+<!-- end tracking -->
+
+<script src="//katacoda.com/embed.js"></script>
+<div id="katacoda-scenario-1"
+    data-katacoda-id="sensu/sensu-pagerduty"
+    data-katacoda-color="2c3458"
+    data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/"
+    data-katacoda-ctatext="Learn more in the Sensu Sandbox"
+    style="height: 800px; padding-top: 10px;" 
+></div>
+<br><br>
+[**<-- Back to Learn Sensu Go with interactive training**][1]
+
+[1]: ../learn-sensu-go/


### PR DESCRIPTION
## Description
Adds links to our new PagerDuty scenario to the following pages in 5.18 and 5.19 docs:
- /guides/install-check-executables-with-assets/
- /guides/send-slack-alerts/
- /learn/learn-sensu-go/

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2299
