### PR TITLE
Add web UI management info for events, entities, and silences

### DIFF
--- a/content/sensu-go/5.18/web-ui/view-manage-resources.md
+++ b/content/sensu-go/5.18/web-ui/view-manage-resources.md
@@ -12,10 +12,12 @@ menu:
 ---
 
 - [Use the namespace switcher](#use-the-namespace-switcher)
+- [Manage events](#manage-events)
 - [Manage entities](#manage-entities)
+- [Manage silences](#manage-silences)
 - [Manage checks, handlers, event filters, and mutators](#manage-checks-handlers-event-filters-and-mutators)
 
-You can view and manage Sensu resources in the web UI, including entities, checks, handlers, event filters, and mutators.
+You can view and manage Sensu resources in the web UI, including events, entities, silences, checks, handlers, event filters, and mutators.
 
 ## Use the namespace switcher
 
@@ -32,15 +34,23 @@ To switch namespaces, select the menu icon in the upper-left corner and choose a
 
 <p style="text-align:center"><i>Sensu web UI namespace switcher</i></p>
 
+## Manage events
+
+Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
+
 ## Manage entities
 
-You can delete Sensu entities in the web UI Entities page.
+Silence and delete Sensu entities in the web UI Entities page.
+
+## Manage silences
+
+Create and clear silences in the web UI Silences page.
 
 ## Manage checks, handlers, event filters, and mutators
 
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
-You can create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
+Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 
 
 [1]: ../../commercial/

--- a/content/sensu-go/5.19/web-ui/view-manage-resources.md
+++ b/content/sensu-go/5.19/web-ui/view-manage-resources.md
@@ -12,10 +12,12 @@ menu:
 ---
 
 - [Use the namespace switcher](#use-the-namespace-switcher)
+- [Manage events](#manage-events)
 - [Manage entities](#manage-entities)
+- [Manage silences](#manage-silences)
 - [Manage checks, handlers, event filters, and mutators](#manage-checks-handlers-event-filters-and-mutators)
 
-You can view and manage Sensu resources in the web UI, including entities, checks, handlers, event filters, and mutators.
+You can view and manage Sensu resources in the web UI, including events, entities, silences, checks, handlers, event filters, and mutators.
 
 ## Use the namespace switcher
 
@@ -32,15 +34,23 @@ To switch namespaces, select the menu icon in the upper-left corner and choose a
 
 <p style="text-align:center"><i>Sensu web UI namespace switcher</i></p>
 
+## Manage events
+
+Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
+
 ## Manage entities
 
-You can delete Sensu entities in the web UI Entities page.
+Silence and delete Sensu entities in the web UI Entities page.
+
+## Manage silences
+
+Create and clear silences in the web UI Silences page.
 
 ## Manage checks, handlers, event filters, and mutators
 
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
-You can create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
+Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 
 
 [1]: ../../commercial/

--- a/content/sensu-go/5.20/web-ui/view-manage-resources.md
+++ b/content/sensu-go/5.20/web-ui/view-manage-resources.md
@@ -12,10 +12,12 @@ menu:
 ---
 
 - [Use the namespace switcher](#use-the-namespace-switcher)
+- [Manage events](#manage-events)
 - [Manage entities](#manage-entities)
+- [Manage silences](#manage-silences)
 - [Manage checks, handlers, event filters, and mutators](#manage-checks-handlers-event-filters-and-mutators)
 
-You can view and manage Sensu resources in the web UI, including entities, checks, handlers, event filters, and mutators.
+You can view and manage Sensu resources in the web UI, including events, entities, silences, checks, handlers, event filters, and mutators.
 
 ## Use the namespace switcher
 
@@ -32,15 +34,23 @@ To switch namespaces, select the menu icon in the upper-left corner and choose a
 
 <p style="text-align:center"><i>Sensu web UI namespace switcher</i></p>
 
+## Manage events
+
+Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
+
 ## Manage entities
 
-You can delete Sensu entities in the web UI Entities page.
+Silence and delete Sensu entities in the web UI Entities page.
+
+## Manage silences
+
+Create and clear silences in the web UI Silences page.
 
 ## Manage checks, handlers, event filters, and mutators
 
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
-You can create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
+Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 
 
 [1]: ../../commercial/

--- a/content/sensu-go/5.21/web-ui/view-manage-resources.md
+++ b/content/sensu-go/5.21/web-ui/view-manage-resources.md
@@ -12,10 +12,12 @@ menu:
 ---
 
 - [Use the namespace switcher](#use-the-namespace-switcher)
+- [Manage events](#manage-events)
 - [Manage entities](#manage-entities)
+- [Manage silences](#manage-silences)
 - [Manage checks, handlers, event filters, and mutators](#manage-checks-handlers-event-filters-and-mutators)
 
-You can view and manage Sensu resources in the web UI, including entities, checks, handlers, event filters, and mutators.
+You can view and manage Sensu resources in the web UI, including events, entities, silences, checks, handlers, event filters, and mutators.
 
 ## Use the namespace switcher
 
@@ -32,15 +34,23 @@ To switch namespaces, select the menu icon in the upper-left corner and choose a
 
 <p style="text-align:center"><i>Sensu web UI namespace switcher</i></p>
 
+## Manage events
+
+Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
+
 ## Manage entities
 
-You can delete Sensu entities in the web UI Entities page.
+Silence and delete Sensu entities in the web UI Entities page.
+
+## Manage silences
+
+Create and clear silences in the web UI Silences page.
 
 ## Manage checks, handlers, event filters, and mutators
 
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
-You can create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
+Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 
 
 [1]: ../../commercial/


### PR DESCRIPTION
## Description
Adds the following information to https://docs.sensu.io/sensu-go/latest/web-ui/view-manage-resources/:
- Events: I can view, re-run-resolve, silence, and delete events in the web UI
- Entities: I can silence entities in the web UI in addition to deleting them
- Silences: I can create and clear silences in the web UI

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2518