### PR TITLE
Correct sensu-backend start command in clustering guide

### DIFF
--- a/content/sensu-go/5.16/guides/clustering.md
+++ b/content/sensu-go/5.16/guides/clustering.md
@@ -283,7 +283,7 @@ sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./client.pem \
 --etcd-key-file=./client-key.pem \
---etcd-advertise-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /highlight >}}
 

--- a/content/sensu-go/5.17/guides/clustering.md
+++ b/content/sensu-go/5.17/guides/clustering.md
@@ -283,7 +283,7 @@ sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./client.pem \
 --etcd-key-file=./client-key.pem \
---etcd-advertise-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /highlight >}}
 

--- a/content/sensu-go/5.18/guides/clustering.md
+++ b/content/sensu-go/5.18/guides/clustering.md
@@ -297,7 +297,7 @@ sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./client.pem \
 --etcd-key-file=./client-key.pem \
---etcd-advertise-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /highlight >}}
 

--- a/content/sensu-go/5.19/guides/clustering.md
+++ b/content/sensu-go/5.19/guides/clustering.md
@@ -297,7 +297,7 @@ sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./client.pem \
 --etcd-key-file=./client-key.pem \
---etcd-advertise-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /highlight >}}
 


### PR DESCRIPTION
## Description
Remove `advertising-` from client URLs flag in last line of sensu-backend start command in "Use an external etcd cluster" section of clustering guide

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2324