### PR TITLE
Add realistic values for executed field in events API doc

### DIFF
--- a/content/sensu-go/5.16/api/events.md
+++ b/content/sensu-go/5.16/api/events.md
@@ -459,19 +459,19 @@ HTTP/1.1 200 OK
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,
@@ -541,19 +541,19 @@ output               | {{< highlight json >}}
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,

--- a/content/sensu-go/5.16/reference/events.md
+++ b/content/sensu-go/5.16/reference/events.md
@@ -513,7 +513,7 @@ example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.
 required     | false
 type         | Integer
 example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}

--- a/content/sensu-go/5.17/api/events.md
+++ b/content/sensu-go/5.17/api/events.md
@@ -459,19 +459,19 @@ HTTP/1.1 200 OK
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,
@@ -541,19 +541,19 @@ output               | {{< highlight json >}}
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,

--- a/content/sensu-go/5.17/reference/events.md
+++ b/content/sensu-go/5.17/reference/events.md
@@ -513,7 +513,7 @@ example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.
 required     | false
 type         | Integer
 example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}

--- a/content/sensu-go/5.18/api/events.md
+++ b/content/sensu-go/5.18/api/events.md
@@ -465,19 +465,19 @@ HTTP/1.1 200 OK
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,
@@ -548,19 +548,19 @@ output               | {{< highlight json >}}
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,

--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -525,7 +525,7 @@ example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.
 required     | false
 type         | Integer
 example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}

--- a/content/sensu-go/5.19/api/events.md
+++ b/content/sensu-go/5.19/api/events.md
@@ -476,19 +476,19 @@ HTTP/1.1 200 OK
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,
@@ -561,19 +561,19 @@ output               | {{< highlight json >}}
         "ttl": 0,
         "timeout": 0,
         "round_robin": false,
-        "executed": 0,
+        "executed": 1543880280,
         "history": [
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543880296
             },
             {
                 "status": 2,
-                "executed": 0
+                "executed": 1543880435
             },
             {
                 "status": 1,
-                "executed": 0
+                "executed": 1543889363
             }
         ],
         "issued": 0,

--- a/content/sensu-go/5.19/reference/events.md
+++ b/content/sensu-go/5.19/reference/events.md
@@ -533,7 +533,7 @@ example      | {{< highlight shell >}}"duration": 1.903135228{{< /highlight >}}
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.
 required     | false
 type         | Integer
 example      | {{< highlight shell >}}"executed": 1522100915{{< /highlight >}}


### PR DESCRIPTION
## Description
- Adds realistic values for `executed` field in event definition and event history in API doc
- Adds unit for `executed` field in event definition in reference doc

Updates are included for 5.16 through 5.19 docs.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2332
