### PR TITLE
Remove stray space in OIDC json example

### DIFF
--- a/content/sensu-go/5.16/installation/auth.md
+++ b/content/sensu-go/5.16/installation/auth.md
@@ -1140,7 +1140,7 @@ spec:
       ],
       "client_id": "a8e43af034e7f2608780",
       "client_secret": "b63968394be6ed2edb61c93847ee792f31bf6216",
-      " redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
+      "redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
       "server": "https://oidc.example.com:9031",
       "groups_claim": "groups",
       "groups_prefix": "oidc:",

--- a/content/sensu-go/5.17/installation/auth.md
+++ b/content/sensu-go/5.17/installation/auth.md
@@ -1140,7 +1140,7 @@ spec:
       ],
       "client_id": "a8e43af034e7f2608780",
       "client_secret": "b63968394be6ed2edb61c93847ee792f31bf6216",
-      " redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
+      "redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
       "server": "https://oidc.example.com:9031",
       "groups_claim": "groups",
       "groups_prefix": "oidc:",

--- a/content/sensu-go/5.18/installation/auth.md
+++ b/content/sensu-go/5.18/installation/auth.md
@@ -1150,7 +1150,7 @@ spec:
       ],
       "client_id": "a8e43af034e7f2608780",
       "client_secret": "b63968394be6ed2edb61c93847ee792f31bf6216",
-      " redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
+      "redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
       "server": "https://oidc.example.com:9031",
       "groups_claim": "groups",
       "groups_prefix": "oidc:",

--- a/content/sensu-go/5.19/installation/auth.md
+++ b/content/sensu-go/5.19/installation/auth.md
@@ -1150,7 +1150,7 @@ spec:
       ],
       "client_id": "a8e43af034e7f2608780",
       "client_secret": "b63968394be6ed2edb61c93847ee792f31bf6216",
-      " redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
+      "redirect_uri": "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback",
       "server": "https://oidc.example.com:9031",
       "groups_claim": "groups",
       "groups_prefix": "oidc:",


### PR DESCRIPTION
## Description
Removed stray space in `redirect_uri` line in OIDC example JSON

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2325