### PR TITLE
Fix link for SQL flags in 5.19.2 release notes

### DIFF
--- a/content/sensu-go/5.19/reference/datastore.md
+++ b/content/sensu-go/5.19/reference/datastore.md
@@ -180,6 +180,8 @@ default      | `0` (unlimited)
 type         | Integer
 example      | {{< highlight shell >}}pool_size: 20{{< /highlight >}}
 
+<a name="max_conn_lifetime"></a>
+
 max_conn_lifetime    |      |
 -------------|------
 description  | Available in [Sensu Go 5.19.2][4]. Maximum time a connection can persist before being destroyed. Specify values with a numeral and a letter indicator: `s` to indicate seconds, `m` to indicate minutes, and `h` to indicate hours. For example, `1m`, `2h`, and `2h1m3s` are valid. 

--- a/content/sensu-go/5.19/release-notes.md
+++ b/content/sensu-go/5.19/release-notes.md
@@ -1200,6 +1200,6 @@ To get started with Sensu Go:
 [129]: /sensu-go/5.19/sensuctl/reference/#sensuctl-prune
 [130]: /sensu-go/5.19/reference/tessen/
 [131]: /sensu-go/5.19/reference/handlers/#pipe-handler-command
-[132]: /sensu-go/5.19/api/datastore/
+[132]: /sensu-go/5.19/reference/datastore/#max_conn_lifetime
 [133]: /sensu-go/5.19/installation/platforms/
 [134]: /sensu-go/5.19/installation/install-sensu/

--- a/content/sensu-go/5.20/release-notes.md
+++ b/content/sensu-go/5.20/release-notes.md
@@ -1200,6 +1200,6 @@ To get started with Sensu Go:
 [129]: /sensu-go/5.19/sensuctl/reference/#sensuctl-prune
 [130]: /sensu-go/5.19/reference/tessen/
 [131]: /sensu-go/5.19/reference/handlers/#pipe-handler-command
-[132]: /sensu-go/5.19/api/datastore/
+[132]: /sensu-go/5.19/reference/datastore/#max_conn_lifetime
 [133]: /sensu-go/5.19/installation/platforms/
 [134]: /sensu-go/5.19/installation/install-sensu/


### PR DESCRIPTION
## Description
I decided it would be better to link to the spec in the datastore reference rather than the datastore API doc.