### PR TITLE
Update timeout query parameter default to 3 in 5.20 cluster and health API docs

### DIFF
--- a/content/sensu-go/5.20/api/cluster.md
+++ b/content/sensu-go/5.20/api/cluster.md
@@ -60,7 +60,7 @@ HTTP/1.1 200 OK
 ------------------------|------
 description             | Returns the etcd cluster definition.
 example url             | http://hostname:8080/api/core/v2/cluster/members
-query parameters        | `timeout`: Defines the timeout when querying etcd. Default is `0`.
+query parameters        | `timeout`: Defines the timeout when querying etcd. Default is `3`.
 response type           | Map
 response codes          | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 example output          | {{< highlight shell >}}
@@ -222,7 +222,7 @@ HTTP/1.1 200 OK
 ------------------|------
 description       | Returns the unique Sensu cluster ID.
 example url       | http://hostname:8080/api/core/v2/cluster/id
-query parameters  | `timeout`: Defines the timeout when querying etcd. Default is `0`.
+query parameters  | `timeout`: Defines the timeout when querying etcd. Default is `3`.
 response type     | String
 response codes    | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 example output    | {{< highlight shell >}}

--- a/content/sensu-go/5.20/api/health.md
+++ b/content/sensu-go/5.20/api/health.md
@@ -55,7 +55,7 @@ HTTP/1.1 200 OK
 -----------------|------
 description      | Returns health information about the Sensu instance.
 example url      | http://hostname:8080/health
-query parameters | `timeout`: Defines the timeout when querying etcd. Default is `0`.
+query parameters | `timeout`: Defines the timeout when querying etcd. Default is `3`.
 response type    | Map
 response codes   | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output           | {{< highlight shell >}}


### PR DESCRIPTION
## Description
Updates `timeout` query parameter default to 3 in cluster and health API docs for 5.20.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2370