### PR TITLE
Add PowerShell example with -f flag to check reference

### DIFF
--- a/content/sensu-go/5.19/reference/checks.md
+++ b/content/sensu-go/5.19/reference/checks.md
@@ -1008,6 +1008,7 @@ spec:
 ### PowerShell script in check commands
 
 If you use a PowerShell script in your check command, make sure to include the `-f` flag in the command.
+The `-f` flag ensures that the proper exit code is passed into Sensu.
 For example:
 
 {{< language-toggle >}}

--- a/content/sensu-go/5.19/reference/checks.md
+++ b/content/sensu-go/5.19/reference/checks.md
@@ -1005,6 +1005,50 @@ spec:
 
 {{< /language-toggle >}}
 
+### PowerShell script in check commands
+
+If you use a PowerShell script in your check command, make sure to include the `-f` flag in the command.
+For example:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: interval_test
+  namespace: default
+spec:
+  command: powershell.exe -f c:\\users\\tester\\test.ps1
+  subscriptions:
+  - system
+  handlers:
+  - slack
+  interval: 60
+  publish: true
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "interval_test",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "powershell.exe -f c:\\users\\tester\\test.ps1",
+    "subscriptions": ["system"],
+    "handlers": ["slack"],
+    "interval": 60,
+    "publish": true
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+
 [1]: #subscription-checks
 [2]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [3]: https://en.wikipedia.org/wiki/Standard_streams


### PR DESCRIPTION
## Description
Adds a check example with PowerShell in command to check reference.

**Question**: Does the PowerShell workaround work with YAML? I included a yaml example, but the original issue only included JSON so I thought I should check.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2330