### PR TITLE
Add timeout query param to health and cluster API description tables

### DIFF
--- a/content/sensu-go/5.19/api/cluster.md
+++ b/content/sensu-go/5.19/api/cluster.md
@@ -57,12 +57,13 @@ HTTP/1.1 200 OK
 #### API Specification {#clustermembers-get-specification}
 
 /cluster/members (GET)  | 
----------------|------
-description    | Returns the etcd cluster definition.
-example url    | http://hostname:8080/api/core/v2/cluster/members
-response type  | Map
-response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-example output | {{< highlight shell >}}
+------------------------|------
+description             | Returns the etcd cluster definition.
+example url             | http://hostname:8080/api/core/v2/cluster/members
+query parameters        | `timeout`: Defines the timeout when querying etcd. Default is `0`.
+response type           | Map
+response codes          | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+example output          | {{< highlight shell >}}
 {
   "header": {
     "cluster_id": 4255616304056076734,
@@ -217,13 +218,14 @@ HTTP/1.1 200 OK
 
 #### API Specification {#clusterid-get-specification}
 
-/cluster/id (GET) |  |
----------------|------
-description    | Returns the unique Sensu cluster ID.
-example url    | http://hostname:8080/api/core/v2/cluster/id
-response type  | String
-response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-example output | {{< highlight shell >}}
+/cluster/id (GET) | |
+------------------|------
+description       | Returns the unique Sensu cluster ID.
+example url       | http://hostname:8080/api/core/v2/cluster/id
+query parameters  | `timeout`: Defines the timeout when querying etcd. Default is `0`.
+response type     | String
+response codes    | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+example output    | {{< highlight shell >}}
 "23481e76-5844-4d07-b714-6e2ffbbf9315"
 {{< /highlight >}}
 

--- a/content/sensu-go/5.19/api/health.md
+++ b/content/sensu-go/5.19/api/health.md
@@ -51,13 +51,14 @@ HTTP/1.1 200 OK
 
 #### API Specification {#health-get-specification}
 
-/health (GET)  | 
----------------|------
-description    | Returns health information about the Sensu instance.
-example url    | http://hostname:8080/health
-response type  | Map
-response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-output         | {{< highlight shell >}}
+/health (GET)    | 
+-----------------|------
+description      | Returns health information about the Sensu instance.
+example url      | http://hostname:8080/health
+query parameters | `timeout`: Defines the timeout when querying etcd. Default is `0`.
+response type    | Map
+response codes   | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output           | {{< highlight shell >}}
 {
   "Alarms": null,
   "ClusterHealth": [


### PR DESCRIPTION
## Description
Adds `timeout` query parameter description in API description tables for the following endpoints:
- https://docs.sensu.io/sensu-go/latest/api/health/#health-get-specification
- https://docs.sensu.io/sensu-go/latest/api/cluster/#clustermembers-get
- https://docs.sensu.io/sensu-go/latest/api/cluster/#clusterid-get

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2323

## Review Instructions
I'm thinking of adding something like "The default is `0`, but we recommend using this query parameter to set `?timeout=3` to match the sensuctl default." or even just acknowledging the bug. Wdyt? It looks like your PR is merged into 5.19, but I don't think the issue is closed.