### PR TITLE
Change default agent log level to info

### DIFF
--- a/content/sensu-go/5.20/guides/troubleshooting.md
+++ b/content/sensu-go/5.20/guides/troubleshooting.md
@@ -58,8 +58,6 @@ kill -s SIGUSR1 $(pidof sensu-agent)
 
 When you increment the log at the trace level (the most verbose log level), the log will wrap around to the error level.
 
-You must restart the service after making this change.
-
 ### Log file locations
 
 {{< platformBlock "Linux" >}}

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -768,7 +768,7 @@ Flags:
       --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
       --key-file string                       TLS certificate key in PEM format
       --labels stringToString                 entity labels map (default [])
-      --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "info")
       --name string                           agent name (defaults to hostname) (default "my-hostname")
       --namespace string                      agent namespace (default "default")
       --password string                       agent password (default "P@ssw0rd!")


### PR DESCRIPTION
## Description

Update `sensu-agent` reference to show that the default log level is now `info` instead of `warn`.

## Motivation and Context

See https://github.com/sensu/sensu-go/issues/3704 https://github.com/sensu/sensu-go/pull/3817