### PR TITLE
Fix typo in check token substitution section

### DIFF
--- a/content/sensu-go/5.16/reference/checks.md
+++ b/content/sensu-go/5.16/reference/checks.md
@@ -451,7 +451,7 @@ If you add the `splay` attribute (set to `true`) and the `splay_coverage` attrib
 
 Sensu check definitions may include attributes that you  wish to override on an entity-by-entity basis.
 For example, [check commands][4], which may include command line arguments for controlling the behavior of the check command, may benefit from entity-specific thresholds.
-Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attributes values (including custom attributes).
+Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attribute values (including custom attributes).
 
 Learn how to use check tokens with the [Sensu tokens reference documentation][5].
 

--- a/content/sensu-go/5.17/reference/checks.md
+++ b/content/sensu-go/5.17/reference/checks.md
@@ -451,7 +451,7 @@ If you add the `splay` attribute (set to `true`) and the `splay_coverage` attrib
 
 Sensu check definitions may include attributes that you  wish to override on an entity-by-entity basis.
 For example, [check commands][4], which may include command line arguments for controlling the behavior of the check command, may benefit from entity-specific thresholds.
-Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attributes values (including custom attributes).
+Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attribute values (including custom attributes).
 
 Learn how to use check tokens with the [Sensu tokens reference documentation][5].
 

--- a/content/sensu-go/5.18/reference/checks.md
+++ b/content/sensu-go/5.18/reference/checks.md
@@ -463,7 +463,7 @@ If you add the `splay` attribute (set to `true`) and the `splay_coverage` attrib
 
 Sensu check definitions may include attributes that you  wish to override on an entity-by-entity basis.
 For example, [check commands][4], which may include command line arguments for controlling the behavior of the check command, may benefit from entity-specific thresholds.
-Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attributes values (including custom attributes).
+Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attribute values (including custom attributes).
 
 Learn how to use check tokens with the [Sensu tokens reference documentation][5].
 

--- a/content/sensu-go/5.19/reference/checks.md
+++ b/content/sensu-go/5.19/reference/checks.md
@@ -463,7 +463,7 @@ If you add the `splay` attribute (set to `true`) and the `splay_coverage` attrib
 
 Sensu check definitions may include attributes that you  wish to override on an entity-by-entity basis.
 For example, [check commands][4], which may include command line arguments for controlling the behavior of the check command, may benefit from entity-specific thresholds.
-Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attributes values (including custom attributes).
+Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attribute values (including custom attributes).
 
 Learn how to use check tokens with the [Sensu tokens reference documentation][5].
 

--- a/content/sensu-go/5.20/reference/checks.md
+++ b/content/sensu-go/5.20/reference/checks.md
@@ -463,7 +463,7 @@ If you add the `splay` attribute (set to `true`) and the `splay_coverage` attrib
 
 Sensu check definitions may include attributes that you  wish to override on an entity-by-entity basis.
 For example, [check commands][4], which may include command line arguments for controlling the behavior of the check command, may benefit from entity-specific thresholds.
-Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attributes values (including custom attributes).
+Sensu check tokens are check definition placeholders that the Sensu agent will replace with the corresponding entity definition attribute values (including custom attributes).
 
 Learn how to use check tokens with the [Sensu tokens reference documentation][5].
 


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/reference/checks/#check-token-substitution, change
`...corresponding entity definition attributes values...`
to
`...corresponding entity definition attribute values...`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2385