### PR TITLE
Add max_conn_lifetime and max_idle_conns params to datastore API and reference docs

### DIFF
--- a/content/sensu-go/5.19/reference/datastore.md
+++ b/content/sensu-go/5.19/reference/datastore.md
@@ -180,9 +180,26 @@ default      | `0` (unlimited)
 type         | Integer
 example      | {{< highlight shell >}}pool_size: 20{{< /highlight >}}
 
+max_conn_lifetime    |      |
+-------------|------
+description  | Available in [Sensu Go 5.19.2][4]. Maximum time a connection can persist before being destroyed. Specify values with a numeral and a letter indicator: `s` to indicate seconds, `m` to indicate minutes, and `h` to indicate hours. For example, `1m`, `2h`, and `2h1m3s` are valid. 
+required     | false
+type         | String
+example      | {{< highlight shell >}}max_conn_lifetime: 5m{{< /highlight >}}
+
+max_idle_conns    |      |
+-------------|------
+description  | Available in [Sensu Go 5.19.2][4]. Maximum number of number of idle connections to retain. 
+required     | false
+default      | `2`
+type         | Integer
+example      | {{< highlight shell >}}max_idle_conns: 2{{< /highlight >}}
+
+
 [1]: ../../sensuctl/reference/#first-time-setup
 [2]: ../../guides/troubleshooting/
 [3]: https://aws.amazon.com/rds/
+[4]: ../../release-notes/#5-19-2-release-notes
 [8]: ../../guides/clustering/#use-an-external-etcd-cluster
 [9]: ../../dashboard/overview/
 [10]: ../../sensuctl/reference/#sensuctl-event

--- a/content/sensu-go/5.20/api/datastore.md
+++ b/content/sensu-go/5.20/api/datastore.md
@@ -41,6 +41,8 @@ HTTP/1.1 200 OK
     },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/otherdbname",
+      "max_conn_lifetime": "5m",
+      "max_idle_conns": 2,
       "pool_size": 20
     }
   },
@@ -53,6 +55,8 @@ HTTP/1.1 200 OK
     },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/dbname",
+      "max_conn_lifetime": "5m",
+      "max_idle_conns": 2,
       "pool_size": 20
     }
   }
@@ -78,6 +82,8 @@ output         | {{< highlight json >}}
     },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/otherdbname",
+      "max_conn_lifetime": "5m",
+      "max_idle_conns": 2,
       "pool_size": 20
     }
   },
@@ -90,6 +96,8 @@ output         | {{< highlight json >}}
     },
     "spec": {
       "dsn": "postgresql://user:secret@host:port/dbname",
+      "max_conn_lifetime": "5m",
+      "max_idle_conns": 2,
       "pool_size": 20
     }
   }
@@ -117,6 +125,8 @@ HTTP/1.1 200 OK
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",
+    "max_conn_lifetime": "5m",
+    "max_idle_conns": 2,
     "pool_size": 20
   }
 }
@@ -140,6 +150,8 @@ output         | {{< highlight json >}}
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",
+    "max_conn_lifetime": "5m",
+    "max_idle_conns": 2,
     "pool_size": 20
   }
 }
@@ -161,6 +173,8 @@ http://127.0.0.1:8080/api/enterprise/store/v1/provider/my-postgres \
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",
+    "max_conn_lifetime": "5m",
+    "max_idle_conns": 2,
     "pool_size": 20
   }
 }'
@@ -185,6 +199,8 @@ payload         | {{< highlight shell >}}
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",
+    "max_conn_lifetime": "5m",
+    "max_idle_conns": 2,
     "pool_size": 20
   }
 }

--- a/content/sensu-go/5.20/reference/datastore.md
+++ b/content/sensu-go/5.20/reference/datastore.md
@@ -62,6 +62,8 @@ metadata:
   name: my-postgres
 spec:
   dsn: "postgresql://user:secret@host:port/dbname"
+  max_conn_lifetime: 5m
+  max_idle_conns: 2
   pool_size: 20
 {{< /highlight >}}
 
@@ -74,6 +76,8 @@ spec:
   },
   "spec": {
     "dsn": "postgresql://user:secret@host:port/dbname",
+    "max_conn_lifetime": "5m",
+    "max_idle_conns": 2,
     "pool_size": 20
   }
 }
@@ -144,6 +148,8 @@ type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 spec:
   dsn: "postgresql://user:secret@host:port/dbname"
+  max_conn_lifetime: 5m
+  max_idle_conns: 2
   pool_size: 20
 {{< /highlight >}}
 
@@ -171,6 +177,21 @@ description  | Data source names. Specified as a URL or PostgreSQL connection st
 required     | true
 type         | String
 example      | {{< highlight shell >}}dsn: "postgresql://user:secret@host:port/dbname"{{< /highlight >}}
+
+max_conn_lifetime    |      |
+-------------|------
+description  | Maximum time a connection can persist before being destroyed. Specify values with a numeral and a letter indicator: `s` to indicate seconds, `m` to indicate minutes, and `h` to indicate hours. For example, `1m`, `2h`, and `2h1m3s` are valid. 
+required     | false
+type         | String
+example      | {{< highlight shell >}}max_conn_lifetime: 5m{{< /highlight >}}
+
+max_idle_conns    |      |
+-------------|------
+description  | Maximum number of number of idle connections to retain. 
+required     | false
+default      | `2`
+type         | Integer
+example      | {{< highlight shell >}}max_idle_conns: 2{{< /highlight >}}
 
 pool_size    |      |
 -------------|------


### PR DESCRIPTION
## Description
- Adds max_conn_lifetime and max_idle_conns params to 5.19 and 5.20 datastore reference doc
- Adds max_conn_lifetime and max_idle_conns params to 5.20 datastore API doc

I did not add these new params to the 5.19 datastore API doc because they would not appear in the responses unless the user upgraded to 5.19.2.

## Motivation and Context
Support 5.19.2 patch release.
Details pulled from https://github.com/sensu/sensu-enterprise-go/pull/989
