### PR TITLE
Remove notes about TCP rather than UDP on Windows systems for statsd

### DIFF
--- a/content/sensu-go/5.17/getting-started/faq.md
+++ b/content/sensu-go/5.17/getting-started/faq.md
@@ -104,7 +104,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][21]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][21]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 

--- a/content/sensu-go/5.17/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.17/guides/aggregate-metrics-statsd.md
@@ -37,8 +37,6 @@ echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
 Metrics received through the StatsD listener are not stored in etcd.
 Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
 
-_**NOTE**: On Windows machines running Sensu, the StatsD UDP port is not supported. Instead, the TCP port is exposed._
-
 ## Configure the StatsD listener
 
 Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.

--- a/content/sensu-go/5.17/reference/agent.md
+++ b/content/sensu-go/5.17/reference/agent.md
@@ -225,7 +225,7 @@ example url     | http://hostname:3031/healthz
 ## Create monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.
-By default, Sensu agents listen on UDP socket 8125 (TCP on Windows systems) for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
+By default, Sensu agents listen on UDP socket 8125 for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
 
 For example, you can use the [Netcat][19] utility to send metrics to the StatsD listener:
 

--- a/content/sensu-go/5.18/getting-started/faq.md
+++ b/content/sensu-go/5.18/getting-started/faq.md
@@ -104,7 +104,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][21]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][21]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 

--- a/content/sensu-go/5.18/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.18/guides/aggregate-metrics-statsd.md
@@ -37,11 +37,6 @@ echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
 Metrics received through the StatsD listener are not stored in etcd.
 Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
 
-{{% notice note %}}
-**NOTE**: On Windows machines running Sensu, the StatsD UDP port is not supported.
-Instead, the TCP port is exposed.
-{{% /notice %}}
-
 ## Configure the StatsD listener
 
 Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.

--- a/content/sensu-go/5.18/reference/agent.md
+++ b/content/sensu-go/5.18/reference/agent.md
@@ -227,7 +227,7 @@ example url     | http://hostname:3031/healthz
 ## Create monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.
-By default, Sensu agents listen on UDP socket 8125 (TCP on Windows systems) for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
+By default, Sensu agents listen on UDP socket 8125 for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
 
 For example, you can use the [Netcat][19] utility to send metrics to the StatsD listener:
 

--- a/content/sensu-go/5.19/getting-started/faq.md
+++ b/content/sensu-go/5.19/getting-started/faq.md
@@ -104,7 +104,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][21]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][21]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 

--- a/content/sensu-go/5.19/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.19/guides/aggregate-metrics-statsd.md
@@ -37,11 +37,6 @@ echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
 Metrics received through the StatsD listener are not stored in etcd.
 Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
 
-{{% notice note %}}
-**NOTE**: On Windows machines running Sensu, the StatsD UDP port is not supported.
-Instead, the TCP port is exposed.
-{{% /notice %}}
-
 ## Configure the StatsD listener
 
 Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.

--- a/content/sensu-go/5.19/installation/upgrade.md
+++ b/content/sensu-go/5.19/installation/upgrade.md
@@ -162,7 +162,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][41]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][41]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][42]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][42]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][41].
 

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -227,7 +227,7 @@ example url     | http://hostname:3031/healthz
 ## Create monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.
-By default, Sensu agents listen on UDP socket 8125 (TCP on Windows systems) for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
+By default, Sensu agents listen on UDP socket 8125 for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
 
 For example, you can use the [Netcat][19] utility to send metrics to the StatsD listener:
 

--- a/content/sensu-go/5.20/getting-started/faq.md
+++ b/content/sensu-go/5.20/getting-started/faq.md
@@ -104,7 +104,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][21]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][21]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 

--- a/content/sensu-go/5.20/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.20/guides/aggregate-metrics-statsd.md
@@ -37,11 +37,6 @@ echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
 Metrics received through the StatsD listener are not stored in etcd.
 Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
 
-{{% notice note %}}
-**NOTE**: On Windows machines running Sensu, the StatsD UDP port is not supported.
-Instead, the TCP port is exposed.
-{{% /notice %}}
-
 ## Configure the StatsD listener
 
 Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.

--- a/content/sensu-go/5.20/installation/upgrade.md
+++ b/content/sensu-go/5.20/installation/upgrade.md
@@ -162,7 +162,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][41]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][41]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][42]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][42]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][41].
 

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -227,7 +227,7 @@ example url     | http://hostname:3031/healthz
 ## Create monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.
-By default, Sensu agents listen on UDP socket 8125 (TCP on Windows systems) for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
+By default, Sensu agents listen on UDP socket 8125 for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
 
 For example, you can use the [Netcat][19] utility to send metrics to the StatsD listener:
 

--- a/content/sensu-go/5.21/getting-started/faq.md
+++ b/content/sensu-go/5.21/getting-started/faq.md
@@ -104,7 +104,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][21]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][21]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][23]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 

--- a/content/sensu-go/5.21/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.21/guides/aggregate-metrics-statsd.md
@@ -37,11 +37,6 @@ echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
 Metrics received through the StatsD listener are not stored in etcd.
 Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
 
-{{% notice note %}}
-**NOTE**: On Windows machines running Sensu, the StatsD UDP port is not supported.
-Instead, the TCP port is exposed.
-{{% /notice %}}
-
 ## Configure the StatsD listener
 
 Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.

--- a/content/sensu-go/5.21/installation/upgrade.md
+++ b/content/sensu-go/5.21/installation/upgrade.md
@@ -162,7 +162,7 @@ The [Sensu agent][26] uses:
 
 - 3030 (TCP/UDP) Sensu [agent socket][41]: Required for Sensu agents using the agent socket
 - 3031 (HTTP) Sensu [agent API][41]: Required for all users accessing the agent API
-- 8125 (UDP, TCP on Windows) [StatsD listener][42]: Required for all Sensu agents using the StatsD listener
+- 8125 (UDP) [StatsD listener][42]: Required for all Sensu agents using the StatsD listener
 
 The agent TCP and UDP sockets are deprecated in favor of the [agent API][41].
 

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -227,7 +227,7 @@ example url     | http://hostname:3031/healthz
 ## Create monitoring events using the StatsD listener
 
 Sensu agents include a listener to send [StatsD][21] metrics to the event pipeline.
-By default, Sensu agents listen on UDP socket 8125 (TCP on Windows systems) for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
+By default, Sensu agents listen on UDP socket 8125 for messages that follow the [StatsD line protocol][21] and send metric events for handling by the Sensu backend.
 
 For example, you can use the [Netcat][19] utility to send metrics to the StatsD listener:
 


### PR DESCRIPTION
## Description
Removes note about UDP exception to TCP for Windows systems in association with statsd in the following pages:
- https://docs.sensu.io/sensu-go/latest/getting-started/faq/
- https://docs.sensu.io/sensu-go/latest/guides/aggregate-metrics-statsd/
- https://docs.sensu.io/sensu-go/latest/reference/agent/#create-monitoring-events-using-the-statsd-listener

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2519