### PR TITLE
Add web configuration documentation

### DIFF
--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -1,0 +1,328 @@
+---
+title: "Web configuration API"
+linkTitle: "Web Configuration API"
+description: "The Sensu web API provides HTTP access to the active web UI configuration. This reference includes examples for returning the active web configuration and adding or updating the web configuration. Read on for the full reference."
+version: "5.20"
+product: "Sensu Go"
+menu:
+  sensu-go-5.20:
+    parent: api
+---
+
+- [The `/globals` API endpoint](#the-globals-api-endpoint)
+  - [`/globals` (GET)](#globals-get)
+- [The `/globals/:globalconfig` API endpoint](#the-globalsglobalconfig-api-endpoint)
+  - [`/globals/:globalconfig` (GET)](#globalsglobalconfig-get)
+  - [`/globals/:globalconfig` (PUT)](#globalsglobalconfig-put)
+  - [`/globals/:globalconfig` (DELETE)](#globalsglobalconfig-delete)
+
+## The `/globals` API endpoints
+
+For more information about commercial features designed for enterprises, see [Get started with commercial features][1].
+
+### `/globals` (GET)
+
+The `/globals` API endpoint provides HTTP GET access to the global web UI configuration.
+
+#### EXAMPLE {#globals-get-example}
+
+The following example demonstrates a request to the `/web` API endpoint, resulting in a JSON array that contains the global web UI configuration.
+
+{{< highlight shell >}}
+curl -X GET \
+http://127.0.0.1:8080/api/enterprise/web/v1/globals \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
+-H 'Content-Type: application/json'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "GlobalConfig",
+    "api_version": "web/v1",
+    "metadata": {
+      "name": "custom-web-ui",
+      "created_by": "admin"
+    },
+    "spec": {
+      "always_show_local_cluster": false,
+      "default_preferences": {
+        "page_size": 50,
+        "theme": "classic"
+      },
+      "link_policy": {
+        "allow_list": true,
+        "urls": [
+          "https://example.com",
+          "steamapp://34234234",
+          "//google.com",
+          "//*.google.com",
+          "//bob.local"
+        ]
+      }
+    }
+  },
+  {
+    "type": "GlobalConfig",
+    "api_version": "web/v1",
+    "metadata": {
+      "name": "new-web-ui",
+      "created_by": "admin"
+    },
+    "spec": {
+      "always_show_local_cluster": true,
+      "default_preferences": {
+        "page_size": 20,
+        "theme": "classic"
+      },
+      "link_policy": {
+        "allow_list": true,
+        "urls": [
+          "https://example.com"
+        ]
+      }
+    }
+  }
+]
+{{< /highlight >}}
+
+#### API Specification {#globals-get-specification}
+
+/web (GET)  | 
+---------------|------
+description    | Returns the list of global web UI configurations.
+example url    | http://hostname:8080/api/enterprise/web/v1/globals
+response type  | Map
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< highlight shell >}}
+[
+  {
+    "type": "GlobalConfig",
+    "api_version": "web/v1",
+    "metadata": {
+      "name": "custom-web-ui",
+      "created_by": "admin"
+    },
+    "spec": {
+      "always_show_local_cluster": false,
+      "default_preferences": {
+        "page_size": 50,
+        "theme": "classic"
+      },
+      "link_policy": {
+        "allow_list": true,
+        "urls": [
+          "https://example.com",
+          "steamapp://34234234",
+          "//google.com",
+          "//*.google.com",
+          "//bob.local"
+        ]
+      }
+    }
+  },
+  {
+    "type": "GlobalConfig",
+    "api_version": "web/v1",
+    "metadata": {
+      "name": "new-web-ui",
+      "created_by": "admin"
+    },
+    "spec": {
+      "always_show_local_cluster": true,
+      "default_preferences": {
+        "page_size": 20,
+        "theme": "classic"
+      },
+      "link_policy": {
+        "allow_list": true,
+        "urls": [
+          "https://example.com"
+        ]
+      }
+    }
+  }
+]
+{{< /highlight >}}
+
+## The `/globals/:globalconfig` API endpoint {#the-globalsglobalconfig-api-endpoint}
+
+### `/globals/:globalconfig` (GET) {#globalsglobalconfig-get}
+
+The `/globals/:globalconfig` API endpoint provides HTTP GET access to global web UI configuration data, specified by configuration name.
+
+#### EXAMPLE {#globalsglobalconfig-get-example}
+
+In the following example, querying the `/globals/:globalconfig` API endpoint returns a JSON map that contains the requested [`:globalconfig` definition][1] (in this example, for the `:globalconfig` named `custom-web-ui`).
+
+{{< highlight shell >}}
+curl -X GET \
+http://127.0.0.1:8080/api/enterprise/web/v1/globals/custom-web-ui \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+
+HTTP/1.1 200 OK
+{
+  "type": "GlobalConfig",
+  "api_version": "web/v1",
+  "metadata": {
+    "name": "custom-web-ui",
+    "created_by": "admin"
+  },
+  "spec": {
+    "always_show_local_cluster": false,
+    "default_preferences": {
+      "page_size": 50,
+      "theme": "classic"
+    },
+    "link_policy": {
+      "allow_list": true,
+      "urls": [
+        "https://example.com",
+        "steamapp://34234234",
+        "//google.com",
+        "//*.google.com",
+        "//bob.local"
+      ]
+    }
+  }
+}
+{{< /highlight >}}
+
+#### API Specification {#globalsglobalconfig-get-specification}
+
+/globals/:globalconfig (GET) | 
+---------------------|------
+description          | Returns the specified global web UI configuration.
+example url          | http://hostname:8080/api/enterprise/web/v1/globals/custom-web-ui
+response type        | Map
+response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output               | {{< highlight json >}}
+{
+  "type": "GlobalConfig",
+  "api_version": "web/v1",
+  "metadata": {
+    "name": "custom-web-ui",
+    "created_by": "admin"
+  },
+  "spec": {
+    "always_show_local_cluster": false,
+    "default_preferences": {
+      "page_size": 50,
+      "theme": "classic"
+    },
+    "link_policy": {
+      "allow_list": true,
+      "urls": [
+        "https://example.com",
+        "steamapp://34234234",
+        "//google.com",
+        "//*.google.com",
+        "//bob.local"
+      ]
+    }
+  }
+}
+{{< /highlight >}}
+
+### `/globals/:globalconfig` (PUT) {#globalsglobalconfig-put}
+
+The `/globals/:globalconfig` API endpoint provides HTTP PUT access to create and update global web UI configurations, specified by configuration name.
+
+#### EXAMPLE {#globalsglobalconfighooks-put-example}
+
+In the following example, an HTTP PUT request is submitted to the `/globals/:globalconfig` API endpoint to update the `custom-web-ui` configuration, resulting in an HTTP `200 OK` response and the updated configuration definition.
+
+{{< highlight shell >}}
+curl -X PUT \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
+-H 'Content-Type: application/json' \
+-d '{
+  "type": "GlobalConfig",
+  "api_version": "web/v1",
+  "metadata": {
+    "name": "custom-web-ui",
+    "created_by": "admin"
+  },
+  "spec": {
+    "always_show_local_cluster": false,
+    "default_preferences": {
+      "page_size": 50,
+      "theme": "classic"
+    },
+    "link_policy": {
+      "allow_list": true,
+      "urls": [
+        "https://example.com",
+        "steamapp://34234234",
+        "//google.com",
+        "//*.google.com",
+        "//bob.local"
+      ]
+    }
+  }
+}' \
+http://127.0.0.1:8080/api/enterprise/web/v1/globals/custom-web-ui
+
+HTTP/1.1 201 Created
+{{< /highlight >}}
+
+#### API Specification {#globalsglobalconfig-put-specification}
+
+/globals/:globalconfig (PUT) | 
+----------------|------
+description     | Creates or updates the specified global web UI configuration.
+example URL     | http://hostname:8080/api/enterprise/web/v1/globals/custom-web-ui
+payload         | {{< highlight shell >}}
+{
+  "type": "GlobalConfig",
+  "api_version": "web/v1",
+  "metadata": {
+    "name": "custom-web-ui",
+    "created_by": "admin"
+  },
+  "spec": {
+    "always_show_local_cluster": false,
+    "default_preferences": {
+      "page_size": 50,
+      "theme": "classic"
+    },
+    "link_policy": {
+      "allow_list": true,
+      "urls": [
+        "https://example.com",
+        "steamapp://34234234",
+        "//google.com",
+        "//*.google.com",
+        "//bob.local"
+      ]
+    }
+  }
+}
+{{< /highlight >}}
+response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+### `/globals/:globalconfig` (DELETE) {#globalsglobalconfig-delete}
+
+The `/globals/:globalconfig` API endpoint provides HTTP DELETE access to delete a global web UI configuration from Sensu, specified by the configuration name.
+
+#### EXAMPLE {#globalsglobalconfig-delete-example}
+
+The following example shows a request to the `/globals/:globalconfig` API endpoint to delete the global web UI configuration named `custom-web-ui`, resulting in a successful HTTP `204 No Content` response.
+
+{{< highlight shell >}}
+curl -X DELETE \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
+http://127.0.0.1:8080/api/enterprise/web/v1/globals/custom-web-ui
+
+HTTP/1.1 204 No Content
+{{< /highlight >}}
+
+#### API Specification {#globalsglobalconfig-delete-specification}
+
+/globals/:globalconfig (DELETE) | 
+--------------------------|------
+description               | Removes the specified global web UI configuration from Sensu.
+example url               | http://hostname:8080/api/enterprise/web/v1/globals/custom-web-ui
+response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+
+[1]: ../../getting-started/enterprise/

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -47,7 +47,7 @@ HTTP/1.1 200 OK
       "always_show_local_cluster": false,
       "default_preferences": {
         "page_size": 50,
-        "theme": "classic"
+        "theme": "dark"
       },
       "link_policy": {
         "allow_list": true,
@@ -75,7 +75,7 @@ HTTP/1.1 200 OK
         "theme": "classic"
       },
       "link_policy": {
-        "allow_list": true,
+        "allow_list": false,
         "urls": [
           "https://example.com"
         ]
@@ -106,7 +106,7 @@ output         | {{< highlight shell >}}
       "always_show_local_cluster": false,
       "default_preferences": {
         "page_size": 50,
-        "theme": "classic"
+        "theme": "dark"
       },
       "link_policy": {
         "allow_list": true,
@@ -134,7 +134,7 @@ output         | {{< highlight shell >}}
         "theme": "classic"
       },
       "link_policy": {
-        "allow_list": true,
+        "allow_list": false,
         "urls": [
           "https://example.com"
         ]
@@ -171,7 +171,7 @@ HTTP/1.1 200 OK
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "classic"
+      "theme": "dark"
     },
     "link_policy": {
       "allow_list": true,
@@ -207,7 +207,7 @@ output               | {{< highlight json >}}
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "classic"
+      "theme": "dark"
     },
     "link_policy": {
       "allow_list": true,
@@ -246,7 +246,7 @@ curl -X PUT \
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "classic"
+      "theme": "dark"
     },
     "link_policy": {
       "allow_list": true,
@@ -283,7 +283,7 @@ payload         | {{< highlight shell >}}
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "classic"
+      "theme": "dark"
     },
     "link_policy": {
       "allow_list": true,

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -16,6 +16,9 @@ menu:
   - [`/config/:globalconfig` (PUT)](#configglobalconfig-put)
   - [`/config/:globalconfig` (DELETE)](#configglobalconfig-delete)
 
+**COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features][1].
+
 ## The `/config` API endpoint
 
 ### `/config` (GET)

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -31,7 +31,7 @@ The following example demonstrates a request to the `/config` API endpoint, resu
 
 {{< highlight shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/enterprise/web/v2/config \
+http://127.0.0.1:8080/api/enterprise/web/v1/config \
 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 
@@ -39,7 +39,7 @@ HTTP/1.1 200 OK
 [
   {
     "type": "GlobalConfig",
-    "api_version": "web/v2",
+    "api_version": "web/v1",
     "metadata": {
       "name": "custom-web-ui",
       "created_by": "admin"
@@ -70,14 +70,14 @@ HTTP/1.1 200 OK
 /web (GET)  | 
 ---------------|------
 description    | Returns the list of global web UI configurations.
-example url    | http://hostname:8080/api/enterprise/web/v2/config
+example url    | http://hostname:8080/api/enterprise/web/v1/config
 response type  | Map
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< highlight shell >}}
 [
   {
     "type": "GlobalConfig",
-    "api_version": "web/v2",
+    "api_version": "web/v1",
     "metadata": {
       "name": "custom-web-ui",
       "created_by": "admin"
@@ -115,13 +115,13 @@ In the following example, querying the `/config/:globalconfig` API endpoint retu
 
 {{< highlight shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/enterprise/web/v2/config/custom-web-ui \
+http://127.0.0.1:8080/api/enterprise/web/v1/config/custom-web-ui \
 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
   "type": "GlobalConfig",
-  "api_version": "web/v2",
+  "api_version": "web/v1",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -151,13 +151,13 @@ HTTP/1.1 200 OK
 /config/:globalconfig (GET) | 
 ---------------------|------
 description          | Returns the specified global web UI configuration.
-example url          | http://hostname:8080/api/enterprise/web/v2/config/custom-web-ui
+example url          | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< highlight json >}}
 {
   "type": "GlobalConfig",
-  "api_version": "web/v2",
+  "api_version": "web/v1",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -196,7 +196,7 @@ curl -X PUT \
 -H 'Content-Type: application/json' \
 -d '{
   "type": "GlobalConfig",
-  "api_version": "web/v2",
+  "api_version": "web/v1",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -219,7 +219,7 @@ curl -X PUT \
     }
   }
 }' \
-http://127.0.0.1:8080/api/enterprise/web/v2/config/custom-web-ui
+http://127.0.0.1:8080/api/enterprise/web/v1/config/custom-web-ui
 
 HTTP/1.1 201 Created
 {{< /highlight >}}
@@ -229,11 +229,11 @@ HTTP/1.1 201 Created
 /config/:globalconfig (PUT) | 
 ----------------|------
 description     | Creates or updates the specified global web UI configuration.
-example URL     | http://hostname:8080/api/enterprise/web/v2/config/custom-web-ui
+example URL     | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 payload         | {{< highlight shell >}}
 {
   "type": "GlobalConfig",
-  "api_version": "web/v2",
+  "api_version": "web/v1",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -270,7 +270,7 @@ The following example shows a request to the `/config/:globalconfig` API endpoin
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
-http://127.0.0.1:8080/api/enterprise/web/v2/config/custom-web-ui
+http://127.0.0.1:8080/api/enterprise/web/v1/config/custom-web-ui
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
@@ -280,7 +280,7 @@ HTTP/1.1 204 No Content
 /config/:globalconfig (DELETE) | 
 --------------------------|------
 description               | Removes the specified global web UI configuration from Sensu.
-example url               | http://hostname:8080/api/enterprise/web/v2/config/custom-web-ui
+example url               | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -16,7 +16,7 @@ menu:
   - [`/globals/:globalconfig` (PUT)](#globalsglobalconfig-put)
   - [`/globals/:globalconfig` (DELETE)](#globalsglobalconfig-delete)
 
-## The `/globals` API endpoints
+## The `/globals` API endpoint
 
 For more information about commercial features designed for enterprises, see [Get started with commercial features][1].
 
@@ -47,7 +47,7 @@ HTTP/1.1 200 OK
       "always_show_local_cluster": false,
       "default_preferences": {
         "page_size": 50,
-        "theme": "dark"
+        "theme": "sensu"
       },
       "link_policy": {
         "allow_list": true,
@@ -106,7 +106,7 @@ output         | {{< highlight shell >}}
       "always_show_local_cluster": false,
       "default_preferences": {
         "page_size": 50,
-        "theme": "dark"
+        "theme": "sensu"
       },
       "link_policy": {
         "allow_list": true,
@@ -171,7 +171,7 @@ HTTP/1.1 200 OK
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "dark"
+      "theme": "sensu"
     },
     "link_policy": {
       "allow_list": true,
@@ -207,7 +207,7 @@ output               | {{< highlight json >}}
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "dark"
+      "theme": "sensu"
     },
     "link_policy": {
       "allow_list": true,
@@ -246,7 +246,7 @@ curl -X PUT \
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "dark"
+      "theme": "sensu"
     },
     "link_policy": {
       "allow_list": true,
@@ -283,7 +283,7 @@ payload         | {{< highlight shell >}}
     "always_show_local_cluster": false,
     "default_preferences": {
       "page_size": 50,
-      "theme": "dark"
+      "theme": "sensu"
     },
     "link_policy": {
       "allow_list": true,

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -1,7 +1,7 @@
 ---
 title: "Web UI configuration API"
 linkTitle: "Web UI Configuration API"
-description: "The Sensu web API provides HTTP access to the active web UI configuration. This reference includes examples for returning the active web configuration and adding or updating the web configuration. Read on for the full reference."
+description: "The Sensu web configuration API provides HTTP access to the global web UI configuration. This reference includes examples for returning the global web UI configuration and adding or updating the web UI configuration. Read on for the full reference."
 version: "5.20"
 product: "Sensu Go"
 menu:
@@ -17,8 +17,6 @@ menu:
   - [`/config/:globalconfig` (DELETE)](#configglobalconfig-delete)
 
 ## The `/config` API endpoint
-
-For more information about commercial features designed for enterprises, see [Get started with commercial features][1].
 
 ### `/config` (GET)
 
@@ -110,7 +108,7 @@ The `/config/:globalconfig` API endpoint provides HTTP GET access to global web 
 
 #### EXAMPLE {#configglobalconfig-get-example}
 
-In the following example, querying the `/config/:globalconfig` API endpoint returns a JSON map that contains the requested [`:globalconfig` definition][1] (in this example, for the `:globalconfig` named `custom-web-ui`).
+In the following example, querying the `/config/:globalconfig` API endpoint returns a JSON map that contains the requested `:globalconfig` definition (in this example, for the `:globalconfig` named `custom-web-ui`).
 
 {{< highlight shell >}}
 curl -X GET \

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -60,27 +60,6 @@ HTTP/1.1 200 OK
         ]
       }
     }
-  },
-  {
-    "type": "GlobalConfig",
-    "api_version": "web/v1",
-    "metadata": {
-      "name": "new-web-ui",
-      "created_by": "admin"
-    },
-    "spec": {
-      "always_show_local_cluster": true,
-      "default_preferences": {
-        "page_size": 20,
-        "theme": "classic"
-      },
-      "link_policy": {
-        "allow_list": false,
-        "urls": [
-          "https://example.com"
-        ]
-      }
-    }
   }
 ]
 {{< /highlight >}}
@@ -116,27 +95,6 @@ output         | {{< highlight shell >}}
           "//google.com",
           "//*.google.com",
           "//bob.local"
-        ]
-      }
-    }
-  },
-  {
-    "type": "GlobalConfig",
-    "api_version": "web/v1",
-    "metadata": {
-      "name": "new-web-ui",
-      "created_by": "admin"
-    },
-    "spec": {
-      "always_show_local_cluster": true,
-      "default_preferences": {
-        "page_size": 20,
-        "theme": "classic"
-      },
-      "link_policy": {
-        "allow_list": false,
-        "urls": [
-          "https://example.com"
         ]
       }
     }

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -9,28 +9,28 @@ menu:
     parent: api
 ---
 
-- [The `/globals` API endpoint](#the-globals-api-endpoint)
-  - [`/globals` (GET)](#globals-get)
-- [The `/globals/:globalconfig` API endpoint](#the-globalsglobalconfig-api-endpoint)
-  - [`/globals/:globalconfig` (GET)](#globalsglobalconfig-get)
-  - [`/globals/:globalconfig` (PUT)](#globalsglobalconfig-put)
-  - [`/globals/:globalconfig` (DELETE)](#globalsglobalconfig-delete)
+- [The `/config` API endpoint](#the-config-api-endpoint)
+  - [`/config` (GET)](#config-get)
+- [The `/config/:globalconfig` API endpoint](#the-configglobalconfig-api-endpoint)
+  - [`/config/:globalconfig` (GET)](#configglobalconfig-get)
+  - [`/config/:globalconfig` (PUT)](#configglobalconfig-put)
+  - [`/config/:globalconfig` (DELETE)](#configglobalconfig-delete)
 
-## The `/globals` API endpoint
+## The `/config` API endpoint
 
 For more information about commercial features designed for enterprises, see [Get started with commercial features][1].
 
-### `/globals` (GET)
+### `/config` (GET)
 
-The `/globals` API endpoint provides HTTP GET access to the global web UI configuration.
+The `/config` API endpoint provides HTTP GET access to the global web UI configuration.
 
-#### EXAMPLE {#globals-get-example}
+#### EXAMPLE {#config-get-example}
 
-The following example demonstrates a request to the `/web` API endpoint, resulting in a JSON array that contains the global web UI configuration.
+The following example demonstrates a request to the `/config` API endpoint, resulting in a JSON array that contains the global web UI configuration.
 
 {{< highlight shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/enterprise/web/v1/globals \
+http://127.0.0.1:8080/api/enterprise/web/v2/config \
 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json'
 
@@ -38,7 +38,7 @@ HTTP/1.1 200 OK
 [
   {
     "type": "GlobalConfig",
-    "api_version": "web/v1",
+    "api_version": "web/v2",
     "metadata": {
       "name": "custom-web-ui",
       "created_by": "admin"
@@ -64,19 +64,19 @@ HTTP/1.1 200 OK
 ]
 {{< /highlight >}}
 
-#### API Specification {#globals-get-specification}
+#### API Specification {#config-get-specification}
 
 /web (GET)  | 
 ---------------|------
 description    | Returns the list of global web UI configurations.
-example url    | http://hostname:8080/api/enterprise/web/v1/globals
+example url    | http://hostname:8080/api/enterprise/web/v2/config
 response type  | Map
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< highlight shell >}}
 [
   {
     "type": "GlobalConfig",
-    "api_version": "web/v1",
+    "api_version": "web/v2",
     "metadata": {
       "name": "custom-web-ui",
       "created_by": "admin"
@@ -102,25 +102,25 @@ output         | {{< highlight shell >}}
 ]
 {{< /highlight >}}
 
-## The `/globals/:globalconfig` API endpoint {#the-globalsglobalconfig-api-endpoint}
+## The `/config/:globalconfig` API endpoint {#the-configglobalconfig-api-endpoint}
 
-### `/globals/:globalconfig` (GET) {#globalsglobalconfig-get}
+### `/config/:globalconfig` (GET) {#configglobalconfig-get}
 
-The `/globals/:globalconfig` API endpoint provides HTTP GET access to global web UI configuration data, specified by configuration name.
+The `/config/:globalconfig` API endpoint provides HTTP GET access to global web UI configuration data, specified by configuration name.
 
-#### EXAMPLE {#globalsglobalconfig-get-example}
+#### EXAMPLE {#configglobalconfig-get-example}
 
-In the following example, querying the `/globals/:globalconfig` API endpoint returns a JSON map that contains the requested [`:globalconfig` definition][1] (in this example, for the `:globalconfig` named `custom-web-ui`).
+In the following example, querying the `/config/:globalconfig` API endpoint returns a JSON map that contains the requested [`:globalconfig` definition][1] (in this example, for the `:globalconfig` named `custom-web-ui`).
 
 {{< highlight shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/enterprise/web/v1/globals/custom-web-ui \
+http://127.0.0.1:8080/api/enterprise/web/v2/config/custom-web-ui \
 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
 
 HTTP/1.1 200 OK
 {
   "type": "GlobalConfig",
-  "api_version": "web/v1",
+  "api_version": "web/v2",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -145,18 +145,18 @@ HTTP/1.1 200 OK
 }
 {{< /highlight >}}
 
-#### API Specification {#globalsglobalconfig-get-specification}
+#### API Specification {#configglobalconfig-get-specification}
 
-/globals/:globalconfig (GET) | 
+/config/:globalconfig (GET) | 
 ---------------------|------
 description          | Returns the specified global web UI configuration.
-example url          | http://hostname:8080/api/enterprise/web/v1/globals/custom-web-ui
+example url          | http://hostname:8080/api/enterprise/web/v2/config/custom-web-ui
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< highlight json >}}
 {
   "type": "GlobalConfig",
-  "api_version": "web/v1",
+  "api_version": "web/v2",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -181,13 +181,13 @@ output               | {{< highlight json >}}
 }
 {{< /highlight >}}
 
-### `/globals/:globalconfig` (PUT) {#globalsglobalconfig-put}
+### `/config/:globalconfig` (PUT) {#configglobalconfig-put}
 
-The `/globals/:globalconfig` API endpoint provides HTTP PUT access to create and update global web UI configurations, specified by configuration name.
+The `/config/:globalconfig` API endpoint provides HTTP PUT access to create and update global web UI configurations, specified by configuration name.
 
-#### EXAMPLE {#globalsglobalconfighooks-put-example}
+#### EXAMPLE {#configglobalconfighooks-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/globals/:globalconfig` API endpoint to update the `custom-web-ui` configuration, resulting in an HTTP `200 OK` response and the updated configuration definition.
+In the following example, an HTTP PUT request is submitted to the `/config/:globalconfig` API endpoint to update the `custom-web-ui` configuration, resulting in an HTTP `200 OK` response and the updated configuration definition.
 
 {{< highlight shell >}}
 curl -X PUT \
@@ -195,7 +195,7 @@ curl -X PUT \
 -H 'Content-Type: application/json' \
 -d '{
   "type": "GlobalConfig",
-  "api_version": "web/v1",
+  "api_version": "web/v2",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -218,21 +218,21 @@ curl -X PUT \
     }
   }
 }' \
-http://127.0.0.1:8080/api/enterprise/web/v1/globals/custom-web-ui
+http://127.0.0.1:8080/api/enterprise/web/v2/config/custom-web-ui
 
 HTTP/1.1 201 Created
 {{< /highlight >}}
 
-#### API Specification {#globalsglobalconfig-put-specification}
+#### API Specification {#configglobalconfig-put-specification}
 
-/globals/:globalconfig (PUT) | 
+/config/:globalconfig (PUT) | 
 ----------------|------
 description     | Creates or updates the specified global web UI configuration.
-example URL     | http://hostname:8080/api/enterprise/web/v1/globals/custom-web-ui
+example URL     | http://hostname:8080/api/enterprise/web/v2/config/custom-web-ui
 payload         | {{< highlight shell >}}
 {
   "type": "GlobalConfig",
-  "api_version": "web/v1",
+  "api_version": "web/v2",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"
@@ -258,28 +258,28 @@ payload         | {{< highlight shell >}}
 {{< /highlight >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-### `/globals/:globalconfig` (DELETE) {#globalsglobalconfig-delete}
+### `/config/:globalconfig` (DELETE) {#configglobalconfig-delete}
 
-The `/globals/:globalconfig` API endpoint provides HTTP DELETE access to delete a global web UI configuration from Sensu, specified by the configuration name.
+The `/config/:globalconfig` API endpoint provides HTTP DELETE access to delete a global web UI configuration from Sensu, specified by the configuration name.
 
-#### EXAMPLE {#globalsglobalconfig-delete-example}
+#### EXAMPLE {#configglobalconfig-delete-example}
 
-The following example shows a request to the `/globals/:globalconfig` API endpoint to delete the global web UI configuration named `custom-web-ui`, resulting in a successful HTTP `204 No Content` response.
+The following example shows a request to the `/config/:globalconfig` API endpoint to delete the global web UI configuration named `custom-web-ui`, resulting in a successful HTTP `204 No Content` response.
 
 {{< highlight shell >}}
 curl -X DELETE \
 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
-http://127.0.0.1:8080/api/enterprise/web/v1/globals/custom-web-ui
+http://127.0.0.1:8080/api/enterprise/web/v2/config/custom-web-ui
 
 HTTP/1.1 204 No Content
 {{< /highlight >}}
 
-#### API Specification {#globalsglobalconfig-delete-specification}
+#### API Specification {#configglobalconfig-delete-specification}
 
-/globals/:globalconfig (DELETE) | 
+/config/:globalconfig (DELETE) | 
 --------------------------|------
 description               | Removes the specified global web UI configuration from Sensu.
-example url               | http://hostname:8080/api/enterprise/web/v1/globals/custom-web-ui
+example url               | http://hostname:8080/api/enterprise/web/v2/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 

--- a/content/sensu-go/5.20/api/webconfig.md
+++ b/content/sensu-go/5.20/api/webconfig.md
@@ -1,6 +1,6 @@
 ---
-title: "Web configuration API"
-linkTitle: "Web Configuration API"
+title: "Web UI configuration API"
+linkTitle: "Web UI Configuration API"
 description: "The Sensu web API provides HTTP access to the active web UI configuration. This reference includes examples for returning the active web configuration and adding or updating the web configuration. Read on for the full reference."
 version: "5.20"
 product: "Sensu Go"

--- a/content/sensu-go/5.20/dashboard/filtering.md
+++ b/content/sensu-go/5.20/dashboard/filtering.md
@@ -2,6 +2,7 @@
 title: "Dashboard filtering"
 linkTitle: "Filtering"
 description: "The Sensu dashboard supports filtering on the Events, Entities, Checks, Handlers, Filters, Mutators, and Silences pages. Learn more about filtering in the Sensu dashboard."
+weight: 20
 version: "5.20"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.20/dashboard/overview.md
+++ b/content/sensu-go/5.20/dashboard/overview.md
@@ -2,7 +2,7 @@
 title: "Dashboard overview"
 linkTitle: "Overview"
 description: "The Sensu backend includes the Sensu dashboard: a unified view of your Sensu resources with user-friendly tools to reduce alert fatigue. Read this guide to start using the Sensu dashboard."
-weight: 120
+weight: 10
 version: "5.20"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/5.20/dashboard/webconfig.md
+++ b/content/sensu-go/5.20/dashboard/webconfig.md
@@ -26,7 +26,7 @@ You can define a single custom web UI configuration to federate to all, some, or
 Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
 The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
 
-{{% notice important %}}
+{{% notice note %}}
 **NOTE**: Each cluster should have only one web configuration.
 {{% /notice %}}
 

--- a/content/sensu-go/5.20/dashboard/webconfig.md
+++ b/content/sensu-go/5.20/dashboard/webconfig.md
@@ -13,7 +13,7 @@ menu:
 
 - [Create a web UI configuration](#create-a-web-ui-configuration)
 - [Federate a web UI configuration to specific clusters](#federate-a-web-ui-configuration-to-specific-clusters)
-- [Local cluster settings for debugging](#local-cluster-settings-for-debugging)
+- [Debugging in federated environments](#debugging-in-federated-environments)
 
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
@@ -26,9 +26,8 @@ You can define a single custom web UI configuration to federate to all, some, or
 Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
 The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
 
-{{% notice note %}}
+{{% notice important %}}
 **NOTE**: Each cluster should have only one web configuration.
-If you provide more than one, Sensu will automatically use the earliest-created configuration.
 {{% /notice %}}
 
 If an individual user's settings conflict with the web UI configuration settings, Sensu will use the individual user's settings.
@@ -39,7 +38,7 @@ For example, if a user's system is set to dark mode and their web UI settings ar
 The web UI configuration in use is provided by the cluster you are connected to.
 For example, if you open the web UI for https://cluster-a.sensu.my.org:3000, the web UI display will be configured according to the `GlobalConfig` resource for cluster-a.
 
-In a federated environment, we recommend creating an [etcd replicator][6] for your `GlobalConfig` resource:
+In a federated environment, you can create an [etcd replicator][6] for your `GlobalConfig` resource so you can use it for different clusters:
 
 {{< language-toggle >}}
 
@@ -82,15 +81,17 @@ spec:
 
 {{< /language-toggle >}}
 
-## Local cluster settings for debugging
+## Debugging in federated environments
 
-To help with debugging, set the [`always_show_local_cluster` attribute][7] to `true` to display the cluster you are currently connected to in the [namespace switcher][8].
+In a federated environment, a problem like incorrect configuration, an error, or a network issue could prevent a cluster from appearing in the web UI [namespace switcher][8].
 
-For example, if you connect to the web UI on cluster-a, the namespace switcher should include a `local-cluster` heading that lists all the namespaces on cluster-a.
-If cluster-a is not listed in the namespace switcher, [NEED TO EXPLAIN WHAT THIS MEANS].
+If you set the [`always_show_local_cluster` attribute][7] to `true` in your web UI configuration, the namespace switcher will display a heading for each federated cluster, along with the local-cluster heading to indicate the cluster you are currently connected to.
+With `always_show_local_cluster` set to `true`, the cluster administrator can directly connect to the local cluster even if there is a problem that would otherwise prevent the cluster from being listed in the namespace switcher.
 
-If you set the `always_show_local_cluster` attribute to `false` for cluster-a, the cluster will not be listed in the namespace switcher.
-You will still be able to directly connect to cluster-a, but other clusters will not be aware of it.
+{{% notice note %}}
+**NOTE**: Use the `always_show_local_cluster` attribute only in federated environments.
+In a single-cluster environment, the namespace switcher will only list a local-cluster heading and the namespaces for that cluster.
+{{% /notice %}}
 
 
 [1]: ../../getting-started/enterprise/

--- a/content/sensu-go/5.20/dashboard/webconfig.md
+++ b/content/sensu-go/5.20/dashboard/webconfig.md
@@ -1,0 +1,103 @@
+---
+title: "Configure the web UI"
+linkTitle: "Configure the Web UI"
+description: "Web UI configuration allows you to define certain display options for the Sensu web UI. Read this guide to configure customized displays for your Sensu web UI."
+weight: 30
+version: "5.20"
+product: "Sensu Go"
+platformContent: false
+menu:
+  sensu-go-5.20:
+    parent: dashboard
+---
+
+- [Create a web UI configuration](#create-a-web-ui-configuration)
+- [Federate a web UI configuration to specific clusters](#federate-a-web-ui-configuration-to-specific-clusters)
+- [Local cluster settings for debugging](#local-cluster-settings-for-debugging)
+
+**COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features][1].
+
+Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
+You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
+
+## Create a web UI configuration
+
+Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
+The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
+
+{{% notice note %}}
+**NOTE**: Each cluster should have only one web configuration.
+If you provide more than one, Sensu will automatically use the earliest-created configuration.
+{{% /notice %}}
+
+If an individual user's settings conflict with the web UI configuration settings, Sensu will use the individual user's settings.
+For example, if a user's system is set to dark mode and their web UI settings are configured to use their system settings, the user will see dark mode in Sensu's web UI, even if you set the theme to `classic` in your web UI configuration.
+
+## Federate a web UI configuration to specific clusters
+
+The web UI configuration in use is provided by the cluster you are connected to.
+For example, if you open the web UI for https://cluster-a.sensu.my.org:3000, the web UI display will be configured according to the `GlobalConfig` resource for cluster-a.
+
+In a federated environment, we recommend creating an [etcd replicator][6] for your `GlobalConfig` resource:
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+--- 
+type: EtcdReplicator
+api_version: federation/v1
+metadata: 
+  name: web_global_config
+spec: 
+  api_version: web/v1
+  ca_cert: /path/to/ssl/trusted-certificate-authorities.pem
+  cert: /path/to/ssl/cert.pem
+  insecure: false
+  key: /path/to/ssl/key.pem
+  replication_interval_seconds: 120
+  resource: GlobalConfig
+  url: "http://127.0.0.1:2379"
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "EtcdReplicator",
+  "api_version": "federation/v1",
+  "metadata": {
+    "name": "web_global_config"
+  },
+  "spec": {
+    "api_version": "web/v1",
+    "ca_cert": "/path/to/ssl/trusted-certificate-authorities.pem",
+    "cert": "/path/to/ssl/cert.pem",
+    "insecure": false,
+    "key": "/path/to/ssl/key.pem",
+    "replication_interval_seconds": 120,
+    "resource": "GlobalConfig",
+    "url": "http://127.0.0.1:2379"
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+## Local cluster settings for debugging
+
+To help with debugging, set the [`always_show_local_cluster` attribute][7] to `true` to display the cluster you are currently connected to in the [namespace switcher][8].
+
+For example, if you connect to the web UI on cluster-a, the namespace switcher should include a `local-cluster` heading that lists all the namespaces on cluster-a.
+If cluster-a is not listed in the namespace switcher, [NEED TO EXPLAIN WHAT THIS MEANS].
+
+If you set the `always_show_local_cluster` attribute to `false` for cluster-a, the cluster will not be listed in the namespace switcher.
+You will still be able to directly connect to cluster-a, but other clusters will not be aware of it.
+
+
+[1]: ../../getting-started/enterprise/
+[2]: ../../api/webconfig/
+[3]: ../../dashboard/overview/
+[4]: ../../reference/webconfig/
+[5]: ../../sensuctl/reference/#create-resources
+[6]: ../../reference/etcdreplicators/
+[7]: ../../reference/webconfig/#show-local-cluster
+[8]: ../../dashboard/overview/#namespace-switcher

--- a/content/sensu-go/5.20/getting-started/enterprise.md
+++ b/content/sensu-go/5.20/getting-started/enterprise.md
@@ -22,7 +22,7 @@ Avoid exposing usernames, passwords, and access keys in your Sensu configuration
 - **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
 Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
 - **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
-- **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and filters using the Sensu [web UI][8], and access the [federated Sensu web UI homepage][23], which you can filter by cluster and namespace.
+- **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and filters using the Sensu [web UI][8],  access the [federated Sensu web UI homepage][23], which you can filter by cluster and namespace, and create [custom web UI configurations][24].
 - **Control permissions with Sensu role-based access control (RBAC)**, with the option of using [Lightweight Directory Access Protocol (LDAP) and Active Directory (AD)][9] for authentication.
 - **Use powerful filtering capabilities** designed for large installations. With label and field selectors, you can filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes. Plus, [save, recall, and delete][22] your filtered searches in the web UI.
 - **Log event data** [to a file][10] you can use as an input to your favorite data lake solution.
@@ -99,6 +99,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [18]: ../../reference/license/
 [19]: ../../guides/secrets-management/
 [20]: ../../guides/use-federation/
-[21]: ../../guides/securing-sensu/#sensu-agent-tls-authentication
+[21]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
 [22]: ../../dashboard/filtering/#save-a-filtered-search
 [23]: ../../dashboard/overview/#federated-webui
+[24]: ../../dashboard/webconfig/

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -102,7 +102,7 @@ example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 always_show_local_cluster | 
 -------------|------ 
-description  | To display the cluster the user is currently connected to in the [namespace switcher][5], `true`. To omit these details, `false`. Set to `true` for help with debugging.
+description  | Use only in federated environments. Set to `true` to display the cluster the user is currently connected to in the [namespace switcher][5]. To omit local cluster details, set to `false`.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -1,0 +1,220 @@
+---
+title: "Web UI configuration"
+linkTitle: "Web UI Configuration"
+description: "Sensu's web UI configuration feature allows you to customize your web UI displays. Read the reference to create and update web UI configurations."
+weight: 165
+version: "5.20"
+product: "Sensu Go"
+menu: 
+  sensu-go-5.20:
+    parent: reference
+---
+
+- [Web UI configuration specification](#web-ui-configuration-specification)
+  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
+- [Web UI examples](#web-ui-examples)
+
+**COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features][1].
+
+NEED TO DEVELOP INTRO CONTENT
+
+{{% notice note %}}
+**NOTE**: The web UI configuration feature is an exception to the rule in that there should only ever be a single web configuration present.
+{{% /notice %}}
+ 
+## Web UI configuration specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For web UI configuration, the type should always be `GlobalConfig`.
+required     | Required for web UI configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< highlight shell >}}"type": "GlobalConfig"{{< /highlight >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. For web UI configuration in this version of Sensu, the api_version should always be `web/v1`.
+required     | Required for web UI configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< highlight shell >}}"api_version": "web/v1"{{< /highlight >}}
+
+metadata     |      |
+-------------|------
+description  | Top-level scope that contains the web UI configuration's `name`.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"metadata": {
+  "name": "custom-web-ui",
+}
+{{< /highlight >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes web UI configuration [spec attributes][8].
+required     | Required for web UI configuration in `wrapped-json` or `yaml` format.
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}
+"spec": {
+  "always_show_local_cluster": false,
+  "default_preferences": {
+    "page_size": 50,
+    "theme": "classic"
+  },
+  "link_policy": {
+    "allow_list": true,
+    "urls": [
+      "https://example.com",
+      "steamapp://34234234",
+      "//google.com",
+      "//*.google.com",
+      "//bob.local"
+    ]
+  }
+}
+{{< /highlight >}}
+
+### Metadata attributes
+
+name         |      |
+-------------|------
+description  | Name for the web UI configuration that is used internally by Sensu.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"name": "custom-web-ui"{{< /highlight >}}
+
+### Spec attributes
+
+always_show_local_cluster | 
+-------------|------ 
+description  | When one or more clusters are configured the default behaviour of the application is to omit the details of the cluster the user is currently connected to. For purposes of debugging it can be useful to enable.
+required     | false
+type         | Boolean
+example      | {{< highlight shell >}}"always_show_local_cluster": false{{< /highlight >}}
+
+default_preferences | 
+-------------|------ 
+description  | Global default preferences for all users.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"default_preferences": {
+  "page_size": 50,
+  "theme": "classic"
+}{{< /highlight >}}
+
+link_policy | 
+-------------|------ 
+description  | For labels or annotations that contain a URL, the policy for which domains are valid and invalid targets for conversion to a link or an image.
+required     | true
+type         | Map of key-value pairs
+example      | {{< highlight shell >}}"link_policy": {
+  "allow_list": true,
+  "urls": [
+    "https://example.com",
+    "steamapp://34234234",
+    "//google.com",
+    "//*.google.com",
+    "//bob.local"
+  ]
+}{{< /highlight >}}
+
+#### Default preferences attributes
+
+page_size | 
+-------------|------ 
+description  | The default number of items a user can see on each page.
+required     | true
+type         | Integer
+example      | {{< highlight shell >}}"page_size": 50{{< /highlight >}}
+
+theme | 
+-------------|------ 
+description  | The default theme users will see.
+required     | true
+type         | String
+example      | {{< highlight shell >}}"theme": "classic"{{< /highlight >}}
+
+#### Link policy attributes
+
+allow_list | 
+-------------|------ 
+description  | If the list of URLs acts as an allow list, `true`. If the list of URLs acts as a deny list, `false`. As an allow list, only matching URLs will be expanded. As a deny list, matching URLs will not be expanded, but any other URLs will be expanded.
+required     | true
+type         | Boolean
+example      | {{< highlight shell >}}"allow_list": true{{< /highlight >}}
+
+urls | 
+-------------|------ 
+description  | The list of URLs to use as an allow or deny list.
+required     | false
+type         | Array
+example      | {{< highlight shell >}}"urls": [
+  "https://example.com",
+  "steamapp://34234234",
+  "//google.com",
+  "//*.google.com",
+  "//bob.local"
+]{{< /highlight >}}
+
+## Web UI configuration examples
+
+NEED TO DEVELOP
+
+{{< language-toggle >}}
+
+{{< highlight yml >}}
+type: GlobalConfig
+api_version: web/v1
+metadata:
+  name: custom-web-ui
+spec:
+  always_show_local_cluster: false
+  default_preferences:
+    page_size: 50
+    theme: classic
+  link_policy:
+    allow_list: true
+    urls:
+    - https://example.com
+    - steamapp://34234234
+    - //google.com
+    - //*.google.com
+    - //bob.local
+{{< /highlight >}}
+
+{{< highlight json >}}
+{
+  "type": "GlobalConfig",
+  "api_version": "web/v1",
+  "metadata": {
+    "name": "custom-web-ui",
+    "created_by": "admin"
+  },
+  "spec": {
+    "always_show_local_cluster": false,
+    "default_preferences": {
+      "page_size": 50,
+      "theme": "classic"
+    },
+    "link_policy": {
+      "allow_list": true,
+      "urls": [
+        "https://example.com",
+        "steamapp://34234234",
+        "//google.com",
+        "//*.google.com",
+        "//bob.local"
+      ]
+    }
+  }
+}
+{{< /highlight >}}
+
+{{< /language-toggle >}}
+
+
+[1]: ../../getting-started/enterprise/
+[2]: ../../api/webconfig/

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -17,10 +17,11 @@ menu:
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 
-NEED TO DEVELOP INTRO CONTENT
+Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
+You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
 
 {{% notice note %}}
-**NOTE**: The web UI configuration feature is an exception to the rule in that there should only ever be a single web configuration present.
+**NOTE**: The web UI configuration feature is an exception to the rule in that there should only be a single web configuration present.
 {{% /notice %}}
  
 ## Web UI configuration specification
@@ -43,12 +44,13 @@ example      | {{< highlight shell >}}"api_version": "web/v1"{{< /highlight >}}
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the web UI configuration's `name`.
+description  | Top-level scope that contains the web UI configuration's `name` and `created_by` information.
 required     | true
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
 "metadata": {
   "name": "custom-web-ui",
+  "created_by": "admin"
 }
 {{< /highlight >}}
 
@@ -86,19 +88,27 @@ required     | true
 type         | String
 example      | {{< highlight shell >}}"name": "custom-web-ui"{{< /highlight >}}
 
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created or last updated the web UI configuration. Sensu automatically populates the `created_by` field when the web UI configuration is created or updated.
+required     | false
+type         | String
+example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
+
 ### Spec attributes
 
 always_show_local_cluster | 
 -------------|------ 
-description  | When one or more clusters are configured the default behaviour of the application is to omit the details of the cluster the user is currently connected to. For purposes of debugging it can be useful to enable.
+description  | To display the details of the cluster the user is currently connected to, `true`. To omit these details, `false`. Setting this parameter to `true` can be useful for debugging.
 required     | false
 type         | Boolean
+default      | false
 example      | {{< highlight shell >}}"always_show_local_cluster": false{{< /highlight >}}
 
 default_preferences | 
 -------------|------ 
-description  | Global default preferences for all users.
-required     | true
+description  | Global default page size and theme preferences for all users.
+required     | false
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"default_preferences": {
   "page_size": 50,
@@ -108,7 +118,7 @@ example      | {{< highlight shell >}}"default_preferences": {
 link_policy | 
 -------------|------ 
 description  | For labels or annotations that contain a URL, the policy for which domains are valid and invalid targets for conversion to a link or an image.
-required     | true
+required     | false
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}"link_policy": {
   "allow_list": true,
@@ -125,15 +135,16 @@ example      | {{< highlight shell >}}"link_policy": {
 
 page_size | 
 -------------|------ 
-description  | The default number of items a user can see on each page.
-required     | true
+description  | The number of items users will see on each page.
+required     | false
 type         | Integer
+default      | 0
 example      | {{< highlight shell >}}"page_size": 50{{< /highlight >}}
 
 theme | 
 -------------|------ 
-description  | The default theme users will see.
-required     | true
+description  | The theme users will see.
+required     | false
 type         | String
 example      | {{< highlight shell >}}"theme": "classic"{{< /highlight >}}
 
@@ -142,8 +153,9 @@ example      | {{< highlight shell >}}"theme": "classic"{{< /highlight >}}
 allow_list | 
 -------------|------ 
 description  | If the list of URLs acts as an allow list, `true`. If the list of URLs acts as a deny list, `false`. As an allow list, only matching URLs will be expanded. As a deny list, matching URLs will not be expanded, but any other URLs will be expanded.
-required     | true
+required     | false
 type         | Boolean
+default      | false
 example      | {{< highlight shell >}}"allow_list": true{{< /highlight >}}
 
 urls | 
@@ -161,7 +173,12 @@ example      | {{< highlight shell >}}"urls": [
 
 ## Web UI configuration examples
 
-NEED TO DEVELOP
+In this web UI configuration example:
+
+- Details for the local cluster will not be displayed
+- Each page will list 50 items
+- The web UI will use the classic theme
+- Expanded links and images will be allowed for the listed URLs
 
 {{< language-toggle >}}
 
@@ -218,3 +235,4 @@ spec:
 
 [1]: ../../getting-started/enterprise/
 [2]: ../../api/webconfig/
+[3]: ../../dashboard/overview/

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -22,7 +22,6 @@ You can define a single custom web UI configuration to federate to all, some, or
 
 {{% notice note %}}
 **NOTE**: Each cluster should have only one web configuration.
-If you provide more than one, Sensu will automatically use the web UI configuration that was created or updated first.
 {{% /notice %}}
  
 ## Web UI configuration specification

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -37,10 +37,10 @@ example      | {{< highlight shell >}}"type": "GlobalConfig"{{< /highlight >}}
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For web UI configuration in this version of Sensu, the api_version should always be `web/v2`.
+description  | Top-level attribute that specifies the Sensu API group and version. For web UI configuration in this version of Sensu, the api_version should always be `web/v1`.
 required     | Required for web UI configuration in `wrapped-json` or `yaml` format.
 type         | String
-example      | {{< highlight shell >}}"api_version": "web/v2"{{< /highlight >}}
+example      | {{< highlight shell >}}"api_version": "web/v1"{{< /highlight >}}
 
 metadata     |      |
 -------------|------
@@ -191,7 +191,7 @@ In this web UI configuration example:
 
 {{< highlight yml >}}
 type: GlobalConfig
-api_version: web/v2
+api_version: web/v1
 metadata:
   name: custom-web-ui
 spec:
@@ -212,7 +212,7 @@ spec:
 {{< highlight json >}}
 {
   "type": "GlobalConfig",
-  "api_version": "web/v2",
+  "api_version": "web/v1",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -38,10 +38,10 @@ example      | {{< highlight shell >}}"type": "GlobalConfig"{{< /highlight >}}
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For web UI configuration in this version of Sensu, the api_version should always be `web/v1`.
+description  | Top-level attribute that specifies the Sensu API group and version. For web UI configuration in this version of Sensu, the api_version should always be `web/v2`.
 required     | Required for web UI configuration in `wrapped-json` or `yaml` format.
 type         | String
-example      | {{< highlight shell >}}"api_version": "web/v1"{{< /highlight >}}
+example      | {{< highlight shell >}}"api_version": "web/v2"{{< /highlight >}}
 
 metadata     |      |
 -------------|------
@@ -192,7 +192,7 @@ In this web UI configuration example:
 
 {{< highlight yml >}}
 type: GlobalConfig
-api_version: web/v1
+api_version: web/v2
 metadata:
   name: custom-web-ui
 spec:
@@ -213,7 +213,7 @@ spec:
 {{< highlight json >}}
 {
   "type": "GlobalConfig",
-  "api_version": "web/v1",
+  "api_version": "web/v2",
   "metadata": {
     "name": "custom-web-ui",
     "created_by": "admin"

--- a/content/sensu-go/5.20/reference/webconfig.md
+++ b/content/sensu-go/5.20/reference/webconfig.md
@@ -12,7 +12,7 @@ menu:
 
 - [Web UI configuration specification](#web-ui-configuration-specification)
   - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Web UI examples](#web-ui-examples)
+- [Web UI configuration examples](#web-ui-configuration-examples)
 
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
@@ -21,7 +21,8 @@ Web UI configuration allows you to define certain display options for the Sensu 
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
 
 {{% notice note %}}
-**NOTE**: The web UI configuration feature is an exception to the rule in that there should only be a single web configuration present.
+**NOTE**: Each cluster should have only one web configuration.
+If you provide more than one, Sensu will automatically use the web UI configuration that was created or updated first.
 {{% /notice %}}
  
 ## Web UI configuration specification
@@ -56,7 +57,7 @@ example      | {{< highlight shell >}}
 
 spec         | 
 -------------|------
-description  | Top-level map that includes web UI configuration [spec attributes][8].
+description  | Top-level map that includes web UI configuration [spec attributes][4].
 required     | Required for web UI configuration in `wrapped-json` or `yaml` format.
 type         | Map of key-value pairs
 example      | {{< highlight shell >}}
@@ -90,19 +91,21 @@ example      | {{< highlight shell >}}"name": "custom-web-ui"{{< /highlight >}}
 
 | created_by |      |
 -------------|------
-description  | Username of the Sensu user who created or last updated the web UI configuration. Sensu automatically populates the `created_by` field when the web UI configuration is created or updated.
+description  | Username of the Sensu user who created or last updated the web UI configuration. Sensu automatically populates the `created_by` field when the web UI configuration is created or updated. The admin user, cluster admins, and any user with access to the [`GlobalConfig`][2] resource can create and update web UI configurations.
 required     | false
 type         | String
 example      | {{< highlight shell >}}"created_by": "admin"{{< /highlight >}}
 
 ### Spec attributes
 
+<a name="show-local-cluster"></a>
+
 always_show_local_cluster | 
 -------------|------ 
-description  | To display the details of the cluster the user is currently connected to, `true`. To omit these details, `false`. Setting this parameter to `true` can be useful for debugging.
+description  | To display the cluster the user is currently connected to in the [namespace switcher][5], `true`. To omit these details, `false`. Set to `true` for help with debugging.
 required     | false
 type         | Boolean
-default      | false
+default      | `false`
 example      | {{< highlight shell >}}"always_show_local_cluster": false{{< /highlight >}}
 
 default_preferences | 
@@ -138,15 +141,20 @@ page_size |
 description  | The number of items users will see on each page.
 required     | false
 type         | Integer
-default      | 0
-example      | {{< highlight shell >}}"page_size": 50{{< /highlight >}}
+default      | `25`
+example      | {{< highlight shell >}}"page_size": 25{{< /highlight >}}
 
 theme | 
--------------|------ 
-description  | The theme users will see.
-required     | false
-type         | String
-example      | {{< highlight shell >}}"theme": "classic"{{< /highlight >}}
+---------------|------ 
+description    | The theme users will see.<br>{{% notice note %}}
+**NOTE**: If an individual user's settings conflict with the web UI configuration settings, Sensu will use the individual user's settings.
+For example, if a user's system is set to dark mode and their web UI settings are configured to use their system settings, the user will see dark mode in Sensu's web UI, even if you set the theme to `classic` in your web UI configuration.
+{{% /notice %}}
+required       | false
+type           | String
+default        | `sensu`
+allowed values | `sensu`, `classic`, `uchiwa`, `tritanopia`, and `deuteranopia`
+example        | {{< highlight shell >}}"theme": "classic"{{< /highlight >}}
 
 #### Link policy attributes
 
@@ -155,7 +163,7 @@ allow_list |
 description  | If the list of URLs acts as an allow list, `true`. If the list of URLs acts as a deny list, `false`. As an allow list, only matching URLs will be expanded. As a deny list, matching URLs will not be expanded, but any other URLs will be expanded.
 required     | false
 type         | Boolean
-default      | false
+default      | `false`
 example      | {{< highlight shell >}}"allow_list": true{{< /highlight >}}
 
 urls | 
@@ -236,3 +244,5 @@ spec:
 [1]: ../../getting-started/enterprise/
 [2]: ../../api/webconfig/
 [3]: ../../dashboard/overview/
+[4]: #spec-attributes
+[5]: ../../dashboard/overview/#namespace-switcher

--- a/content/sensu-go/5.20/sensuctl/reference.md
+++ b/content/sensu-go/5.20/sensuctl/reference.md
@@ -344,12 +344,13 @@ cat my-resources.yml | sensuctl create
 `CheckConfig` | `check_config` | `ClusterRole`  | `cluster_role`
 `ClusterRoleBinding`  | `cluster_role_binding` | `Entity` | [`Env`][43]
 `entity` | [`EtcdReplicators`][35] | `Event` | `event`
-`EventFilter` | `event_filter` | `Handler` | `handler`
-`Hook` | `hook` | `HookConfig` | `hook_config`
-`Mutator` | `mutator` | `Namespace` | `namespace`
-`Role` | `role` | `RoleBinding` | `role_binding`
-[`Secret`][41] | `Silenced` | `silenced` | [`VaultProvider`][43]
-[`ldap`][26] | [`ad`][42] | [`TessenConfig`][27] | [`PostgresConfig`][32] |
+`EventFilter` | `event_filter` | [`GlobalConfig`][50] | `Handler` 
+`handler` | `Hook` | `hook` | `HookConfig`
+`hook_config` | `Mutator` | `mutator` | `Namespace`
+`namespace` | `Role` | `role` | `RoleBinding`
+`role_binding` | [`Secret`][41] | `Silenced` | `silenced`
+[`VaultProvider`][43] | [`ldap`][26] | [`ad`][42] | [`TessenConfig`][27]
+[`PostgresConfig`][32] |
 
 ### Create resources across namespaces
 
@@ -1274,3 +1275,4 @@ Flags are optional and apply only to the `delete` command.
 [47]: ../../api/overview/#operators
 [48]: #sensuctl-prune-resource-types
 [49]: #examples
+[50]: ../../reference/webconfig/


### PR DESCRIPTION
## Description
- Adds web configuration API doc
- Adds web configuration reference doc
- Adds web configuration guide in Dashboard section
- Adds `GlobalConfig` resource to sensuctl create types
- Fixes weight of other two Dashboard section docs so the new doc is in the correct order
- Updates commercial features doc to include web config info

## Motivation and Context
Closes #2432 