### PR TITLE
Add example registration handler

### DIFF
--- a/content/sensu-go/5.16/reference/agent.md
+++ b/content/sensu-go/5.16/reference/agent.md
@@ -666,7 +666,7 @@ _**PRO TIP**: Use a [handler set][34] to execute multiple handlers in response t
 You can use registration events to execute one-time handlers for new Sensu agents.
 For example, you can use registration event handlers to update external [configuration management databases (CMDBs)][11] such as [ServiceNow][12].
 
-To configure a registration event handler, see the [Handlers documentation][8], which includes instructions for creating a handler named `registration`.
+The handlers reference includes an [example registration event handler][42].
 
 _**WARNING**: Registration events are not stored in the event registry, so they are not accessible via the Sensu API. However, all registration events are logged in the [Sensu backend][2] log._
 
@@ -1437,6 +1437,7 @@ For example, if you configure a `SENSU_TEST_VAR` variable in your sensu-agent fi
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
 [41]: ../rbac/#namespaced-resource-types
+[42]: ../handlers/#send-registration-events
 [44]: ../checks#ttl-attribute
 [45]: https://en.m.wikipedia.org/wiki/WebSocket
 [46]: ../../guides/securing-sensu/

--- a/content/sensu-go/5.16/reference/handlers.md
+++ b/content/sensu-go/5.16/reference/handlers.md
@@ -79,7 +79,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "keepalive",
     "namespace": "default"
   },
@@ -125,7 +125,7 @@ example      | {{< highlight shell >}}
     "region": "us-west-1"
   },
   "annotations": {
-    "slack-channel" : "#monitoring"
+    "slack-channel": "#monitoring"
   }
 }
 {{< /highlight >}}
@@ -142,7 +142,7 @@ example      | {{< highlight shell >}}
     "host": "10.0.1.99",
     "port": 4444
   },
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   }
@@ -420,7 +420,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   },
@@ -459,7 +459,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "udp_handler",
     "namespace": "default"
   },
@@ -474,6 +474,48 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+### Send registration events
+
+If you configure a Sensu event handler named `registration`, the Sensu backend will create and process an event for the agent registration, apply any configured filters and mutators, and execute the registration handler.
+
+You can use registration events to execute one-time handlers for new Sensu agents to update an external configuration management database (CMDB).
+This example demonstrates how to configure a registration event handler to create or update a ServiceNow incident or event with the [Sensu Go ServiceNow Handler][17]:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: Handler
+api_version: core/v2
+metadata:
+  name: registration
+  namespace: default
+spec:
+  handlers:
+  - servicenow-cmdb
+  type: set
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "registration",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "servicenow-cmdb"
+    ],
+    "type": "set"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+The [agent reference][27] describes agent registration and registration events in more detail.
 
 ### Execute multiple handlers
 
@@ -499,7 +541,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "notify_all_the_things",
     "namespace": "default"
   },
@@ -532,7 +574,9 @@ spec:
 [14]: ../backend/
 [15]: ../../guides/send-slack-alerts/
 [16]: https://bonsai.sensu.io/
+[17]: https://github.com/sensu/sensu-servicenow-handler
 [18]: https://regex101.com/r/zo9mQU/2
 [23]: ../../guides/install-check-executables-with-assets
 [24]: ../filters/
 [25]: ../../dashboard/filtering#filter-with-label-selectors
+[27]: ../agent/#registration

--- a/content/sensu-go/5.17/reference/agent.md
+++ b/content/sensu-go/5.17/reference/agent.md
@@ -669,7 +669,7 @@ _**PRO TIP**: Use a [handler set][34] to execute multiple handlers in response t
 You can use registration events to execute one-time handlers for new Sensu agents.
 For example, you can use registration event handlers to update external [configuration management databases (CMDBs)][11] such as [ServiceNow][12].
 
-To configure a registration event handler, see the [Handlers documentation][8], which includes instructions for creating a handler named `registration`.
+The handlers reference includes an [example registration event handler][42].
 
 _**WARNING**: Registration events are not stored in the event registry, so they are not accessible via the Sensu API. However, all registration events are logged in the [Sensu backend][2] log._
 
@@ -1454,6 +1454,7 @@ For example, if you configure a `SENSU_TEST_VAR` variable in your sensu-agent fi
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
 [41]: ../rbac/#namespaced-resource-types
+[42]: ../handlers/#send-registration-events
 [44]: ../checks#ttl-attribute
 [45]: https://en.m.wikipedia.org/wiki/WebSocket
 [46]: ../../guides/securing-sensu/

--- a/content/sensu-go/5.17/reference/handlers.md
+++ b/content/sensu-go/5.17/reference/handlers.md
@@ -79,7 +79,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "keepalive",
     "namespace": "default"
   },
@@ -128,7 +128,7 @@ example      | {{< highlight shell >}}
     "region": "us-west-1"
   },
   "annotations": {
-    "slack-channel" : "#monitoring"
+    "slack-channel": "#monitoring"
   }
 }
 {{< /highlight >}}
@@ -145,7 +145,7 @@ example      | {{< highlight shell >}}
     "host": "10.0.1.99",
     "port": 4444
   },
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   }
@@ -455,7 +455,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   },
@@ -494,7 +494,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "udp_handler",
     "namespace": "default"
   },
@@ -509,6 +509,48 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+### Send registration events
+
+If you configure a Sensu event handler named `registration`, the Sensu backend will create and process an event for the agent registration, apply any configured filters and mutators, and execute the registration handler.
+
+You can use registration events to execute one-time handlers for new Sensu agents to update an external configuration management database (CMDB).
+This example demonstrates how to configure a registration event handler to create or update a ServiceNow incident or event with the [Sensu Go ServiceNow Handler][17]:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: Handler
+api_version: core/v2
+metadata:
+  name: registration
+  namespace: default
+spec:
+  handlers:
+  - servicenow-cmdb
+  type: set
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "registration",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "servicenow-cmdb"
+    ],
+    "type": "set"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+The [agent reference][27] describes agent registration and registration events in more detail.
 
 ### Execute multiple handlers
 
@@ -534,7 +576,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "notify_all_the_things",
     "namespace": "default"
   },
@@ -617,6 +659,7 @@ spec:
 [14]: ../backend/
 [15]: ../../guides/send-slack-alerts/
 [16]: https://bonsai.sensu.io/
+[17]: https://github.com/sensu/sensu-servicenow-handler
 [18]: https://regex101.com/r/zo9mQU/2
 [19]: ../agent/#keepalive-handlers-flag
 [20]: ../../reference/secrets/
@@ -625,3 +668,4 @@ spec:
 [24]: ../filters/
 [25]: ../../dashboard/filtering#filter-with-label-selectors
 [26]: ../../guides/secrets-management/
+[27]: ../agent/#registration

--- a/content/sensu-go/5.18/reference/agent.md
+++ b/content/sensu-go/5.18/reference/agent.md
@@ -692,7 +692,7 @@ If a [Sensu event handler][8] named `registration` is configured, the [Sensu bac
 You can use registration events to execute one-time handlers for new Sensu agents.
 For example, you can use registration event handlers to update external [configuration management databases (CMDBs)][11] such as [ServiceNow][12].
 
-To configure a registration event handler, see the [Handlers documentation][8], which includes instructions for creating a handler named `registration`.
+The handlers reference includes an [example registration event handler][41].
 
 {{% notice warning %}}
 **WARNING**: Registration events are not stored in the event registry, so they are not accessible via the Sensu API. However, all registration events are logged in the [Sensu backend log](../backend/#event-logging).
@@ -1514,6 +1514,7 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [38]: #name
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
+[41]: ../handlers/#send-registration-events
 [44]: ../checks#ttl-attribute
 [45]: https://en.m.wikipedia.org/wiki/WebSocket
 [46]: ../../guides/securing-sensu/

--- a/content/sensu-go/5.18/reference/handlers.md
+++ b/content/sensu-go/5.18/reference/handlers.md
@@ -82,7 +82,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "keepalive",
     "namespace": "default"
   },
@@ -131,7 +131,7 @@ example      | {{< highlight shell >}}
     "region": "us-west-1"
   },
   "annotations": {
-    "slack-channel" : "#monitoring"
+    "slack-channel": "#monitoring"
   }
 }
 {{< /highlight >}}
@@ -148,7 +148,7 @@ example      | {{< highlight shell >}}
     "host": "10.0.1.99",
     "port": 4444
   },
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   }
@@ -466,7 +466,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   },
@@ -505,7 +505,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "udp_handler",
     "namespace": "default"
   },
@@ -520,6 +520,48 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+### Send registration events
+
+If you configure a Sensu event handler named `registration`, the Sensu backend will create and process an event for the agent registration, apply any configured filters and mutators, and execute the registration handler.
+
+You can use registration events to execute one-time handlers for new Sensu agents to update an external configuration management database (CMDB).
+This example demonstrates how to configure a registration event handler to create or update a ServiceNow incident or event with the [Sensu Go ServiceNow Handler][17]:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: Handler
+api_version: core/v2
+metadata:
+  name: registration
+  namespace: default
+spec:
+  handlers:
+  - servicenow-cmdb
+  type: set
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "registration",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "servicenow-cmdb"
+    ],
+    "type": "set"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+The [agent reference][27] describes agent registration and registration events in more detail.
 
 ### Execute multiple handlers
 
@@ -545,7 +587,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "notify_all_the_things",
     "namespace": "default"
   },
@@ -628,6 +670,7 @@ spec:
 [14]: ../backend/
 [15]: ../../guides/send-slack-alerts/
 [16]: https://bonsai.sensu.io/
+[17]: https://github.com/sensu/sensu-servicenow-handler
 [18]: https://regex101.com/r/zo9mQU/2
 [19]: ../agent/#keepalive-handlers-flag
 [20]: ../../reference/secrets/
@@ -636,3 +679,4 @@ spec:
 [24]: ../filters/
 [25]: ../../dashboard/filtering#filter-with-label-selectors
 [26]: ../../guides/secrets-management/
+[27]: ../agent/#registration

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -692,7 +692,7 @@ If a [Sensu event handler][8] named `registration` is configured, the [Sensu bac
 You can use registration events to execute one-time handlers for new Sensu agents.
 For example, you can use registration event handlers to update external [configuration management databases (CMDBs)][11] such as [ServiceNow][12].
 
-To configure a registration event handler, see the [Handlers documentation][8], which includes instructions for creating a handler named `registration`.
+The handlers reference includes an [example registration event handler][41].
 
 {{% notice warning %}}
 **WARNING**: Registration events are not stored in the event registry, so they are not accessible via the Sensu API. However, all registration events are logged in the [Sensu backend log](../backend/#event-logging).
@@ -1558,6 +1558,7 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [38]: #name
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
+[41]: ../handlers/#send-registration-events
 [44]: ../checks#ttl-attribute
 [45]: https://en.m.wikipedia.org/wiki/WebSocket
 [46]: ../../guides/securing-sensu/

--- a/content/sensu-go/5.19/reference/handlers.md
+++ b/content/sensu-go/5.19/reference/handlers.md
@@ -82,7 +82,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "keepalive",
     "namespace": "default"
   },
@@ -132,7 +132,7 @@ example      | {{< highlight shell >}}
     "region": "us-west-1"
   },
   "annotations": {
-    "slack-channel" : "#monitoring"
+    "slack-channel": "#monitoring"
   }
 }
 {{< /highlight >}}
@@ -149,7 +149,7 @@ example      | {{< highlight shell >}}
     "host": "10.0.1.99",
     "port": 4444
   },
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   }
@@ -474,7 +474,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   },
@@ -513,7 +513,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "udp_handler",
     "namespace": "default"
   },
@@ -528,6 +528,48 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+### Send registration events
+
+If you configure a Sensu event handler named `registration`, the Sensu backend will create and process an event for the agent registration, apply any configured filters and mutators, and execute the registration handler.
+
+You can use registration events to execute one-time handlers for new Sensu agents to update an external configuration management database (CMDB).
+This example demonstrates how to configure a registration event handler to create or update a ServiceNow incident or event with the [Sensu Go ServiceNow Handler][17]:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: Handler
+api_version: core/v2
+metadata:
+  name: registration
+  namespace: default
+spec:
+  handlers:
+  - servicenow-cmdb
+  type: set
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "registration",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "servicenow-cmdb"
+    ],
+    "type": "set"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+The [agent reference][27] describes agent registration and registration events in more detail.
 
 ### Execute multiple handlers
 
@@ -553,7 +595,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "notify_all_the_things",
     "namespace": "default"
   },
@@ -636,6 +678,7 @@ spec:
 [14]: ../backend/
 [15]: ../../guides/send-slack-alerts/
 [16]: https://bonsai.sensu.io/
+[17]: https://github.com/sensu/sensu-servicenow-handler
 [18]: https://regex101.com/r/zo9mQU/2
 [19]: ../agent/#keepalive-handlers-flag
 [20]: ../../reference/secrets/
@@ -644,3 +687,4 @@ spec:
 [24]: ../filters/
 [25]: ../../dashboard/filtering#filter-with-label-selectors
 [26]: ../../guides/secrets-management/
+[27]: ../agent/#registration

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -692,7 +692,7 @@ If a [Sensu event handler][8] named `registration` is configured, the [Sensu bac
 You can use registration events to execute one-time handlers for new Sensu agents.
 For example, you can use registration event handlers to update external [configuration management databases (CMDBs)][11] such as [ServiceNow][12].
 
-To configure a registration event handler, see the [Handlers documentation][8], which includes instructions for creating a handler named `registration`.
+The handlers reference includes an [example registration event handler][41].
 
 {{% notice warning %}}
 **WARNING**: Registration events are not stored in the event registry, so they are not accessible via the Sensu API. However, all registration events are logged in the [Sensu backend log](../backend/#event-logging).
@@ -1574,6 +1574,7 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [38]: #name
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
+[41]: ../handlers/#send-registration-events
 [44]: ../checks#ttl-attribute
 [45]: https://en.m.wikipedia.org/wiki/WebSocket
 [46]: ../../guides/securing-sensu/

--- a/content/sensu-go/5.20/reference/handlers.md
+++ b/content/sensu-go/5.20/reference/handlers.md
@@ -82,7 +82,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "keepalive",
     "namespace": "default"
   },
@@ -132,7 +132,7 @@ example      | {{< highlight shell >}}
     "region": "us-west-1"
   },
   "annotations": {
-    "slack-channel" : "#monitoring"
+    "slack-channel": "#monitoring"
   }
 }
 {{< /highlight >}}
@@ -149,7 +149,7 @@ example      | {{< highlight shell >}}
     "host": "10.0.1.99",
     "port": 4444
   },
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   }
@@ -474,7 +474,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "tcp_handler",
     "namespace": "default"
   },
@@ -513,7 +513,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "udp_handler",
     "namespace": "default"
   },
@@ -528,6 +528,48 @@ spec:
 {{< /highlight >}}
 
 {{< /language-toggle >}}
+
+### Send registration events
+
+If you configure a Sensu event handler named `registration`, the Sensu backend will create and process an event for the agent registration, apply any configured filters and mutators, and execute the registration handler.
+
+You can use registration events to execute one-time handlers for new Sensu agents to update an external configuration management database (CMDB).
+This example demonstrates how to configure a registration event handler to create or update a ServiceNow incident or event with the [Sensu Go ServiceNow Handler][17]:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: Handler
+api_version: core/v2
+metadata:
+  name: registration
+  namespace: default
+spec:
+  handlers:
+  - servicenow-cmdb
+  type: set
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "registration",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "servicenow-cmdb"
+    ],
+    "type": "set"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+The [agent reference][27] describes agent registration and registration events in more detail.
 
 ### Execute multiple handlers
 
@@ -553,7 +595,7 @@ spec:
 {
   "type": "Handler",
   "api_version": "core/v2",
-  "metadata" : {
+  "metadata": {
     "name": "notify_all_the_things",
     "namespace": "default"
   },
@@ -636,6 +678,7 @@ spec:
 [14]: ../backend/
 [15]: ../../guides/send-slack-alerts/
 [16]: https://bonsai.sensu.io/
+[17]: https://github.com/sensu/sensu-servicenow-handler
 [18]: https://regex101.com/r/zo9mQU/2
 [19]: ../agent/#keepalive-handlers-flag
 [20]: ../../reference/secrets/
@@ -644,3 +687,4 @@ spec:
 [24]: ../filters/
 [25]: ../../dashboard/filtering#filter-with-label-selectors
 [26]: ../../guides/secrets-management/
+[27]: ../agent/#registration


### PR DESCRIPTION
## Description
- Adds an example registration handler in the handlers reference.
- Updates link in registration events content in agent reference so that it points to the new registration handler.

## Motivation and Context
Jef noticed that our agent reference says the handlers reference includes a registration handler example, but it does not.

## Review Instructions
Once approved, is it appropriate to propagate this to the 5.16, 5.17, and 5.18 docs?
