### PR TITLE
Use double negation in label and annotation example in SQE doc

### DIFF
--- a/content/sensu-go/5.17/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.17/reference/sensu-query-expressions.md
@@ -148,13 +148,13 @@ Although you can use annotations to create SQEs, we recommend using labels becau
 This expression returns `true` if the event's entity includes the label `webserver`:
 
 {{< highlight go >}}
-event.entity.labels.indexOf('webserver') >= 0
+!!event.entity.labels.webserver
 {{< /highlight >}}
 
 Likewise, this expression returns `true` if the event's entity includes the annotation `www.company.com`:
 
 {{< highlight go >}}
-event.entity.annotations.indexOf('www.company.com') >= 0
+!!event.entity.annotations['www.company.com']
 {{< /highlight >}}
 
 

--- a/content/sensu-go/5.18/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.18/reference/sensu-query-expressions.md
@@ -148,13 +148,13 @@ Although you can use annotations to create SQEs, we recommend using labels becau
 This expression returns `true` if the event's entity includes the label `webserver`:
 
 {{< highlight go >}}
-event.entity.labels.indexOf('webserver') >= 0
+!!event.entity.labels.webserver
 {{< /highlight >}}
 
 Likewise, this expression returns `true` if the event's entity includes the annotation `www.company.com`:
 
 {{< highlight go >}}
-event.entity.annotations.indexOf('www.company.com') >= 0
+!!event.entity.annotations['www.company.com']
 {{< /highlight >}}
 
 

--- a/content/sensu-go/5.19/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.19/reference/sensu-query-expressions.md
@@ -148,13 +148,13 @@ Although you can use annotations to create SQEs, we recommend using labels becau
 This expression returns `true` if the event's entity includes the label `webserver`:
 
 {{< highlight go >}}
-event.entity.labels.indexOf('webserver') >= 0
+!!event.entity.labels.webserver
 {{< /highlight >}}
 
 Likewise, this expression returns `true` if the event's entity includes the annotation `www.company.com`:
 
 {{< highlight go >}}
-event.entity.annotations.indexOf('www.company.com') >= 0
+!!event.entity.annotations['www.company.com']
 {{< /highlight >}}
 
 

--- a/content/sensu-go/5.20/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.20/reference/sensu-query-expressions.md
@@ -148,13 +148,13 @@ Although you can use annotations to create SQEs, we recommend using labels becau
 This expression returns `true` if the event's entity includes the label `webserver`:
 
 {{< highlight go >}}
-event.entity.labels.indexOf('webserver') >= 0
+!!event.entity.labels.webserver
 {{< /highlight >}}
 
 Likewise, this expression returns `true` if the event's entity includes the annotation `www.company.com`:
 
 {{< highlight go >}}
-event.entity.annotations.indexOf('www.company.com') >= 0
+!!event.entity.annotations['www.company.com']
 {{< /highlight >}}
 
 


### PR DESCRIPTION
## Description
Changes examples under https://docs.sensu.io/sensu-go/latest/reference/sensu-query-expressions/#evaluate-labels-and-annotations to use `!!` rather than `indexOf`.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2480
