### PR TITLE
Fix links at top of version index pages

### DIFF
--- a/content/sensu-core/0.29/_index.md
+++ b/content/sensu-core/0.29/_index.md
@@ -10,7 +10,7 @@ tags: ["sensu", "core", "sensu core", "0.29", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.0/_index.md
+++ b/content/sensu-core/1.0/_index.md
@@ -10,7 +10,7 @@ tags: ["sensu", "core", "sensu core", "1.0", "frog", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.1/_index.md
+++ b/content/sensu-core/1.1/_index.md
@@ -10,7 +10,7 @@ tags: ["sensu", "core", "sensu core", "1.1", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.2/_index.md
+++ b/content/sensu-core/1.2/_index.md
@@ -10,7 +10,7 @@ tags: ["sensu", "core", "sensu core", "1.2", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.3/_index.md
+++ b/content/sensu-core/1.3/_index.md
@@ -10,7 +10,7 @@ tags: ["sensu", "core", "sensu core", "1.3", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.4/_index.md
+++ b/content/sensu-core/1.4/_index.md
@@ -9,7 +9,7 @@ tags: ["sensu", "core", "sensu core", "1.4", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.5/_index.md
+++ b/content/sensu-core/1.5/_index.md
@@ -9,7 +9,7 @@ tags: ["sensu", "core", "sensu core", "1.4", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.6/_index.md
+++ b/content/sensu-core/1.6/_index.md
@@ -9,7 +9,7 @@ tags: ["sensu", "core", "sensu core", "1.4", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.7/_index.md
+++ b/content/sensu-core/1.7/_index.md
@@ -9,7 +9,7 @@ tags: ["sensu", "core", "sensu core", "1.4", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.8/_index.md
+++ b/content/sensu-core/1.8/_index.md
@@ -9,7 +9,7 @@ tags: ["sensu", "core", "sensu core", "1.4", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-core/1.9/_index.md
+++ b/content/sensu-core/1.9/_index.md
@@ -9,7 +9,7 @@ tags: ["sensu", "core", "sensu core", "1.4", "index"]
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | [Learn about Sensu Go](/sensu-go/latest/)
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
 _**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
 

--- a/content/sensu-go/5.18/_index.md
+++ b/content/sensu-go/5.18/_index.md
@@ -8,7 +8,7 @@ product: "Sensu Go"
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | [Learn about licensing][18]
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/commercial/">Learn about licensing</a>
 
 Sensu is the industry-leading solution for multi-cloud monitoring at scale.
 The Sensu monitoring event pipeline empowers businesses to automate their monitoring workflows and gain deep visibility into their multi-cloud environments.

--- a/content/sensu-go/5.19/_index.md
+++ b/content/sensu-go/5.19/_index.md
@@ -8,7 +8,7 @@ product: "Sensu Go"
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | [Learn about licensing][18]
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/commercial/">Learn about licensing</a>
 
 Sensu is the industry-leading solution for multi-cloud monitoring at scale.
 The Sensu monitoring event pipeline empowers businesses to automate their monitoring workflows and gain deep visibility into their multi-cloud environments.

--- a/content/sensu-go/5.20/_index.md
+++ b/content/sensu-go/5.20/_index.md
@@ -8,7 +8,7 @@ product: "Sensu Go"
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | [Learn about licensing][18]
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/commercial/">Learn about licensing</a>
 
 Sensu is the industry-leading solution for multi-cloud monitoring at scale.
 The Sensu monitoring event pipeline empowers businesses to automate their monitoring workflows and gain deep visibility into their multi-cloud environments.

--- a/content/sensu-go/5.21/_index.md
+++ b/content/sensu-go/5.21/_index.md
@@ -8,7 +8,7 @@ product: "Sensu Go"
 layout: "single"
 ---
 
-<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | [Learn about licensing][18]
+<iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu-go&type=star&count=true" frameborder="0" scrolling="0" width="87px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/commercial/">Learn about licensing</a>
 
 Sensu is the industry-leading solution for multi-cloud monitoring at scale.
 The Sensu monitoring event pipeline empowers businesses to automate their monitoring workflows and gain deep visibility into their multi-cloud environments.


### PR DESCRIPTION
## Description
Reformats links at the top of the index page for each Core and Go docs version to use HTML rather than Markdown.

## Motivation and Context
Merging https://github.com/sensu/sensu-docs/pull/2544 changed the way these links worked
