### PR TITLE
Add note to confirm all backends are configured and running before sensu-backend init

### DIFF
--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -163,6 +163,10 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
+{{% notice important %}}
+**IMPORTANT**: If you plan to [run a Sensu cluster](../../guides/clustering/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% /notice %}}
+
 ### 3. Initialize
 
 {{% notice note %}}

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -60,6 +60,10 @@ Although initialization is required for every new installation, the implementati
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
+{{% notice important %}}
+**IMPORTANT**: If you plan to [run a Sensu cluster](../../guides/clustering/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% /notice %}}
+
 ### Docker initialization
 
 For Docker installations, set administrator credentials with environment variables when you [configure and start][24] the backend as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:

--- a/content/sensu-go/5.19/installation/install-sensu.md
+++ b/content/sensu-go/5.19/installation/install-sensu.md
@@ -163,6 +163,10 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
+{{% notice important %}}
+**IMPORTANT**: If you plan to [run a Sensu cluster](../../guides/clustering/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% /notice %}}
+
 ### 3. Initialize
 
 {{% notice note %}}

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -60,6 +60,10 @@ Although initialization is required for every new installation, the implementati
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
+{{% notice important %}}
+**IMPORTANT**: If you plan to [run a Sensu cluster](../../guides/clustering/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% /notice %}}
+
 ### Docker initialization
 
 For Docker installations, set administrator credentials with environment variables when you [configure and start][24] the backend as shown below, replacing `YOUR_USERNAME` and `YOUR_PASSWORD` with the username and password you want to use:


### PR DESCRIPTION
## Description
Adds IMPORTANT note for users who plan to run a cluster that they should make sure all their backend nodes are configured and running before the initialize with `sensu-backend init`:
- https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#2-configure-and-start
- https://docs.sensu.io/sensu-go/latest/reference/backend/#initialization

I don't think we can ask them to confirm with `sensuctl cluster health` because at the initialize step, they haven't installed sensuctl yet.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2314