### PR TITLE
Fix typo in troubleshooting front matter description

### DIFF
--- a/content/sensu-go/5.16/guides/troubleshooting.md
+++ b/content/sensu-go/5.16/guides/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshoot"
 linkTitle: "Troubleshoot"
-description: "Here’s how to troublshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
+description: "Here’s how to troubleshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
 weight: 210
 version: "5.16"
 product: "Sensu Go"

--- a/content/sensu-go/5.17/guides/troubleshooting.md
+++ b/content/sensu-go/5.17/guides/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshoot"
 linkTitle: "Troubleshoot"
-description: "Here’s how to troublshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
+description: "Here’s how to troubleshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
 weight: 210
 version: "5.17"
 product: "Sensu Go"

--- a/content/sensu-go/5.18/guides/troubleshooting.md
+++ b/content/sensu-go/5.18/guides/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshoot"
 linkTitle: "Troubleshoot"
-description: "Here’s how to troublshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
+description: "Here’s how to troubleshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
 weight: 210
 version: "5.18"
 product: "Sensu Go"

--- a/content/sensu-go/5.19/guides/troubleshooting.md
+++ b/content/sensu-go/5.19/guides/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshoot"
 linkTitle: "Troubleshoot"
-description: "Here’s how to troublshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
+description: "Here’s how to troubleshoot Sensu, including how to look into errors, service logging, log levels. Sensu service logs produced by sensu-backend and sensu-agent are often the best source of truth when troubleshooting issues, so start there."
 weight: 210
 version: "5.19"
 product: "Sensu Go"


### PR DESCRIPTION
## Description
Typo in Troubleshooting guide front matter description: `troublshoot` ---> `troubleshoot`

## Motivation and Context
Fix typo