### PR TITLE
Add OpenSSL/FIPS flags to agent and backend references

### DIFF
--- a/content/sensu-go/5.21/platforms.md
+++ b/content/sensu-go/5.21/platforms.md
@@ -104,18 +104,14 @@ Docker images that contain the Sensu backend and Sensu agent are available for L
 
 Sensu binary-only distributions that contain the Sensu backend, agent, and sensuctl tool are available in `.zip` and `.tar.gz` formats.
 
-| Platform & Version | Linux | Windows | macOS | FreeBSD | Solaris |
-|--------------------|-------|---------|-------|---------| ------- |
-| `386`              | {{< check >}} | {{< check >}} | | {{< check >}}               |     
-| `amd64`            | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}}  | {{< check >}} 
-| `arm64`            | {{< check >}} |               |               |             |             |
-| `armv5`            | {{< check >}} |               |               |             |             |
-| `armv6`            | {{< check >}} |               |               |             |             |
-| `armv7`            | {{< check >}} |               |               |             |             |
-| `MIPS`             | {{< check >}} |               |               |             |             |
-| `MIPS LE`          | {{< check >}} |               |               |             |             |
-| `MIPS 64`          | {{< check >}} |               |               |             |             |
-| `MIPS 64 LE`       | {{< check >}} |               |               |             |             |
+| Platform | Architectures |
+|----------|---------------|
+| Linux | `386` `amd64` `amd64 OpenSSL 1.0 and 1.1` `arm64` `armv5` `armv6` `armv7`<br>`MIPS` `MIPS LE` `MIPS 64` `MIPS 64 LE` |
+| Windows | `386` `amd64` |
+| macOS | `amd64` |
+| FreeBSD | `386` `amd64` |
+| Solaris | `amd64` |
+| AIX | `ppc64` |
 
 {{< platformBlock "Linux" >}}
 
@@ -123,22 +119,16 @@ Sensu binary-only distributions that contain the Sensu backend, agent, and sensu
 
 Sensu binary-only distributions for Linux are available for these architectures and formats:
 
-| arch | format |
-| --- | --- |
-| `386` | [`.tar.gz`][19] \| [`.zip`][25] |
-| `amd64` | [`.tar.gz`][54] \| [`.zip`][20] |
-| `arm64` | [`.tar.gz`][55] \| [`.zip`][21]
-| `armv5` (agent and CLI) | [`.tar.gz`][56] \| [`.zip`][22] |
-| `armv6` (agent and CLI) | [`.tar.gz`][57] \| [`.zip`][23] |
-| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24] |
-| `MIPS hard float` | [`.tar.gz`][38] \| [`.zip`][39] |
-| `MIPS soft float` | [`.tar.gz`][40] \| [`.zip`][41] |
-| `MIPS LE hard float` | [`.tar.gz`][42] \| [`.zip`][43] |
-| `MIPS LE soft float` | [`.tar.gz`][44] \| [`.zip`][45] |
-| `MIPS 64 hard float` | [`.tar.gz`][46] \| [`.zip`][47] |
-| `MIPS 64 soft float` | [`.tar.gz`][48] \| [`.zip`][49] |
-| `MIPS 64 LE hard float` | [`.tar.gz`][50] \| [`.zip`][51] |
-| `MIPS 64 LE soft float` | [`.tar.gz`][52] \| [`.zip`][53] |
+| Architecture | Format | Architecture | Format |
+| --- | --- | --- | --- |
+| `386` | [`.tar.gz`][19] \| [`.zip`][25] | `MIPS hard float` | [`.tar.gz`][38] \| [`.zip`][39] |
+| `amd64` | [`.tar.gz`][54] \| [`.zip`][20] | `MIPS soft float` | [`.tar.gz`][40] \| [`.zip`][41] |
+| `amd64 OpenSSL 1.0` with FIPS support | [`.tar.gz`][58] \| [`.zip`][59] | `MIPS LE hard float` | [`.tar.gz`][42] \| [`.zip`][43] |
+| `amd64 OpenSSL 1.1` with FIPS support | [`.tar.gz`][60] \| [`.zip`][61] |  `MIPS LE soft float` | [`.tar.gz`][44] \| [`.zip`][45] |
+| `arm64` | [`.tar.gz`][55] \| [`.zip`][21] | `MIPS 64 hard float` | [`.tar.gz`][46] \| [`.zip`][47] |
+| `armv5` (agent and CLI) | [`.tar.gz`][56] \| [`.zip`][22] | `MIPS 64 soft float` | [`.tar.gz`][48] \| [`.zip`][49] |
+| `armv6` (agent and CLI) | [`.tar.gz`][57] \| [`.zip`][23] | `MIPS 64 LE hard float` | [`.tar.gz`][50] \| [`.zip`][51] |
+| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24] | `MIPS 64 LE soft float` | [`.tar.gz`][52] \| [`.zip`][53] |
 
 {{% notice note %}}
 **NOTE**: 32-bit systems cannot run the Sensu backend reliably, so `armv5`, `armv6`, and `armv7` packages include the agent and CLI only.
@@ -171,7 +161,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.
 
 Sensu binary-only distributions for Windows are available for these architectures and formats:
 
-| arch | format |
+| Architecture | Format |
 | --- | --- |
 | `amd64` | [`.tar.gz`][26] \| [`.zip`][28]
 | `386` | [`.tar.gz`][27] \| [`.zip`][29]
@@ -204,7 +194,7 @@ Get-Content "$env:userprofile\sensu-go_5.20.2_checksums.txt" | Select-String -Pa
 
 Sensu binary-only distributions for macOS are available for these architectures and formats:
 
-| arch | format |
+| Architecture | Format |
 | --- | --- |
 | `amd64` | [`.tar.gz`][30] \| [`.zip`][31]
 
@@ -246,7 +236,7 @@ sudo cp sensuctl /usr/local/bin/
 
 Sensu binary-only distributions for FreeBSD are available for these architectures and formats:
 
-| arch | format |
+| Architecture | Format |
 | --- | --- |
 | `amd64` | [`.tar.gz`][32] \| [`.zip`][33]
 | `386` | [`.tar.gz`][34] \| [`.zip`][35]
@@ -277,7 +267,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.
 
 Sensu binary-only distributions for Solaris are available for these architectures and formats:
 
-| arch | format |
+| Architecture | Format |
 | --- | --- |
 | `amd64` | [`.tar.gz`][36] \| [`.zip`][37]
 
@@ -366,3 +356,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [55]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.20.2_linux_arm64.tar.gz
 [56]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.20.2_linux_armv5.tar.gz
 [57]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.20.2_linux_armv6.tar.gz
+[58]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.0_5.21.0_linux_amd64.tar.gz
+[59]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.0_5.21.0_linux_amd64.zip
+[60]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.1_5.21.0_linux_amd64.tar.gz
+[61]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.1_5.21.0_linux_amd64.zip

--- a/content/sensu-go/5.21/platforms.md
+++ b/content/sensu-go/5.21/platforms.md
@@ -88,7 +88,7 @@ Sensu binary-only distributions that contain the Sensu backend, agent, and sensu
 
 | Platform | Architectures |
 |----------|---------------|
-| Linux | `386` `amd64` `amd64 OpenSSL 1.0 and 1.1` `arm64` `armv5` `armv6` `armv7`<br>`MIPS` `MIPS LE` `MIPS 64` `MIPS 64 LE` |
+| Linux | `386` `amd64` `arm64` `armv5` `armv6` `armv7`<br>`MIPS` `MIPS LE` `MIPS 64` `MIPS 64 LE` |
 | Windows | `386` `amd64` |
 | macOS | `amd64` |
 | FreeBSD | `386` `amd64` |
@@ -100,16 +100,15 @@ Sensu binary-only distributions that contain the Sensu backend, agent, and sensu
 
 Sensu binary-only distributions for Linux are available for these architectures and formats:
 
-| Architecture | Format | Architecture | Format |
+| Architecture | Formats | Architecture | Formats |
 | --- | --- | --- | --- |
 | `386` | [`.tar.gz`][19] \| [`.zip`][25] | `MIPS hard float` | [`.tar.gz`][38] \| [`.zip`][39] |
 | `amd64` | [`.tar.gz`][54] \| [`.zip`][20] | `MIPS soft float` | [`.tar.gz`][40] \| [`.zip`][41] |
-| `amd64 OpenSSL 1.0` with FIPS support | [`.tar.gz`][58] \| [`.zip`][59] | `MIPS LE hard float` | [`.tar.gz`][42] \| [`.zip`][43] |
-| `amd64 OpenSSL 1.1` with FIPS support | [`.tar.gz`][60] \| [`.zip`][61] |  `MIPS LE soft float` | [`.tar.gz`][44] \| [`.zip`][45] |
-| `arm64` | [`.tar.gz`][55] \| [`.zip`][21] | `MIPS 64 hard float` | [`.tar.gz`][46] \| [`.zip`][47] |
-| `armv5` (agent and CLI) | [`.tar.gz`][56] \| [`.zip`][22] | `MIPS 64 soft float` | [`.tar.gz`][48] \| [`.zip`][49] |
-| `armv6` (agent and CLI) | [`.tar.gz`][57] \| [`.zip`][23] | `MIPS 64 LE hard float` | [`.tar.gz`][50] \| [`.zip`][51] |
-| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24] | `MIPS 64 LE soft float` | [`.tar.gz`][52] \| [`.zip`][53] |
+| `arm64` | [`.tar.gz`][55] \| [`.zip`][21] | `MIPS LE hard float` | [`.tar.gz`][42] \| [`.zip`][43] |
+| `armv5` (agent and CLI) | [`.tar.gz`][56] \| [`.zip`][22] | `MIPS LE soft float` | [`.tar.gz`][44] \| [`.zip`][45] |
+| `armv6` (agent and CLI) | [`.tar.gz`][57] \| [`.zip`][23] | `MIPS 64 hard float` | [`.tar.gz`][46] \| [`.zip`][47] |
+| `armv7` (agent and CLI) | [`.tar.gz`][18] \| [`.zip`][24] | `MIPS 64 soft float` | [`.tar.gz`][48] \| [`.zip`][49] |
+| `MIPS 64 LE hard float` | [`.tar.gz`][50] \| [`.zip`][51] | `MIPS 64 LE soft float` | [`.tar.gz`][52] \| [`.zip`][53] |
 
 {{% notice note %}}
 **NOTE**: 32-bit systems cannot run the Sensu backend reliably, so `armv5`, `armv6`, and `armv7` packages include the agent and CLI only.
@@ -337,7 +336,3 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [55]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.20.2_linux_arm64.tar.gz
 [56]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.20.2_linux_armv5.tar.gz
 [57]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.2/sensu-go_5.20.2_linux_armv6.tar.gz
-[58]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.0_5.21.0_linux_amd64.tar.gz
-[59]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.0_5.21.0_linux_amd64.zip
-[60]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.1_5.21.0_linux_amd64.tar.gz
-[61]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.0/sensu-go-openssl-1.1_5.21.0_linux_amd64.zip

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -774,7 +774,7 @@ Flags:
       --namespace string                      agent namespace (default "default")
       --password string                       agent password (default "P@ssw0rd!")
       --redact string                         comma-delimited customized list of fields to redact
-      --require-fips                              indicates whether fips support should be required in openssl
+      --require-fips                          indicates whether fips support should be required in openssl
       --require-openssl                       indicates whether openssl should be required instead of go's built-in crypto
       --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
       --socket-port int                       port the Sensu client socket listens on (default 3030)

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -774,6 +774,8 @@ Flags:
       --namespace string                      agent namespace (default "default")
       --password string                       agent password (default "P@ssw0rd!")
       --redact string                         comma-delimited customized list of fields to redact
+      --require-fips
+      --require-openssl
       --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
       --socket-port int                       port the Sensu client socket listens on (default 3030)
       --statsd-disable                        disables the statsd listener and metrics server
@@ -1276,6 +1278,36 @@ sensu-agent start --insecure-skip-tls-verify
 
 # /etc/sensu/agent.yml example
 insecure-skip-tls-verify: true{{< /highlight >}}
+
+<a name="fips-openssl"></a>
+
+| require-fips |      |
+------------------|------
+description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode.<br>{{% notice note %}}
+**NOTE**: The `--require-fips` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+{{% /notice %}}
+type              | Boolean
+default           | false
+environment variable | `SENSU_REQUIRE_FIPS`
+example           | {{< highlight shell >}}# Command line example
+sensu-agent start --require-fips
+
+# /etc/sensu/agent.yml example
+require-fips: true{{< /highlight >}}
+
+| require-openssl |      |
+------------------|------
+description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded.<br>{{% notice note %}}
+**NOTE**: The `--require-openssl` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+{{% /notice %}}
+type              | Boolean
+default           | false
+environment variable | `SENSU_REQUIRE_OPENSSL`
+example           | {{< highlight shell >}}# Command line example
+sensu-agent start --require-openssl
+
+# /etc/sensu/agent.yml example
+require-openssl: true{{< /highlight >}}
 
 
 ### Socket configuration flags

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -1284,7 +1284,8 @@ insecure-skip-tls-verify: true{{< /highlight >}}
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode.<br>{{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+[Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
 default           | false
@@ -1298,7 +1299,8 @@ require-fips: true{{< /highlight >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded.<br>{{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+[Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
 default           | false

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -774,8 +774,8 @@ Flags:
       --namespace string                      agent namespace (default "default")
       --password string                       agent password (default "P@ssw0rd!")
       --redact string                         comma-delimited customized list of fields to redact
-      --require-fips
-      --require-openssl
+      --require-fips                              indicates whether fips support should be required in openssl
+      --require-openssl                       indicates whether openssl should be required instead of go's built-in crypto
       --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
       --socket-port int                       port the Sensu client socket listens on (default 3030)
       --statsd-disable                        disables the statsd listener and metrics server

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -307,7 +307,7 @@ General Flags:
       --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
-      --require-fips                            indicates whether fips support should be required in openssl
+      --require-fips                        indicates whether fips support should be required in openssl
       --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -671,7 +671,8 @@ key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode.<br>{{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+[Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
 default           | false
@@ -685,7 +686,8 @@ require-fips: true{{< /highlight >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded.<br>{{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+[Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
 default           | false

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -307,6 +307,8 @@ General Flags:
       --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
+      --require-fips
+      --require-openssl
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format
 
@@ -623,7 +625,7 @@ insecure-skip-tls-verify: true{{< /highlight >}}
 
 | jwt-private-key-file |      |
 -------------|------
-description  | Path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs). {{% notice note %}}
+description  | Path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs).<br>{{% notice note %}}
 **NOTE**: The internal symmetric secret key is used by default to sign all JWTs unless a private key is specified via this attribute.
 {{% /notice %}}
 type         | String
@@ -638,7 +640,7 @@ jwt-private-key-file: /path/to/key/private.pem{{< /highlight >}}
 
 | jwt-public-key-file |      |
 -------------|------
-description  | Path to the PEM-encoded public key to use to verify JSON Web Token (JWT) signatures. {{% notice note %}}
+description  | Path to the PEM-encoded public key to use to verify JSON Web Token (JWT) signatures.<br>{{% notice note %}}
 **NOTE**: JWTs signed with the internal symmetric secret key will continue to be verified with that key.
 {{% /notice %}}
 type         | String
@@ -664,6 +666,35 @@ sensu-backend start --key-file /path/to/ssl/key.pem
 # /etc/sensu/backend.yml example
 key-file: "/path/to/ssl/key.pem"{{< /highlight >}}
 
+<a name="fips-openssl"></a>
+
+| require-fips |      |
+------------------|------
+description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode.<br>{{% notice note %}}
+**NOTE**: The `--require-fips` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+{{% /notice %}}
+type              | Boolean
+default           | false
+environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
+example           | {{< highlight shell >}}# Command line example
+sensu-backend start --require-fips
+
+# /etc/sensu/backend.yml example
+require-fips: true{{< /highlight >}}
+
+| require-openssl |      |
+------------------|------
+description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded.<br>{{% notice note %}}
+**NOTE**: The `--require-openssl` flag is only available within the [Linux amd64 OpenSSL-linked binary](../../platforms/#linux).
+{{% /notice %}}
+type              | Boolean
+default           | false
+environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
+example           | {{< highlight shell >}}# Command line example
+sensu-backend start --require-openssl
+
+# /etc/sensu/backend.yml example
+require-openssl: true{{< /highlight >}}
 
 | trusted-ca-file |      |
 ------------------|------

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -307,8 +307,8 @@ General Flags:
       --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
-      --require-fips
-      --require-openssl
+      --require-fips                            indicates whether fips support should be required in openssl
+      --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format
 


### PR DESCRIPTION
## Description
- Adds --require-openssl and --require-fips flags and descriptions to https://docs.sensu.io/sensu-go/5.21/reference/agent/ and https://docs.sensu.io/sensu-go/5.21/reference/backend/

## Motivation and Context
Closes #2506 
