### PR TITLE
Fix order of Docker and Docker Compose code elements for backend installation

### DIFF
--- a/content/sensu-go/5.17/installation/install-sensu.md
+++ b/content/sensu-go/5.17/installation/install-sensu.md
@@ -98,9 +98,10 @@ For details about intialization in Docker, see the [backend reference][38]._
 # you want to use for your admin user credentials.
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
--p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
 -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu/sensu:latest \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
@@ -111,7 +112,6 @@ sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080
@@ -122,6 +122,7 @@ services:
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+    image: sensu/sensu:latest
 
 volumes:
   sensu-backend-data:

--- a/content/sensu-go/5.17/reference/backend.md
+++ b/content/sensu-go/5.17/reference/backend.md
@@ -69,9 +69,10 @@ For Docker installations, set administrator credentials with environment variabl
 {{< highlight Docker >}}
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
--p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
 -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu/sensu:latest \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
@@ -80,17 +81,17 @@ sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080
     - 8081:8081
     volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
+    - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+    image: sensu/sensu:latest
 
 volumes:
   sensu-backend-data:

--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -106,9 +106,10 @@ For details about intialization in Docker, see the [backend reference](../../ref
 # you want to use for your admin user credentials.
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
--p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
 -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu/sensu:latest \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
@@ -119,7 +120,6 @@ sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080
@@ -130,6 +130,7 @@ services:
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+    image: sensu/sensu:latest
 
 volumes:
   sensu-backend-data:

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -73,9 +73,10 @@ For Docker installations, set administrator credentials with environment variabl
 {{< highlight Docker >}}
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
--p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
 -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu/sensu:latest \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
@@ -84,17 +85,17 @@ sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080
     - 8081:8081
     volumes:
-    - "sensu-backend-data:/var/lib/sensu/etcd"
+    - "sensu-backend-data:/var/lib/sensu/sensu-backend/etcd"
     command: "sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug"
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+    image: sensu/sensu:latest
 
 volumes:
   sensu-backend-data:

--- a/content/sensu-go/5.19/installation/install-sensu.md
+++ b/content/sensu-go/5.19/installation/install-sensu.md
@@ -106,9 +106,10 @@ For details about intialization in Docker, see the [backend reference](../../ref
 # you want to use for your admin user credentials.
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
--p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
 -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu/sensu:latest \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
@@ -119,7 +120,6 @@ sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080
@@ -130,6 +130,7 @@ services:
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+    image: sensu/sensu:latest
 
 volumes:
   sensu-backend-data:

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -73,9 +73,10 @@ For Docker installations, set administrator credentials with environment variabl
 {{< highlight Docker >}}
 docker run -v /var/lib/sensu:/var/lib/sensu \
 -d --name sensu-backend \
--p 3000:3000 -p 8080:8080 -p 8081:8081 sensu/sensu:latest \
+-p 3000:3000 -p 8080:8080 -p 8081:8081 \
 -e SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME \
 -e SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD \
+sensu/sensu:latest \
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 {{< /highlight >}}
 
@@ -84,7 +85,6 @@ sensu-backend start --state-dir /var/lib/sensu/sensu-backend --log-level debug
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080
@@ -95,6 +95,7 @@ services:
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=YOUR_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=YOUR_PASSWORD
+    image: sensu/sensu: latest
 
 volumes:
   sensu-backend-data:


### PR DESCRIPTION
## Description
Moves `sensu/sensu:latest` to the end of the Docker code example and `image: sensu/sensu:latest` to the end of the Docker Compose code example in in two docs:
- https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#2-configure-and-start
- https://docs.sensu.io/sensu-go/latest/reference/backend/#docker-initialization

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2358