### PR TITLE
Add RBAC explanation for searches resource

### DIFF
--- a/content/sensu-go/5.19/dashboard/filtering.md
+++ b/content/sensu-go/5.19/dashboard/filtering.md
@@ -201,9 +201,10 @@ To save a filtered search:
 4. Type the name you want to use for the saved search.
 5. Press **Return/Enter**.
 
-Any Sensu user with access to the namespace where you save the search will be able to recall it at any time.
+Sensu saves your filtered searches to etcd in a [namespaced resource][11] named `searches`.
+To recall a saved filtered search, a Sensu user must be assigned to a [role][12] that includes permissions for both the `searches` resource and the namespace where you save the search.
 
-Sensu saves your filtered searches to etcd in a resource named `searches`.
+The role-based access control (RBAC) reference includes [example workflows][13] that demonstrate how to configure a user's roles and role bindings to include full permissions for namespaced resources, including saved searches.
 
 ### Recall a saved filtered search
 
@@ -230,3 +231,6 @@ To delete a saved search:
 [8]: #save-a-filtered-search
 [9]: #operators-quick-reference
 [10]: #examples
+[11]: ../../reference/rbac/#namespaced-resource-types
+[12]: ../../reference/rbac/#roles-and-cluster-roles
+[13]: ../../reference/rbac/#example-workflows

--- a/content/sensu-go/5.19/reference/rbac.md
+++ b/content/sensu-go/5.19/reference/rbac.md
@@ -206,7 +206,7 @@ You can access namespaced resources by [roles][13] and [cluster roles][21].
 | `mutators` | [Mutator][11] resources within a namespace |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
-| `searches` | [Web UI][3] search queries |
+| `searches` | Saved [web UI][49] search queries |
 | `silenced` | [Silencing][14] resources within a namespace |
 
 ### Cluster-wide resource types
@@ -1075,7 +1075,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
         "resource_names": [],
         "resources": [
           "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1138,7 +1138,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
         "resource_names": [],
         "resources": [
           "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1254,7 +1254,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [18]: #cluster-wide-resource-types
 [19]: ../../api/overview/
 [20]: #default-users
-[21]: #roles-and-cluster-roles
+[21]: #cluster-roles
 [22]: ../filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -1280,3 +1280,4 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [46]: ../secrets-providers/
 [47]: ../datastore/
 [48]: ../secrets/
+[49]: ../../dashboard/filtering/#save-a-filtered-search

--- a/content/sensu-go/5.20/dashboard/filtering.md
+++ b/content/sensu-go/5.20/dashboard/filtering.md
@@ -202,8 +202,8 @@ To save a filtered search:
 4. Type the name you want to use for the saved search.
 5. Press **Return/Enter**.
 
-Sensu saves your filtered searches to etcd in a resource named `searches`.
-The `searches` resource is a [namespaced resource type][11], so any Sensu user assigned to a [role][12] that includes permissions for the namespace where you save the search will be able to recall it at any time.
+Sensu saves your filtered searches to etcd in a [namespaced resource][11] named `searches`.
+To recall a saved filtered search, a Sensu user must be assigned to a [role][12] that includes permissions for both the `searches` resource and the namespace where you save the search.
 
 The role-based access control (RBAC) reference includes [example workflows][13] that demonstrate how to configure a user's roles and role bindings to include full permissions for namespaced resources, including saved searches.
 

--- a/content/sensu-go/5.20/dashboard/filtering.md
+++ b/content/sensu-go/5.20/dashboard/filtering.md
@@ -202,9 +202,10 @@ To save a filtered search:
 4. Type the name you want to use for the saved search.
 5. Press **Return/Enter**.
 
-Any Sensu user with access to the namespace where you save the search will be able to recall it at any time.
-
 Sensu saves your filtered searches to etcd in a resource named `searches`.
+The `searches` resource is a [namespaced resource type][11], so any Sensu user assigned to a [role][12] that includes permissions for the namespace where you save the search will be able to recall it at any time.
+
+The role-based access control (RBAC) reference includes [example workflows][13] that demonstrate how to configure a user's roles and role bindings to include full permissions for namespaced resources, including saved searches.
 
 ### Recall a saved filtered search
 
@@ -231,3 +232,6 @@ To delete a saved search:
 [8]: #save-a-filtered-search
 [9]: #operators-quick-reference
 [10]: #examples
+[11]: ../../reference/rbac/#namespaced-resource-types
+[12]: ../../reference/rbac/#roles-and-cluster-roles
+[13]: ../../reference/rbac/#example-workflows

--- a/content/sensu-go/5.20/reference/rbac.md
+++ b/content/sensu-go/5.20/reference/rbac.md
@@ -206,7 +206,7 @@ You can access namespaced resources by [roles][13] and [cluster roles][21].
 | `mutators` | [Mutator][11] resources within a namespace |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
-| `searches` | [Web UI][3] search queries |
+| `searches` | Saved [web UI][49] search queries |
 | `silenced` | [Silencing][14] resources within a namespace |
 
 ### Cluster-wide resource types
@@ -1075,7 +1075,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
         "resource_names": [],
         "resources": [
           "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1138,7 +1138,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
         "resource_names": [],
         "resources": [
           "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
         ],
         "verbs": ["get", "list", "create", "update", "delete"]
       }
@@ -1236,6 +1236,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 }
 {{< /highlight >}}
 
+
 [1]: ../backend/
 [2]: ../../sensuctl/reference/
 [3]: ../../dashboard/overview/
@@ -1254,7 +1255,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [18]: #cluster-wide-resource-types
 [19]: ../../api/overview/
 [20]: #default-users
-[21]: #roles-and-cluster-roles
+[21]: #cluster-roles
 [22]: ../filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -1280,3 +1281,4 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [46]: ../secrets-providers/
 [47]: ../datastore/
 [48]: ../secrets/
+[49]: ../../dashboard/filtering/#save-a-filtered-search


### PR DESCRIPTION
## Description
- Adds `searches` resource in example workflows in RBAC reference and minor wording adjustment in the `searches` description under namespaced resource types
- Adds link to example workflows in Dashboard filtering doc, along with a better explanation for how user permissions affect who can see saved searches in the web UI

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2335

## Review instructions
I'm not quite sure my explanation is complete or clear enough in the Dashboard filtering doc.