### PR TITLE
Add reset-password and hash-password commands

### DIFF
--- a/content/sensu-go/5.21/reference/rbac.md
+++ b/content/sensu-go/5.21/reference/rbac.md
@@ -285,6 +285,8 @@ To change the password for a user:
 sensuctl user change-password USERNAME --current-password CURRENT_PASSWORD --new-password NEW_PASSWORD
 {{< /highlight >}}
 
+You can also use sensuctl to [reset a user's password][50] or [generate a password hash][51].
+
 To disable a user:
 
 {{< highlight shell >}}
@@ -1282,3 +1284,5 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [47]: ../datastore/
 [48]: ../secrets/
 [49]: ../../dashboard/filtering/#save-a-filtered-search
+[50]: ../../sensuctl/reference/#reset-a-user-password
+[51]: ../../sensuctl/reference/#generate-a-password-hash

--- a/content/sensu-go/5.21/sensuctl/reference.md
+++ b/content/sensu-go/5.21/sensuctl/reference.md
@@ -103,7 +103,7 @@ To generate a password hash for the given cleartext password, run:
 sensuctl user hash-password
 {{< /highlight >}}
 
-The `sensuctl user hash-password` command adds a field to the `User` resource, `password_hash`, whose value is a hash for the user's password.
+The `sensuctl user hash-password` command creates a [bcrypt hash][54] of the password.
 You can use this hash instead of the password when you use sensuctl to [create][8], [edit][51], or [dump][52] users.
 
 ### Preferred output format
@@ -1303,3 +1303,4 @@ Flags are optional and apply only to the `delete` command.
 [51]: #update-resources
 [52]: #export-resources
 [53]: ../../reference/rbac/#user-specification
+[54]: https://en.wikipedia.org/wiki/Bcrypt

--- a/content/sensu-go/5.21/sensuctl/reference.md
+++ b/content/sensu-go/5.21/sensuctl/reference.md
@@ -97,13 +97,13 @@ You must have admin permissions to use the `sensuctl user reset-password` comman
 
 #### Generate a password hash
 
-To generate a password hash for the given cleartext password, run:
+To generate a password hash for a specified cleartext password, run:
 
 {{< highlight shell >}}
-sensuctl user hash-password
+sensuctl user hash-password PASSWORD
 {{< /highlight >}}
 
-The `sensuctl user hash-password` command creates a [bcrypt hash][54] of the password.
+The `sensuctl user hash-password` command creates a [bcrypt hash][54] of the specified password.
 You can use this hash instead of the password when you use sensuctl to [create][8], [edit][51], or [dump][52] users.
 
 ### Preferred output format

--- a/content/sensu-go/5.21/sensuctl/reference.md
+++ b/content/sensu-go/5.21/sensuctl/reference.md
@@ -83,6 +83,29 @@ Run:
 sensuctl user change-password --interactive
 {{< /highlight >}}
 
+You must specify the user's current password to use the `sensuctl user change-password` command.
+
+#### Reset a user password
+
+To reset a user password without specifying the current password, run:
+
+{{< highlight shell >}}
+sensuctl user reset-password USERNAME --interactive
+{{< /highlight >}}
+
+You must have admin permissions to use the `sensuctl user reset-password` command.
+
+#### Generate a password hash
+
+To generate a password hash for the given cleartext password, run:
+
+{{< highlight shell >}}
+sensuctl user hash-password
+{{< /highlight >}}
+
+The `sensuctl user hash-password` command adds a field to the `User` resource, `password_hash`, whose value is a hash for the user's password.
+You can use this hash instead of the password when you use sensuctl to [create][8], [edit][51], or [dump][52] users.
+
 ### Preferred output format
 
 Sensuctl supports the following output formats:
@@ -349,8 +372,8 @@ cat my-resources.yml | sensuctl create
 `hook_config` | `Mutator` | `mutator` | `Namespace`
 `namespace` | `Role` | `role` | `RoleBinding`
 `role_binding` | [`Secret`][41] | `Silenced` | `silenced`
-[`VaultProvider`][43] | [`ldap`][26] | [`ad`][42] | [`TessenConfig`][27]
-[`PostgresConfig`][32] |
+[`User`][53] | `user` | [`VaultProvider`][43] | [`ldap`][26]
+[`ad`][42] | [`TessenConfig`][27] | [`PostgresConfig`][32]
 
 ### Create resources across namespaces
 
@@ -1227,6 +1250,7 @@ Replace `[flags]` with the flags you want to use.
 Run `sensuctl command delete -h` to view flags.
 Flags are optional and apply only to the `delete` command.
 
+
 [1]: ../../reference/rbac/
 [2]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [3]: #sensuctl-create-resource-types
@@ -1276,3 +1300,6 @@ Flags are optional and apply only to the `delete` command.
 [48]: #sensuctl-prune-resource-types
 [49]: #examples
 [50]: ../../reference/webconfig/
+[51]: #update-resources
+[52]: #export-resources
+[53]: ../../reference/rbac/#user-specification


### PR DESCRIPTION
## Description
- Adds `reset-password` and `hash-password` commands in sensuctl reference
- Adds `User` and `user` as sensuctl create types
- Adds links to `reset-password` and `hash-password` commands in user section of RBAC reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2499