### PR TITLE
Add note about trace log level in Troubleshooting

### DIFF
--- a/content/sensu-go/5.16/guides/troubleshooting.md
+++ b/content/sensu-go/5.16/guides/troubleshooting.md
@@ -46,6 +46,11 @@ sensu-agent start --log-level debug
 You must restart the service if you change log levels via configuration files or command line arguments.
 For help with restarting a service, see the [agent reference][5] or [backend reference][9].
 
+{{% notice note %}}
+**NOTE**: You can set the log level to `trace`, but Sensu does not log at the trace level.
+The trace log level is the same as `debug` in Sensu.
+{{% /notice %}}
+
 ### Log file locations
 
 {{< platformBlock "Linux" >}}

--- a/content/sensu-go/5.17/guides/troubleshooting.md
+++ b/content/sensu-go/5.17/guides/troubleshooting.md
@@ -46,6 +46,11 @@ sensu-agent start --log-level debug
 You must restart the service if you change log levels via configuration files or command line arguments.
 For help with restarting a service, see the [agent reference][5] or [backend reference][9].
 
+{{% notice note %}}
+**NOTE**: You can set the log level to `trace`, but Sensu does not log at the trace level.
+The trace log level is the same as `debug` in Sensu.
+{{% /notice %}}
+
 ### Log file locations
 
 {{< platformBlock "Linux" >}}

--- a/content/sensu-go/5.18/guides/troubleshooting.md
+++ b/content/sensu-go/5.18/guides/troubleshooting.md
@@ -46,6 +46,11 @@ sensu-agent start --log-level debug
 You must restart the service if you change log levels via configuration files or command line arguments.
 For help with restarting a service, see the [agent reference][5] or [backend reference][9].
 
+{{% notice note %}}
+**NOTE**: You can set the log level to `trace`, but Sensu does not log at the trace level.
+The trace log level is the same as `debug` in Sensu.
+{{% /notice %}}
+
 ### Log file locations
 
 {{< platformBlock "Linux" >}}

--- a/content/sensu-go/5.19/guides/troubleshooting.md
+++ b/content/sensu-go/5.19/guides/troubleshooting.md
@@ -46,6 +46,11 @@ sensu-agent start --log-level debug
 You must restart the service if you change log levels via configuration files or command line arguments.
 For help with restarting a service, see the [agent reference][5] or [backend reference][9].
 
+{{% notice note %}}
+**NOTE**: You can set the log level to `trace`, but Sensu does not log at the trace level.
+The trace log level is the same as `debug` in Sensu.
+{{% /notice %}}
+
 ### Log file locations
 
 {{< platformBlock "Linux" >}}

--- a/content/sensu-go/5.20/guides/troubleshooting.md
+++ b/content/sensu-go/5.20/guides/troubleshooting.md
@@ -46,6 +46,11 @@ sensu-agent start --log-level debug
 You must restart the service after you change log levels via configuration files or command line arguments.
 For help with restarting a service, see the [agent reference][5] or [backend reference][9].
 
+{{% notice note %}}
+**NOTE**: You can set the log level to `trace`, but Sensu does not log at the trace level.
+The trace log level is the same as `debug` in Sensu.
+{{% /notice %}}
+
 #### Increment log level verbosity
 
 Use these commands to increment the log level verbosity at runtime:


### PR DESCRIPTION
## Description
Adds note to explain that trace is the same as debug in Sensu.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2407