### PR TITLE
Update default log level in flag description

### DIFF
--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -965,12 +965,13 @@ sensu-agent start --name agent-01
 # /etc/sensu/agent.yml example
 name: "agent-01" {{< /highlight >}}
 
+<a name="log-level"></a>
 
 | log-level   |      |
 --------------|------
 description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type          | String
-default       | `warn`
+default       | `info`
 environment variable | `SENSU_LOG_LEVEL`
 example       | {{< highlight shell >}}# Command line example
 sensu-agent start --log-level debug


### PR DESCRIPTION
## Description
Update default listed in log-level flag description table to `info`. I did not do this in the previous PR, https://github.com/sensu/sensu-docs/pull/2490
