### PR TITLE
add "client auth" to the certificate usages for backend

### DIFF
--- a/content/sensu-go/5.18/guides/generate-certificates.md
+++ b/content/sensu-go/5.18/guides/generate-certificates.md
@@ -95,7 +95,7 @@ cd /etc/sensu/tls
 # Create the Certificate Authority
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
 # Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
-echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
+echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /highlight >}}
 
 <a name="copy-ca-pem"></a>

--- a/content/sensu-go/5.19/guides/generate-certificates.md
+++ b/content/sensu-go/5.19/guides/generate-certificates.md
@@ -95,7 +95,7 @@ cd /etc/sensu/tls
 # Create the Certificate Authority
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
 # Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
-echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
+echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /highlight >}}
 
 <a name="copy-ca-pem"></a>

--- a/content/sensu-go/5.20/guides/generate-certificates.md
+++ b/content/sensu-go/5.20/guides/generate-certificates.md
@@ -95,7 +95,7 @@ cd /etc/sensu/tls
 # Create the Certificate Authority
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
 # Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
-echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
+echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /highlight >}}
 
 <a name="copy-ca-pem"></a>

--- a/content/sensu-go/5.21/guides/generate-certificates.md
+++ b/content/sensu-go/5.21/guides/generate-certificates.md
@@ -95,7 +95,7 @@ cd /etc/sensu/tls
 # Create the Certificate Authority
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
 # Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
-echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
+echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /highlight >}}
 
 <a name="copy-ca-pem"></a>


### PR DESCRIPTION
## Description

Add "client auth" to the allowed certificate usages for backend profile in CA configuration of Generate Certificates guide.

## Motivation and Context

Make backend certificates valid for use when authenticating etcd peer via certificates.

## Review Instructions
<!--- Optional -->
