### PR TITLE
Promote Sensu Enterprise 3.8 docs to latest

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -162,7 +162,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     description = "The powerful and simple monitoring product, built on Sensu Core"
     notice = "End of life: March 31, 2020"
     weight = 3
-    latest = "3.7"
+    latest = "3.8"
 
     [[params.products.sensu_enterprise.versions]]
     version = "3.8"

--- a/static.json
+++ b/static.json
@@ -15,7 +15,7 @@
             "url": "/uchiwa/latest/$1",
             "status": 302
         },
-        "~ ^/sensu-enterprise/3.7/?((?<=\/).*)?$": {
+        "~ ^/sensu-enterprise/3.8/?((?<=\/).*)?$": {
             "url": "/sensu-enterprise/latest/$1",
             "status": 302
         },


### PR DESCRIPTION
## Description
Promotes 3.8 to latest for Sensu Enterprise documentation.

## Motivation and Context
Support Sensu Enterprise 3.8.0 release.
