### PR TITLE
Fix link to API page in 5.17, 5.18, 5.19. and 5.20

### DIFF
--- a/content/sensu-go/5.17/reference/license.md
+++ b/content/sensu-go/5.17/reference/license.md
@@ -100,7 +100,7 @@ If your license expires, you will still have access to [commercial features][5],
 [6]: ../../guides/troubleshooting/
 [7]: https://sensu.io/contact?subject=contact-sales
 [8]: https://account.sensu.io/support
-[9]: ../../../latest/api/
+[9]: ../../api/
 [10]: ../../installation/auth/
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4
 [12]: ../../guides/install-check-executables-with-assets/

--- a/content/sensu-go/5.18/reference/license.md
+++ b/content/sensu-go/5.18/reference/license.md
@@ -100,7 +100,7 @@ If your license expires, you will still have access to [commercial features][5],
 [6]: ../../guides/troubleshooting/
 [7]: https://sensu.io/contact?subject=contact-sales
 [8]: https://account.sensu.io/support
-[9]: ../../../latest/api/
+[9]: ../../api/
 [10]: ../../installation/auth/
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4
 [12]: ../../guides/install-check-executables-with-assets/

--- a/content/sensu-go/5.19/reference/license.md
+++ b/content/sensu-go/5.19/reference/license.md
@@ -100,7 +100,7 @@ If your license expires, you will still have access to [commercial features][5],
 [6]: ../../guides/troubleshooting/
 [7]: https://sensu.io/contact?subject=contact-sales
 [8]: https://account.sensu.io/support
-[9]: ../../../latest/api/
+[9]: ../../api/
 [10]: ../../installation/auth/
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4
 [12]: ../../guides/install-check-executables-with-assets/

--- a/content/sensu-go/5.20/reference/license.md
+++ b/content/sensu-go/5.20/reference/license.md
@@ -146,7 +146,7 @@ If your license expires, you will still have access to [commercial features][5],
 [6]: ../../guides/troubleshooting/
 [7]: https://sensu.io/contact?subject=contact-sales
 [8]: https://account.sensu.io/support
-[9]: ../../../latest/api/
+[9]: ../../api/
 [10]: ../../installation/auth/
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4
 [12]: ../../guides/install-check-executables-with-assets/


### PR DESCRIPTION
Fixes link from ../../../latest/api to ../../api in license reference docs for 5.17, 5.18, 5.19. and 5.20.