### PR TITLE
Add global rate limit flags for assets

### DIFF
--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -740,8 +740,8 @@ Flags:
       --annotations stringToString            entity annotations map (default [])
       --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
-      --assets-burst-limit int                asset fetch burst limit (default 100) -- Sensu Go 5.19.3
-      --assets-rate-limit float               maximum number of assets fetched per second -- Sensu Go 5.19.3
+      --assets-burst-limit int                asset fetch burst limit (default 100)
+      --assets-rate-limit float               maximum number of assets fetched per second
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -811,7 +811,7 @@ annotations:
 
 | assets-burst-limit   |      |
 --------------|------
-description   | Maximum amount of burst allowed in a rate interval when fetching assets. Added in [Sensu Go 5.19.3][55].
+description   | Available in [Sensu Go 5.19.3][28]. Maximum amount of burst allowed in a rate interval when fetching assets.
 type          | Integer
 default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
@@ -824,7 +824,7 @@ assets-burst-limit: 100{{< /highlight >}}
 
 | assets-rate-limit   |      |
 --------------|------
-description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour. Added in [Sensu Go 5.19.3][55].
+description   | Available in [Sensu Go 5.19.3][28]. Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour.
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -740,6 +740,8 @@ Flags:
       --annotations stringToString            entity annotations map (default [])
       --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
+      --assets-burst-limit int                asset fetch burst limit (default 100) -- Sensu Go 5.19.3
+      --assets-rate-limit float               maximum number of assets fetched per second -- Sensu Go 5.19.3
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -805,6 +807,32 @@ sensu-agent start --annotations example-key="example value" --annotations exampl
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /highlight >}}
+
+
+| assets-burst-limit   |      |
+--------------|------
+description   | Maximum amount of burst allowed in a rate interval when fetching assets. Added in [Sensu Go 5.19.3][55].
+type          | Integer
+default       | `100`
+environment variable | `SENSU_ASSETS_BURST_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-agent start --assets-burst-limit 100
+
+# /etc/sensu/agent.yml example
+assets-burst-limit: 100{{< /highlight >}}
+
+
+| assets-rate-limit   |      |
+--------------|------
+description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour. Added in [Sensu Go 5.19.3][55].
+type          | Float
+default       | `1.39`
+environment variable | `SENSU_ASSETS_RATE_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-agent start --assets-rate-limit 1.39
+
+# /etc/sensu/agent.yml example
+assets-rate-limit: 1.39{{< /highlight >}}
 
 
 | backend-url |      |
@@ -1539,3 +1567,4 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [52]: ../handlers/#keepalive-event-handlers
 [53]: #keepalive-handlers-flag
 [54]: ../../dashboard/filtering#filter-with-label-selectors
+[55]: ../../release-notes/#5-19-3-release-notes

--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -60,6 +60,8 @@ If the downloaded artifact's SHA512 checksum matches the checksum provided by th
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
 
+Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching assets (available in [Sensu Go 5.19.3][42]).
+
 ### Asset build execution
 
 The directory path of each asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
@@ -798,3 +800,6 @@ You must remove the archive and downloaded files from the asset cache manually.
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../dashboard/filtering#filter-with-label-selectors
+[40]: ../../reference/agent/#configuration
+[41]: ../../reference/backend/#configuration
+[42]: ../../release-notes/#5-19-3-release-notes

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -279,8 +279,8 @@ General Flags:
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
       --api-url string                      URL of the API to connect to (default "http://localhost:8080")
-      --assets-burst-limit int              asset fetch burst limit (default 100) -- Sensu Go 5.19.3
-      --assets-rate-limit float             maximum number of assets fetched per second -- Sensu Go 5.19.3
+      --assets-burst-limit int              asset fetch burst limit (default 100)
+      --assets-rate-limit float             maximum number of assets fetched per second
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
   -c, --config-file string                  path to sensu-backend config file
@@ -368,7 +368,7 @@ api-url: "http://localhost:8080"{{< /highlight >}}
 
 | assets-burst-limit   |      |
 --------------|------
-description   | Maximum amount of burst allowed in a rate interval when fetching assets. Added in [Sensu Go 5.19.3][28].
+description   | Available in [Sensu Go 5.19.3][28]. Maximum amount of burst allowed in a rate interval when fetching assets.
 type          | Integer
 default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
@@ -381,7 +381,7 @@ assets-burst-limit: 100{{< /highlight >}}
 
 | assets-rate-limit   |      |
 --------------|------
-description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour. Added in [Sensu Go 5.19.3][28].
+description   | Available in [Sensu Go 5.19.3][28]. Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour.
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -279,6 +279,8 @@ General Flags:
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
       --api-url string                      URL of the API to connect to (default "http://localhost:8080")
+      --assets-burst-limit int              asset fetch burst limit (default 100) -- Sensu Go 5.19.3
+      --assets-rate-limit float             maximum number of assets fetched per second -- Sensu Go 5.19.3
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
   -c, --config-file string                  path to sensu-backend config file
@@ -362,6 +364,32 @@ sensu-backend start --api-url http://localhost:8080
 
 # /etc/sensu/backend.yml example
 api-url: "http://localhost:8080"{{< /highlight >}}
+
+
+| assets-burst-limit   |      |
+--------------|------
+description   | Maximum amount of burst allowed in a rate interval when fetching assets. Added in [Sensu Go 5.19.3][28].
+type          | Integer
+default       | `100`
+environment variable | `SENSU_ASSETS_BURST_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-backend start --assets-burst-limit 100
+
+# /etc/sensu/backend.yml example
+assets-burst-limit: 100{{< /highlight >}}
+
+
+| assets-rate-limit   |      |
+--------------|------
+description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour. Added in [Sensu Go 5.19.3][28].
+type          | Float
+default       | `1.39`
+environment variable | `SENSU_ASSETS_RATE_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-backend start --assets-rate-limit 1.39
+
+# /etc/sensu/backend.yml example
+assets-rate-limit: 1.39{{< /highlight >}}
 
 
 | cache-dir   |      |
@@ -1306,3 +1334,4 @@ Here are some log rotate sample configurations:
 [25]: ../../installation/install-sensu#3-initialize
 [26]: ../../sensuctl/reference/#change-admin-user-s-password
 [27]: #configuration-via-environment-variables
+[28]: ../../release-notes/#5-19-3-release-notes

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -740,6 +740,8 @@ Flags:
       --annotations stringToString            entity annotations map (default [])
       --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
+      --assets-burst-limit int                asset fetch burst limit (default 100)
+      --assets-rate-limit float               maximum number of assets fetched per second
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -821,6 +823,32 @@ sensu-agent start --annotations example-key="example value" --annotations exampl
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /highlight >}}
+
+
+| assets-burst-limit   |      |
+--------------|------
+description   | Maximum amount of burst allowed in a rate interval when fetching assets.
+type          | Integer
+default       | `100`
+environment variable | `SENSU_ASSETS_BURST_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-agent start --assets-burst-limit 100
+
+# /etc/sensu/agent.yml example
+assets-burst-limit: 100{{< /highlight >}}
+
+
+| assets-rate-limit   |      |
+--------------|------
+description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour.
+type          | Float
+default       | `1.39`
+environment variable | `SENSU_ASSETS_RATE_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-agent start --assets-rate-limit 1.39
+
+# /etc/sensu/agent.yml example
+assets-rate-limit: 1.39{{< /highlight >}}
 
 
 | backend-url |      |

--- a/content/sensu-go/5.20/reference/assets.md
+++ b/content/sensu-go/5.20/reference/assets.md
@@ -60,6 +60,8 @@ If the downloaded artifact's SHA512 checksum matches the checksum provided by th
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
 
+Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching assets.
+
 ### Asset build execution
 
 The directory path of each asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
@@ -798,3 +800,5 @@ You must remove the archive and downloaded files from the asset cache manually.
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../dashboard/filtering#filter-with-label-selectors
+[40]: ../../reference/agent/#configuration
+[41]: ../../reference/backend/#configuration

--- a/content/sensu-go/5.20/reference/backend.md
+++ b/content/sensu-go/5.20/reference/backend.md
@@ -280,6 +280,8 @@ General Flags:
       --annotations stringToString          entity annotations map (default [])
       --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
       --api-url string                      URL of the API to connect to (default "http://localhost:8080")
+      --assets-burst-limit int              asset fetch burst limit (default 100)
+      --assets-rate-limit float             maximum number of assets fetched per second
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
   -c, --config-file string                  path to sensu-backend config file
@@ -381,6 +383,32 @@ sensu-backend start --api-url http://localhost:8080
 
 # /etc/sensu/backend.yml example
 api-url: "http://localhost:8080"{{< /highlight >}}
+
+
+| assets-burst-limit   |      |
+--------------|------
+description   | Maximum amount of burst allowed in a rate interval when fetching assets.
+type          | Integer
+default       | `100`
+environment variable | `SENSU_ASSETS_BURST_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-backend start --assets-burst-limit 100
+
+# /etc/sensu/backend.yml example
+assets-burst-limit: 100{{< /highlight >}}
+
+
+| assets-rate-limit   |      |
+--------------|------
+description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour.
+type          | Float
+default       | `1.39`
+environment variable | `SENSU_ASSETS_RATE_LIMIT`
+example       | {{< highlight shell >}}# Command line example
+sensu-backend start --assets-rate-limit 1.39
+
+# /etc/sensu/backend.yml example
+assets-rate-limit: 1.39{{< /highlight >}}
 
 
 | cache-dir   |      |


### PR DESCRIPTION
## Description
- Adds `--assets-burst-limit` and `--assets-rate-limit` global rate limit flags for assets to agent and backend references.
- Adds global rate limit flag information and link to configuration sections of agent and backend references to the assets reference.

Also propagates these changes to 5.20 docs (so that I don't forget to remove the "added in 5.19.3" caveat)

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2414
