### PR TITLE
Fix double trailing slash in upgrade guide link list

### DIFF
--- a/content/sensu-go/5.16/installation/upgrade.md
+++ b/content/sensu-go/5.16/installation/upgrade.md
@@ -188,7 +188,7 @@ See the metadata attributes section in the reference documentation for more info
 [13]: ../../reference/rbac/
 [14]: ../../guides/create-read-only-user/
 [16]: ../../reference/tokens
-[17]: ../../api/overview//
+[17]: ../../api/overview/
 [18]: https://github.com/sensu/sensu-translator/
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/

--- a/content/sensu-go/5.17/installation/upgrade.md
+++ b/content/sensu-go/5.17/installation/upgrade.md
@@ -188,7 +188,7 @@ See the metadata attributes section in the reference documentation for more info
 [13]: ../../reference/rbac/
 [14]: ../../guides/create-read-only-user/
 [16]: ../../reference/tokens
-[17]: ../../api/overview//
+[17]: ../../api/overview/
 [18]: https://github.com/sensu/sensu-translator/
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/

--- a/content/sensu-go/5.18/installation/upgrade.md
+++ b/content/sensu-go/5.18/installation/upgrade.md
@@ -194,7 +194,7 @@ See the metadata attributes section in the reference documentation for more info
 [13]: ../../reference/rbac/
 [14]: ../../guides/create-read-only-user/
 [16]: ../../reference/tokens
-[17]: ../../api/overview//
+[17]: ../../api/overview/
 [18]: https://github.com/sensu/sensu-translator/
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/

--- a/content/sensu-go/5.19/installation/upgrade.md
+++ b/content/sensu-go/5.19/installation/upgrade.md
@@ -194,7 +194,7 @@ See the metadata attributes section in the reference documentation for more info
 [13]: ../../reference/rbac/
 [14]: ../../guides/create-read-only-user/
 [16]: ../../reference/tokens
-[17]: ../../api/overview//
+[17]: ../../api/overview/
 [18]: https://github.com/sensu/sensu-translator/
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/

--- a/content/sensu-go/5.20/installation/upgrade.md
+++ b/content/sensu-go/5.20/installation/upgrade.md
@@ -194,7 +194,7 @@ See the metadata attributes section in the reference documentation for more info
 [13]: ../../reference/rbac/
 [14]: ../../guides/create-read-only-user/
 [16]: ../../reference/tokens
-[17]: ../../api/overview//
+[17]: ../../api/overview/
 [18]: https://github.com/sensu/sensu-translator/
 [19]: /sensu-core/1.6/
 [20]: https://packagecloud.io/sensu/community/


### PR DESCRIPTION
## Description
Fixes a `//` in a link listed at the end of the upgrade guide

## Motivation and Context
Found in SEMrush site audit crawl