### PR TITLE
Add refresh rate for discover-processes

### DIFF
--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -916,7 +916,7 @@ disable-assets: true{{< /highlight >}}
 
 | discover-processes |      |
 --------------|------
-description   | When set to `true`, the agent populates the `processes` field in `entity.system`.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].
+description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`


### PR DESCRIPTION
## Description
Adds the 20-second refresh rate to the description table for the discover-processes flag in the agent reference.

## Motivation and Context
Customer question