### PR TITLE
Add note about Vault KV secrets engine and client version value v2

### DIFF
--- a/content/sensu-go/5.17/guides/secrets-management.md
+++ b/content/sensu-go/5.17/guides/secrets-management.md
@@ -116,7 +116,8 @@ Skip to the [add a handler][19] section, where you'll use your `pagerduty_key` s
 
 This section explains how to use [HashiCorp Vault][1] as your external [secrets provider][2] to authenticate via the HashiCorp Vault integration's [token auth method][3] or [TLS certificate auth method][4].
 
-_**NOTE**: You will need to set up [HashiCorp Vault][15] to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server][32], which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault._
+_**NOTE**: You must set up [HashiCorp Vault][15] to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server][32], which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum][16] when you are ready to set up a production server in Vault.<br><br>The examples in this guide use the [Vault KV secrets engine][27] with the path `"secret/"`. Using the Vault KV secrets engine with the Vault dev server requires v2 connections.
+For this reason, in the `VaultProvider` spec in these examples, the client `version` value is **v2**._
 
 ### Configure your Vault authentication method (token or TLS)
 
@@ -338,6 +339,7 @@ Read the [secrets][9] or [secrets providers][10] reference for in-depth secrets 
 [24]: ../monitor-server-resources/
 [25]: https://www.vaultproject.io/downloads/
 [26]: ../install-check-executables-with-assets/#2-adjust-the-asset-definition
+[27]: https://www.vaultproject.io/api/secret/kv/kv-v2.html
 [28]: #create-your-backend-environment-variable
 [29]: #create-your-vault-secret
 [30]: #retrieve-your-pagerduty-integration-key

--- a/content/sensu-go/5.18/guides/secrets-management.md
+++ b/content/sensu-go/5.18/guides/secrets-management.md
@@ -117,7 +117,13 @@ Skip to the [add a handler][19] section, where you'll use your `pagerduty_key` s
 This section explains how to use [HashiCorp Vault][1] as your external [secrets provider][2] to authenticate via the HashiCorp Vault integration's [token auth method][3] or [TLS certificate auth method][4].
 
 {{% notice note %}}
-**NOTE**: You will need to set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.
+**NOTE**: You must set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production.
+The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting.
+The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away.
+Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.<br><br>
+The examples in this guide use the [Vault KV secrets engine](https://www.vaultproject.io/api/secret/kv/kv-v2.html) with the path `"secret/"`.
+Using the Vault KV secrets engine with the Vault dev server requires v2 connections.
+For this reason, in the `VaultProvider` spec in these examples, the client `version` value is **v2**.
 {{% /notice %}}
 
 ### Configure your Vault authentication method (token or TLS)

--- a/content/sensu-go/5.19/guides/secrets-management.md
+++ b/content/sensu-go/5.19/guides/secrets-management.md
@@ -117,7 +117,13 @@ Skip to the [add a handler][19] section, where you'll use your `pagerduty_key` s
 This section explains how to use [HashiCorp Vault][1] as your external [secrets provider][2] to authenticate via the HashiCorp Vault integration's [token auth method][3] or [TLS certificate auth method][4].
 
 {{% notice note %}}
-**NOTE**: You will need to set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.
+**NOTE**: You must set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production.
+The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting.
+The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away.
+Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.<br><br>
+The examples in this guide use the [Vault KV secrets engine](https://www.vaultproject.io/api/secret/kv/kv-v2.html) with the path `"secret/"`.
+Using the Vault KV secrets engine with the Vault dev server requires v2 connections.
+For this reason, in the `VaultProvider` spec in these examples, the client `version` value is **v2**.
 {{% /notice %}}
 
 ### Configure your Vault authentication method (token or TLS)

--- a/content/sensu-go/5.20/guides/secrets-management.md
+++ b/content/sensu-go/5.20/guides/secrets-management.md
@@ -117,7 +117,13 @@ Skip to the [add a handler][19] section, where you'll use your `pagerduty_key` s
 This section explains how to use [HashiCorp Vault][1] as your external [secrets provider][2] to authenticate via the HashiCorp Vault integration's [token auth method][3] or [TLS certificate auth method][4].
 
 {{% notice note %}}
-**NOTE**: You will need to set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production. The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting. The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away. Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.
+**NOTE**: You must set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production.
+The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting.
+The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away.
+Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.</br></br>
+The examples in this guide use the [Vault KV secrets engine](https://www.vaultproject.io/api/secret/kv/kv-v2.html) with the path `"secret/"`.
+Using the Vault KV secrets engine with the Vault dev server requires v2 connections.
+For this reason, in the `VaultProvider` spec in these examples, the client `version` value is **v2**.
 {{% /notice %}}
 
 ### Configure your Vault authentication method (token or TLS)

--- a/content/sensu-go/5.20/guides/secrets-management.md
+++ b/content/sensu-go/5.20/guides/secrets-management.md
@@ -120,7 +120,7 @@ This section explains how to use [HashiCorp Vault][1] as your external [secrets 
 **NOTE**: You must set up [HashiCorp Vault](https://www.vaultproject.io/docs/install/) to use `VaultProvider` secrets management in production.
 The examples in this guide use the [Vault dev server](https://www.vaultproject.io/docs/concepts/dev-server/), which is useful for learning and experimenting.
 The Vault dev server gives you access to a preconfigured, running Vault server with in-memory storage that you can use right away.
-Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.</br></br>
+Follow the [HashiCorp Learn curriculum](https://learn.hashicorp.com/vault) when you are ready to set up a production server in Vault.<br><br>
 The examples in this guide use the [Vault KV secrets engine](https://www.vaultproject.io/api/secret/kv/kv-v2.html) with the path `"secret/"`.
 Using the Vault KV secrets engine with the Vault dev server requires v2 connections.
 For this reason, in the `VaultProvider` spec in these examples, the client `version` value is **v2**.


### PR DESCRIPTION
## Description
In secrets management guide, adds note about using v2 as the value for the client version in example VaultProvider specs and explains the reason.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2469
