### PR TITLE
Add BACKEND_ to backend reference env vars examples

### DIFF
--- a/content/sensu-go/5.16/reference/backend.md
+++ b/content/sensu-go/5.16/reference/backend.md
@@ -278,7 +278,7 @@ discovery instead of the static `--initial-cluster method`
 description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
-environment variable | `SENSU_API_LISTEN_ADDRESS`
+environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-listen-address [::]:8080
 
@@ -291,7 +291,7 @@ api-listen-address: "[::]:8080"{{< /highlight >}}
 description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080`
-environment variable | `SENSU_API_URL`
+environment variable | `SENSU_BACKEND_API_URL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-url http://localhost:8080
 
@@ -304,7 +304,7 @@ api-url: "http://localhost:8080"{{< /highlight >}}
 description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
-environment variable | `SENSU_CACHE_DIR`
+environment variable | `SENSU_BACKEND_CACHE_DIR`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --cache-dir /cache/sensu-backend
 
@@ -317,7 +317,7 @@ cache-dir: "/cache/sensu-backend"{{< /highlight >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | `SENSU_BACKEND_CONFIG_FILE`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
@@ -331,7 +331,7 @@ config-file: "/etc/sensu/backend.yml"{{< /highlight >}}
 description | If `true`, enable debugging and profiling features. Otherwise, `false`.
 type        | Boolean
 default     | `false`
-environment variable | `SENSU_DEBUG`
+environment variable | `SENSU_BACKEND_DEBUG`
 example     | {{< highlight shell >}}# Command line example
 sensu-backend start --debug
 
@@ -344,7 +344,7 @@ debug: true{{< /highlight >}}
 description              | Default event handler to use when processing agent deregistration events.
 type                     | String
 default                  | `""`
-environment variable     | `SENSU_DEREGISTRATION_HANDLER`
+environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 example                  | {{< highlight shell >}}# Command line example
 sensu-backend start --deregistration-handler /path/to/handler.sh
 
@@ -357,7 +357,7 @@ deregistration-handler: "/path/to/handler.sh"{{< /highlight >}}
 description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type         | String
 default      | `warn`
-environment variable | `SENSU_LOG_LEVEL`
+environment variable | `SENSU_BACKEND_LOG_LEVEL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --log-level debug
 
@@ -370,7 +370,7 @@ log-level: "debug"{{< /highlight >}}
 description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
-environment variable | `SENSU_STATE_DIR`
+environment variable | `SENSU_BACKEND_STATE_DIR`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
@@ -386,7 +386,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /highlight >}}
 description  | TLS certificate in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CERT_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
 
@@ -399,7 +399,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /highlight >}}
 description  | URLs of CRLs for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CRL_URLS`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
 
@@ -412,7 +412,7 @@ agent-auth-crl-urls: http://localhost/CARoot.crl{{< /highlight >}}
 description  | TLS certificate key in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_KEY_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
 
@@ -425,7 +425,7 @@ agent-auth-key-file: /path/to/ssl/key.pem{{< /highlight >}}
 description  | TLS CA certificate bundle in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
 
@@ -438,7 +438,7 @@ agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /highlight >}}
 description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by default.
 type           | String
 default        | `[::]`
-environment variable | `SENSU_AGENT_HOST`
+environment variable | `SENSU_BACKEND_AGENT_HOST`
 example        | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-host 127.0.0.1
 
@@ -451,7 +451,7 @@ agent-host: "127.0.0.1"{{< /highlight >}}
 description  | Agent listener port.
 type         | Integer
 default      | `8081`
-environment variable | `SENSU_AGENT_PORT`
+environment variable | `SENSU_BACKEND_AGENT_PORT`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-port 8081
 
@@ -466,7 +466,7 @@ agent-port: 8081{{< /highlight >}}
 description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_CERT_FILE`
+environment variable | `SENSU_BACKEND_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --cert-file /path/to/ssl/cert.pem
 
@@ -479,7 +479,7 @@ cert-file: "/path/to/ssl/cert.pem"{{< /highlight >}}
 description                | If `true`, skip SSL verification. Otherwise, `false`. _**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production._
 type                       | Boolean
 default                    | `false`
-environment variable | `SENSU_INSECURE_SKIP_TLS_VERIFY`
+environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 example                    | {{< highlight shell >}}# Command line example
 sensu-backend start --insecure-skip-tls-verify
 
@@ -494,7 +494,7 @@ insecure-skip-tls-verify: true{{< /highlight >}}
 description  | Path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs). _**NOTE**: The internal symmetric secret key is used by default to sign all JWTs unless a private key is specified via this attribute._
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PRIVATE_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem
 
@@ -507,7 +507,7 @@ jwt-private-key-file: /path/to/key/private.pem{{< /highlight >}}
 description  | Path to the PEM-encoded public key to use to verify JSON Web Token (JWT) signatures. _**NOTE**: JWTs signed with the internal symmetric secret key will continue to be verified with that key._
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PUBLIC_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem
@@ -521,7 +521,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /highlight >}}
 description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_KEY_FILE`
+environment variable | `SENSU_BACKEND_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --key-file /path/to/ssl/key.pem
 
@@ -534,7 +534,7 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
-environment variable | `SENSU_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 example           | {{< highlight shell >}}# Command line example
 sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
 
@@ -549,7 +549,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /highlight >}
 description  | Dashboard TLS certificate in PEM format. This certificate secures communication with the Sensu dashboard. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_CERT_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
 
@@ -562,7 +562,7 @@ dashboard-cert-file: "/path/to/tls/cert.pem"{{< /highlight >}}
 description      | Dashboard listener host.
 type             | String
 default          | `[::]`
-environment variable | `SENSU_DASHBOARD_HOST`
+environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-host 127.0.0.1
 
@@ -575,7 +575,7 @@ dashboard-host: "127.0.0.1"{{< /highlight >}}
 description  | Dashboard TLS certificate key in PEM format. This key secures communication with the Sensu dashboard. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_KEY_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-key-file /path/to/tls/key.pem
 
@@ -588,7 +588,7 @@ dashboard-key-file: "/path/to/tls/key.pem"{{< /highlight >}}
 description      | Dashboard listener port.
 type             | Integer
 default          | `3000`
-environment variable | `SENSU_DASHBOARD_PORT`
+environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-port 4000
 
@@ -603,7 +603,7 @@ dashboard-port: 4000{{< /highlight >}}
 description   | List of this member's client URLs to advertise to the rest of the cluster.
 type          | List
 default       | `http://localhost:2379`
-environment variable | `SENSU_ETCD_ADVERTISE_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 example       | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
@@ -620,7 +620,7 @@ etcd-advertise-client-urls:
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 default          | `""`
-environment variable | `SENSU_ETCD_CERT_FILE`
+environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-cert-file ./client.pem
 
@@ -643,7 +643,7 @@ etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
-environment variable | `SENSU_ETCD_CIPHER_SUITES`
+environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -660,7 +660,7 @@ etcd-cipher-suites:
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.
 type                    | Boolean
 default                 | `false`
-environment variable | `SENSU_ETCD_CLIENT_CERT_AUTH`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-client-cert-auth
 
@@ -673,7 +673,7 @@ etcd-client-cert-auth: true{{< /highlight >}}
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
 type                    | List
 default                 | `http://127.0.0.1:2379`
-environment variable | `SENSU_ETCD_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
@@ -690,7 +690,7 @@ etcd-client-urls:
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 
@@ -705,7 +705,7 @@ etcd-discovery:
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY_SRV`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery-srv example.org
 
@@ -720,7 +720,7 @@ etcd-discovery-srv:
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.
 type                               | List
 default                            | `http://127.0.0.1:2380`
-environment variable               | `SENSU_ETCD_INITIAL_ADVERTISE_PEER_URLS`
+environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 example                            | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
@@ -737,7 +737,7 @@ etcd-initial-advertise-peer-urls:
 description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380`
-environment variable   | `SENSU_ETCD_INITIAL_CLUSTER`
+environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
 
@@ -750,7 +750,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_STATE`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-state existing
 
@@ -763,7 +763,7 @@ etcd-initial-cluster-state: "existing"{{< /highlight >}}
 description                  | Initial cluster token for the etcd cluster during bootstrap.
 type                         | String
 default                      | `""`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_TOKEN`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-token sensu
 
@@ -775,7 +775,7 @@ etcd-initial-cluster-token: "sensu"{{< /highlight >}}
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
-environment variable | `SENSU_ETCD_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-key-file ./client-key.pem
 
@@ -789,7 +789,7 @@ etcd-key-file: "./client-key.pem"{{< /highlight >}}
 description               | List of URLs to listen on for client traffic.
 type                      | List
 default                   | `http://127.0.0.1:2379`
-environment variable      | `SENSU_ETCD_LISTEN_CLIENT_URLS`
+environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
@@ -806,7 +806,7 @@ etcd-listen-client-urls:
 description             | List of URLs to listen on for peer traffic.
 type                    | List
 default                 | `http://127.0.0.1:2380`
-environment variable    | `SENSU_ETCD_LISTEN_PEER_URLS`
+environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
@@ -823,7 +823,7 @@ etcd-listen-peer-urls:
 description      | Human-readable name for this member.
 type             | String
 default          | `default`
-environment variable | `SENSU_ETCD_NAME`
+environment variable | `SENSU_BACKEND_ETCD_NAME`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-name backend-0
 
@@ -835,7 +835,7 @@ etcd-name: "backend-0"{{< /highlight >}}
 ----------------------|------
 description           | Path to the peer server TLS certificate file.
 type                  | String
-environment variable  | `SENSU_ETCD_PEER_CERT_FILE`
+environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-cert-file ./backend-0.pem
 
@@ -848,7 +848,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /highlight >}}
 description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
-environment variable         | `SENSU_ETCD_PEER_CLIENT_CERT_AUTH`
+environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-client-cert-auth
 
@@ -860,7 +860,7 @@ etcd-peer-client-cert-auth: true{{< /highlight >}}
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
-environment variable | `SENSU_ETCD_PEER_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 example              | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
 
@@ -872,7 +872,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /highlight >}}
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
-environment variable        | `SENSU_ETCD_PEER_TRUSTED_CA_FILE`
+environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 example                     | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
 
@@ -885,7 +885,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
 type                   | String
 default                | `""`
-environment variable   | `SENSU_ETCD_TRUSTED_CA_FILE`
+environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-trusted-ca-file ./ca.pem
 
@@ -898,7 +898,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
 type             | Boolean
 default          | `false`
-environment variable | `SENSU_NO_EMBED_ETCD`
+environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --no-embed-etcd
 
@@ -913,7 +913,7 @@ no-embed-etcd: true{{< /highlight >}}
 description            | Number of incoming events that can be buffered before being processed by an eventd worker. _**WARNING**: Modify with caution. Increasing this value may result in greater memory usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-buffer-size 100
 
@@ -927,7 +927,7 @@ eventd-buffer-size: 100{{< /highlight >}}
 description            | Number of workers spawned for processing incoming events that are stored in the eventd buffer. _**WARNING**: Modify with caution. Increasing this value may result in greater CPU usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_WORKERS`
+environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-workers 100
 
@@ -940,7 +940,7 @@ eventd-workers: 100{{< /highlight >}}
 description            | Number of incoming keepalives that can be buffered before being processed by a keepalived worker. _**WARNING**: Modify with caution. Increasing this value may result in greater memory usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-buffer-size 100
 
@@ -953,7 +953,7 @@ keepalived-buffer-size: 100{{< /highlight >}}
 description            | Number of workers spawned for processing incoming keepalives that are stored in the keepalived buffer. _**WARNING**: Modify with caution. Increasing this value may result in greater CPU usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_WORKERS`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-workers 100
 
@@ -966,7 +966,7 @@ keepalived-workers: 100{{< /highlight >}}
 description            | Number of events to handle that can be buffered before being processed by a pipelined worker. _**WARNING**: Modify with caution. Increasing this value may result in greater memory usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-buffer-size 100
 
@@ -979,7 +979,7 @@ pipelined-buffer-size: 100{{< /highlight >}}
 description            | Number of workers spawned for handling events through the event pipeline that are stored in the pipelined buffer. _**WARNING**: Modify with caution. Increasing this value may result in greater CPU usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_WORKERS`
+environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-workers 100
 
@@ -992,7 +992,7 @@ pipelined-workers: 100{{< /highlight >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). See [etcd time parameter documentation][16] for details and other considerations. _**WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability._
 type                   | Integer
 default                | `1000`
-environment variable   | `SENSU_ETCD_ELECTION_TIMEOUT`
+environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-election-timeout 1000
 
@@ -1005,7 +1005,7 @@ etcd-election-timeout: 1000{{< /highlight >}}
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. _**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_ETCD_HEARTBEAT_INTERVAL`
+environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-heartbeat-interval 100
 
@@ -1018,7 +1018,7 @@ etcd-heartbeat-interval: 100{{< /highlight >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. _**WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance._
 type                   | Integer
 default                | `1572864`
-environment variable   | `SENSU_ETCD_MAX_REQUEST_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-max-request-bytes 1572864
 
@@ -1031,7 +1031,7 @@ etcd-max-request-bytes: 1572864{{< /highlight >}}
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. _**WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance._
 type                   | Integer
 default                | `4294967296`
-environment variable   | `SENSU_ETCD_QUOTA_BACKEND_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-quota-backend-bytes 4294967296
 
@@ -1055,7 +1055,7 @@ $ sudo touch /etc/sysconfig/sensu-backend
 
 {{< /language-toggle >}}
 
-For any configuration flag you wish to specify as an environment variable, you must prepend `SENSU_`, convert dashes (`-`) to underscores (`_`), and capitalize all letters.
+For any backend configuration flag you wish to specify as an environment variable, you must prepend `SENSU_BACKEND_`, convert dashes (`-`) to underscores (`_`), and capitalize all letters.
 Then, add the resulting environment variable to the appropriate environment file described above.
 You must restart the service for these settings to take effect.
 
@@ -1064,12 +1064,12 @@ In this example, the `api-listen-address` flag is configured as an environment v
 {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
+$ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
+$ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
@@ -1090,7 +1090,7 @@ The event logging functionality provides better performance and reliability than
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
-environment variable   | `SENSU_EVENT_LOG_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-buffer-size 100000
 
@@ -1103,7 +1103,7 @@ event-log-buffer-size: 100000{{< /highlight >}}
 -----------------------|------
 description            | Path to the event log file. _**WARNING**: The log file should be located on a local drive. Logging directly to network drives is not supported._
 type                   | String
-environment variable   | `SENSU_EVENT_LOG_FILE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-file /var/log/sensu/events.log
 

--- a/content/sensu-go/5.17/reference/backend.md
+++ b/content/sensu-go/5.17/reference/backend.md
@@ -330,7 +330,7 @@ discovery instead of the static `--initial-cluster method`
 description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
-environment variable | `SENSU_API_LISTEN_ADDRESS`
+environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-listen-address [::]:8080
 
@@ -343,7 +343,7 @@ api-listen-address: "[::]:8080"{{< /highlight >}}
 description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080`
-environment variable | `SENSU_API_URL`
+environment variable | `SENSU_BACKEND_API_URL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-url http://localhost:8080
 
@@ -356,7 +356,7 @@ api-url: "http://localhost:8080"{{< /highlight >}}
 description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
-environment variable | `SENSU_CACHE_DIR`
+environment variable | `SENSU_BACKEND_CACHE_DIR`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --cache-dir /cache/sensu-backend
 
@@ -369,7 +369,7 @@ cache-dir: "/cache/sensu-backend"{{< /highlight >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | `SENSU_BACKEND_CONFIG_FILE`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
@@ -383,7 +383,7 @@ config-file: "/etc/sensu/backend.yml"{{< /highlight >}}
 description | If `true`, enable debugging and profiling features. Otherwise, `false`.
 type        | Boolean
 default     | `false`
-environment variable | `SENSU_DEBUG`
+environment variable | `SENSU_BACKEND_DEBUG`
 example     | {{< highlight shell >}}# Command line example
 sensu-backend start --debug
 
@@ -396,7 +396,7 @@ debug: true{{< /highlight >}}
 description              | Default event handler to use when processing agent deregistration events.
 type                     | String
 default                  | `""`
-environment variable     | `SENSU_DEREGISTRATION_HANDLER`
+environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 example                  | {{< highlight shell >}}# Command line example
 sensu-backend start --deregistration-handler /path/to/handler.sh
 
@@ -409,7 +409,7 @@ deregistration-handler: "/path/to/handler.sh"{{< /highlight >}}
 description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type         | String
 default      | `warn`
-environment variable | `SENSU_LOG_LEVEL`
+environment variable | `SENSU_BACKEND_LOG_LEVEL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --log-level debug
 
@@ -422,7 +422,7 @@ log-level: "debug"{{< /highlight >}}
 description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
-environment variable | `SENSU_STATE_DIR`
+environment variable | `SENSU_BACKEND_STATE_DIR`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
@@ -438,7 +438,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /highlight >}}
 description  | TLS certificate in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CERT_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
 
@@ -451,7 +451,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /highlight >}}
 description  | URLs of CRLs for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CRL_URLS`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
 
@@ -464,7 +464,7 @@ agent-auth-crl-urls: http://localhost/CARoot.crl{{< /highlight >}}
 description  | TLS certificate key in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_KEY_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
 
@@ -477,7 +477,7 @@ agent-auth-key-file: /path/to/ssl/key.pem{{< /highlight >}}
 description  | TLS CA certificate bundle in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
 
@@ -490,7 +490,7 @@ agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /highlight >}}
 description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by default.
 type           | String
 default        | `[::]`
-environment variable | `SENSU_AGENT_HOST`
+environment variable | `SENSU_BACKEND_AGENT_HOST`
 example        | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-host 127.0.0.1
 
@@ -503,7 +503,7 @@ agent-host: "127.0.0.1"{{< /highlight >}}
 description  | Agent listener port.
 type         | Integer
 default      | `8081`
-environment variable | `SENSU_AGENT_PORT`
+environment variable | `SENSU_BACKEND_AGENT_PORT`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-port 8081
 
@@ -518,7 +518,7 @@ agent-port: 8081{{< /highlight >}}
 description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_CERT_FILE`
+environment variable | `SENSU_BACKEND_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --cert-file /path/to/ssl/cert.pem
 
@@ -531,7 +531,7 @@ cert-file: "/path/to/ssl/cert.pem"{{< /highlight >}}
 description                | If `true`, skip SSL verification. Otherwise, `false`. _**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production._
 type                       | Boolean
 default                    | `false`
-environment variable | `SENSU_INSECURE_SKIP_TLS_VERIFY`
+environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 example                    | {{< highlight shell >}}# Command line example
 sensu-backend start --insecure-skip-tls-verify
 
@@ -546,7 +546,7 @@ insecure-skip-tls-verify: true{{< /highlight >}}
 description  | Path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs). _**NOTE**: The internal symmetric secret key is used by default to sign all JWTs unless a private key is specified via this attribute._
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PRIVATE_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem
 
@@ -559,7 +559,7 @@ jwt-private-key-file: /path/to/key/private.pem{{< /highlight >}}
 description  | Path to the PEM-encoded public key to use to verify JSON Web Token (JWT) signatures. _**NOTE**: JWTs signed with the internal symmetric secret key will continue to be verified with that key._
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PUBLIC_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem
@@ -573,7 +573,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /highlight >}}
 description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_KEY_FILE`
+environment variable | `SENSU_BACKEND_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --key-file /path/to/ssl/key.pem
 
@@ -586,7 +586,7 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
-environment variable | `SENSU_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 example           | {{< highlight shell >}}# Command line example
 sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
 
@@ -601,7 +601,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /highlight >}
 description  | Dashboard TLS certificate in PEM format. This certificate secures communication with the Sensu dashboard. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_CERT_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
 
@@ -614,7 +614,7 @@ dashboard-cert-file: "/path/to/tls/cert.pem"{{< /highlight >}}
 description      | Dashboard listener host.
 type             | String
 default          | `[::]`
-environment variable | `SENSU_DASHBOARD_HOST`
+environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-host 127.0.0.1
 
@@ -627,7 +627,7 @@ dashboard-host: "127.0.0.1"{{< /highlight >}}
 description  | Dashboard TLS certificate key in PEM format. This key secures communication with the Sensu dashboard. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_KEY_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-key-file /path/to/tls/key.pem
 
@@ -640,7 +640,7 @@ dashboard-key-file: "/path/to/tls/key.pem"{{< /highlight >}}
 description      | Dashboard listener port.
 type             | Integer
 default          | `3000`
-environment variable | `SENSU_DASHBOARD_PORT`
+environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-port 4000
 
@@ -655,7 +655,7 @@ dashboard-port: 4000{{< /highlight >}}
 description   | List of this member's client URLs to advertise to the rest of the cluster.
 type          | List
 default       | `http://localhost:2379`
-environment variable | `SENSU_ETCD_ADVERTISE_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 example       | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
@@ -672,7 +672,7 @@ etcd-advertise-client-urls:
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 default          | `""`
-environment variable | `SENSU_ETCD_CERT_FILE`
+environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-cert-file ./client.pem
 
@@ -695,7 +695,7 @@ etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
-environment variable | `SENSU_ETCD_CIPHER_SUITES`
+environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -712,7 +712,7 @@ etcd-cipher-suites:
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.
 type                    | Boolean
 default                 | `false`
-environment variable | `SENSU_ETCD_CLIENT_CERT_AUTH`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-client-cert-auth
 
@@ -725,7 +725,7 @@ etcd-client-cert-auth: true{{< /highlight >}}
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
 type                    | List
 default                 | `http://127.0.0.1:2379`
-environment variable | `SENSU_ETCD_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
@@ -742,7 +742,7 @@ etcd-client-urls:
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 
@@ -757,7 +757,7 @@ etcd-discovery:
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY_SRV`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery-srv example.org
 
@@ -772,7 +772,7 @@ etcd-discovery-srv:
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.
 type                               | List
 default                            | `http://127.0.0.1:2380`
-environment variable               | `SENSU_ETCD_INITIAL_ADVERTISE_PEER_URLS`
+environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 example                            | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
@@ -789,7 +789,7 @@ etcd-initial-advertise-peer-urls:
 description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380`
-environment variable   | `SENSU_ETCD_INITIAL_CLUSTER`
+environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
 
@@ -802,7 +802,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_STATE`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-state existing
 
@@ -815,7 +815,7 @@ etcd-initial-cluster-state: "existing"{{< /highlight >}}
 description                  | Initial cluster token for the etcd cluster during bootstrap.
 type                         | String
 default                      | `""`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_TOKEN`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-token sensu
 
@@ -827,7 +827,7 @@ etcd-initial-cluster-token: "sensu"{{< /highlight >}}
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
-environment variable | `SENSU_ETCD_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-key-file ./client-key.pem
 
@@ -841,7 +841,7 @@ etcd-key-file: "./client-key.pem"{{< /highlight >}}
 description               | List of URLs to listen on for client traffic.
 type                      | List
 default                   | `http://127.0.0.1:2379`
-environment variable      | `SENSU_ETCD_LISTEN_CLIENT_URLS`
+environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
@@ -858,7 +858,7 @@ etcd-listen-client-urls:
 description             | List of URLs to listen on for peer traffic.
 type                    | List
 default                 | `http://127.0.0.1:2380`
-environment variable    | `SENSU_ETCD_LISTEN_PEER_URLS`
+environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
@@ -875,7 +875,7 @@ etcd-listen-peer-urls:
 description      | Human-readable name for this member.
 type             | String
 default          | `default`
-environment variable | `SENSU_ETCD_NAME`
+environment variable | `SENSU_BACKEND_ETCD_NAME`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-name backend-0
 
@@ -887,7 +887,7 @@ etcd-name: "backend-0"{{< /highlight >}}
 ----------------------|------
 description           | Path to the peer server TLS certificate file.
 type                  | String
-environment variable  | `SENSU_ETCD_PEER_CERT_FILE`
+environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-cert-file ./backend-0.pem
 
@@ -900,7 +900,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /highlight >}}
 description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
-environment variable         | `SENSU_ETCD_PEER_CLIENT_CERT_AUTH`
+environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-client-cert-auth
 
@@ -912,7 +912,7 @@ etcd-peer-client-cert-auth: true{{< /highlight >}}
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
-environment variable | `SENSU_ETCD_PEER_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 example              | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
 
@@ -924,7 +924,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /highlight >}}
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
-environment variable        | `SENSU_ETCD_PEER_TRUSTED_CA_FILE`
+environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 example                     | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
 
@@ -937,7 +937,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
 type                   | String
 default                | `""`
-environment variable   | `SENSU_ETCD_TRUSTED_CA_FILE`
+environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-trusted-ca-file ./ca.pem
 
@@ -950,7 +950,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
 type             | Boolean
 default          | `false`
-environment variable | `SENSU_NO_EMBED_ETCD`
+environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --no-embed-etcd
 
@@ -965,7 +965,7 @@ no-embed-etcd: true{{< /highlight >}}
 description            | Number of incoming events that can be buffered before being processed by an eventd worker. _**WARNING**: Modify with caution. Increasing this value may result in greater memory usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-buffer-size 100
 
@@ -979,7 +979,7 @@ eventd-buffer-size: 100{{< /highlight >}}
 description            | Number of workers spawned for processing incoming events that are stored in the eventd buffer. _**WARNING**: Modify with caution. Increasing this value may result in greater CPU usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_WORKERS`
+environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-workers 100
 
@@ -992,7 +992,7 @@ eventd-workers: 100{{< /highlight >}}
 description            | Number of incoming keepalives that can be buffered before being processed by a keepalived worker. _**WARNING**: Modify with caution. Increasing this value may result in greater memory usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-buffer-size 100
 
@@ -1005,7 +1005,7 @@ keepalived-buffer-size: 100{{< /highlight >}}
 description            | Number of workers spawned for processing incoming keepalives that are stored in the keepalived buffer. _**WARNING**: Modify with caution. Increasing this value may result in greater CPU usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_WORKERS`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-workers 100
 
@@ -1018,7 +1018,7 @@ keepalived-workers: 100{{< /highlight >}}
 description            | Number of events to handle that can be buffered before being processed by a pipelined worker. _**WARNING**: Modify with caution. Increasing this value may result in greater memory usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-buffer-size 100
 
@@ -1031,7 +1031,7 @@ pipelined-buffer-size: 100{{< /highlight >}}
 description            | Number of workers spawned for handling events through the event pipeline that are stored in the pipelined buffer. _**WARNING**: Modify with caution. Increasing this value may result in greater CPU usage._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_WORKERS`
+environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-workers 100
 
@@ -1044,7 +1044,7 @@ pipelined-workers: 100{{< /highlight >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). See [etcd time parameter documentation][16] for details and other considerations. _**WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability._
 type                   | Integer
 default                | `1000`
-environment variable   | `SENSU_ETCD_ELECTION_TIMEOUT`
+environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-election-timeout 1000
 
@@ -1057,7 +1057,7 @@ etcd-election-timeout: 1000{{< /highlight >}}
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. _**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability._
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_ETCD_HEARTBEAT_INTERVAL`
+environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-heartbeat-interval 100
 
@@ -1070,7 +1070,7 @@ etcd-heartbeat-interval: 100{{< /highlight >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. _**WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance._
 type                   | Integer
 default                | `1572864`
-environment variable   | `SENSU_ETCD_MAX_REQUEST_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-max-request-bytes 1572864
 
@@ -1083,7 +1083,7 @@ etcd-max-request-bytes: 1572864{{< /highlight >}}
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. _**WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance._
 type                   | Integer
 default                | `4294967296`
-environment variable   | `SENSU_ETCD_QUOTA_BACKEND_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-quota-backend-bytes 4294967296
 
@@ -1107,7 +1107,7 @@ $ sudo touch /etc/sysconfig/sensu-backend
 
 {{< /language-toggle >}}
 
-For any configuration flag you wish to specify as an environment variable, you must prepend `SENSU_`, convert dashes (`-`) to underscores (`_`), and capitalize all letters.
+For any backend configuration flag you wish to specify as an environment variable, you must prepend `SENSU_BACKEND_`, convert dashes (`-`) to underscores (`_`), and capitalize all letters.
 Then, add the resulting environment variable to the appropriate environment file described above.
 You must restart the service for these settings to take effect.
 
@@ -1116,12 +1116,12 @@ In this example, the `api-listen-address` flag is configured as an environment v
 {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
+$ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a/etc/sysconfig/sensu-backend
+$ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a/etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
@@ -1142,7 +1142,7 @@ The event logging functionality provides better performance and reliability than
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
-environment variable   | `SENSU_EVENT_LOG_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-buffer-size 100000
 
@@ -1155,7 +1155,7 @@ event-log-buffer-size: 100000{{< /highlight >}}
 -----------------------|------
 description            | Path to the event log file. _**WARNING**: The log file should be located on a local drive. Logging directly to network drives is not supported._
 type                   | String
-environment variable   | `SENSU_EVENT_LOG_FILE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-file /var/log/sensu/events.log
 

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -343,7 +343,7 @@ discovery instead of the static `--initial-cluster method`
 description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
-environment variable | `SENSU_API_LISTEN_ADDRESS`
+environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-listen-address [::]:8080
 
@@ -356,7 +356,7 @@ api-listen-address: "[::]:8080"{{< /highlight >}}
 description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080`
-environment variable | `SENSU_API_URL`
+environment variable | `SENSU_BACKEND_API_URL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-url http://localhost:8080
 
@@ -369,7 +369,7 @@ api-url: "http://localhost:8080"{{< /highlight >}}
 description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
-environment variable | `SENSU_CACHE_DIR`
+environment variable | `SENSU_BACKEND_CACHE_DIR`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --cache-dir /cache/sensu-backend
 
@@ -382,7 +382,7 @@ cache-dir: "/cache/sensu-backend"{{< /highlight >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | `SENSU_BACKEND_CONFIG_FILE`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
@@ -396,7 +396,7 @@ config-file: "/etc/sensu/backend.yml"{{< /highlight >}}
 description | If `true`, enable debugging and profiling features. Otherwise, `false`.
 type        | Boolean
 default     | `false`
-environment variable | `SENSU_DEBUG`
+environment variable | `SENSU_BACKEND_DEBUG`
 example     | {{< highlight shell >}}# Command line example
 sensu-backend start --debug
 
@@ -409,7 +409,7 @@ debug: true{{< /highlight >}}
 description              | Default event handler to use when processing agent deregistration events.
 type                     | String
 default                  | `""`
-environment variable     | `SENSU_DEREGISTRATION_HANDLER`
+environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 example                  | {{< highlight shell >}}# Command line example
 sensu-backend start --deregistration-handler /path/to/handler.sh
 
@@ -422,7 +422,7 @@ deregistration-handler: "/path/to/handler.sh"{{< /highlight >}}
 description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type         | String
 default      | `warn`
-environment variable | `SENSU_LOG_LEVEL`
+environment variable | `SENSU_BACKEND_LOG_LEVEL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --log-level debug
 
@@ -435,7 +435,7 @@ log-level: "debug"{{< /highlight >}}
 description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
-environment variable | `SENSU_STATE_DIR`
+environment variable | `SENSU_BACKEND_STATE_DIR`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
@@ -451,7 +451,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /highlight >}}
 description  | TLS certificate in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CERT_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
 
@@ -464,7 +464,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /highlight >}}
 description  | URLs of CRLs for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CRL_URLS`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
 
@@ -477,7 +477,7 @@ agent-auth-crl-urls: http://localhost/CARoot.crl{{< /highlight >}}
 description  | TLS certificate key in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_KEY_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
 
@@ -490,7 +490,7 @@ agent-auth-key-file: /path/to/ssl/key.pem{{< /highlight >}}
 description  | TLS CA certificate bundle in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
 
@@ -503,7 +503,7 @@ agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /highlight >}}
 description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by default.
 type           | String
 default        | `[::]`
-environment variable | `SENSU_AGENT_HOST`
+environment variable | `SENSU_BACKEND_AGENT_HOST`
 example        | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-host 127.0.0.1
 
@@ -516,7 +516,7 @@ agent-host: "127.0.0.1"{{< /highlight >}}
 description  | Agent listener port.
 type         | Integer
 default      | `8081`
-environment variable | `SENSU_AGENT_PORT`
+environment variable | `SENSU_BACKEND_AGENT_PORT`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-port 8081
 
@@ -531,7 +531,7 @@ agent-port: 8081{{< /highlight >}}
 description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_CERT_FILE`
+environment variable | `SENSU_BACKEND_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --cert-file /path/to/ssl/cert.pem
 
@@ -546,7 +546,7 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
-environment variable | `SENSU_INSECURE_SKIP_TLS_VERIFY`
+environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 example                    | {{< highlight shell >}}# Command line example
 sensu-backend start --insecure-skip-tls-verify
 
@@ -563,7 +563,7 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 {{% /notice %}}
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PRIVATE_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem
 
@@ -578,7 +578,7 @@ description  | Path to the PEM-encoded public key to use to verify JSON Web Toke
 {{% /notice %}}
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PUBLIC_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem
@@ -592,7 +592,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /highlight >}}
 description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_KEY_FILE`
+environment variable | `SENSU_BACKEND_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --key-file /path/to/ssl/key.pem
 
@@ -605,7 +605,7 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
-environment variable | `SENSU_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 example           | {{< highlight shell >}}# Command line example
 sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
 
@@ -620,7 +620,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /highlight >}
 description  | Dashboard TLS certificate in PEM format. This certificate secures communication with the Sensu dashboard. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_CERT_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
 
@@ -633,7 +633,7 @@ dashboard-cert-file: "/path/to/tls/cert.pem"{{< /highlight >}}
 description      | Dashboard listener host.
 type             | String
 default          | `[::]`
-environment variable | `SENSU_DASHBOARD_HOST`
+environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-host 127.0.0.1
 
@@ -646,7 +646,7 @@ dashboard-host: "127.0.0.1"{{< /highlight >}}
 description  | Dashboard TLS certificate key in PEM format. This key secures communication with the Sensu dashboard. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_KEY_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-key-file /path/to/tls/key.pem
 
@@ -659,7 +659,7 @@ dashboard-key-file: "/path/to/tls/key.pem"{{< /highlight >}}
 description      | Dashboard listener port.
 type             | Integer
 default          | `3000`
-environment variable | `SENSU_DASHBOARD_PORT`
+environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-port 4000
 
@@ -674,7 +674,7 @@ dashboard-port: 4000{{< /highlight >}}
 description   | List of this member's client URLs to advertise to the rest of the cluster.
 type          | List
 default       | `http://localhost:2379`
-environment variable | `SENSU_ETCD_ADVERTISE_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 example       | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
@@ -691,7 +691,7 @@ etcd-advertise-client-urls:
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 default          | `""`
-environment variable | `SENSU_ETCD_CERT_FILE`
+environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-cert-file ./client.pem
 
@@ -716,7 +716,7 @@ etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
-environment variable | `SENSU_ETCD_CIPHER_SUITES`
+environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -733,7 +733,7 @@ etcd-cipher-suites:
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.
 type                    | Boolean
 default                 | `false`
-environment variable | `SENSU_ETCD_CLIENT_CERT_AUTH`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-client-cert-auth
 
@@ -746,7 +746,7 @@ etcd-client-cert-auth: true{{< /highlight >}}
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
 type                    | List
 default                 | `http://127.0.0.1:2379`
-environment variable | `SENSU_ETCD_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
@@ -763,7 +763,7 @@ etcd-client-urls:
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 
@@ -778,7 +778,7 @@ etcd-discovery:
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY_SRV`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery-srv example.org
 
@@ -793,7 +793,7 @@ etcd-discovery-srv:
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.
 type                               | List
 default                            | `http://127.0.0.1:2380`
-environment variable               | `SENSU_ETCD_INITIAL_ADVERTISE_PEER_URLS`
+environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 example                            | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
@@ -810,7 +810,7 @@ etcd-initial-advertise-peer-urls:
 description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380`
-environment variable   | `SENSU_ETCD_INITIAL_CLUSTER`
+environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
 
@@ -823,7 +823,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_STATE`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-state existing
 
@@ -836,7 +836,7 @@ etcd-initial-cluster-state: "existing"{{< /highlight >}}
 description                  | Initial cluster token for the etcd cluster during bootstrap.
 type                         | String
 default                      | `""`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_TOKEN`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-token sensu
 
@@ -848,7 +848,7 @@ etcd-initial-cluster-token: "sensu"{{< /highlight >}}
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
-environment variable | `SENSU_ETCD_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-key-file ./client-key.pem
 
@@ -862,7 +862,7 @@ etcd-key-file: "./client-key.pem"{{< /highlight >}}
 description               | List of URLs to listen on for client traffic.
 type                      | List
 default                   | `http://127.0.0.1:2379`
-environment variable      | `SENSU_ETCD_LISTEN_CLIENT_URLS`
+environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
@@ -879,7 +879,7 @@ etcd-listen-client-urls:
 description             | List of URLs to listen on for peer traffic.
 type                    | List
 default                 | `http://127.0.0.1:2380`
-environment variable    | `SENSU_ETCD_LISTEN_PEER_URLS`
+environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
@@ -896,7 +896,7 @@ etcd-listen-peer-urls:
 description      | Human-readable name for this member.
 type             | String
 default          | `default`
-environment variable | `SENSU_ETCD_NAME`
+environment variable | `SENSU_BACKEND_ETCD_NAME`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-name backend-0
 
@@ -908,7 +908,7 @@ etcd-name: "backend-0"{{< /highlight >}}
 ----------------------|------
 description           | Path to the peer server TLS certificate file.
 type                  | String
-environment variable  | `SENSU_ETCD_PEER_CERT_FILE`
+environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-cert-file ./backend-0.pem
 
@@ -921,7 +921,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /highlight >}}
 description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
-environment variable         | `SENSU_ETCD_PEER_CLIENT_CERT_AUTH`
+environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-client-cert-auth
 
@@ -933,7 +933,7 @@ etcd-peer-client-cert-auth: true{{< /highlight >}}
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
-environment variable | `SENSU_ETCD_PEER_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 example              | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
 
@@ -945,7 +945,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /highlight >}}
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
-environment variable        | `SENSU_ETCD_PEER_TRUSTED_CA_FILE`
+environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 example                     | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
 
@@ -958,7 +958,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
 type                   | String
 default                | `""`
-environment variable   | `SENSU_ETCD_TRUSTED_CA_FILE`
+environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-trusted-ca-file ./ca.pem
 
@@ -971,7 +971,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
 type             | Boolean
 default          | `false`
-environment variable | `SENSU_NO_EMBED_ETCD`
+environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --no-embed-etcd
 
@@ -988,7 +988,7 @@ description            | Number of incoming events that can be buffered before b
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-buffer-size 100
 
@@ -1004,7 +1004,7 @@ description            | Number of workers spawned for processing incoming event
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_WORKERS`
+environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-workers 100
 
@@ -1019,7 +1019,7 @@ description            | Number of incoming keepalives that can be buffered befo
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-buffer-size 100
 
@@ -1033,7 +1033,7 @@ description            | Number of workers spawned for processing incoming keepa
 **WARNING**: Modify with caution. Increasing this value may result in greater CPU usage.{{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_WORKERS`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-workers 100
 
@@ -1048,7 +1048,7 @@ description            | Number of events to handle that can be buffered before 
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-buffer-size 100
 
@@ -1063,7 +1063,7 @@ description            | Number of workers spawned for handling events through t
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_WORKERS`
+environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-workers 100
 
@@ -1078,7 +1078,7 @@ description            | Time that a follower node will go without hearing a hea
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
-environment variable   | `SENSU_ETCD_ELECTION_TIMEOUT`
+environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-election-timeout 1000
 
@@ -1092,7 +1092,7 @@ description            | Interval at which the etcd leader will notify followers
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_ETCD_HEARTBEAT_INTERVAL`
+environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-heartbeat-interval 100
 
@@ -1107,7 +1107,7 @@ description            | Maximum etcd request size in bytes that can be sent to 
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
-environment variable   | `SENSU_ETCD_MAX_REQUEST_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-max-request-bytes 1572864
 
@@ -1122,7 +1122,7 @@ description            | Maximum etcd database size in bytes. Increasing this va
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`
-environment variable   | `SENSU_ETCD_QUOTA_BACKEND_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-quota-backend-bytes 4294967296
 
@@ -1151,12 +1151,12 @@ $ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_API_LISTEN_ADDRESS`.
+     To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1165,12 +1165,12 @@ All environment variables controlling Sensu configuration begin with `SENSU_`.
      {{< language-toggle >}}
 
 {{< highlight "Ubuntu/Debian" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
+$ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
 {{< highlight "RHEL/CentOS" >}}
-$ echo 'SENSU_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
+$ echo 'SENSU_BACKEND_PI_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 $ sudo systemctl restart sensu-backend
 {{< /highlight >}}
 
@@ -1199,7 +1199,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_TEST_VAR`.
+For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_TEST_VAR`.
 
 ## Event logging
 
@@ -1216,7 +1216,7 @@ The event logging functionality provides better performance and reliability than
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
-environment variable   | `SENSU_EVENT_LOG_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-buffer-size 100000
 
@@ -1231,7 +1231,7 @@ description            | Path to the event log file. {{% notice warning %}}
 **WARNING**: The log file should be located on a local drive. Logging directly to network drives is not supported.
 {{% /notice %}}
 type                   | String
-environment variable   | `SENSU_EVENT_LOG_FILE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-file /var/log/sensu/events.log
 

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -345,7 +345,7 @@ discovery instead of the static `--initial-cluster method`
 description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
-environment variable | `SENSU_API_LISTEN_ADDRESS`
+environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-listen-address [::]:8080
 
@@ -358,7 +358,7 @@ api-listen-address: "[::]:8080"{{< /highlight >}}
 description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080`
-environment variable | `SENSU_API_URL`
+environment variable | `SENSU_BACKEND_API_URL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-url http://localhost:8080
 
@@ -371,7 +371,7 @@ api-url: "http://localhost:8080"{{< /highlight >}}
 description   | Available in [Sensu Go 5.19.3][28]. Maximum amount of burst allowed in a rate interval when fetching assets.
 type          | Integer
 default       | `100`
-environment variable | `SENSU_ASSETS_BURST_LIMIT`
+environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --assets-burst-limit 100
 
@@ -384,7 +384,7 @@ assets-burst-limit: 100{{< /highlight >}}
 description   | Available in [Sensu Go 5.19.3][28]. Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour.
 type          | Float
 default       | `1.39`
-environment variable | `SENSU_ASSETS_RATE_LIMIT`
+environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --assets-rate-limit 1.39
 
@@ -397,7 +397,7 @@ assets-rate-limit: 1.39{{< /highlight >}}
 description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
-environment variable | `SENSU_CACHE_DIR`
+environment variable | `SENSU_BACKEND_CACHE_DIR`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --cache-dir /cache/sensu-backend
 
@@ -410,7 +410,7 @@ cache-dir: "/cache/sensu-backend"{{< /highlight >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | `SENSU_BACKEND_CONFIG_FILE`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
@@ -424,7 +424,7 @@ config-file: "/etc/sensu/backend.yml"{{< /highlight >}}
 description | If `true`, enable debugging and profiling features. Otherwise, `false`.
 type        | Boolean
 default     | `false`
-environment variable | `SENSU_DEBUG`
+environment variable | `SENSU_BACKEND_DEBUG`
 example     | {{< highlight shell >}}# Command line example
 sensu-backend start --debug
 
@@ -437,7 +437,7 @@ debug: true{{< /highlight >}}
 description              | Default event handler to use when processing agent deregistration events.
 type                     | String
 default                  | `""`
-environment variable     | `SENSU_DEREGISTRATION_HANDLER`
+environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 example                  | {{< highlight shell >}}# Command line example
 sensu-backend start --deregistration-handler /path/to/handler.sh
 
@@ -450,7 +450,7 @@ deregistration-handler: "/path/to/handler.sh"{{< /highlight >}}
 description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type         | String
 default      | `warn`
-environment variable | `SENSU_LOG_LEVEL`
+environment variable | `SENSU_BACKEND_LOG_LEVEL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --log-level debug
 
@@ -463,7 +463,7 @@ log-level: "debug"{{< /highlight >}}
 description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
-environment variable | `SENSU_STATE_DIR`
+environment variable | `SENSU_BACKEND_STATE_DIR`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
@@ -479,7 +479,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /highlight >}}
 description  | TLS certificate in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CERT_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
 
@@ -492,7 +492,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /highlight >}}
 description  | URLs of CRLs for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CRL_URLS`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
 
@@ -505,7 +505,7 @@ agent-auth-crl-urls: http://localhost/CARoot.crl{{< /highlight >}}
 description  | TLS certificate key in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_KEY_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
 
@@ -518,7 +518,7 @@ agent-auth-key-file: /path/to/ssl/key.pem{{< /highlight >}}
 description  | TLS CA certificate bundle in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
 
@@ -531,7 +531,7 @@ agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /highlight >}}
 description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by default.
 type           | String
 default        | `[::]`
-environment variable | `SENSU_AGENT_HOST`
+environment variable | `SENSU_BACKEND_AGENT_HOST`
 example        | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-host 127.0.0.1
 
@@ -544,7 +544,7 @@ agent-host: "127.0.0.1"{{< /highlight >}}
 description  | Agent listener port.
 type         | Integer
 default      | `8081`
-environment variable | `SENSU_AGENT_PORT`
+environment variable | `SENSU_BACKEND_AGENT_PORT`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-port 8081
 
@@ -559,7 +559,7 @@ agent-port: 8081{{< /highlight >}}
 description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_CERT_FILE`
+environment variable | `SENSU_BACKEND_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --cert-file /path/to/ssl/cert.pem
 
@@ -574,7 +574,7 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
-environment variable | `SENSU_INSECURE_SKIP_TLS_VERIFY`
+environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 example                    | {{< highlight shell >}}# Command line example
 sensu-backend start --insecure-skip-tls-verify
 
@@ -591,7 +591,7 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 {{% /notice %}}
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PRIVATE_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem
 
@@ -606,7 +606,7 @@ description  | Path to the PEM-encoded public key to use to verify JSON Web Toke
 {{% /notice %}}
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PUBLIC_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem
@@ -620,7 +620,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /highlight >}}
 description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_KEY_FILE`
+environment variable | `SENSU_BACKEND_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --key-file /path/to/ssl/key.pem
 
@@ -633,7 +633,7 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
-environment variable | `SENSU_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 example           | {{< highlight shell >}}# Command line example
 sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
 
@@ -648,7 +648,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /highlight >}
 description  | Dashboard TLS certificate in PEM format. This certificate secures communication with the Sensu dashboard. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_CERT_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
 
@@ -661,7 +661,7 @@ dashboard-cert-file: "/path/to/tls/cert.pem"{{< /highlight >}}
 description      | Dashboard listener host.
 type             | String
 default          | `[::]`
-environment variable | `SENSU_DASHBOARD_HOST`
+environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-host 127.0.0.1
 
@@ -674,7 +674,7 @@ dashboard-host: "127.0.0.1"{{< /highlight >}}
 description  | Dashboard TLS certificate key in PEM format. This key secures communication with the Sensu dashboard. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_KEY_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-key-file /path/to/tls/key.pem
 
@@ -687,7 +687,7 @@ dashboard-key-file: "/path/to/tls/key.pem"{{< /highlight >}}
 description      | Dashboard listener port.
 type             | Integer
 default          | `3000`
-environment variable | `SENSU_DASHBOARD_PORT`
+environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-port 4000
 
@@ -702,7 +702,7 @@ dashboard-port: 4000{{< /highlight >}}
 description   | List of this member's client URLs to advertise to the rest of the cluster.
 type          | List
 default       | `http://localhost:2379`
-environment variable | `SENSU_ETCD_ADVERTISE_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 example       | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
@@ -719,7 +719,7 @@ etcd-advertise-client-urls:
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 default          | `""`
-environment variable | `SENSU_ETCD_CERT_FILE`
+environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-cert-file ./client.pem
 
@@ -744,7 +744,7 @@ etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
-environment variable | `SENSU_ETCD_CIPHER_SUITES`
+environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -761,7 +761,7 @@ etcd-cipher-suites:
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.
 type                    | Boolean
 default                 | `false`
-environment variable | `SENSU_ETCD_CLIENT_CERT_AUTH`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-client-cert-auth
 
@@ -774,7 +774,7 @@ etcd-client-cert-auth: true{{< /highlight >}}
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
 type                    | List
 default                 | `http://127.0.0.1:2379`
-environment variable | `SENSU_ETCD_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
@@ -791,7 +791,7 @@ etcd-client-urls:
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 
@@ -806,7 +806,7 @@ etcd-discovery:
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY_SRV`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery-srv example.org
 
@@ -821,7 +821,7 @@ etcd-discovery-srv:
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.
 type                               | List
 default                            | `http://127.0.0.1:2380`
-environment variable               | `SENSU_ETCD_INITIAL_ADVERTISE_PEER_URLS`
+environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 example                            | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
@@ -838,7 +838,7 @@ etcd-initial-advertise-peer-urls:
 description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380`
-environment variable   | `SENSU_ETCD_INITIAL_CLUSTER`
+environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
 
@@ -851,7 +851,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_STATE`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-state existing
 
@@ -864,7 +864,7 @@ etcd-initial-cluster-state: "existing"{{< /highlight >}}
 description                  | Initial cluster token for the etcd cluster during bootstrap.
 type                         | String
 default                      | `""`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_TOKEN`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-token sensu
 
@@ -876,7 +876,7 @@ etcd-initial-cluster-token: "sensu"{{< /highlight >}}
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
-environment variable | `SENSU_ETCD_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-key-file ./client-key.pem
 
@@ -890,7 +890,7 @@ etcd-key-file: "./client-key.pem"{{< /highlight >}}
 description               | List of URLs to listen on for client traffic.
 type                      | List
 default                   | `http://127.0.0.1:2379`
-environment variable      | `SENSU_ETCD_LISTEN_CLIENT_URLS`
+environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
@@ -907,7 +907,7 @@ etcd-listen-client-urls:
 description             | List of URLs to listen on for peer traffic.
 type                    | List
 default                 | `http://127.0.0.1:2380`
-environment variable    | `SENSU_ETCD_LISTEN_PEER_URLS`
+environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
@@ -924,7 +924,7 @@ etcd-listen-peer-urls:
 description      | Human-readable name for this member.
 type             | String
 default          | `default`
-environment variable | `SENSU_ETCD_NAME`
+environment variable | `SENSU_BACKEND_ETCD_NAME`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-name backend-0
 
@@ -936,7 +936,7 @@ etcd-name: "backend-0"{{< /highlight >}}
 ----------------------|------
 description           | Path to the peer server TLS certificate file.
 type                  | String
-environment variable  | `SENSU_ETCD_PEER_CERT_FILE`
+environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-cert-file ./backend-0.pem
 
@@ -949,7 +949,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /highlight >}}
 description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
-environment variable         | `SENSU_ETCD_PEER_CLIENT_CERT_AUTH`
+environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-client-cert-auth
 
@@ -961,7 +961,7 @@ etcd-peer-client-cert-auth: true{{< /highlight >}}
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
-environment variable | `SENSU_ETCD_PEER_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 example              | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
 
@@ -973,7 +973,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /highlight >}}
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
-environment variable        | `SENSU_ETCD_PEER_TRUSTED_CA_FILE`
+environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 example                     | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
 
@@ -986,7 +986,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
 type                   | String
 default                | `""`
-environment variable   | `SENSU_ETCD_TRUSTED_CA_FILE`
+environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-trusted-ca-file ./ca.pem
 
@@ -999,7 +999,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
 type             | Boolean
 default          | `false`
-environment variable | `SENSU_NO_EMBED_ETCD`
+environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --no-embed-etcd
 
@@ -1016,7 +1016,7 @@ description            | Number of incoming events that can be buffered before b
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-buffer-size 100
 
@@ -1032,7 +1032,7 @@ description            | Number of workers spawned for processing incoming event
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_WORKERS`
+environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-workers 100
 
@@ -1047,7 +1047,7 @@ description            | Number of incoming keepalives that can be buffered befo
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-buffer-size 100
 
@@ -1061,7 +1061,7 @@ description            | Number of workers spawned for processing incoming keepa
 **WARNING**: Modify with caution. Increasing this value may result in greater CPU usage.{{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_WORKERS`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-workers 100
 
@@ -1076,7 +1076,7 @@ description            | Number of events to handle that can be buffered before 
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-buffer-size 100
 
@@ -1091,7 +1091,7 @@ description            | Number of workers spawned for handling events through t
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_WORKERS`
+environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-workers 100
 
@@ -1106,7 +1106,7 @@ description            | Time that a follower node will go without hearing a hea
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
-environment variable   | `SENSU_ETCD_ELECTION_TIMEOUT`
+environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-election-timeout 1000
 
@@ -1120,7 +1120,7 @@ description            | Interval at which the etcd leader will notify followers
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_ETCD_HEARTBEAT_INTERVAL`
+environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-heartbeat-interval 100
 
@@ -1135,7 +1135,7 @@ description            | Maximum etcd request size in bytes that can be sent to 
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
-environment variable   | `SENSU_ETCD_MAX_REQUEST_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-max-request-bytes 1572864
 
@@ -1150,7 +1150,7 @@ description            | Maximum etcd database size in bytes. Increasing this va
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`
-environment variable   | `SENSU_ETCD_QUOTA_BACKEND_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-quota-backend-bytes 4294967296
 
@@ -1179,12 +1179,12 @@ $ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_API_LISTEN_ADDRESS`.
+     To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1227,7 +1227,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_TEST_VAR`.
+For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_TEST_VAR`.
 
 ## Event logging
 
@@ -1244,7 +1244,7 @@ The event logging functionality provides better performance and reliability than
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
-environment variable   | `SENSU_EVENT_LOG_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-buffer-size 100000
 
@@ -1259,7 +1259,7 @@ description            | Path to the event log file. {{% notice warning %}}
 **WARNING**: The log file should be located on a local drive. Logging directly to network drives is not supported.
 {{% /notice %}}
 type                   | String
-environment variable   | `SENSU_EVENT_LOG_FILE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-file /var/log/sensu/events.log
 

--- a/content/sensu-go/5.20/reference/backend.md
+++ b/content/sensu-go/5.20/reference/backend.md
@@ -348,7 +348,7 @@ description  | Non-identifying metadata to include with entity data for backend 
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
-environment variable | `SENSU_ANNOTATIONS`
+environment variable | `SENSU_BACKEND_ANNOTATIONS`
 example      | {{< highlight shell >}}# Command line examples
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
@@ -364,7 +364,7 @@ annotations:
 description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
-environment variable | `SENSU_API_LISTEN_ADDRESS`
+environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-listen-address [::]:8080
 
@@ -377,7 +377,7 @@ api-listen-address: "[::]:8080"{{< /highlight >}}
 description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080`
-environment variable | `SENSU_API_URL`
+environment variable | `SENSU_BACKEND_API_URL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --api-url http://localhost:8080
 
@@ -390,7 +390,7 @@ api-url: "http://localhost:8080"{{< /highlight >}}
 description   | Maximum amount of burst allowed in a rate interval when fetching assets.
 type          | Integer
 default       | `100`
-environment variable | `SENSU_ASSETS_BURST_LIMIT`
+environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --assets-burst-limit 100
 
@@ -403,7 +403,7 @@ assets-burst-limit: 100{{< /highlight >}}
 description   | Maximum number of assets to fetch per second. The default value `1.39` is equivalent to approximately 5000 user-to-server requests per hour.
 type          | Float
 default       | `1.39`
-environment variable | `SENSU_ASSETS_RATE_LIMIT`
+environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --assets-rate-limit 1.39
 
@@ -416,7 +416,7 @@ assets-rate-limit: 1.39{{< /highlight >}}
 description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
-environment variable | `SENSU_CACHE_DIR`
+environment variable | `SENSU_BACKEND_CACHE_DIR`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --cache-dir /cache/sensu-backend
 
@@ -429,7 +429,7 @@ cache-dir: "/cache/sensu-backend"{{< /highlight >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | `SENSU_BACKEND_CONFIG_FILE`
 example       | {{< highlight shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
@@ -443,7 +443,7 @@ config-file: "/etc/sensu/backend.yml"{{< /highlight >}}
 description | If `true`, enable debugging and profiling features. Otherwise, `false`.
 type        | Boolean
 default     | `false`
-environment variable | `SENSU_DEBUG`
+environment variable | `SENSU_BACKEND_DEBUG`
 example     | {{< highlight shell >}}# Command line example
 sensu-backend start --debug
 
@@ -456,7 +456,7 @@ debug: true{{< /highlight >}}
 description              | Default event handler to use when processing agent deregistration events.
 type                     | String
 default                  | `""`
-environment variable     | `SENSU_DEREGISTRATION_HANDLER`
+environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 example                  | {{< highlight shell >}}# Command line example
 sensu-backend start --deregistration-handler /path/to/handler.sh
 
@@ -470,7 +470,7 @@ description  | Custom attributes to include with entity data for backend assets 
 required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
-environment variable | `SENSU_LABELS`
+environment variable | `SENSU_BACKEND_LABELS`
 example               | {{< highlight shell >}}# Command line examples
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
@@ -486,7 +486,7 @@ labels:
 description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type         | String
 default      | `warn`
-environment variable | `SENSU_LOG_LEVEL`
+environment variable | `SENSU_BACKEND_LOG_LEVEL`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --log-level debug
 
@@ -499,7 +499,7 @@ log-level: "debug"{{< /highlight >}}
 description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
-environment variable | `SENSU_STATE_DIR`
+environment variable | `SENSU_BACKEND_STATE_DIR`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
@@ -515,7 +515,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /highlight >}}
 description  | TLS certificate in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CERT_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
 
@@ -528,7 +528,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /highlight >}}
 description  | URLs of CRLs for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_CRL_URLS`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
 
@@ -541,7 +541,7 @@ agent-auth-crl-urls: http://localhost/CARoot.crl{{< /highlight >}}
 description  | TLS certificate key in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_KEY_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
 
@@ -554,7 +554,7 @@ agent-auth-key-file: /path/to/ssl/key.pem{{< /highlight >}}
 description  | TLS CA certificate bundle in PEM format for agent certificate authentication.
 type         | String
 default      | `""`
-environment variable | `SENSU_AGENT_AUTH_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
 
@@ -567,7 +567,7 @@ agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /highlight >}}
 description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by default.
 type           | String
 default        | `[::]`
-environment variable | `SENSU_AGENT_HOST`
+environment variable | `SENSU_BACKEND_AGENT_HOST`
 example        | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-host 127.0.0.1
 
@@ -580,7 +580,7 @@ agent-host: "127.0.0.1"{{< /highlight >}}
 description  | Agent listener port.
 type         | Integer
 default      | `8081`
-environment variable | `SENSU_AGENT_PORT`
+environment variable | `SENSU_BACKEND_AGENT_PORT`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --agent-port 8081
 
@@ -595,7 +595,7 @@ agent-port: 8081{{< /highlight >}}
 description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_CERT_FILE`
+environment variable | `SENSU_BACKEND_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --cert-file /path/to/ssl/cert.pem
 
@@ -610,7 +610,7 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
-environment variable | `SENSU_INSECURE_SKIP_TLS_VERIFY`
+environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 example                    | {{< highlight shell >}}# Command line example
 sensu-backend start --insecure-skip-tls-verify
 
@@ -627,7 +627,7 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 {{% /notice %}}
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PRIVATE_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem
 
@@ -642,7 +642,7 @@ description  | Path to the PEM-encoded public key to use to verify JSON Web Toke
 {{% /notice %}}
 type         | String
 default      | `""`
-environment variable | `SENSU_JWT_PUBLIC_KEY_FILE`
+environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem
@@ -656,7 +656,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /highlight >}}
 description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
-environment variable | `SENSU_KEY_FILE`
+environment variable | `SENSU_BACKEND_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --key-file /path/to/ssl/key.pem
 
@@ -669,7 +669,7 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu dashboard and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
-environment variable | `SENSU_TRUSTED_CA_FILE`
+environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 example           | {{< highlight shell >}}# Command line example
 sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
 
@@ -684,7 +684,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /highlight >}
 description  | Dashboard TLS certificate in PEM format. This certificate secures communication with the Sensu dashboard. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_CERT_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
 
@@ -697,7 +697,7 @@ dashboard-cert-file: "/path/to/tls/cert.pem"{{< /highlight >}}
 description      | Dashboard listener host.
 type             | String
 default          | `[::]`
-environment variable | `SENSU_DASHBOARD_HOST`
+environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-host 127.0.0.1
 
@@ -710,7 +710,7 @@ dashboard-host: "127.0.0.1"{{< /highlight >}}
 description  | Dashboard TLS certificate key in PEM format. This key secures communication with the Sensu dashboard. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the dashboard.
 type         | String
 default      | `""`
-environment variable | `SENSU_DASHBOARD_KEY_FILE`
+environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 example      | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-key-file /path/to/tls/key.pem
 
@@ -723,7 +723,7 @@ dashboard-key-file: "/path/to/tls/key.pem"{{< /highlight >}}
 description      | Dashboard listener port.
 type             | Integer
 default          | `3000`
-environment variable | `SENSU_DASHBOARD_PORT`
+environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --dashboard-port 4000
 
@@ -738,7 +738,7 @@ dashboard-port: 4000{{< /highlight >}}
 description   | List of this member's client URLs to advertise to the rest of the cluster.
 type          | List
 default       | `http://localhost:2379`
-environment variable | `SENSU_ETCD_ADVERTISE_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 example       | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
@@ -755,7 +755,7 @@ etcd-advertise-client-urls:
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 default          | `""`
-environment variable | `SENSU_ETCD_CERT_FILE`
+environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-cert-file ./client.pem
 
@@ -780,7 +780,7 @@ etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 {{< /highlight >}}
 type                    | List
-environment variable | `SENSU_ETCD_CIPHER_SUITES`
+environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -797,7 +797,7 @@ etcd-cipher-suites:
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.
 type                    | Boolean
 default                 | `false`
-environment variable | `SENSU_ETCD_CLIENT_CERT_AUTH`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-client-cert-auth
 
@@ -810,7 +810,7 @@ etcd-client-cert-auth: true{{< /highlight >}}
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
 type                    | List
 default                 | `http://127.0.0.1:2379`
-environment variable | `SENSU_ETCD_CLIENT_URLS`
+environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
@@ -827,7 +827,7 @@ etcd-client-urls:
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 
@@ -842,7 +842,7 @@ etcd-discovery:
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
 type                    | String
 default                 | ""
-environment variable | `SENSU_ETCD_DISCOVERY_SRV`
+environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 example                 | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-discovery-srv example.org
 
@@ -857,7 +857,7 @@ etcd-discovery-srv:
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.
 type                               | List
 default                            | `http://127.0.0.1:2380`
-environment variable               | `SENSU_ETCD_INITIAL_ADVERTISE_PEER_URLS`
+environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 example                            | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
@@ -874,7 +874,7 @@ etcd-initial-advertise-peer-urls:
 description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380`
-environment variable   | `SENSU_ETCD_INITIAL_CLUSTER`
+environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
 
@@ -887,7 +887,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_STATE`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-state existing
 
@@ -900,7 +900,7 @@ etcd-initial-cluster-state: "existing"{{< /highlight >}}
 description                  | Initial cluster token for the etcd cluster during bootstrap.
 type                         | String
 default                      | `""`
-environment variable         | `SENSU_ETCD_INITIAL_CLUSTER_TOKEN`
+environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-initial-cluster-token sensu
 
@@ -912,7 +912,7 @@ etcd-initial-cluster-token: "sensu"{{< /highlight >}}
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
-environment variable | `SENSU_ETCD_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-key-file ./client-key.pem
 
@@ -926,7 +926,7 @@ etcd-key-file: "./client-key.pem"{{< /highlight >}}
 description               | List of URLs to listen on for client traffic.
 type                      | List
 default                   | `http://127.0.0.1:2379`
-environment variable      | `SENSU_ETCD_LISTEN_CLIENT_URLS`
+environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 example                   | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
@@ -943,7 +943,7 @@ etcd-listen-client-urls:
 description             | List of URLs to listen on for peer traffic.
 type                    | List
 default                 | `http://127.0.0.1:2380`
-environment variable    | `SENSU_ETCD_LISTEN_PEER_URLS`
+environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 example                 | {{< highlight shell >}}# Command line examples
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
@@ -960,7 +960,7 @@ etcd-listen-peer-urls:
 description      | Human-readable name for this member.
 type             | String
 default          | `default`
-environment variable | `SENSU_ETCD_NAME`
+environment variable | `SENSU_BACKEND_ETCD_NAME`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-name backend-0
 
@@ -972,7 +972,7 @@ etcd-name: "backend-0"{{< /highlight >}}
 ----------------------|------
 description           | Path to the peer server TLS certificate file.
 type                  | String
-environment variable  | `SENSU_ETCD_PEER_CERT_FILE`
+environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-cert-file ./backend-0.pem
 
@@ -985,7 +985,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /highlight >}}
 description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
-environment variable         | `SENSU_ETCD_PEER_CLIENT_CERT_AUTH`
+environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 example                      | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-client-cert-auth
 
@@ -997,7 +997,7 @@ etcd-peer-client-cert-auth: true{{< /highlight >}}
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
-environment variable | `SENSU_ETCD_PEER_KEY_FILE`
+environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 example              | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
 
@@ -1009,7 +1009,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /highlight >}}
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
-environment variable        | `SENSU_ETCD_PEER_TRUSTED_CA_FILE`
+environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 example                     | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
 
@@ -1022,7 +1022,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
 type                   | String
 default                | `""`
-environment variable   | `SENSU_ETCD_TRUSTED_CA_FILE`
+environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-trusted-ca-file ./ca.pem
 
@@ -1035,7 +1035,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /highlight >}}
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
 type             | Boolean
 default          | `false`
-environment variable | `SENSU_NO_EMBED_ETCD`
+environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 example          | {{< highlight shell >}}# Command line example
 sensu-backend start --no-embed-etcd
 
@@ -1052,7 +1052,7 @@ description            | Number of incoming events that can be buffered before b
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-buffer-size 100
 
@@ -1068,7 +1068,7 @@ description            | Number of workers spawned for processing incoming event
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_EVENTD_WORKERS`
+environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --eventd-workers 100
 
@@ -1083,7 +1083,7 @@ description            | Number of incoming keepalives that can be buffered befo
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-buffer-size 100
 
@@ -1097,7 +1097,7 @@ description            | Number of workers spawned for processing incoming keepa
 **WARNING**: Modify with caution. Increasing this value may result in greater CPU usage.{{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_KEEPALIVED_WORKERS`
+environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --keepalived-workers 100
 
@@ -1112,7 +1112,7 @@ description            | Number of events to handle that can be buffered before 
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-buffer-size 100
 
@@ -1127,7 +1127,7 @@ description            | Number of workers spawned for handling events through t
 {{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_PIPELINED_WORKERS`
+environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --pipelined-workers 100
 
@@ -1142,7 +1142,7 @@ description            | Time that a follower node will go without hearing a hea
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
-environment variable   | `SENSU_ETCD_ELECTION_TIMEOUT`
+environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-election-timeout 1000
 
@@ -1156,7 +1156,7 @@ description            | Interval at which the etcd leader will notify followers
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
 type                   | Integer
 default                | `100`
-environment variable   | `SENSU_ETCD_HEARTBEAT_INTERVAL`
+environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-heartbeat-interval 100
 
@@ -1171,7 +1171,7 @@ description            | Maximum etcd request size in bytes that can be sent to 
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
-environment variable   | `SENSU_ETCD_MAX_REQUEST_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-max-request-bytes 1572864
 
@@ -1186,7 +1186,7 @@ description            | Maximum etcd database size in bytes. Increasing this va
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`
-environment variable   | `SENSU_ETCD_QUOTA_BACKEND_BYTES`
+environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --etcd-quota-backend-bytes 4294967296
 
@@ -1215,12 +1215,12 @@ $ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_API_LISTEN_ADDRESS`.
+     To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1263,7 +1263,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_TEST_VAR`.
+For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_TEST_VAR`.
 
 ## Event logging
 
@@ -1280,7 +1280,7 @@ The event logging functionality provides better performance and reliability than
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
-environment variable   | `SENSU_EVENT_LOG_BUFFER_SIZE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-buffer-size 100000
 
@@ -1295,7 +1295,7 @@ description            | Path to the event log file. {{% notice warning %}}
 **WARNING**: The log file should be located on a local drive. Logging directly to network drives is not supported.
 {{% /notice %}}
 type                   | String
-environment variable   | `SENSU_EVENT_LOG_FILE`
+environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 example                | {{< highlight shell >}}# Command line example
 sensu-backend start --event-log-file /var/log/sensu/events.log
 


### PR DESCRIPTION
## Description
Adds `BACKEND_` to environment variables examples in the backend references for all supported versions.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2437#issuecomment-626806133