### PR TITLE
Correct Docker Compose volume in backend installation instructions

### DIFF
--- a/content/sensu-go/5.16/installation/install-sensu.md
+++ b/content/sensu-go/5.16/installation/install-sensu.md
@@ -108,7 +108,7 @@ services:
     - 8080:8080
     - 8081:8081
     volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
+    - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
 
 volumes:

--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -117,7 +117,7 @@ services:
     - 8080:8080
     - 8081:8081
     volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
+    - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME

--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -125,7 +125,7 @@ services:
     - 8080:8080
     - 8081:8081
     volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
+    - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME

--- a/content/sensu-go/5.19/installation/install-sensu.md
+++ b/content/sensu-go/5.19/installation/install-sensu.md
@@ -125,7 +125,7 @@ services:
     - 8080:8080
     - 8081:8081
     volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
+    - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#2-configure-and-start, in the Docker Compose code example,

...replace:
```
volumes:
    - "sensu-backend-data:/var/lib/sensu/etcd"
```

…with:
```
volumes:
  - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
```

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2351