### PR TITLE
Remove manual top-of-page TOCs for 5.18 and 5.19 docs

### DIFF
--- a/content/sensu-go/5.18/api/auth.md
+++ b/content/sensu-go/5.18/api/auth.md
@@ -60,7 +60,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication).
 {{% /notice %}}
  
 #### EXAMPLE {#authtest-get-example}
@@ -130,5 +130,5 @@ output               | {{< code json >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../installation/auth#use-built-in-basic-authentication
-[2]: ../../installation/auth#ldap-authentication
-[3]: ../../installation/auth/#ad-authentication
+[2]: ../../installation/auth#lightweight-directory-access-protocol-ldap-authentication
+[3]: ../../installation/auth/#active-directory-ad-authentication

--- a/content/sensu-go/5.18/api/users.md
+++ b/content/sensu-go/5.18/api/users.md
@@ -27,7 +27,7 @@ menu:
   - [`/users/:user/groups/:group` (DELETE)](#usersusergroupsgroup-delete)
 
 {{% notice note %}}
-**NOTE**: The users API allows you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication), use Sensu's [authentication providers API](../authproviders/).
+**NOTE**: The users API allows you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication), use Sensu's [authentication providers API](../authproviders/).
 {{% /notice %}}
 
 ## The `/users` API endpoint

--- a/content/sensu-go/5.18/getting-started/faq.md
+++ b/content/sensu-go/5.18/getting-started/faq.md
@@ -13,42 +13,27 @@ menu:
 Thank you for visiting the Sensu FAQ!
 For a list of Sensu terms and definitions, see the [glossary][7].
 
-- [What platforms does Sensu support?](#platform-support)
-- [Is Sensu available as a hosted solution?](#hosted-solution)
-- [What are the hardware requirements for running a Sensu backend?](#hardware-requirements)
-- [Is there an enterprise version of Sensu Go?](#enterprise-version)
-- [What's the difference between the OSS, free, and commercial versions?](#version-comparison)
-- [How can I contact the Sensu sales team?](#sales-team)
-- [What can I monitor with Sensu?](#monitor-with-sensu)
-- [Does Sensu include a time series database for long-term storage?](#long-term-storage)
-- [Can I connect Sensu Go to clients and servers from earlier versions of Sensu Core and Sensu Enterprise?](#connect-earlier-versions)
-- [Can I upgrade my Sensu Core 1.x deployment to Sensu Go?](#upgrade-1x-to-go)
-- [Which ports does Sensu use?](#go-ports)
-- [Can one Sensu backend monitor multiple sites?](#monitor-multiple-sites)
-- [Can I use Uchiwa with Sensu Go?](#uchiwa-with-go)
-
-
-## What platforms does Sensu support? {#platform-support}
+## What platforms does Sensu support?
 
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), Solaris, and Docker.
 See the list of [supported platforms][1] and the [installation guide][2] for more information.
 
-## Is Sensu available as a hosted solution? {#hosted-solution}
+## Is Sensu available as a hosted solution?
 
 No, Sensu is installed on your organization’s infrastructure alongside other applications and services.
 See the list of [supported platforms][1] and the [installation guide][2] for more information.
 
-## What are the hardware requirements for running a Sensu backend? {#hardware-requirements}
+## What are the hardware requirements for running a Sensu backend?
 
 See the [hardware requirements guide][5] for minimum and recommended hardware to run a Sensu backend.
 
-## Is there an enterprise version of Sensu Go? {#enterprise-version}
+## Is there an enterprise version of Sensu Go?
 
 [Yes][31]! Sensu Inc. offers support packages for Sensu Go as well as commercial features designed for monitoring at scale.
 [Contact the Sensu sales team][6] for a personalized demo.
 See [Get started with commercial features][28] for more information.
 
-## What's the difference between the OSS, free, and commercial versions? {#version-comparison}
+## What's the difference between the OSS, free, and commercial versions?
 
 See the [Enterprise page][30] for a complete comparison. 
 
@@ -56,12 +41,12 @@ All [commercial features][28] are available for free in the packaged Sensu Go di
 If your Sensu instance includes more than 100 entities, [contact us][36] to learn how to upgrade your installation and increase your limit.
 See the [announcement on our blog][34] for more information about our usage policy.
 
-## How can I contact the Sensu sales team? {#sales-team}
+## How can I contact the Sensu sales team?
 
 We'd love to chat about solving your organization's monitoring challenges with Sensu.
 Get in touch with us using [this form][6].
 
-## What can I monitor with Sensu? {#monitor-with-sensu}
+## What can I monitor with Sensu?
 
 Sensu supports a wide range of plugins for monitoring everything from the server closet to the cloud.
 [Install the Sensu agent][8] on the hosts you want to monitor, integrate with the [Sensu API][9], or take advantage of [proxy entities][10] to monitor anything on your network.
@@ -71,17 +56,17 @@ If you want to add your own asset, read the [guide for sharing an asset on Bonsa
 
 You can also check out the 200+ plugins shared in the [Sensu plugins community][11], including monitoring checks for [AWS][13], [Jenkins][14], [Puppet][15], [InfluxDB][16], and [SNMP][17], or write your own Sensu plugins in any language using the [Sensu plugin specification][12].
 
-## Does Sensu include a time series database for long-term storage? {#long-term-storage}
+## Does Sensu include a time series database for long-term storage?
 
 No, Sensu does not store event data.
 We recommend integrating Sensu with a time series database, like [InfluxDB][19], to store event data.
 See the [guide to storing metrics with InfluxDB][18] to get started.
 
-## Can I connect Sensu Go to clients and servers from earlier versions of Sensu Core and Sensu Enterprise? {#connect-earlier-versions}
+## Can I connect Sensu Go to clients and servers from Sensu Core and Sensu Enterprise?
 
 No, Sensu Go agents and backends are not compatible with Sensu Core or Sensu Enterprise services.
 
-## Can I upgrade my Sensu Core 1.x deployment to Sensu Go? {#upgrade-1x-to-go}
+## Can I upgrade my Sensu Core 1.x deployment to Sensu Go?
 
 Sensu Go is a complete redesign of the original Sensu.
 It uses separate packages, dependencies, and data models to bring you powerful new features.
@@ -110,11 +95,11 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 
 For more information, see the [Secure Sensu guide][20].
 
-## Can one Sensu backend monitor multiple sites? {#monitor-multiple-sites}
+## Can one Sensu backend monitor multiple sites?
 
 Yes, as long as you meet the [port requirements][37], a single Sensu backend can monitor Sensu agents at multiple sites.
 
-## Can I use Uchiwa with Sensu Go? {#uchiwa-with-go}
+## Can I use Uchiwa with Sensu Go?
 
 Due to Sensu Go's implementation, it is not possible to use Uchiwa with Sensu Go.
 Sensu Go does have a [built-in web UI][24] that you can use to visually interact with your Sensu Go deployment.

--- a/content/sensu-go/5.18/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.18/guides/aggregate-metrics-statsd.md
@@ -11,10 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Use Sensu to implement StatsD](#use-sensu-to-implement-statsd)
-- [Configure the StatsD listener](#configure-the-statsd-listener)
-- [Next steps](#next-steps)
-
 [StatsD][1] is a daemon, tool, and protocol that you can use to send, collect, and aggregate custom metrics.
 Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 

--- a/content/sensu-go/5.18/guides/clustering.md
+++ b/content/sensu-go/5.18/guides/clustering.md
@@ -11,13 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Configure a cluster](#configure-a-cluster)
-- [Manage and monitor clusters with sensuctl](#manage-and-monitor-clusters-with-sensuctl)
-- [Manage cluster members](#add-a-cluster-member)
-- [Cluster security](#cluster-security)
-- [Use an external etcd cluster](#use-an-external-etcd-cluster)
-- [Troubleshoot clusters](#troubleshoot-clusters)
-
 A Sensu cluster is a group of [at least three][1] sensu-backend nodes, each connected to a shared etcd cluster, using Sensu's embedded etcd or an external etcd cluster.
 Creating a Sensu cluster ultimately configures an [etcd cluster][2].
 

--- a/content/sensu-go/5.18/guides/contact-routing.md
+++ b/content/sensu-go/5.18/guides/contact-routing.md
@@ -11,16 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Prerequisites](#prerequisites)
-- [Configure contact routing](#configure-contact-routing)
-  - [1. Register the has-contact filter asset](#1-register-the-has-contact-filter-asset)
-  - [2. Create contact filters](#2-create-contact-filters)
-  - [3. Create a handler for each contact](#3-create-a-handler-for-each-contact)
-  - [4. Create a handler set](#4-create-a-handler-set)
-- [Test contact routing](#test-contact-routing)
-- [Manage contact labels in checks and entities](#manage-contact-labels-in-checks-and-entities)
-- [Next steps](#next-steps)
-
 Every alert has an ideal first responder: a team or person who knows how to triage and address the issue.
 Sensu contact routing lets you alert the right people using their preferred contact methods, reducing mean time to response and recovery.
 

--- a/content/sensu-go/5.18/guides/create-read-only-user.md
+++ b/content/sensu-go/5.18/guides/create-read-only-user.md
@@ -12,10 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Create a read-only user](#create-a-read-only-user)
-- [Create a cluster-wide event-reader user](#create-a-cluster-wide-event-reader-user)
-- [Next steps](#next-steps)
-
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.
 Use RBAC rules to achieve **multitenancy** so different projects and teams can share a Sensu instance. 
 

--- a/content/sensu-go/5.18/guides/deploying.md
+++ b/content/sensu-go/5.18/guides/deploying.md
@@ -11,19 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Create and maintain clusters](#create-and-maintain-clusters)
-- [Hardware sizing](#hardware-sizing)
-- [Communications security](#communications-security)
-  - [Plan TLS for etcd](#plan-tls-for-etcd)
-- [Common Sensu architectures](#common-sensu-architectures)
-  - [Single backend (standalone)](#single-backend-standalone)
-  - [Clustered deployment for single availability zone](#clustered-deployment-for-single-availability-zone)
-  - [Clustered deployment for multiple availability zones](#clustered-deployment-for-multiple-availability-zones)
-  - [Large-scale clustered deployment for multiple availability zones](#large-scale-clustered-deployment-for-multiple-availability-zones)
-- [Architecture considerations](#architecture-considerations)
-  - [Networking](#networking)
-  - [Load balancing](#load-balancing)
-
 This guide describes various deployment considerations and recommendations for a production-ready Sensu deployment, including details related to communication security and common deployment architectures.
 
 etcd is a key-value store that is used by applications of varying complexity, from simple web apps to Kubernetes.

--- a/content/sensu-go/5.18/guides/email-handler.md
+++ b/content/sensu-go/5.18/guides/email-handler.md
@@ -11,12 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Add the email handler asset](#add-the-email-handler-asset)
-- [Add an event filter](#add-an-event-filter)
-- [Create the email handler definition](#create-the-email-handler-definition)
-- [Create and trigger an ad hoc event](#create-and-trigger-an-ad-hoc-event)
-- [Next steps](#next-steps)
-
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 This guide explains how to use the [Sensu Go Email Handler][3] asset to send notification emails.
 

--- a/content/sensu-go/5.18/guides/enrich-events-with-hooks.md
+++ b/content/sensu-go/5.18/guides/enrich-events-with-hooks.md
@@ -12,9 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Use check hooks to gather context](#use-check-hooks-to-gather-context)
-- [Next steps](#next-steps)
-
 Check hooks are **commands** the Sensu agent runs in response to the result of **check** command execution. 
 The Sensu agent executes the appropriate configured hook command based on the exit status code of the check command (e.g. `1`).
 
@@ -22,11 +19,9 @@ Check hooks allow Sensu users to automate data collection that operators would r
 Although you can use check hooks for rudimentary auto-remediation tasks, they are intended to enrich monitoring event data.
 This guide helps you create a check hook that captures the process tree in case a service check returns a critical status.
 
-## Use check hooks to gather context
-
 Follow these steps to create a check hook that captures the process tree in the event that an `nginx_process` check returns a status of `2` (critical, not running).
 
-### 1. Create a hook
+## Create a hook
 
 Create a new hook that runs a specific command to capture the process tree.
 Set an execution **timeout** of 10 seconds for this command:
@@ -37,7 +32,7 @@ sensuctl hook create process_tree  \
 --timeout 10
 {{< /code >}}
 
-### 2. Assign the hook to a check
+## Assign the hook to a check
 
 Now that you've created the `process_tree` hook, you can assign it to a check.
 This example assumes you've already set up the `nginx_process` check.
@@ -49,7 +44,7 @@ sensuctl check set-hooks nginx_process  \
 --hooks process_tree
 {{< /code >}}
 
-### 3. Validate the check hook
+## Validate the check hook
 
 Verify that the check hook is behaving properly against a specific event with `sensuctl`.
 It might take a few moments after you assign the check hook for the check to be scheduled on the entity and the result sent back to the Sensu backend.

--- a/content/sensu-go/5.18/guides/extract-metrics-with-checks.md
+++ b/content/sensu-go/5.18/guides/extract-metrics-with-checks.md
@@ -11,9 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Extract metrics from check output](#extract-metrics-from-check-output)
-- [Next steps](#next-steps)
-
 Sensu checks are **commands** (or scripts) that the Sensu agent executes that output data and produce an exit code to indicate a state.
 If you are unfamiliar with checks or want to learn how to configure a check before reading this guide, read the [check reference][1] and [Monitor server resources][2].
 
@@ -63,7 +60,7 @@ output_metric_format | `opentsdb_line`
 documentation        | [OpenTSDB Data Specification][9]
 example              | {{< code plain >}}sys.cpu.user 1356998400 42.5 host=webserver01 cpu=0{{< /code >}}
 
-### Validate the metrics
+## Validate the metrics
 
 If the check output is formatted correctly according to its `output_metric_format`, the metrics will be extracted in Sensu metric format and passed to the event pipeline.
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.

--- a/content/sensu-go/5.18/guides/generate-certificates.md
+++ b/content/sensu-go/5.18/guides/generate-certificates.md
@@ -10,14 +10,6 @@ menu:
   sensu-go-5.18:
     parent: guides
 ---
-- [Prerequisites](#prerequisites)
-- [Public key infrastructure](#public-key-infrastructure-pki)
-- [Issue certificates](#issue-certificates)
-    - [Install TLS](#install-tls)
-    - [Create a Certificate Authority (CA)](#create-a-certificate-authority-ca)
-    - [Generate backend cluster certificates](#generate-backend-cluster-certificates)
-    - [Generate agent certificate](#generate-agent-certificate)
-- [Next step: Secure Sensu](#next-step-secure-sensu)
 
 This guide explains how to generate the certificates you need to secure a Sensu cluster and its agents.
 

--- a/content/sensu-go/5.18/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.18/guides/influx-db-metric-handler.md
@@ -11,19 +11,14 @@ menu:
     parent: guides
 ---
 
-- [Use a handler to populate InfluxDB](#use-a-handler-to-populate-influxdb)
-- [Next steps](#next-steps)
-
 A Sensu event handler is an action the Sensu backend executes when a specific [event][1] occurs.
 In this guide, you'll use a handler to populate the time series database [InfluxDB][2].
 If you're not familiar with handlers, consider reading the [handlers reference][9] before continuing through this guide.
 
-## Use a handler to populate InfluxDB
-
 The example in this guide explains how to populate Sensu metrics into the time series database [InfluxDB][2].
 Metrics can be collected from [check output][10] or the [Sensu StatsD Server][3].
 
-### Register the asset
+## Register the asset
 
 [Assets][12] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 This example uses the [Sensu InfluxDB Handler][13] asset to power an `influx-db` handler.
@@ -46,7 +41,7 @@ Created
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
-### Create the handler
+## Create the handler
 
 Now that you have registered the asset, you'll use sensuctl to create a handler called `influx-db` that pipes event data to InfluxDB with the `sensu-influxdb-handler` asset.
 Edit the command below to include your database name, address, username, and password.
@@ -66,7 +61,7 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
-### Assign the handler to an event
+## Assign the handler to an event
 
 With the `influx-db` handler created, you can assign it to a check for [check output metric extraction][10]. 
 In this example, the check name is `collect-metrics`:
@@ -81,7 +76,7 @@ You can also assign the handler to the [Sensu StatsD listener][3] at agent start
 sensu-agent start --statsd-event-handlers influx-db
 {{< /code >}}
 
-### Validate the handler
+## Validate the handler
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled you should start to see metrics populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.

--- a/content/sensu-go/5.18/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.18/guides/install-check-executables-with-assets.md
@@ -11,17 +11,12 @@ menu:
     parent: guides
 ---
 
-- [1. Register the Sensu PagerDuty Handler asset](#1-register-the-sensu-pagerduty-handler-asset)
-- [2. Adjust the asset definition](#2-adjust-the-asset-definition)
-- [3. Create a monitoring workflow](#3-create-a-workflow)
-- [Next steps](#next-steps)
-
 Assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
 You can use assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
 See the [asset reference][1] for more information about assets.
 This guide uses the [Sensu PagerDuty Handler asset][7] as an example.
 
-## 1. Register the Sensu PagerDuty Handler asset
+## Register the Sensu PagerDuty Handler asset
 
 To add the [Sensu PagerDuty Handler asset][7] to Sensu, use [`sensuctl asset add`][6]:
 
@@ -33,7 +28,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
 
-## 2. Adjust the asset definition
+## Adjust the asset definition
 
 Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.
 
@@ -71,7 +66,7 @@ Use sensuctl to verify that the asset is registered and ready to use:
 sensuctl asset list --format yaml
 {{< /code >}}
 
-## 3. Create a workflow
+## Create a workflow
 
 With the asset downloaded and registered, you can use it in a monitoring workflow.
 Assets may provide executable plugins intended for use with a Sensu check, handler, mutator, or hook, or JavaScript libraries intended to provide functionality for use in event filters.

--- a/content/sensu-go/5.18/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.18/guides/monitor-external-resources.md
@@ -11,9 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Use a proxy entity to monitor a website](#use-a-proxy-entity-to-monitor-a-website)
-- [Use proxy requests to monitor a group of websites](#use-proxy-requests-to-monitor-a-group-of-websites)
-
 Proxy entities allow Sensu to monitor external resources on systems and devices where a Sensu agent cannot be installed, like a network switch or a website.
 You can create [proxy entities][1] with [sensuctl][8], the [Sensu API][9], and the [`proxy_entity_name` check attribute][2].
 When executing checks that include a `proxy_entity_name` or `proxy_requests` attributes, Sensu agents report the resulting event under the proxy entity instead of the agent entity.

--- a/content/sensu-go/5.18/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.18/guides/monitor-server-resources.md
@@ -19,12 +19,10 @@ Sensu checks use the same specification as **Nagios**, so you can use Nagios che
 
 You can use checks to monitor server resources, services, and application health (for example, to check whether Nginx is running) and collect and analyze metrics (for example, to learn how much disk space you have left).
 
-## Use checks to monitor a service
-
 This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check-cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
 To use this guide, you'll need to install a Sensu backend and have at least one Sensu agent running on Linux.
 
-### Register assets
+## Register assets
 
 To power the check, you'll use the [Sensu CPU Checks][1] asset and the [Sensu Ruby Runtime][7] asset.
 
@@ -56,7 +54,7 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
-### Create a check
+## Create a check
 
 Now that the assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
@@ -69,7 +67,7 @@ sensuctl check create check-cpu \
 --runtime-assets cpu-checks-plugins,sensu-ruby-runtime
 {{< /code >}}
 
-### Configure the subscription
+## Configure the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `system`.
 After you [install an agent][4], open `/etc/sensu/agent.yml` and add the `system` subscription so the subscription configuration looks like this:
@@ -85,7 +83,7 @@ Then, restart the agent:
 sudo service sensu-agent restart
 {{< /code >}}
 
-### Validate the check
+## Validate the check
 
 Use sensuctl to confirm that Sensu is monitoring CPU usage using the `check-cpu`, returning an OK status (`0`).
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.

--- a/content/sensu-go/5.18/guides/plan-maintenance.md
+++ b/content/sensu-go/5.18/guides/plan-maintenance.md
@@ -12,9 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Use silencing to plan maintenance](#use-silencing-to-plan-maintenance)
-- [Next steps](#next-steps)
-
 As the Sensu backend processes check results, the server executes [event handlers][1] to send alerts to personnel or otherwise relay event data to external services.
 Sensu’s built-in silencing, along with the built-in `not_silenced` filter, provides a way to suppress execution of event handlers on an ad hoc basis.
 
@@ -29,12 +26,10 @@ Sensu silencing makes it possible to:
 * [Silence a specific check on entities with a specific subscription][5]
 * [Silence a specific check on every entity][6]
 
-## Use silencing to plan maintenance
-
 Suppose you want to plan a maintenance window.
 In this example, you'll create a silenced entry for a specific entity named `i-424242` and its check, `check-http`, to prevent alerts as you restart and redeploy the services associated with this entity.
 
-### Create the silenced entry
+## Create the silenced entry
 
 To begin, create a silenced entry that will silence the check `check-http` on the entity `i-424242` for a planned maintenance window that starts at **01:00** on **Sunday** and ends **1 hour** later.
 Your username will be added automatically as the **creator** of the silenced entry:
@@ -50,7 +45,7 @@ sensuctl silenced create \
 
 See the [sensuctl documentation][8] for the supported time formats for the `begin` flag.
 
-### Validate the silenced entry
+## Validate the silenced entry
 
 Use sensuctl to verify that the silenced entry against the entity `i-424242` was created properly:
 

--- a/content/sensu-go/5.18/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.18/guides/reduce-alert-fatigue.md
@@ -11,15 +11,10 @@ menu:
     parent: guides
 ---
 
-- [Use event filters to reduce alert fatigue](#use-event-filters-to-reduce-alert-fatigue)
-- [Next steps](#next-steps)
-
 Sensu event filters allow you to filter events destined for one or more event handlers.
 Sensu event filters evaluate their expressions against the event data to determine whether the event should be passed to an event handler.
 
 Use event filters to eliminate notification noise from recurring events and to filter events from systems in pre-production environments.
-
-## Use event filters to reduce alert fatigue
 
 In this guide, you learn how to reduce alert fatigue by configuring an event filter named `hourly` for a handler named `slack` to prevent alerts from being sent to Slack every minute.
 If you don't already have a handler in place, follow [Send Slack alerts with handlers][3] before continuing with this guide.
@@ -29,7 +24,7 @@ You can use either of two approaches to create the event filter to handle occurr
 - [Use sensuctl][4]
 - [Use a filter asset][5]
 
-### Approach 1: Use sensuctl to create an event filter
+## Approach 1: Use sensuctl to create an event filter
 
 First, create an event filter called `hourly` that matches new events (where the event's `occurrences` is equal to `1`) or hourly events (every hour after the first occurrence, calculated with the check's `interval` and the event's `occurrences`).
 
@@ -42,7 +37,7 @@ sensuctl filter create hourly \
 --expressions "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
 {{< /code >}}
 
-#### Assign the event filter to a handler
+### Assign the event filter to a handler
 
 Now that you've created the `hourly` event filter, you can assign it to a handler.
 Because you want to reduce the number of Slack messages Sensu sends, you'll apply the event filter to an existing handler named `slack`, in addition to the built-in `is_incident` filter, so only failing events are handled.
@@ -53,12 +48,12 @@ sensuctl handler update slack
 
 Follow the prompts to add the `hourly` and `is_incident` event filters to the Slack handler.
 
-#### Create a fatigue check event filter
+### Create a fatigue check event filter
 
 Although you can use `sensuctl` to interactively create a filter, you can create more reusable filters with assets.
 Read on to see how to implement a filter using this approach. 
 
-### Approach 2: Use an event filter asset
+## Approach 2: Use an event filter asset
 
 If you're not already familiar with [assets][6], please take a moment to read [Install plugins with assets][7].
 This will help you understand what assets are and how they are used in Sensu. 
@@ -101,7 +96,7 @@ sensuctl create -f sensu-fatigue-check-filter.yml
 
 Now that you've created the filter asset and the event filter, you can create the check annotations you need for the asset to work properly. 
 
-#### Annotate a check for filter asset use
+### Annotate a check for filter asset use
 
 Next, you need to make some additions to any checks you want to use the filter with.
 Here's an example CPU check:
@@ -150,7 +145,7 @@ Specifically, the annotations in this check definition are doing several things:
 For more information about configuring these values, see the [filter asset's README][10].
 Next, you'll assign the newly minted event filter to a handler.
 
-#### Assign the event filter to a handler
+### Assign the event filter to a handler
 
 Just like with the [interactively created event filter][4], you'll introduce the filter into your Sensu workflow by configuring a handler to use it.
 Here's an example:
@@ -173,7 +168,7 @@ spec:
   - fatigue_check
 {{< /code >}}
 
-#### Validate the event filter
+### Validate the event filter
 
 Verify the proper behavior of these event filters with `sensu-backend` logs.
 The default location of these logs varies based on the platform used (see [Troubleshooting][2] for details).

--- a/content/sensu-go/5.18/guides/scale-event-storage.md
+++ b/content/sensu-go/5.18/guides/scale-event-storage.md
@@ -11,12 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres)
-- [Configure Sensu](#configure-sensu)
-- [Revert to the built-in datastore](#revert-to-the-built-in-datastore)
-- [Configure Postgres streaming replication](#configure-postgres-streaming-replication)
-
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][3].
 

--- a/content/sensu-go/5.18/guides/secrets-management.md
+++ b/content/sensu-go/5.18/guides/secrets-management.md
@@ -11,18 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Retrieve your PagerDuty Integration Key](#retrieve-your-pagerduty-integration-key)
-- [Use Env for secrets management](#use-env-for-secrets-management)
-  - [Create your backend environment variable](#create-your-backend-environment-variable)
-  - [Create your Env secret](#create-your-env-secret)
-- [Use HashiCorp Vault for secrets management](#use-hashicorp-vault-for-secrets-management)
-  - [Configure your Vault authentication method (token or TLS)](#configure-your-vault-authentication-method-token-or-tls)
-  - [Create your Vault secret](#create-your-vault-secret)
-- [Add a handler](#add-a-handler)
-  - [Register the PagerDuty handler asset](#register-the-pagerduty-handler-asset)
-  - [Add your secret to the handler spec](#add-your-secret-to-the-handler-spec)
-- [Next steps](#next-steps)
-
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][20].
 
@@ -289,7 +277,7 @@ sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
 
 {{% notice note %}}
-**NOTE**: You can [adjust the asset definition](../install-check-executables-with-assets/#2-adjust-the-asset-definition) according to your Sensu configuration if needed.
+**NOTE**: You can [adjust the asset definition](../install-check-executables-with-assets/#adjust-the-asset-definition) according to your Sensu configuration if needed.
 {{% /notice %}}
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.

--- a/content/sensu-go/5.18/guides/securing-sensu.md
+++ b/content/sensu-go/5.18/guides/securing-sensu.md
@@ -11,12 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Secure etcd peer communication](#secure-etcd-peer-communication)
-- [Secure the API and web UI](#secure-the-api-and-web-ui)
-- [Secure Sensu agent-to-server communication](#secure-sensu-agent-to-server-communication)
-- [Sensu agent mTLS authentication](#sensu-agent-mtls-authentication)
-- [Next step: Run a Sensu cluster](#next-step-run-a-sensu-cluster)
-
 As with any piece of software, it is critical to minimize any attack surface the software exposes.
 Sensu is no different.
 This guide describes the components you need to secure to make Sensu production-ready.

--- a/content/sensu-go/5.18/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.18/guides/send-slack-alerts.md
@@ -11,18 +11,13 @@ menu:
     parent: guides
 ---
 
-- [Use a handler to send alerts to Slack](#use-a-handler-to-send-alerts-to-slack)
-- [Next steps](#next-steps)
-
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 You can use handlers to send an email alert, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
-
-## Use a handler to send alerts to Slack
 
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check-cpu`.
 If you don't already have a check in place, [Monitor server resources][2] is a great place to start.
 
-### Register the asset
+## Register the asset
 
 [Assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
 In this guide, you'll use the [Sensu Slack Handler][14] asset to power a `slack` handler.
@@ -43,13 +38,13 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
-### Get a Slack webhook
+## Get a Slack webhook
 
 If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12].
 After saving, you'll see your webhook URL under Integration Settings.
 
-### Create a handler
+## Create a handler
 
 Use sensuctl to create a handler called `slack` that pipes event data to Slack using the `sensu-slack-handler` asset.
 Edit the command below to include your Slack channel and webhook URL.
@@ -69,7 +64,7 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
-### Assign the handler to a check
+## Assign the handler to a check
 
 With the `slack` handler created, you can assign it to a check.
 In this case, you're using the `check-cpu` check: you want to receive Slack alerts whenever the CPU usage of your systems reach some specific thresholds.
@@ -79,7 +74,7 @@ Assign your handler to the check `check-cpu`:
 sensuctl check set-handlers check-cpu slack
 {{< /code >}}
 
-### Validate the handler
+## Validate the handler
 
 It might take a few moments after you assign the handler to the check for the check to be scheduled on the entities and the result sent back to Sensu backend.
 After an event is handled, you should see the following message in Slack:

--- a/content/sensu-go/5.18/guides/systemd-logs.md
+++ b/content/sensu-go/5.18/guides/systemd-logs.md
@@ -14,11 +14,15 @@ menu:
 By default, systems where systemd is the service manager do not write logs to `/var/log/sensu/` for the `sensu-agent` and the `sensu-backend` services.
 This guide explains how to add log forwarding from journald to syslog, have rsyslog write logging data to disk, and set up log rotation of the newly created log files.
 
+## Configure journald
+
 To configure journald to forward logging data to syslog, modify `/etc/systemd/journald.conf` to include the following line:
 
 {{< code shell >}}
 ForwardToSyslog=yes
 {{< /code >}}
+
+## Configure rsyslog
 
 Next, set up rsyslog to write the logging data received from journald to `/var/log/sensu/servicename.log`.
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
@@ -48,6 +52,8 @@ Restart rsyslog and journald to apply the new configuration:
 systemctl restart systemd-journald
 systemctl restart rsyslog
 {{< /code>}}
+
+## Set up log rotation
 
 Set up log rotation for newly created log files to ensure logging does not fill up your disk.
 

--- a/content/sensu-go/5.18/guides/troubleshooting.md
+++ b/content/sensu-go/5.18/guides/troubleshooting.md
@@ -12,14 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Service logging](#service-logging)
-	- [Log levels](#log-levels)
-	- [Log file locations](#log-file-locations)
-- [Sensu backend startup errors](#sensu-backend-startup-errors)
-- [Permission issues](#permission-issues)
-- [Handlers and event filters](#handlers-and-event-filters)
-- [Assets](#assets)
-
 ## Service logging
 
 Logs produced by Sensu services (sensu-backend and sensu-agent) are often the best place to start when troubleshooting a variety of issues.

--- a/content/sensu-go/5.18/guides/use-apikey-feature.md
+++ b/content/sensu-go/5.18/guides/use-apikey-feature.md
@@ -11,9 +11,6 @@ menu:
     parent: guides
 ---
 
-- [API key authentication](#api-key-authentication)
-- [Sensuctl management commands](#sensuctl-management-commands)
-
 The Sensu API key feature (core/v2.APIKey) is a persistent UUID that maps to a stored Sensu username.
 The advantages of authenticating with API keys rather than [access tokens][1] include:
 

--- a/content/sensu-go/5.18/guides/use-federation.md
+++ b/content/sensu-go/5.18/guides/use-federation.md
@@ -11,16 +11,6 @@ menu:
     parent: guides
 ---
 
-- [What you can do with federation](#what-you-can-do-with-federation)
-- [Configure federation](#configure-federation)
-  - [Step 1 Configure backends for TLS](#step-1-configure-backends-for-tls)
-  - [Step 2 Configure shared token signing keys](#step-2-configure-shared-token-signing-keys)
-  - [Step 3 Add a cluster role binding and user](#step-3-add-a-cluster-role-binding-and-user)
-  - [Step 4 Create etcd replicators](#step-4-create-etcd-replicators)
-  - [Step 5 Register clusters](#step-5-register-clusters): [Register a single cluster](#register-a-single-cluster) | [Register additional clusters](#register-additional-clusters)
-  - [Step 6 Get a unified view of all your clusters in the web UI](#step-6-get-a-unified-view-of-all-your-clusters-in-the-web-ui)
-- [Next steps](#next-steps)
-
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][8].
 

--- a/content/sensu-go/5.18/installation/auth.md
+++ b/content/sensu-go/5.18/installation/auth.md
@@ -9,23 +9,6 @@ menu:
     parent: installation
 ---
 
-- [Use built-in basic authentication](#use-built-in-basic-authentication)
-- [Use an authentication provider](#use-an-authentication-provider)
-   - [Manage authentication providers](#manage-authentication-providers)
-   - [Configure authentication providers](#configure-authentication-providers)
-- [LDAP authentication](#ldap-authentication)
-  - [Examples](#ldap-configuration-examples)
-  - [LDAP specification](#ldap-specification)
-  - [Troubleshooting](#ldap-troubleshooting)
-- [AD authentication](#ad-authentication)
-  - [Examples](#ad-configuration-examples)
-  - [AD specification](#ad-specification)
-  - [Troubleshooting](#ad-troubleshooting)
-- [OIDC authentication](#oidc-authentication)
-  - [OIDC configuration examples](#oidc-configuration-examples)
-  - [OIDC specification](#oidc-specification)
-  - [Okta](#okta)
-
 Sensu requires username and password authentication to access the [Sensu web UI][1], [API][8], and command line tool ([sensuctl][2]).
 You can use Sensu's built-in basic authentication provider or configure external authentication providers to authenticate via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect.
 
@@ -115,7 +98,7 @@ Without an assigned role or cluster role, users can sign in to the Sensu web UI 
 
 After you configure the correct roles and bindings, log in to [sensuctl][36] and the [Sensu web UI][1] using your single-sign-on username and password (no prefix required).
 
-## LDAP authentication
+## Lightweight Directory Access Protocol (LDAP) authentication
 
 Sensu offers [commercial support][6] for a standards-compliant LDAP tool for authentication to the Sensu web UI, API, and sensuctl.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
@@ -244,9 +227,9 @@ spec:
 
 {{< /language-toggle >}}
 
-## LDAP specification
+### LDAP specification
 
-### Top-level attributes
+#### Top-level attributes
 
 type         | 
 -------------|------
@@ -312,7 +295,7 @@ example      | {{< code shell >}}
 }
 {{< /code >}}
 
-### LDAP spec attributes
+#### LDAP spec attributes
 
 | servers    |      |
 -------------|------
@@ -367,7 +350,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"username_prefix": "ldap"{{< /code >}}
 
-### LDAP server attributes
+#### LDAP server attributes
 
 | host       |      |
 -------------|------
@@ -462,7 +445,7 @@ example      | {{< code shell >}}
 }
 {{< /code >}}
 
-### LDAP binding attributes
+#### LDAP binding attributes
 
 | user_dn    |      |
 -------------|------
@@ -478,7 +461,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"password": "YOUR_PASSWORD"{{< /code >}}
 
-### LDAP group search attributes
+#### LDAP group search attributes
 
 | base_dn    |      |
 -------------|------
@@ -511,7 +494,7 @@ type         | String
 default      | `"groupOfNames"`
 example      | {{< code shell >}}"object_class": "groupOfNames"{{< /code >}}
 
-### LDAP user search attributes
+#### LDAP user search attributes
 
 | base_dn    |      |
 -------------|------
@@ -544,7 +527,7 @@ type         | String
 default      | `"person"`
 example      | {{< code shell >}}"object_class": "person"{{< /code >}}
 
-### LDAP metadata attributes
+#### LDAP metadata attributes
 
 | name       |      |
 -------------|------
@@ -553,7 +536,7 @@ required     | true
 type         | String
 example      | {{< code shell >}}"name": "openldap"{{< /code >}}
 
-## LDAP troubleshooting
+### LDAP troubleshooting
 
 To troubleshoot any issue with LDAP authentication, start by [increasing the log verbosity][19] of sensu-backend to the debug log level.
 Most authentication and authorization errors are only displayed on the debug log level to avoid flooding the log files.
@@ -562,7 +545,7 @@ Most authentication and authorization errors are only displayed on the debug log
 **NOTE**: If you can't locate any log entries referencing LDAP authentication, make sure the LDAP provider was successfully installed using [sensuctl](#manage-authentication-providers).
 {{% /notice %}}
 
-### Authentication errors
+#### Authentication errors
 
 This section lists common error messages and possible solutions.
 
@@ -611,7 +594,7 @@ Adjust the `name_attribute` so it specifies a human-readable name for the user.
 The group search returned a group entry (identified by `<DN>`) that doesn't have the [`name_attribute` attribute][21] or a `cn` attribute, so the LDAP provider could not determine which attribute to use as the group name in the group entry.
 Adjust the `name_attribute` so it specifies a human-readable name for the group.
 
-### Authorization issues
+#### Authorization issues
 
 Once authenticated, each user needs to be granted permissions via either a `ClusterRoleBinding` or a `RoleBinding`.
 
@@ -633,12 +616,12 @@ For example:
 [...] could not authorize the request with any ClusterRoleBindings [...]
 ```
 
-## Active Directory (AD) authentication {#ad-authentication}
+## Active Directory (AD) authentication
 
 Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication to the Sensu web UI, API, and sensuctl.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
-### Active Directory (AD) configuration examples {#ad-configuration-examples}
+### AD configuration examples
 
 **Example AD configuration: Minimum required attributes**
 
@@ -765,9 +748,9 @@ spec:
 
 {{< /language-toggle >}}
 
-## AD specification
+### AD specification
 
-### AD top-level attributes
+#### AD top-level attributes
 
 type         | 
 -------------|------
@@ -835,7 +818,7 @@ example      | {{< code shell >}}
 }
 {{< /code >}}
 
-### AD spec attributes
+#### AD spec attributes
 
 | servers    |      |
 -------------|------
@@ -892,7 +875,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"username_prefix": "ad"{{< /code >}}
 
-### AD server attributes
+#### AD server attributes
 
 | host       |      |
 -------------|------
@@ -1007,7 +990,7 @@ example      | {{< code shell >}}
 "include_nested_groups": true
 {{< /code >}}
 
-### AD binding attributes
+#### AD binding attributes
 
 | user_dn    |      |
 -------------|------
@@ -1023,7 +1006,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"password": "YOUR_PASSWORD"{{< /code >}}
 
-### AD group search attributes
+#### AD group search attributes
 
 | base_dn    |      |
 -------------|------
@@ -1056,7 +1039,7 @@ type         | String
 default      | `"group"`
 example      | {{< code shell >}}"object_class": "group"{{< /code >}}
 
-### AD user search attributes
+#### AD user search attributes
 
 | base_dn    |      |
 -------------|------
@@ -1089,7 +1072,7 @@ type         | String
 default      | `"person"`
 example      | {{< code shell >}}"object_class": "person"{{< /code >}}
 
-### AD metadata attributes
+#### AD metadata attributes
 
 | name       |      |
 -------------|------
@@ -1098,15 +1081,15 @@ required     | true
 type         | String
 example      | {{< code shell >}}"name": "activedirectory"{{< /code >}}
 
-## AD troubleshooting
+### AD troubleshooting
 
 The troubleshooting steps in the [LDAP troubleshooting][49] section also apply for AD troubleshooting.
 
-## OIDC authentication
+## OpenID Connect 1.0 protocol (OIDC) authentication
 
 Sensu offers [commercial support][6] for the OIDC provider for using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol for RBAC authentication.
 
-The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52]. 
+The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
 ### OIDC configuration examples
 
@@ -1371,14 +1354,14 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 [34]: #groups-prefix
 [35]: #username-prefix
 [36]: ../../sensuctl/reference#first-time-setup
-[37]: #ad-authentication
+[37]: #active-directory-ad-authentication
 [38]: ../../sensuctl/reference#create-resources
 [39]: #ldap-spec-attributes
 [40]: #ldap-server-attributes
 [41]: https://en.wikipedia.org/wiki/Fully_qualified_domain_name
 [42]: https://regex101.com/r/zo9mQU/2
 [43]: #ldap-binding-attributes
-[44]: #ldap-authentication
+[44]: #lightweight-directory-access-protocol-ldap-authentication
 [45]: #ad-spec-attributes
 [46]: #ad-server-attributes
 [47]: #ad-group-search-attributes

--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -10,13 +10,6 @@ menu:
     parent: installation
 ---
 
-- [Architecture overview](#architecture-overview)
-- [Install the Sensu backend](#install-the-sensu-backend)
-- [Install sensuctl](#install-sensuctl)
-- [Install Sensu agents](#install-sensu-agents)
-- [Commercial features](#commercial-features)
-- [Next steps](#next-steps)
-
 This installation guide describes how to install the Sensu backend, Sensu agent, and sensuctl command line tool.
 If you’re trying Sensu for the first time, we recommend setting up a local environment using the [Sensu sandbox][14].
 

--- a/content/sensu-go/5.18/installation/plugins.md
+++ b/content/sensu-go/5.18/installation/plugins.md
@@ -12,11 +12,6 @@ menu:
     parent: installation
 ---
 
-- [Install plugins with assets](#install-plugins-with-assets)
-- [Use Bonsai, the Sensu asset index](#use-bonsai-the-sensu-asset-index)
-- [Install plugins with the sensu-install tool](#install-plugins-with-the-sensu-install-tool)
-- [Troubleshoot the sensu-install tool](#troubleshoot-the-sensu-install-tool)
-
 Extend Sensu's functionality with [plugins][10], which provide executables for performing status or metric checks, mutators for changing data to a desired format, and handlers for performing an action on a Sensu event.
 
 ## Install plugins with assets

--- a/content/sensu-go/5.18/installation/recommended-hardware.md
+++ b/content/sensu-go/5.18/installation/recommended-hardware.md
@@ -11,11 +11,6 @@ menu:
     parent: installation
 ---
 
-- [Sensu backend requirements](#sensu-backend-requirements)
-- [Sensu agent requirements](#sensu-agent-requirements)
-- [Networking recommendations](#networking-recommendations)
-- [Cloud recommendations](#cloud-recommendations)
-
 ## Sensu backend requirements
 
 ### Backend minimum requirements

--- a/content/sensu-go/5.18/installation/upgrade.md
+++ b/content/sensu-go/5.18/installation/upgrade.md
@@ -11,12 +11,6 @@ menu:
     parent: installation
 ---
 
-- [Upgrade to the latest version of Sensu Go from 5.0.0 or later](#upgrade-to-the-latest-version-of-sensu-go-from-5-0-0-or-later)
-- [Upgrade to Sensu Go 5.16.0 from any earlier version](#upgrade-to-sensu-go-5-16-0-from-any-earlier-version)
-- [Upgrade Sensu clusters from 5.7.0 or earlier to 5.8.0 or later](#upgrade-sensu-clusters-from-5-7-0-or-earlier-to-5-8-0-or-later)
-- [Upgrade Sensu backend binaries to 5.1.0](#upgrade-sensu-backend-binaries-to-5-1-0)
-- [Migrate to Sensu Go from Sensu Core 1.x](#migrate-to-sensu-go-from-sensu-core-1-x)
-
 ## Upgrade to the latest version of Sensu Go from 5.0.0 or later
 
 To upgrade to the latest version of Sensu Go from version 5.0.0 or later, [install the latest packages][23].

--- a/content/sensu-go/5.18/learn/demo.md
+++ b/content/sensu-go/5.18/learn/demo.md
@@ -4,6 +4,7 @@ linkTitle: "Live demo"
 description: "Explore the Sensu web UI and sensuctl command line tool with a live demo that monitors the Sensu docs site. See entities, monitoring events, and active service and metric checks."
 version: "5.18"
 weight: 30
+toc: false
 product: "Sensu Go"
 menu:
   sensu-go-5.18:

--- a/content/sensu-go/5.18/learn/glossary.md
+++ b/content/sensu-go/5.18/learn/glossary.md
@@ -10,95 +10,95 @@ menu:
     parent: learn-sensu
 ---
 
-#### Agent
+## Agent
 A lightweight client that runs on the infrastructure components you want to monitor.
 Agents self-register with the backend, send keepalive messages, and execute monitoring checks.
 Each agent belongs to one or more subscriptions that determine which checks the agent runs.
 An agent can run checks on the entity it’s installed on or connect to a remote proxy entity.
 [Read more about the Sensu agent][1].
 
-#### Asset
+## Asset
 An executable that a check, handler, or mutator can specify as a dependency.
 Assets must be a tar archive (optionally gzipped) with scripts or executables within a bin folder.
 At runtime, the backend or agent installs required assets using the specified URL.
 Assets let you manage runtime dependencies without using configuration management tools.
 [Read more about assets][4].
 
-#### Backend
+## Backend
 A flexible, scalable monitoring event pipeline.
 The Sensu backend processes event data using filters, mutators, and handlers.
 It maintains configuration files, stores recent event data, and schedules monitoring checks.
 You can interact with the backend using the API, command line, and web UI interfaces.
 [Read more about the Sensu backend][2].
 
-#### Check
+## Check
 A recurring check the agent runs to determine the state of a system component or collect metrics.
 The backend is responsible for storing check definitions, scheduling checks, and processing event data.
 Check definitions specify the command to be executed, an interval for execution, one or more subscriptions, and one or more handlers to process the resulting event data.
 [Read more about checks][3].
 
-#### Entity
+## Entity
 Infrastructure components that you want to monitor.
 Each entity runs an agent that executes checks and creates events.
 Events can be tied to the entity where the agent runs or a proxy entity that the agent checks remotely.
 [Read more about entities][7].
 
-#### Event
+## Event
 A representation of the state of an infrastructure component at a point in time.
 The Sensu backend uses events to power the monitoring event pipeline.
 Event data includes the result of a check or metric (or both), the executing agent, and a timestamp.
 [Read more about events][8].
 
-#### Event filter
+## Event filter
 Logical expressions that handlers evaluate before processing monitoring events.
 Event filters can instruct handlers to allow or deny matching events based on day, time, namespace, or any attribute in the event data.
 [Read more about event filters][9].
 
-#### Handler
+## Handler
 A component of the monitoring event pipeline that acts on events.
 Handlers can send monitoring event data to an executable (or handler plugin), a TCP socket, or a UDP socket.
 [Read more about handlers][10].
 
-#### Hook
+## Hook
 A command the agent executes in response to a check result *before* creating a monitoring event.
 Hooks create context-rich events by gathering relevant information based on check status.
 [Read more about hooks][5].
 
-#### Mutator
+## Mutator
 An executable the backend runs prior to a handler to transform event data.
 [Read more about mutators][11].
 
-#### Plugin
+## Plugin
 Executables designed to work with Sensu event data either as a check, mutator, or handler plugin. 
 You can write your own check executables in Go, Ruby, Python, and more, or use one of more than 200 plugins shared by the Sensu community.
 [Read more about plugins][6].
 
-#### Proxy entities
+## Proxy entities
 Components of your infrastructure that can’t run the agent locally (like a network switch or a website) but still need to be monitored.
 Agents create events with information about the proxy entity in place of the local entity when running checks with a specified proxy entity ID.
 [Read more about proxy entities][12].
 
-#### Role-based access control (RBAC)
+## Role-based access control (RBAC)
 Sensu’s local user management system.
 RBAC lets you manage users and permissions with namespaces, users, roles, and role bindings.
 [Read more about RBAC][13].
 
-#### Resources
+## Resources
 Objects within Sensu that you can use to specify access permissions in Sensu roles and cluster roles.
 Resources can be specific to a namespace (like checks and handlers) or cluster-wide (like users and cluster roles).
 [Read more about resources][18].
 
-#### Sensuctl
+## Sensuctl
 The Sensu command line tool that lets you interact with the backend.
 You can use sensuctl to create checks, view events, create users, manage clusters, and more.
 [Read more about sensuctl][14].
 
-#### Silencing
+## Silencing
 Entries that allow you to suppress execution of event handlers on an ad-hoc basis.
 Use silencing to schedule maintenance without being overloaded with alerts.
 [Read more about silencing][17].
 
-#### Token
+## Token
 A placeholder in a check definition that the agent replaces with local information before executing the check.
 Tokens let you fine-tune check attributes (like thresholds) on a per-entity level while reusing the check definition.
 [Read more about tokens][16].

--- a/content/sensu-go/5.18/learn/interactive-tutorials.md
+++ b/content/sensu-go/5.18/learn/interactive-tutorials.md
@@ -10,10 +10,6 @@ menu:
     parent: learn-sensu
 ---
 
-- [Learn Sensu in 15 minutes](#learn-sensu-in-15-minutes)
-- [Up and running with Sensu Go](#up-and-running-with-sensu-go)
-- [Send Sensu Go alerts to PagerDuty](#send-sensu-go-alerts-to-pagerduty)
-
 Sensu is the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
 
 Our interactive training tutorials help you get started with Sensu Go, using only your browser.

--- a/content/sensu-go/5.18/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/5.18/learn/learn-sensu-sandbox.md
@@ -7,13 +7,6 @@ product: "Sensu Go"
 
 In this tutorial, you'll download the Sensu sandbox and create a monitoring workflow with Sensu.
 
-- [Set up the sandbox](#set-up-the-sandbox)
-- [Lesson \#1: Create a monitoring event](#lesson-1-create-a-sensu-monitoring-event)
-- [Lesson \#2: Create an event pipeline](#lesson-2-pipe-keepalive-events-into-slack)
-- [Lesson \#3: Automate event production with the Sensu agent](#lesson-3-automate-event-production-with-the-sensu-agent)
-
----
-
 ## Set up the sandbox
 
 **1. Install Vagrant and VirtualBox**

--- a/content/sensu-go/5.18/learn/prometheus-metrics.md
+++ b/content/sensu-go/5.18/learn/prometheus-metrics.md
@@ -6,22 +6,6 @@ product: "Sensu Go"
 platformContent: false
 ---
 
-- [Set up](#set-up)
-  - [Install and configure Prometheus](#install-and-configure-prometheus)
-  - [Install and configure Sensu Go](#install-and-configure-sensu-go)
-  - [Install and configure InfluxDB](#install-and-configure-influxdb)
-  - [Install and configure Grafana](#install-and-configure-grafana)
-- [Create a Sensu InfluxDB pipeline](#create-a-sensu-influxdb-pipeline)
-  - [Create a Sensu InfluxDB handler asset](#create-a-sensu-influxdb-handler-asset)
-  - [Create a Sensu handler](#create-a-sensu-handler)
-- [Collect Prometheus metrics with Sensu](#collect-prometheus-metrics-with-sensu)
-  - [Create a Sensu Prometheus Collector asset](#create-a-sensu-prometheus-collector-asset)
-  - [Add a Sensu check to complete the pipeline](#add-a-sensu-check-to-complete-the-pipeline)
-- [Visualize metrics with Grafana](#visualize-metrics-with-grafana)
-  - [Configure a dashboard in Grafana](#configure-a-dashboard-in-grafana)
-  - [View metrics in Grafana](#view-metrics-in-grafana)
-- [Next steps](#next-steps)
-
 The [Sensu Prometheus Collector][1] is a check plugin that collects metrics from a [Prometheus exporter][2] or the [Prometheus query API][3].
 This allows Sensu to route the collected metrics to one or more time series databases, such as InfluxDB or Graphite.
 

--- a/content/sensu-go/5.18/learn/sample-app.md
+++ b/content/sensu-go/5.18/learn/sample-app.md
@@ -7,19 +7,6 @@ platformContent: true
 platforms: ["Linux/macOS", "Windows"]
 ---
 
-- [Prerequisites](#prerequisites)
-- [Set up](#set-up)
-- [Multitenancy](#multitenancy)
-- [Deploy Sensu agents and InfluxDB](#deploy-sensu-agents-and-influxdb)
-- [Monitor the app](#monitor-the-app)
-	- [Create a Sensu pipeline to Slack](#create-a-sensu-pipeline-to-slack)
-	- [Create a Sensu service check](#create-a-sensu-service-check-to-monitor-the-status-of-the-dummy-app)
-- [Collect app metrics](#collect-app-metrics)
-	- [Create a Sensu metric check to collect Prometheus metrics](#create-a-sensu-metric-check-to-collect-prometheus-metrics)
-	- [Visualize metrics with Grafana](#visualize-metrics-with-grafana)
-- [Collect Kubernetes metrics](#collect-kubernetes-metrics)
-- [Next steps](#next-steps)
-
 In this tutorial, you'll deploy a sample app with Kubernetes and monitor it with Sensu.
 In the sample app, `/` returns the local hostname.
 The sample app has three endpoints: `/metrics` returns Prometheus metric data, `/healthz` returns the Boolean health state, and `POST /healthz` toggles the health state.

--- a/content/sensu-go/5.18/platforms.md
+++ b/content/sensu-go/5.18/platforms.md
@@ -10,14 +10,6 @@ platformContent: true
 platforms: ["Linux", "Windows", "macOS", "FreeBSD", "Solaris"]
 ---
 
-- [Supported packages](#supported-packages)
-  - [Sensu backend](#sensu-backend) | [Sensu agent](#sensu-agent) | [Sensuctl command line tool](#sensuctl-command-line-tool)
-- [Docker images](#docker-images)
-- [Integrations](#integrations)
-- [Binary-only distributions](#binary-only-distributions)
-  - [Linux](#linux) | [Windows](#windows) | [macOS](#macos) | [FreeBSD](#freebsd) | [Solaris](#solaris)
-- [Build from source](#build-from-source)
-
 Sensu is available as [packages][1], [Docker images][2], and [binary-only distributions][4].
 We recommend [installing Sensu][5] with one of our supported packages, Docker images, or [configuration management][6] integrations.
 Sensu downloads are provided under the [Sensu commercial license][7].

--- a/content/sensu-go/5.18/reference/agent.md
+++ b/content/sensu-go/5.18/reference/agent.md
@@ -12,20 +12,7 @@ menu:
     parent: reference
 ---
 
-- [Installation][1]
-- [Communication between the agent and backend](#communication-between-the-agent-and-backend)
-- [Create monitoring events using service checks](#create-monitoring-events-using-service-checks)
-- [Create monitoring events using the agent API](#create-monitoring-events-using-the-agent-api)
-- [Create monitoring events using the StatsD listener](#create-monitoring-events-using-the-statsd-listener)
-- [Create monitoring events using the agent TCP and UDP sockets](#create-monitoring-events-using-the-agent-tcp-and-udp-sockets) (deprecated)
-- [Keepalive monitoring](#keepalive-monitoring)
-- [Service management](#operation)
-  - [Start and stop the service](#start-the-service) | [Register and deregister](#registration) | [Cluster](#cluster) | [Synchronize time](#synchronize-time)
-- [Configuration via flags](#configuration-via-flags)
-  - [General configuration flags](#general-configuration-flags) | [API configuration flags](#api-configuration-flags) | [Ephemeral agent configuration flags](#ephemeral-agent-configuration-flags) | [Keepalive configuration flags](#keepalive-configuration-flags) | [Security configuration](#security-configuration-flags) | [Socket configuration flags](#socket-configuration-flags) | [StatsD configuration flags](#statsd-configuration-flags)
-  - [Allow list configuration commands](#allow-list-configuration-commands) and [example allow list configuration file](#example-allow-list-configuration-file)
-- [Configuration via environment variables](#configuration-via-environment-variables)
-- [Example Sensu agent configuration file](../../files/agent.yml) (download)
+[Example Sensu agent configuration file](../../files/agent.yml) (download)
 
 The Sensu agent is a lightweight client that runs on the infrastructure components you want to monitor.
 Agents register with the Sensu backend as [monitoring entities][3] with `type: "agent"`.

--- a/content/sensu-go/5.18/reference/apikeys.md
+++ b/content/sensu-go/5.18/reference/apikeys.md
@@ -9,12 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Authorization header format](#authorization-header-format)
-- [API key resource structure](#api-key-resource-structure)
-- [API key specification](#api-key-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-
 API keys are long-lived authentication tokens that make it more convenient for Sensu plugins and other Sensu-adjacent applications to authenticate with the Sensu API.
 Unlike [authentication tokens][2], API keys are persistent and do not need to be refreshed every 15 minutes.
 

--- a/content/sensu-go/5.18/reference/assets.md
+++ b/content/sensu-go/5.18/reference/assets.md
@@ -11,15 +11,6 @@ menu:
     parent: reference
 ---
 
-- [Asset builds](#asset-builds)
-- [Asset format specification](#asset-format-specification)
-- [Asset specification](#asset-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Asset filters based on entity.system attributes](#asset-filters-based-on-entity-system-attributes)
-- [Examples](#examples)
-- [Share an asset on Bonsai](#share-an-asset-on-bonsai)
-- [Delete assets](#delete-assets)
-
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read [Install plugins with assets][23] to get started.
 

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -11,25 +11,14 @@ menu:
     parent: reference
 ---
 
-- [Installation][1]
-- [Create event pipelines](#create-event-pipelines)
-- [Schedule checks](#schedule-checks)
-- [Initialization](#initialization)
-- [Operation and service management](#operation)
-  - [Start and stop the service](#start-the-service) | [Cluster](#cluster) | [Synchronize time](#synchronize-time)
-- [Configuration](#configuration)
-  - [General configuration](#general-configuration-flags) | [Agent communication configuration](#agent-communication-configuration-flags) | [Security configuration](#security-configuration-flags) | [Web UI configuration](#web-ui-configuration-flags) | [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags) | [Advanced configuration options](#advanced-configuration-options)
-  - [Configuration via environment variables](#configuration-via-environment-variables)
-- [Event logging](#event-logging)
-  - [Log rotation](#log-rotation)
-- [Example Sensu backend configuration file](../../files/backend.yml) (download)
+[Example Sensu backend configuration file](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, a [Sensu web UI][6], and the `sensu-backend` command line tool.
 The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
 See the [installation guide][1] to install the backend.
 
-### Create event pipelines
+## Create event pipelines
 
 The backend processes event data and executes filters, mutators, and handlers.
 These pipelines are powerful tools to automate your monitoring workflows.
@@ -41,7 +30,7 @@ To learn more about filters, mutators, and handlers, see:
 - [Mutators reference documentation][10]
 - [Handlers reference documentation][11]
 
-### Schedule checks
+## Schedule checks
 
 The backend is responsible for storing check definitions and scheduling check requests.
 Check scheduling is subscription-based: the backend sends check requests to subscriptions. where they're picked up by subscribing agents.

--- a/content/sensu-go/5.18/reference/checks.md
+++ b/content/sensu-go/5.18/reference/checks.md
@@ -10,16 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Check commands](#check-commands)
-- [Check result specification](#check-result-specification)
-- [Check scheduling](#check-scheduling): [Subscriptions](#subscriptions) | [Scheduling](#scheduling)
-- [Proxy checks](#proxy-checks)
-- [Check token substitution](#check-token-substitution)
-- [Check hooks](#check-hooks)
-- [Check specification](#check-specification)
-	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Proxy requests attributes](#proxy-requests-attributes) | [Check output truncation attributes](#check-output-truncation-attributes) | [`secrets` attributes](#secrets-attributes)
-- [Examples](#examples)
-
 Checks work with Sensu agents to produce monitoring events automatically.
 You can use checks to monitor server resources, services, and application health as well as collect and analyze metrics.
 Read [Monitor server resources][12] to get started.

--- a/content/sensu-go/5.18/reference/datastore.md
+++ b/content/sensu-go/5.18/reference/datastore.md
@@ -9,14 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Event storage](#event-storage)
-- [Scale event storage](#scale-event-storage) (commercial feature)
-  - [Requirements](#requirements)
-  - [Configuration](#configuration)
-  - [Datastore specification](#datastore-specification)
-
-## Event storage
-
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
 You can access event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
@@ -33,12 +25,12 @@ When configured with a PostgreSQL event store, Sensu connects to PostgreSQL to s
 Etcd continues to store Sensu entity and configuration data.
 You can access event data stored in PostgreSQL using the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
 
-### Requirements
+## Requirements
 
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-### Configuration
+## Configuration
 
 At the time when you enable the PostgreSQL event store, event data cuts over from etcd to PostgreSQL.
 This results in a loss of recent event history.
@@ -90,7 +82,7 @@ sensuctl create --file postgres.yml
 To update your Sensu PostgreSQL configuration, repeat the `sensuctl create` process.
 You can expect to see PostgreSQL status updates in the [Sensu backend logs][2] at the `warn` log level and PostgreSQL error messages in the [Sensu backend logs][2] at the `error` log level.
 
-#### Disable the PostgreSQL event store
+### Disable the PostgreSQL event store
 
 To disable the PostgreSQL event store, use `sensuctl delete` with your `PostgresConfig` resource definition:
 
@@ -107,9 +99,9 @@ Mar 10 17:35:04 sensu-centos sensu-backend[1365]: {"component":"store-providers"
 When you disable the PostgreSQL event store, event data cuts over from PostgreSQL to etcd, which results in a loss of recent event history.
 No restarts or Sensu backend configuration changes are required to disable the PostgreSQL event store.
 
-### Datastore specification
+## Datastore specification
 
-#### Top-level attributes
+### Top-level attributes
 
 type         |      |
 -------------|------
@@ -146,7 +138,7 @@ spec:
   pool_size: 20
 {{< /code >}}
 
-#### Metadata attributes
+### Metadata attributes
 
 name         |      |
 -------------|------
@@ -155,7 +147,7 @@ required     | true
 type         | String
 example      | {{< code shell >}}name: my-postgres{{< /code >}}
 
-#### Spec attributes
+### Spec attributes
 
 dsn          |      |
 -------------|------

--- a/content/sensu-go/5.18/reference/entities.md
+++ b/content/sensu-go/5.18/reference/entities.md
@@ -10,13 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Usage limits](#usage-limits)
-- [Proxy entities](#proxy-entities)
-- [Manage entity labels](#manage-entity-labels): [Proxy entity labels](#proxy-entities-managed) | [Agent entity labels](#agent-entities-managed)
-- [Entities specification](#entities-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [System attributes](#system-attributes) | [Network attributes](#network-attributes) | [NetworkInterface attributes](#networkinterface-attributes) | [Deregistration attributes](#deregistration-attributes)
-- [Examples](#examples)
-
 An entity represents anything that needs to be monitored, such as a server, container, or network switch, including the full range of infrastructure, runtime, and application types that compose a complete monitoring environment (from server hardware to serverless functions).
 We call these monitored parts of an infrastructure "entities."
 

--- a/content/sensu-go/5.18/reference/etcdreplicators.md
+++ b/content/sensu-go/5.18/reference/etcdreplicators.md
@@ -10,13 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Create a replicator](#create-a-replicator)
-- [Delete a replicator](#delete-a-replicator)
-- [Replicator configuration](#replicator-configuration)
-- [etcd-replicators specification](#etcd-replicators-specification)
-- [Example EtcdReplicator resources](#example-etcdreplicator-resources)
-- [Critical success factors for etcd replication](#critical-success-factors-for-etcd-replication)
-
 **COMMERCIAL FEATURE**: Access the etcd-replicators datatype in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -10,19 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Check-only events](#check-only-events)
-- [Metric-only events](#metric-only-events)
-- [Check and metric events](#check-and-metric-events)
-- [Create events using the Sensu agent](#create-events-using-the-sensu-agent)
-- [Create events using the events API](#create-events-using-the-events-api)
-- [Manage events](#manage-events): [View events](#view-events) | [Delete events](#delete-events) | [Resolve events](#resolve-events)
-- [Event format](#event-format)
-- [Use event data](#use-event-data)
-  - [Occurrences](#occurrences-and-occurrences-watermark)
-- [Events specification](#events-specification)
-	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
-- [Examples](#examples)
-
 An event is a generic container used by Sensu to provide context to checks and metrics.
 The context, called event data, contains information about the originating entity and the corresponding check or metric result.
 An event must contain a check or metrics.
@@ -30,7 +17,7 @@ In certain cases, an event can contain both.
 These generic containers allow Sensu to handle different types of events in the pipeline.
 Because events are polymorphic in nature, it is important to never assume their contents (or lack of content).
 
-### Check-only events
+## Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu server, regardless of the status indicated by the check result.
 The agent creates an event upon receipt of the check execution result.
@@ -38,13 +25,13 @@ The agent will execute any configured [hooks][4] the check might have.
 From there, the result is forwarded to the Sensu backend for processing.
 Potentially noteworthy events may be processed by one or more event handlers, for example to send an email or invoke an automated action.
 
-### Metric-only events
+## Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the [StatsD listener][5].
 The agent will translate the StatsD metrics to Sensu metric format and place them inside an event.
 Because these events do not contain checks, they bypass the store and are sent to the event pipeline and corresponding event handlers.
 
-### Check and metric events
+## Check and metric events
 
 Events that contain _both_ a check and metrics most likely originated from [check output metric extraction][6].
 If a check is configured for metric extraction, the agent will parse the check output and transform it to Sensu metric format.

--- a/content/sensu-go/5.18/reference/filters.md
+++ b/content/sensu-go/5.18/reference/filters.md
@@ -10,19 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Inclusive and exclusive event filters](#inclusive-and-exclusive-event-filters)
-- [Built-in event filters](#built-in-event-filters)
-- [Build event filter expressions](#build-event-filter-expressions)
-- [Event filter specification](#event-filter-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Event filter examples](#event-filter-examples)
-	- [Handle production events](#handle-production-events)
-	- [Handle non-production events](#handle-non-production-events)
-	- [Handle state change only](#handle-state-change-only)
-	- [Handle repeated events](#handle-repeated-events)
-	- [Handle events during office hours only](#handle-events-during-office-hours-only)
-- [Use JavaScript libraries with Sensu filters](#use-javascript-libraries-with-sensu-filters)
-
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the event data.
 If the filters do not remove the event, the handler will be executed.

--- a/content/sensu-go/5.18/reference/handlers.md
+++ b/content/sensu-go/5.18/reference/handlers.md
@@ -10,14 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Pipe handlers](#pipe-handlers)
-- [TCP/UDP handlers](#tcp-udp-handlers)
-- [Handler sets](#handler-sets)
-- [Keepalive event handlers](#keepalive-event-handlers)
-- [Handler specification](#handler-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`socket` attributes](#socket-attributes) | [`secrets` attributes](#secrets-attributes)
-- [Examples](#handler-examples)
-
 Handlers are actions the Sensu backend executes on events.
 Several types of handlers are available.
 The most common are `pipe` handlers, which work similarly to [checks][1] and enable Sensu to interact with almost any computer program via [standard streams][2].

--- a/content/sensu-go/5.18/reference/health.md
+++ b/content/sensu-go/5.18/reference/health.md
@@ -9,10 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Health payload example](#health-payload-example)
-- [Health specification](#health-specification)
-  - [Top-level attributes](#top-level-attributes) | [ClusterHealth attributes](#clusterhealth-attributes) | [Header attributes](#header-attributes)
-
 Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members.
 
 ## Health payload example

--- a/content/sensu-go/5.18/reference/hooks.md
+++ b/content/sensu-go/5.18/reference/hooks.md
@@ -10,15 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Check response types](#check-response-types)
-- [Check hooks](#check-hooks)
-- [Hook specification](#hook-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-  - [Rudimentary auto-rememdiation](#rudimentary-auto-remediation)
-  - [Capture the process tree](#capture-the-process-tree)
-  - [Check hook using token substitution](#check-hook-using-token-substitution)
-
 Hooks are reusable commands the agent executes in response to a check result before creating a monitoring event.
 You can create, manage, and reuse hooks independently of checks.
 Hooks enrich monitoring event context by gathering relevant information based on the exit status code of a check (ex: `1`).

--- a/content/sensu-go/5.18/reference/license.md
+++ b/content/sensu-go/5.18/reference/license.md
@@ -10,11 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Activate your commercial license](#activate-your-commercial-license)
-- [Entity limit](#entity-limit)
-- [License expiration](#license-expiration)
-- [Quick links](#quick-links)
-
 ## Activate your commercial license
 
 If you haven't already, [install the backend, agent, and sensuctl][2] and [configure sensuctl][3].

--- a/content/sensu-go/5.18/reference/mutators.md
+++ b/content/sensu-go/5.18/reference/mutators.md
@@ -10,12 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Commands](#commands)
-- [Built-in mutators](#built-in-mutators)
-- [Mutator specification](#mutator-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`secrets` attributes](#secrets-attributes)
-- [Examples](#examples)
-
 Handlers can specify a mutator to execute and transform event data before any handlers are applied.
 
 * When the Sensu backend processes an event, it checks the handler for the presence of a mutator and executes that mutator before executing the handler.

--- a/content/sensu-go/5.18/reference/rbac.md
+++ b/content/sensu-go/5.18/reference/rbac.md
@@ -10,23 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Namespaces](#namespaces)
-  - [Manage namespaces](#manage-namespaces) | [Namespace specification](#namespace-specification) | [Namespace example](#namespace-example)
-- [Resources](#resources)
-  - [Namespaced resource types](#namespaced-resource-types) | [Cluster-wide resource types](#cluster-wide-resource-types) | [Special resource types](#special-resource-types)
-- [Users](#users)
-  - [Manage users](#manage-users) | [User specification](#user-specification) | [User example](#user-example)
-- [Groups](#groups)
-  - [Manage groups](#manage-groups)
-- [Roles and cluster roles](#roles-and-cluster-roles)
-  - [Manage roles and cluster roles](#manage-roles-and-cluster-roles) | [Role and cluster role specification](#role-and-cluster-role-specification) | [Role and cluster role examples](#role-and-cluster-role-examples)
-- [Role bindings and cluster role bindings](#role-bindings-and-cluster-role-bindings)
-  - [Manage role bindings and cluster role bindings](#manage-role-bindings-and-cluster-role-bindings) | [Role binding and cluster role binding specification](#role-binding-and-cluster-role-binding-specification) | [Role binding and cluster role binding examples](#role-binding-and-cluster-role-binding-examples)
-- [Example workflows](#example-workflows)
-  - [Assign user permissions within a namespace](#assign-user-permissions-within-a-namespace)
-  - [Assign group permissions within a namespace](#assign-group-permissions-within-a-namespace)
-  - [Assign group permissions across all namespaces](#assign-group-permissions-across-all-namespaces)
-
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows you to manage user access and resources based on namespaces, groups, roles, and bindings.
 
@@ -275,7 +258,7 @@ A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
 **NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication).
-It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication). 
+It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication). 
 {{% /notice %}}
 
 To change the password for a user:
@@ -1273,8 +1256,8 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [40]: ../../reference/etcdreplicators/
 [41]: ../agent/#security-configuration-flags
 [42]: ../../installation/install-sensu/#install-the-sensu-backend
-[43]: ../../installation/auth#ldap-authentication
-[44]: ../../installation/auth/#ad-authentication
+[43]: ../../installation/auth#lightweight-directory-access-protocol-ldap-authentication
+[44]: ../../installation/auth/#active-directory-ad-authentication
 [45]: ../../sensuctl/reference/#change-admin-user-s-password
 [46]: ../secrets-providers/
 [47]: ../datastore/

--- a/content/sensu-go/5.18/reference/secrets-providers.md
+++ b/content/sensu-go/5.18/reference/secrets-providers.md
@@ -10,11 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Secrets providers specification](#secrets-providers-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Secrets providers configuration](#secrets-providers-configuration)
-- [Secrets providers examples](#secrets-providers-examples)
-
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.18/reference/secrets.md
+++ b/content/sensu-go/5.18/reference/secrets.md
@@ -10,11 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Secret specification](#secret-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Secret configuration](#secret-configuration)
-- [Secret examples](#secret-examples)
-
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.18/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.18/reference/sensu-query-expressions.md
@@ -11,11 +11,6 @@ menu:
     parent: reference
 ---
 
-- [Syntax quick reference](#syntax-quick-reference)
-- [Specification](#specification)
-  - [Custom functions](#custom-functions)
-- [Examples](#examples)
-
 Sensu query expressions (SQEs) are JavaScript-based expressions that provide additional functionality for using Sensu, like nested parameters and custom functions.
 
 SQEs are defined in [event filters][3], so they act in the context of determining whether a given event should be passed to the handler.

--- a/content/sensu-go/5.18/reference/silencing.md
+++ b/content/sensu-go/5.18/reference/silencing.md
@@ -10,16 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Silencing specification](#silencing-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-	- [Silence all checks on a specific entity](#silence-all-checks-on-a-specific-entity)
-	- [Silence a specific check on a specific entity](#silence-a-specific-check-on-a-specific-entity)
-	- [Silence all checks on entities with a specific subscription](#silence-all-checks-on-entities-with-a-specific-subscription)
-	- [Silence a specific check on entities with a specific subscription](#silence-a-specific-check-on-entities-with-a-specific-subscription)
-	- [Silence a specific check on every entity](#silence-a-specific-check-on-every-entity)
-	- [Delete a silence](#delete-a-silence)
-
 Sensu's silencing capability allows you to suppress event handler execution on an ad hoc basis so you can plan maintenance and reduce alert fatigue.
 Silences are created on an ad hoc basis using `sensuctl`.
 Successfully created silencing entries are assigned a `name` in the format `$SUBSCRIPTION:$CHECK`, where `$SUBSCRIPTION` is the name of a Sensu entity subscription and `$CHECK` is the name of a Sensu check.

--- a/content/sensu-go/5.18/reference/tessen.md
+++ b/content/sensu-go/5.18/reference/tessen.md
@@ -9,12 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Configure Tessen](#configure-tessen)
-- [Tessen specification](#tessen-specification)
-  - [Top-level attributes](#top-level-attributes) | [Spec attributes](#spec-attributes)
-- [Tessen configuration example](#tessen-configuration-example)
-- [Tessen payload example](#tessen-payload-example)
-
 Tessen is the Sensu call-home service.
 It is enabled by default on Sensu backends.
 Tessen sends anonymized data about Sensu instances to Sensu Inc., including the version, cluster size, number of events processed, and number of resources created (like checks and handlers).

--- a/content/sensu-go/5.18/reference/tokens.md
+++ b/content/sensu-go/5.18/reference/tokens.md
@@ -9,12 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Manage entity labels](#manage-entity-labels)
-- [Token specification](#token-specification)
-- [Unmatched tokens](#unmatched-tokens)
-- [Token data type limitations](#token-data-type-limitations)
-- [Examples](#examples)
-
 Tokens are placeholders in a check definition that the agent replaces with entity information before executing the check.
 You can use tokens to fine-tune check attributes (like alert thresholds) on a per-entity level while reusing the check definition.
 

--- a/content/sensu-go/5.18/sensuctl/quickstart.md
+++ b/content/sensu-go/5.18/sensuctl/quickstart.md
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-### Configure sensuctl and log in
+## Configure sensuctl and log in
 
 {{< code shell >}}
 sensuctl configure
@@ -20,25 +20,25 @@ sensuctl configure
 ? Password: YOUR_PASSWORD
 {{< /code >}}
 
-### Create resources from a file that contains JSON resource definitions
+## Create resources from a file that contains JSON resource definitions
 
 {{< code shell >}}
 sensuctl create --file filename.json
 {{< /code >}}
 
-### View monitored entities
+## View monitored entities
 
 {{< code shell >}}
 sensuctl entity list
 {{< /code >}}
 
-### View monitoring events
+## View monitoring events
 
 {{< code shell >}}
 sensuctl event list
 {{< /code >}}
 
-### Edit a check
+## Edit a check
 
 In this example, the check name is `check-cpu`:
 
@@ -46,7 +46,7 @@ In this example, the check name is `check-cpu`:
 sensuctl edit check check-cpu
 {{< /code >}}
 
-### View the JSON configuration for a check
+## View the JSON configuration for a check
 
 In this example, the check name is `check-cpu`:
 

--- a/content/sensu-go/5.18/sensuctl/reference.md
+++ b/content/sensu-go/5.18/sensuctl/reference.md
@@ -11,26 +11,6 @@ menu:
     parent: sensuctl
 ---
 
-- [First-time setup](#first-time-setup)
-- [Get help](#get-help)
-- [Manage sensuctl](#manage-sensuctl)
-- [Test a user password](#test-a-user-password)
-- [Create resources](#create-resources)
-- [Delete resources](#delete-resources)
-- [Update resources](#update-resources)
-- [Export resources](#export-resources)
-- [Manage resources](#manage-resources)
-  - [Subcommands](#subcommands)
-- [Response filtering](#response-filtering) (commercial feature)
-- [Time formats](#time-formats)
-- [Shell auto-completion](#shell-auto-completion)
-- [Environment variables](#environment-variables)
-- [Config files](#configuration-files)
-- [Interact with Bonsai](#interact-with-bonsai)
-  - [Install asset definitions](#install-asset-definitions)
-  - [Check your Sensu backend for outdated assets](#check-your-sensu-backend-for-outdated-assets)
-  - [Extend sensuctl with commands](#extend-sensuctl-with-commands)
-
 Sensuctl is a command line tool for managing resources within Sensu.
 It works by calling Sensu's underlying API to create, read, update, and delete resources, events, and entities.
 Sensuctl is available for Linux, macOS, and Windows.
@@ -218,7 +198,7 @@ A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
 **NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication).
-It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication). 
+It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication). 
 {{% /notice %}}
 
 For example, if you test LDAP credentials with the `sensuctl user test-creds` command, the backend will log an error, even if you know the LDAP credentials are correct:
@@ -1101,7 +1081,7 @@ Flags are optional and apply only to the `delete` command.
 [23]: #subcommands
 [24]: #sensuctl-edit-resource-types
 [25]: ../../api/overview/
-[26]: ../../installation/auth/#ldap-authentication
+[26]: ../../installation/auth/#lightweight-directory-access-protocol-ldap-authentication
 [27]: ../../reference/tessen/
 [28]: ../../api/overview#response-filtering
 [29]: ../../api/overview#field-selector
@@ -1116,7 +1096,7 @@ Flags are optional and apply only to the `delete` command.
 [39]: #wrapped-json-format
 [40]: ../../installation/install-sensu/#install-the-sensu-backend
 [41]: ../../reference/secrets/
-[42]: ../../installation/auth/#ad-authentication
+[42]: ../../installation/auth/#active-directory-ad-authentication
 [43]: ../../reference/secrets-providers/
 [44]: ../../installation/auth#use-built-in-basic-authentication
 [45]: ../../installation/install-sensu/#2-configure-and-start

--- a/content/sensu-go/5.18/versions.md
+++ b/content/sensu-go/5.18/versions.md
@@ -4,6 +4,7 @@ linkTitle: "Supported Versions"
 description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read this article to learn about supported versions of Sensu."
 version: "5.18"
 weight: -40
+toc: false
 offline: false
 product: "Sensu Go"
 menu: "sensu-go-5.18"

--- a/content/sensu-go/5.18/web-ui/filter.md
+++ b/content/sensu-go/5.18/web-ui/filter.md
@@ -11,12 +11,6 @@ menu:
     parent: web-ui
 ---
 
-- [Basic filters](#basic-filters)
-- [Advanced filters](#advanced-filters)
-- [Create web UI filters](#create-web-ui-filters)
-- [Operators quick reference](#operators-quick-reference)
-- [Examples](#examples)
-
 The Sensu web UI includes basic filters you can use to build customized views of your Sensu resources.
 Sensu also supports advanced web UI filtering based on a wider range of resource attributes and custom labels as a [commercial feature][1].
 

--- a/content/sensu-go/5.18/web-ui/sign-in.md
+++ b/content/sensu-go/5.18/web-ui/sign-in.md
@@ -11,10 +11,6 @@ menu:
     parent: web-ui
 ---
 
-- [Access the web UI](#access-the-web-ui)
-- [Sign in](#sign-in)
-- [Themes](#themes)
-
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][6].

--- a/content/sensu-go/5.18/web-ui/view-manage-resources.md
+++ b/content/sensu-go/5.18/web-ui/view-manage-resources.md
@@ -11,12 +11,6 @@ menu:
     parent: web-ui
 ---
 
-- [Use the namespace switcher](#use-the-namespace-switcher)
-- [Manage events](#manage-events)
-- [Manage entities](#manage-entities)
-- [Manage silences](#manage-silences)
-- [Manage checks, handlers, event filters, and mutators](#manage-checks-handlers-event-filters-and-mutators)
-
 You can view and manage Sensu resources in the web UI, including events, entities, silences, checks, handlers, event filters, and mutators.
 
 ## Use the namespace switcher

--- a/content/sensu-go/5.19/api/auth.md
+++ b/content/sensu-go/5.19/api/auth.md
@@ -60,7 +60,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication).
 {{% /notice %}}
  
 #### EXAMPLE {#authtest-get-example}
@@ -130,5 +130,5 @@ output               | {{< code json >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../installation/auth#use-built-in-basic-authentication
-[2]: ../../installation/auth#ldap-authentication
-[3]: ../../installation/auth/#ad-authentication
+[2]: ../../installation/auth#lightweight-directory-access-protocol-ldap-authentication
+[3]: ../../installation/auth/#active-directory-ad-authentication

--- a/content/sensu-go/5.19/api/users.md
+++ b/content/sensu-go/5.19/api/users.md
@@ -27,7 +27,7 @@ menu:
   - [`/users/:user/groups/:group` (DELETE)](#usersusergroupsgroup-delete)
 
 {{% notice note %}}
-**NOTE**: The users API allows you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication), use Sensu's [authentication providers API](../authproviders/).
+**NOTE**: The users API allows you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication). To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication), use Sensu's [authentication providers API](../authproviders/).
 {{% /notice %}}
 
 ## The `/users` API endpoint

--- a/content/sensu-go/5.19/getting-started/faq.md
+++ b/content/sensu-go/5.19/getting-started/faq.md
@@ -13,42 +13,27 @@ menu:
 Thank you for visiting the Sensu FAQ!
 For a list of Sensu terms and definitions, see the [glossary][7].
 
-- [What platforms does Sensu support?](#platform-support)
-- [Is Sensu available as a hosted solution?](#hosted-solution)
-- [What are the hardware requirements for running a Sensu backend?](#hardware-requirements)
-- [Is there an enterprise version of Sensu Go?](#enterprise-version)
-- [What's the difference between the OSS, free, and commercial versions?](#version-comparison)
-- [How can I contact the Sensu sales team?](#sales-team)
-- [What can I monitor with Sensu?](#monitor-with-sensu)
-- [Does Sensu include a time series database for long-term storage?](#long-term-storage)
-- [Can I connect Sensu Go to clients and servers from earlier versions of Sensu Core and Sensu Enterprise?](#connect-earlier-versions)
-- [Can I upgrade my Sensu Core 1.x deployment to Sensu Go?](#upgrade-1x-to-go)
-- [Which ports does Sensu use?](#go-ports)
-- [Can one Sensu backend monitor multiple sites?](#monitor-multiple-sites)
-- [Can I use Uchiwa with Sensu Go?](#uchiwa-with-go)
-
-
-## What platforms does Sensu support? {#platform-support}
+## What platforms does Sensu support?
 
 Sensu Go is available for Linux, Windows (agent and CLI only), macOS (CLI only), Solaris, and Docker.
 See the list of [supported platforms][1] and the [installation guide][2] for more information.
 
-## Is Sensu available as a hosted solution? {#hosted-solution}
+## Is Sensu available as a hosted solution?
 
 No, Sensu is installed on your organization’s infrastructure alongside other applications and services.
 See the list of [supported platforms][1] and the [installation guide][2] for more information.
 
-## What are the hardware requirements for running a Sensu backend? {#hardware-requirements}
+## What are the hardware requirements for running a Sensu backend?
 
 See the [hardware requirements guide][5] for minimum and recommended hardware to run a Sensu backend.
 
-## Is there an enterprise version of Sensu Go? {#enterprise-version}
+## Is there an enterprise version of Sensu Go?
 
 [Yes][31]! Sensu Inc. offers support packages for Sensu Go as well as commercial features designed for monitoring at scale.
 [Contact the Sensu sales team][6] for a personalized demo.
 See [Get started with commercial features][28] for more information.
 
-## What's the difference between the OSS, free, and commercial versions? {#version-comparison}
+## What's the difference between the OSS, free, and commercial versions?
 
 See the [Enterprise page][30] for a complete comparison. 
 
@@ -56,12 +41,12 @@ All [commercial features][28] are available for free in the packaged Sensu Go di
 If your Sensu instance includes more than 100 entities, [contact us][36] to learn how to upgrade your installation and increase your limit.
 See the [announcement on our blog][34] for more information about our usage policy.
 
-## How can I contact the Sensu sales team? {#sales-team}
+## How can I contact the Sensu sales team?
 
 We'd love to chat about solving your organization's monitoring challenges with Sensu.
 Get in touch with us using [this form][6].
 
-## What can I monitor with Sensu? {#monitor-with-sensu}
+## What can I monitor with Sensu?
 
 Sensu supports a wide range of plugins for monitoring everything from the server closet to the cloud.
 [Install the Sensu agent][8] on the hosts you want to monitor, integrate with the [Sensu API][9], or take advantage of [proxy entities][10] to monitor anything on your network.
@@ -71,17 +56,17 @@ If you want to add your own asset, read the [guide for sharing an asset on Bonsa
 
 You can also check out the 200+ plugins shared in the [Sensu plugins community][11], including monitoring checks for [AWS][13], [Jenkins][14], [Puppet][15], [InfluxDB][16], and [SNMP][17], or write your own Sensu plugins in any language using the [Sensu plugin specification][12].
 
-## Does Sensu include a time series database for long-term storage? {#long-term-storage}
+## Does Sensu include a time series database for long-term storage?
 
 No, Sensu does not store event data.
 We recommend integrating Sensu with a time series database, like [InfluxDB][19], to store event data.
 See the [guide to storing metrics with InfluxDB][18] to get started.
 
-## Can I connect Sensu Go to clients and servers from earlier versions of Sensu Core and Sensu Enterprise? {#connect-earlier-versions}
+## Can I connect Sensu Go to clients and servers from Sensu Core and Sensu Enterprise?
 
 No, Sensu Go agents and backends are not compatible with Sensu Core or Sensu Enterprise services.
 
-## Can I upgrade my Sensu Core 1.x deployment to Sensu Go? {#upgrade-1x-to-go}
+## Can I upgrade my Sensu Core 1.x deployment to Sensu Go?
 
 Sensu Go is a complete redesign of the original Sensu.
 It uses separate packages, dependencies, and data models to bring you powerful new features.
@@ -110,14 +95,14 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][21].
 
 For more information, see the [Secure Sensu guide][20].
 
-## Can one Sensu backend monitor multiple sites? {#monitor-multiple-sites}
+## Can one Sensu backend monitor multiple sites?
 
 Yes, as long as you meet the [port requirements][37], a single Sensu backend can monitor Sensu agents at multiple sites.
 
-## Can I use Uchiwa with Sensu Go? {#uchiwa-with-go}
+## Can I use Uchiwa with Sensu Go?
 
 Due to Sensu Go's implementation, it is not possible to use Uchiwa with Sensu Go.
-Sensu Go does have a [built-in web UI][29] that you can use to visually interact with your Sensu Go deployment.
+Sensu Go does have a [built-in web UI][24] that you can use to visually interact with your Sensu Go deployment.
 
 [1]: ../../platforms/
 [2]: ../../installation/install-sensu/
@@ -147,7 +132,6 @@ Sensu Go does have a [built-in web UI][29] that you can use to visually interact
 [26]: ../../reference/agent/
 [27]: ../../guides/clustering/
 [28]: ../../commercial/
-[29]: ../../web-ui/sign-in/
 [30]: https://sensu.io/enterprise/
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go/
 [32]: https://bonsai.sensu.io/

--- a/content/sensu-go/5.19/guides/aggregate-metrics-statsd.md
+++ b/content/sensu-go/5.19/guides/aggregate-metrics-statsd.md
@@ -11,10 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Use Sensu to implement StatsD](#use-sensu-to-implement-statsd)
-- [Configure the StatsD listener](#configure-the-statsd-listener)
-- [Next steps](#next-steps)
-
 [StatsD][1] is a daemon, tool, and protocol that you can use to send, collect, and aggregate custom metrics.
 Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 

--- a/content/sensu-go/5.19/guides/clustering.md
+++ b/content/sensu-go/5.19/guides/clustering.md
@@ -11,13 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Configure a cluster](#configure-a-cluster)
-- [Manage and monitor clusters with sensuctl](#manage-and-monitor-clusters-with-sensuctl)
-- [Manage cluster members](#add-a-cluster-member)
-- [Cluster security](#cluster-security)
-- [Use an external etcd cluster](#use-an-external-etcd-cluster)
-- [Troubleshoot clusters](#troubleshoot-clusters)
-
 A Sensu cluster is a group of [at least three][1] sensu-backend nodes, each connected to a shared etcd cluster, using Sensu's embedded etcd or an external etcd cluster.
 Creating a Sensu cluster ultimately configures an [etcd cluster][2].
 

--- a/content/sensu-go/5.19/guides/contact-routing.md
+++ b/content/sensu-go/5.19/guides/contact-routing.md
@@ -11,16 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Prerequisites](#prerequisites)
-- [Configure contact routing](#configure-contact-routing)
-  - [1. Register the has-contact filter asset](#1-register-the-has-contact-filter-asset)
-  - [2. Create contact filters](#2-create-contact-filters)
-  - [3. Create a handler for each contact](#3-create-a-handler-for-each-contact)
-  - [4. Create a handler set](#4-create-a-handler-set)
-- [Test contact routing](#test-contact-routing)
-- [Manage contact labels in checks and entities](#manage-contact-labels-in-checks-and-entities)
-- [Next steps](#next-steps)
-
 Every alert has an ideal first responder: a team or person who knows how to triage and address the issue.
 Sensu contact routing lets you alert the right people using their preferred contact methods, reducing mean time to response and recovery.
 

--- a/content/sensu-go/5.19/guides/create-read-only-user.md
+++ b/content/sensu-go/5.19/guides/create-read-only-user.md
@@ -12,10 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Create a read-only user](#create-a-read-only-user)
-- [Create a cluster-wide event-reader user](#create-a-cluster-wide-event-reader-user)
-- [Next steps](#next-steps)
-
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.
 Use RBAC rules to achieve **multitenancy** so different projects and teams can share a Sensu instance. 
 

--- a/content/sensu-go/5.19/guides/deploying.md
+++ b/content/sensu-go/5.19/guides/deploying.md
@@ -11,19 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Create and maintain clusters](#create-and-maintain-clusters)
-- [Hardware sizing](#hardware-sizing)
-- [Communications security](#communications-security)
-  - [Plan TLS for etcd](#plan-tls-for-etcd)
-- [Common Sensu architectures](#common-sensu-architectures)
-  - [Single backend (standalone)](#single-backend-standalone)
-  - [Clustered deployment for single availability zone](#clustered-deployment-for-single-availability-zone)
-  - [Clustered deployment for multiple availability zones](#clustered-deployment-for-multiple-availability-zones)
-  - [Large-scale clustered deployment for multiple availability zones](#large-scale-clustered-deployment-for-multiple-availability-zones)
-- [Architecture considerations](#architecture-considerations)
-  - [Networking](#networking)
-  - [Load balancing](#load-balancing)
-
 This guide describes various deployment considerations and recommendations for a production-ready Sensu deployment, including details related to communication security and common deployment architectures.
 
 etcd is a key-value store that is used by applications of varying complexity, from simple web apps to Kubernetes.

--- a/content/sensu-go/5.19/guides/email-handler.md
+++ b/content/sensu-go/5.19/guides/email-handler.md
@@ -11,12 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Add the email handler asset](#add-the-email-handler-asset)
-- [Add an event filter](#add-an-event-filter)
-- [Create the email handler definition](#create-the-email-handler-definition)
-- [Create and trigger an ad hoc event](#create-and-trigger-an-ad-hoc-event)
-- [Next steps](#next-steps)
-
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 This guide explains how to use the [Sensu Go Email Handler][3] asset to send notification emails.
 

--- a/content/sensu-go/5.19/guides/enrich-events-with-hooks.md
+++ b/content/sensu-go/5.19/guides/enrich-events-with-hooks.md
@@ -12,9 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Use check hooks to gather context](#use-check-hooks-to-gather-context)
-- [Next steps](#next-steps)
-
 Check hooks are **commands** the Sensu agent runs in response to the result of **check** command execution. 
 The Sensu agent executes the appropriate configured hook command based on the exit status code of the check command (e.g. `1`).
 
@@ -22,11 +19,9 @@ Check hooks allow Sensu users to automate data collection that operators would r
 Although you can use check hooks for rudimentary auto-remediation tasks, they are intended to enrich monitoring event data.
 This guide helps you create a check hook that captures the process tree in case a service check returns a critical status.
 
-## Use check hooks to gather context
-
 Follow these steps to create a check hook that captures the process tree in the event that an `nginx_process` check returns a status of `2` (critical, not running).
 
-### 1. Create a hook
+## Create a hook
 
 Create a new hook that runs a specific command to capture the process tree.
 Set an execution **timeout** of 10 seconds for this command:
@@ -37,7 +32,7 @@ sensuctl hook create process_tree  \
 --timeout 10
 {{< /code >}}
 
-### 2. Assign the hook to a check
+## Assign the hook to a check
 
 Now that you've created the `process_tree` hook, you can assign it to a check.
 This example assumes you've already set up the `nginx_process` check.
@@ -49,7 +44,7 @@ sensuctl check set-hooks nginx_process  \
 --hooks process_tree
 {{< /code >}}
 
-### 3. Validate the check hook
+## Validate the check hook
 
 Verify that the check hook is behaving properly against a specific event with `sensuctl`.
 It might take a few moments after you assign the check hook for the check to be scheduled on the entity and the result sent back to the Sensu backend.

--- a/content/sensu-go/5.19/guides/extract-metrics-with-checks.md
+++ b/content/sensu-go/5.19/guides/extract-metrics-with-checks.md
@@ -11,9 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Extract metrics from check output](#extract-metrics-from-check-output)
-- [Next steps](#next-steps)
-
 Sensu checks are **commands** (or scripts) that the Sensu agent executes that output data and produce an exit code to indicate a state.
 If you are unfamiliar with checks or want to learn how to configure a check before reading this guide, read the [check reference][1] and [Monitor server resources][2].
 
@@ -63,7 +60,7 @@ output_metric_format | `opentsdb_line`
 documentation        | [OpenTSDB Data Specification][9]
 example              | {{< code plain >}}sys.cpu.user 1356998400 42.5 host=webserver01 cpu=0{{< /code >}}
 
-### Validate the metrics
+## Validate the metrics
 
 If the check output is formatted correctly according to its `output_metric_format`, the metrics will be extracted in Sensu metric format and passed to the event pipeline.
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.

--- a/content/sensu-go/5.19/guides/generate-certificates.md
+++ b/content/sensu-go/5.19/guides/generate-certificates.md
@@ -10,14 +10,6 @@ menu:
   sensu-go-5.19:
     parent: guides
 ---
-- [Prerequisites](#prerequisites)
-- [Public key infrastructure](#public-key-infrastructure-pki)
-- [Issue certificates](#issue-certificates)
-    - [Install TLS](#install-tls)
-    - [Create a Certificate Authority (CA)](#create-a-certificate-authority-ca)
-    - [Generate backend cluster certificates](#generate-backend-cluster-certificates)
-    - [Generate agent certificate](#generate-agent-certificate)
-- [Next step: Secure Sensu](#next-step-secure-sensu)
 
 This guide explains how to generate the certificates you need to secure a Sensu cluster and its agents.
 

--- a/content/sensu-go/5.19/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.19/guides/influx-db-metric-handler.md
@@ -11,19 +11,14 @@ menu:
     parent: guides
 ---
 
-- [Use a handler to populate InfluxDB](#use-a-handler-to-populate-influxdb)
-- [Next steps](#next-steps)
-
 A Sensu event handler is an action the Sensu backend executes when a specific [event][1] occurs.
 In this guide, you'll use a handler to populate the time series database [InfluxDB][2].
 If you're not familiar with handlers, consider reading the [handlers reference][9] before continuing through this guide.
 
-## Use a handler to populate InfluxDB
-
 The example in this guide explains how to populate Sensu metrics into the time series database [InfluxDB][2].
 Metrics can be collected from [check output][10] or the [Sensu StatsD Server][3].
 
-### Register the asset
+## Register the asset
 
 [Assets][12] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 This example uses the [Sensu InfluxDB Handler][13] asset to power an `influx-db` handler.
@@ -46,7 +41,7 @@ Created
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
-### Create the handler
+## Create the handler
 
 Now that you have registered the asset, you'll use sensuctl to create a handler called `influx-db` that pipes event data to InfluxDB with the `sensu-influxdb-handler` asset.
 Edit the command below to include your database name, address, username, and password.
@@ -66,7 +61,7 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
-### Assign the handler to an event
+## Assign the handler to an event
 
 With the `influx-db` handler created, you can assign it to a check for [check output metric extraction][10]. 
 In this example, the check name is `collect-metrics`:
@@ -81,7 +76,7 @@ You can also assign the handler to the [Sensu StatsD listener][3] at agent start
 sensu-agent start --statsd-event-handlers influx-db
 {{< /code >}}
 
-### Validate the handler
+## Validate the handler
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled you should start to see metrics populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.

--- a/content/sensu-go/5.19/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.19/guides/install-check-executables-with-assets.md
@@ -11,17 +11,12 @@ menu:
     parent: guides
 ---
 
-- [1. Register the Sensu PagerDuty Handler asset](#1-register-the-sensu-pagerduty-handler-asset)
-- [2. Adjust the asset definition](#2-adjust-the-asset-definition)
-- [3. Create a monitoring workflow](#3-create-a-workflow)
-- [Next steps](#next-steps)
-
 Assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
 You can use assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
 See the [asset reference][1] for more information about assets.
 This guide uses the [Sensu PagerDuty Handler asset][7] as an example.
 
-## 1. Register the Sensu PagerDuty Handler asset
+## Register the Sensu PagerDuty Handler asset
 
 To add the [Sensu PagerDuty Handler asset][7] to Sensu, use [`sensuctl asset add`][6]:
 
@@ -33,7 +28,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
 
-## 2. Adjust the asset definition
+## Adjust the asset definition
 
 Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.
 
@@ -71,7 +66,7 @@ Use sensuctl to verify that the asset is registered and ready to use:
 sensuctl asset list --format yaml
 {{< /code >}}
 
-## 3. Create a workflow
+## Create a workflow
 
 With the asset downloaded and registered, you can use it in a monitoring workflow.
 Assets may provide executable plugins intended for use with a Sensu check, handler, mutator, or hook, or JavaScript libraries intended to provide functionality for use in event filters.

--- a/content/sensu-go/5.19/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.19/guides/monitor-external-resources.md
@@ -11,9 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Use a proxy entity to monitor a website](#use-a-proxy-entity-to-monitor-a-website)
-- [Use proxy requests to monitor a group of websites](#use-proxy-requests-to-monitor-a-group-of-websites)
-
 Proxy entities allow Sensu to monitor external resources on systems and devices where a Sensu agent cannot be installed, like a network switch or a website.
 You can create [proxy entities][1] with [sensuctl][8], the [Sensu API][9], and the [`proxy_entity_name` check attribute][2].
 When executing checks that include a `proxy_entity_name` or `proxy_requests` attributes, Sensu agents report the resulting event under the proxy entity instead of the agent entity.

--- a/content/sensu-go/5.19/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.19/guides/monitor-server-resources.md
@@ -11,20 +11,15 @@ menu:
     parent: guides
 ---
 
-- [Use checks to monitor a service](#use-checks-to-monitor-a-service)
-- [Next steps](#next-steps)
-
 Sensu checks are **commands** (or scripts) the Sensu agent executes that output data and produce an exit code to indicate a state.
 Sensu checks use the same specification as **Nagios**, so you can use Nagios check plugins with Sensu.
 
 You can use checks to monitor server resources, services, and application health (for example, to check whether Nginx is running) and collect and analyze metrics (for example, to learn how much disk space you have left).
 
-## Use checks to monitor a service
-
 This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check-cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
 To use this guide, you'll need to install a Sensu backend and have at least one Sensu agent running on Linux.
 
-### Register assets
+## Register assets
 
 To power the check, you'll use the [Sensu CPU Checks][1] asset and the [Sensu Ruby Runtime][7] asset.
 
@@ -56,7 +51,7 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
-### Create a check
+## Create a check
 
 Now that the assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
@@ -69,7 +64,7 @@ sensuctl check create check-cpu \
 --runtime-assets cpu-checks-plugins,sensu-ruby-runtime
 {{< /code >}}
 
-### Configure the subscription
+## Configure the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `system`.
 After you [install an agent][4], open `/etc/sensu/agent.yml` and add the `system` subscription so the subscription configuration looks like this:
@@ -85,7 +80,7 @@ Then, restart the agent:
 sudo service sensu-agent restart
 {{< /code >}}
 
-### Validate the check
+## Validate the check
 
 Use sensuctl to confirm that Sensu is monitoring CPU usage using the `check-cpu`, returning an OK status (`0`).
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.

--- a/content/sensu-go/5.19/guides/plan-maintenance.md
+++ b/content/sensu-go/5.19/guides/plan-maintenance.md
@@ -12,9 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Use silencing to plan maintenance](#use-silencing-to-plan-maintenance)
-- [Next steps](#next-steps)
-
 As the Sensu backend processes check results, the server executes [event handlers][1] to send alerts to personnel or otherwise relay event data to external services.
 Sensu’s built-in silencing, along with the built-in `not_silenced` filter, provides a way to suppress execution of event handlers on an ad hoc basis.
 
@@ -29,12 +26,10 @@ Sensu silencing makes it possible to:
 * [Silence a specific check on entities with a specific subscription][5]
 * [Silence a specific check on every entity][6]
 
-## Use silencing to plan maintenance
-
 Suppose you want to plan a maintenance window.
 In this example, you'll create a silenced entry for a specific entity named `i-424242` and its check, `check-http`, to prevent alerts as you restart and redeploy the services associated with this entity.
 
-### Create the silenced entry
+## Create the silenced entry
 
 To begin, create a silenced entry that will silence the check `check-http` on the entity `i-424242` for a planned maintenance window that starts at **01:00** on **Sunday** and ends **1 hour** later.
 Your username will be added automatically as the **creator** of the silenced entry:
@@ -50,7 +45,7 @@ sensuctl silenced create \
 
 See the [sensuctl documentation][8] for the supported time formats for the `begin` flag.
 
-### Validate the silenced entry
+## Validate the silenced entry
 
 Use sensuctl to verify that the silenced entry against the entity `i-424242` was created properly:
 

--- a/content/sensu-go/5.19/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.19/guides/reduce-alert-fatigue.md
@@ -11,15 +11,10 @@ menu:
     parent: guides
 ---
 
-- [Use event filters to reduce alert fatigue](#use-event-filters-to-reduce-alert-fatigue)
-- [Next steps](#next-steps)
-
 Sensu event filters allow you to filter events destined for one or more event handlers.
 Sensu event filters evaluate their expressions against the event data to determine whether the event should be passed to an event handler.
 
 Use event filters to eliminate notification noise from recurring events and to filter events from systems in pre-production environments.
-
-## Use event filters to reduce alert fatigue
 
 In this guide, you learn how to reduce alert fatigue by configuring an event filter named `hourly` for a handler named `slack` to prevent alerts from being sent to Slack every minute.
 If you don't already have a handler in place, follow [Send Slack alerts with handlers][3] before continuing with this guide.
@@ -29,7 +24,7 @@ You can use either of two approaches to create the event filter to handle occurr
 - [Use sensuctl][4]
 - [Use a filter asset][5]
 
-### Approach 1: Use sensuctl to create an event filter
+## Approach 1: Use sensuctl to create an event filter
 
 First, create an event filter called `hourly` that matches new events (where the event's `occurrences` is equal to `1`) or hourly events (every hour after the first occurrence, calculated with the check's `interval` and the event's `occurrences`).
 
@@ -42,7 +37,7 @@ sensuctl filter create hourly \
 --expressions "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
 {{< /code >}}
 
-#### Assign the event filter to a handler
+### Assign the event filter to a handler
 
 Now that you've created the `hourly` event filter, you can assign it to a handler.
 Because you want to reduce the number of Slack messages Sensu sends, you'll apply the event filter to an existing handler named `slack`, in addition to the built-in `is_incident` filter, so only failing events are handled.
@@ -53,12 +48,12 @@ sensuctl handler update slack
 
 Follow the prompts to add the `hourly` and `is_incident` event filters to the Slack handler.
 
-#### Create a fatigue check event filter
+### Create a fatigue check event filter
 
 Although you can use `sensuctl` to interactively create a filter, you can create more reusable filters with assets.
 Read on to see how to implement a filter using this approach. 
 
-### Approach 2: Use an event filter asset
+## Approach 2: Use an event filter asset
 
 If you're not already familiar with [assets][6], please take a moment to read [Install plugins with assets][7].
 This will help you understand what assets are and how they are used in Sensu. 
@@ -101,7 +96,7 @@ sensuctl create -f sensu-fatigue-check-filter.yml
 
 Now that you've created the filter asset and the event filter, you can create the check annotations you need for the asset to work properly. 
 
-#### Annotate a check for filter asset use
+### Annotate a check for filter asset use
 
 Next, you need to make some additions to any checks you want to use the filter with.
 Here's an example CPU check:
@@ -150,7 +145,7 @@ Specifically, the annotations in this check definition are doing several things:
 For more information about configuring these values, see the [filter asset's README][10].
 Next, you'll assign the newly minted event filter to a handler.
 
-#### Assign the event filter to a handler
+### Assign the event filter to a handler
 
 Just like with the [interactively created event filter][4], you'll introduce the filter into your Sensu workflow by configuring a handler to use it.
 Here's an example:
@@ -173,7 +168,7 @@ spec:
   - fatigue_check
 {{< /code >}}
 
-#### Validate the event filter
+### Validate the event filter
 
 Verify the proper behavior of these event filters with `sensu-backend` logs.
 The default location of these logs varies based on the platform used (see [Troubleshooting][2] for details).

--- a/content/sensu-go/5.19/guides/scale-event-storage.md
+++ b/content/sensu-go/5.19/guides/scale-event-storage.md
@@ -11,12 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Prerequisites](#prerequisites)
-- [Configure Postgres](#configure-postgres)
-- [Configure Sensu](#configure-sensu)
-- [Revert to the built-in datastore](#revert-to-the-built-in-datastore)
-- [Configure Postgres streaming replication](#configure-postgres-streaming-replication)
-
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][3].
 

--- a/content/sensu-go/5.19/guides/secrets-management.md
+++ b/content/sensu-go/5.19/guides/secrets-management.md
@@ -11,18 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Retrieve your PagerDuty Integration Key](#retrieve-your-pagerduty-integration-key)
-- [Use Env for secrets management](#use-env-for-secrets-management)
-  - [Create your backend environment variable](#create-your-backend-environment-variable)
-  - [Create your Env secret](#create-your-env-secret)
-- [Use HashiCorp Vault for secrets management](#use-hashicorp-vault-for-secrets-management)
-  - [Configure your Vault authentication method (token or TLS)](#configure-your-vault-authentication-method-token-or-tls)
-  - [Create your Vault secret](#create-your-vault-secret)
-- [Add a handler](#add-a-handler)
-  - [Register the PagerDuty handler asset](#register-the-pagerduty-handler-asset)
-  - [Add your secret to the handler spec](#add-your-secret-to-the-handler-spec)
-- [Next steps](#next-steps)
-
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][20].
 
@@ -289,7 +277,7 @@ sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
 
 {{% notice note %}}
-**NOTE**: You can [adjust the asset definition](../install-check-executables-with-assets/#2-adjust-the-asset-definition) according to your Sensu configuration if needed.
+**NOTE**: You can [adjust the asset definition](../install-check-executables-with-assets/#adjust-the-asset-definition) according to your Sensu configuration if needed.
 {{% /notice %}}
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.

--- a/content/sensu-go/5.19/guides/securing-sensu.md
+++ b/content/sensu-go/5.19/guides/securing-sensu.md
@@ -11,12 +11,6 @@ menu:
     parent: guides
 ---
 
-- [Secure etcd peer communication](#secure-etcd-peer-communication)
-- [Secure the API and web UI](#secure-the-api-and-web-ui)
-- [Secure Sensu agent-to-server communication](#secure-sensu-agent-to-server-communication)
-- [Sensu agent mTLS authentication](#sensu-agent-mtls-authentication)
-- [Next step: Run a Sensu cluster](#next-step-run-a-sensu-cluster)
-
 As with any piece of software, it is critical to minimize any attack surface the software exposes.
 Sensu is no different.
 This guide describes the components you need to secure to make Sensu production-ready.

--- a/content/sensu-go/5.19/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.19/guides/send-slack-alerts.md
@@ -11,18 +11,13 @@ menu:
     parent: guides
 ---
 
-- [Use a handler to send alerts to Slack](#use-a-handler-to-send-alerts-to-slack)
-- [Next steps](#next-steps)
-
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 You can use handlers to send an email alert, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
-
-## Use a handler to send alerts to Slack
 
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check-cpu`.
 If you don't already have a check in place, [Monitor server resources][2] is a great place to start.
 
-### Register the asset
+## Register the asset
 
 [Assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
 In this guide, you'll use the [Sensu Slack Handler][14] asset to power a `slack` handler.
@@ -43,13 +38,13 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
-### Get a Slack webhook
+## Get a Slack webhook
 
 If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12].
 After saving, you'll see your webhook URL under Integration Settings.
 
-### Create a handler
+## Create a handler
 
 Use sensuctl to create a handler called `slack` that pipes event data to Slack using the `sensu-slack-handler` asset.
 Edit the command below to include your Slack channel and webhook URL.
@@ -69,7 +64,7 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
-### Assign the handler to a check
+## Assign the handler to a check
 
 With the `slack` handler created, you can assign it to a check.
 In this case, you're using the `check-cpu` check: you want to receive Slack alerts whenever the CPU usage of your systems reach some specific thresholds.
@@ -79,7 +74,7 @@ Assign your handler to the check `check-cpu`:
 sensuctl check set-handlers check-cpu slack
 {{< /code >}}
 
-### Validate the handler
+## Validate the handler
 
 It might take a few moments after you assign the handler to the check for the check to be scheduled on the entities and the result sent back to Sensu backend.
 After an event is handled, you should see the following message in Slack:

--- a/content/sensu-go/5.19/guides/systemd-logs.md
+++ b/content/sensu-go/5.19/guides/systemd-logs.md
@@ -14,11 +14,15 @@ menu:
 By default, systems where systemd is the service manager do not write logs to `/var/log/sensu/` for the `sensu-agent` and the `sensu-backend` services.
 This guide explains how to add log forwarding from journald to syslog, have rsyslog write logging data to disk, and set up log rotation of the newly created log files.
 
+## Configure journald
+
 To configure journald to forward logging data to syslog, modify `/etc/systemd/journald.conf` to include the following line:
 
 {{< code shell >}}
 ForwardToSyslog=yes
 {{< /code >}}
+
+## Configure rsyslog
 
 Next, set up rsyslog to write the logging data received from journald to `/var/log/sensu/servicename.log`.
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
@@ -48,6 +52,8 @@ Restart rsyslog and journald to apply the new configuration:
 systemctl restart systemd-journald
 systemctl restart rsyslog
 {{< /code>}}
+
+## Set up log rotation
 
 Set up log rotation for newly created log files to ensure logging does not fill up your disk.
 

--- a/content/sensu-go/5.19/guides/troubleshooting.md
+++ b/content/sensu-go/5.19/guides/troubleshooting.md
@@ -12,14 +12,6 @@ menu:
     parent: guides
 ---
 
-- [Service logging](#service-logging)
-	- [Log levels](#log-levels)
-	- [Log file locations](#log-file-locations)
-- [Sensu backend startup errors](#sensu-backend-startup-errors)
-- [Permission issues](#permission-issues)
-- [Handlers and event filters](#handlers-and-event-filters)
-- [Assets](#assets)
-
 ## Service logging
 
 Logs produced by Sensu services (sensu-backend and sensu-agent) are often the best place to start when troubleshooting a variety of issues.

--- a/content/sensu-go/5.19/guides/use-apikey-feature.md
+++ b/content/sensu-go/5.19/guides/use-apikey-feature.md
@@ -11,9 +11,6 @@ menu:
     parent: guides
 ---
 
-- [API key authentication](#api-key-authentication)
-- [Sensuctl management commands](#sensuctl-management-commands)
-
 The Sensu API key feature (core/v2.APIKey) is a persistent UUID that maps to a stored Sensu username.
 The advantages of authenticating with API keys rather than [access tokens][1] include:
 

--- a/content/sensu-go/5.19/guides/use-federation.md
+++ b/content/sensu-go/5.19/guides/use-federation.md
@@ -11,16 +11,6 @@ menu:
     parent: guides
 ---
 
-- [What you can do with federation](#what-you-can-do-with-federation)
-- [Configure federation](#configure-federation)
-  - [Step 1 Configure backends for TLS](#step-1-configure-backends-for-tls)
-  - [Step 2 Configure shared token signing keys](#step-2-configure-shared-token-signing-keys)
-  - [Step 3 Add a cluster role binding and user](#step-3-add-a-cluster-role-binding-and-user)
-  - [Step 4 Create etcd replicators](#step-4-create-etcd-replicators)
-  - [Step 5 Register clusters](#step-5-register-clusters): [Register a single cluster](#register-a-single-cluster) | [Register additional clusters](#register-additional-clusters)
-  - [Step 6 Get a unified view of all your clusters in the web UI](#step-6-get-a-unified-view-of-all-your-clusters-in-the-web-ui)
-- [Next steps](#next-steps)
-
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][8].
 

--- a/content/sensu-go/5.19/installation/auth.md
+++ b/content/sensu-go/5.19/installation/auth.md
@@ -9,23 +9,6 @@ menu:
     parent: installation
 ---
 
-- [Use built-in basic authentication](#use-built-in-basic-authentication)
-- [Use an authentication provider](#use-an-authentication-provider)
-   - [Manage authentication providers](#manage-authentication-providers)
-   - [Configure authentication providers](#configure-authentication-providers)
-- [LDAP authentication](#ldap-authentication)
-  - [Examples](#ldap-configuration-examples)
-  - [LDAP specification](#ldap-specification)
-  - [Troubleshooting](#ldap-troubleshooting)
-- [AD authentication](#ad-authentication)
-  - [Examples](#ad-configuration-examples)
-  - [AD specification](#ad-specification)
-  - [Troubleshooting](#ad-troubleshooting)
-- [OIDC authentication](#oidc-authentication)
-  - [OIDC configuration examples](#oidc-configuration-examples)
-  - [OIDC specification](#oidc-specification)
-  - [Okta](#okta)
-
 Sensu requires username and password authentication to access the [Sensu web UI][1], [API][8], and command line tool ([sensuctl][2]).
 You can use Sensu's built-in basic authentication provider or configure external authentication providers to authenticate via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect.
 
@@ -115,7 +98,7 @@ Without an assigned role or cluster role, users can sign in to the Sensu web UI 
 
 After you configure the correct roles and bindings, log in to [sensuctl][36] and the [Sensu web UI][1] using your single-sign-on username and password (no prefix required).
 
-## LDAP authentication
+## Lightweight Directory Access Protocol (LDAP) authentication
 
 Sensu offers [commercial support][6] for a standards-compliant LDAP tool for authentication to the Sensu web UI, API, and sensuctl.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
@@ -244,9 +227,9 @@ spec:
 
 {{< /language-toggle >}}
 
-## LDAP specification
+### LDAP specification
 
-### Top-level attributes
+#### Top-level attributes
 
 type         | 
 -------------|------
@@ -312,7 +295,7 @@ example      | {{< code shell >}}
 }
 {{< /code >}}
 
-### LDAP spec attributes
+#### LDAP spec attributes
 
 | servers    |      |
 -------------|------
@@ -367,7 +350,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"username_prefix": "ldap"{{< /code >}}
 
-### LDAP server attributes
+#### LDAP server attributes
 
 | host       |      |
 -------------|------
@@ -462,7 +445,7 @@ example      | {{< code shell >}}
 }
 {{< /code >}}
 
-### LDAP binding attributes
+#### LDAP binding attributes
 
 | user_dn    |      |
 -------------|------
@@ -478,7 +461,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"password": "YOUR_PASSWORD"{{< /code >}}
 
-### LDAP group search attributes
+#### LDAP group search attributes
 
 | base_dn    |      |
 -------------|------
@@ -511,7 +494,7 @@ type         | String
 default      | `"groupOfNames"`
 example      | {{< code shell >}}"object_class": "groupOfNames"{{< /code >}}
 
-### LDAP user search attributes
+#### LDAP user search attributes
 
 | base_dn    |      |
 -------------|------
@@ -544,7 +527,7 @@ type         | String
 default      | `"person"`
 example      | {{< code shell >}}"object_class": "person"{{< /code >}}
 
-### LDAP metadata attributes
+#### LDAP metadata attributes
 
 | name       |      |
 -------------|------
@@ -553,7 +536,7 @@ required     | true
 type         | String
 example      | {{< code shell >}}"name": "openldap"{{< /code >}}
 
-## LDAP troubleshooting
+### LDAP troubleshooting
 
 To troubleshoot any issue with LDAP authentication, start by [increasing the log verbosity][19] of sensu-backend to the debug log level.
 Most authentication and authorization errors are only displayed on the debug log level to avoid flooding the log files.
@@ -562,7 +545,7 @@ Most authentication and authorization errors are only displayed on the debug log
 **NOTE**: If you can't locate any log entries referencing LDAP authentication, make sure the LDAP provider was successfully installed using [sensuctl](#manage-authentication-providers).
 {{% /notice %}}
 
-### Authentication errors
+#### Authentication errors
 
 This section lists common error messages and possible solutions.
 
@@ -611,7 +594,7 @@ Adjust the `name_attribute` so it specifies a human-readable name for the user.
 The group search returned a group entry (identified by `<DN>`) that doesn't have the [`name_attribute` attribute][21] or a `cn` attribute, so the LDAP provider could not determine which attribute to use as the group name in the group entry.
 Adjust the `name_attribute` so it specifies a human-readable name for the group.
 
-### Authorization issues
+#### Authorization issues
 
 Once authenticated, each user needs to be granted permissions via either a `ClusterRoleBinding` or a `RoleBinding`.
 
@@ -633,12 +616,12 @@ For example:
 [...] could not authorize the request with any ClusterRoleBindings [...]
 ```
 
-## Active Directory (AD) authentication {#ad-authentication}
+## Active Directory (AD) authentication
 
 Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication to the Sensu web UI, API, and sensuctl.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
-### Active Directory (AD) configuration examples {#ad-configuration-examples}
+### AD configuration examples
 
 **Example AD configuration: Minimum required attributes**
 
@@ -765,9 +748,9 @@ spec:
 
 {{< /language-toggle >}}
 
-## AD specification
+### AD specification
 
-### AD top-level attributes
+#### AD top-level attributes
 
 type         | 
 -------------|------
@@ -835,7 +818,7 @@ example      | {{< code shell >}}
 }
 {{< /code >}}
 
-### AD spec attributes
+#### AD spec attributes
 
 | servers    |      |
 -------------|------
@@ -892,7 +875,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"username_prefix": "ad"{{< /code >}}
 
-### AD server attributes
+#### AD server attributes
 
 | host       |      |
 -------------|------
@@ -1007,7 +990,7 @@ example      | {{< code shell >}}
 "include_nested_groups": true
 {{< /code >}}
 
-### AD binding attributes
+#### AD binding attributes
 
 | user_dn    |      |
 -------------|------
@@ -1023,7 +1006,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"password": "YOUR_PASSWORD"{{< /code >}}
 
-### AD group search attributes
+#### AD group search attributes
 
 | base_dn    |      |
 -------------|------
@@ -1056,7 +1039,7 @@ type         | String
 default      | `"group"`
 example      | {{< code shell >}}"object_class": "group"{{< /code >}}
 
-### AD user search attributes
+#### AD user search attributes
 
 | base_dn    |      |
 -------------|------
@@ -1089,7 +1072,7 @@ type         | String
 default      | `"person"`
 example      | {{< code shell >}}"object_class": "person"{{< /code >}}
 
-### AD metadata attributes
+#### AD metadata attributes
 
 | name       |      |
 -------------|------
@@ -1098,11 +1081,11 @@ required     | true
 type         | String
 example      | {{< code shell >}}"name": "activedirectory"{{< /code >}}
 
-## AD troubleshooting
+### AD troubleshooting
 
 The troubleshooting steps in the [LDAP troubleshooting][49] section also apply for AD troubleshooting.
 
-## OIDC authentication
+## OpenID Connect 1.0 protocol (OIDC) authentication
 
 Sensu offers [commercial support][6] for the OIDC provider for using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol for RBAC authentication.
 
@@ -1371,14 +1354,14 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 [34]: #groups-prefix
 [35]: #username-prefix
 [36]: ../../sensuctl/reference#first-time-setup
-[37]: #ad-authentication
+[37]: #active-directory-ad-authentication
 [38]: ../../sensuctl/reference#create-resources
 [39]: #ldap-spec-attributes
 [40]: #ldap-server-attributes
 [41]: https://en.wikipedia.org/wiki/Fully_qualified_domain_name
 [42]: https://regex101.com/r/zo9mQU/2
 [43]: #ldap-binding-attributes
-[44]: #ldap-authentication
+[44]: #lightweight-directory-access-protocol-ldap-authentication
 [45]: #ad-spec-attributes
 [46]: #ad-server-attributes
 [47]: #ad-group-search-attributes

--- a/content/sensu-go/5.19/installation/install-sensu.md
+++ b/content/sensu-go/5.19/installation/install-sensu.md
@@ -10,13 +10,6 @@ menu:
     parent: installation
 ---
 
-- [Architecture overview](#architecture-overview)
-- [Install the Sensu backend](#install-the-sensu-backend)
-- [Install sensuctl](#install-sensuctl)
-- [Install Sensu agents](#install-sensu-agents)
-- [Commercial features](#commercial-features)
-- [Next steps](#next-steps)
-
 This installation guide describes how to install the Sensu backend, Sensu agent, and sensuctl command line tool.
 If you’re trying Sensu for the first time, we recommend setting up a local environment using the [Sensu sandbox][14].
 

--- a/content/sensu-go/5.19/installation/plugins.md
+++ b/content/sensu-go/5.19/installation/plugins.md
@@ -12,11 +12,6 @@ menu:
     parent: installation
 ---
 
-- [Install plugins with assets](#install-plugins-with-assets)
-- [Use Bonsai, the Sensu asset index](#use-bonsai-the-sensu-asset-index)
-- [Install plugins with the sensu-install tool](#install-plugins-with-the-sensu-install-tool)
-- [Troubleshoot the sensu-install tool](#troubleshoot-the-sensu-install-tool)
-
 Extend Sensu's functionality with [plugins][10], which provide executables for performing status or metric checks, mutators for changing data to a desired format, and handlers for performing an action on a Sensu event.
 
 ## Install plugins with assets

--- a/content/sensu-go/5.19/installation/recommended-hardware.md
+++ b/content/sensu-go/5.19/installation/recommended-hardware.md
@@ -11,11 +11,6 @@ menu:
     parent: installation
 ---
 
-- [Sensu backend requirements](#sensu-backend-requirements)
-- [Sensu agent requirements](#sensu-agent-requirements)
-- [Networking recommendations](#networking-recommendations)
-- [Cloud recommendations](#cloud-recommendations)
-
 ## Sensu backend requirements
 
 ### Backend minimum requirements

--- a/content/sensu-go/5.19/installation/upgrade.md
+++ b/content/sensu-go/5.19/installation/upgrade.md
@@ -11,12 +11,6 @@ menu:
     parent: installation
 ---
 
-- [Upgrade to the latest version of Sensu Go from 5.0.0 or later](#upgrade-to-the-latest-version-of-sensu-go-from-5-0-0-or-later)
-- [Upgrade to Sensu Go 5.16.0 from any earlier version](#upgrade-to-sensu-go-5-16-0-from-any-earlier-version)
-- [Upgrade Sensu clusters from 5.7.0 or earlier to 5.8.0 or later](#upgrade-sensu-clusters-from-5-7-0-or-earlier-to-5-8-0-or-later)
-- [Upgrade Sensu backend binaries to 5.1.0](#upgrade-sensu-backend-binaries-to-5-1-0)
-- [Migrate to Sensu Go from Sensu Core 1.x](#migrate-to-sensu-go-from-sensu-core-1-x)
-
 ## Upgrade to the latest version of Sensu Go from 5.0.0 or later
 
 To upgrade to the latest version of Sensu Go from version 5.0.0 or later, [install the latest packages][23].

--- a/content/sensu-go/5.19/learn/demo.md
+++ b/content/sensu-go/5.19/learn/demo.md
@@ -4,6 +4,7 @@ linkTitle: "Live demo"
 description: "Explore the Sensu web UI and sensuctl command line tool with a live demo that monitors the Sensu docs site. See entities, monitoring events, and active service and metric checks."
 version: "5.19"
 weight: 30
+toc: false
 product: "Sensu Go"
 menu:
   sensu-go-5.19:

--- a/content/sensu-go/5.19/learn/glossary.md
+++ b/content/sensu-go/5.19/learn/glossary.md
@@ -10,95 +10,95 @@ menu:
     parent: learn-sensu
 ---
 
-#### Agent
+## Agent
 A lightweight client that runs on the infrastructure components you want to monitor.
 Agents self-register with the backend, send keepalive messages, and execute monitoring checks.
 Each agent belongs to one or more subscriptions that determine which checks the agent runs.
 An agent can run checks on the entity it’s installed on or connect to a remote proxy entity.
 [Read more about the Sensu agent][1].
 
-#### Asset
+## Asset
 An executable that a check, handler, or mutator can specify as a dependency.
 Assets must be a tar archive (optionally gzipped) with scripts or executables within a bin folder.
 At runtime, the backend or agent installs required assets using the specified URL.
 Assets let you manage runtime dependencies without using configuration management tools.
 [Read more about assets][4].
 
-#### Backend
+## Backend
 A flexible, scalable monitoring event pipeline.
 The Sensu backend processes event data using filters, mutators, and handlers.
 It maintains configuration files, stores recent event data, and schedules monitoring checks.
 You can interact with the backend using the API, command line, and web UI interfaces.
 [Read more about the Sensu backend][2].
 
-#### Check
+## Check
 A recurring check the agent runs to determine the state of a system component or collect metrics.
 The backend is responsible for storing check definitions, scheduling checks, and processing event data.
 Check definitions specify the command to be executed, an interval for execution, one or more subscriptions, and one or more handlers to process the resulting event data.
 [Read more about checks][3].
 
-#### Entity
+## Entity
 Infrastructure components that you want to monitor.
 Each entity runs an agent that executes checks and creates events.
 Events can be tied to the entity where the agent runs or a proxy entity that the agent checks remotely.
 [Read more about entities][7].
 
-#### Event
+## Event
 A representation of the state of an infrastructure component at a point in time.
 The Sensu backend uses events to power the monitoring event pipeline.
 Event data includes the result of a check or metric (or both), the executing agent, and a timestamp.
 [Read more about events][8].
 
-#### Event filter
+## Event filter
 Logical expressions that handlers evaluate before processing monitoring events.
 Event filters can instruct handlers to allow or deny matching events based on day, time, namespace, or any attribute in the event data.
 [Read more about event filters][9].
 
-#### Handler
+## Handler
 A component of the monitoring event pipeline that acts on events.
 Handlers can send monitoring event data to an executable (or handler plugin), a TCP socket, or a UDP socket.
 [Read more about handlers][10].
 
-#### Hook
+## Hook
 A command the agent executes in response to a check result *before* creating a monitoring event.
 Hooks create context-rich events by gathering relevant information based on check status.
 [Read more about hooks][5].
 
-#### Mutator
+## Mutator
 An executable the backend runs prior to a handler to transform event data.
 [Read more about mutators][11].
 
-#### Plugin
+## Plugin
 Executables designed to work with Sensu event data either as a check, mutator, or handler plugin. 
 You can write your own check executables in Go, Ruby, Python, and more, or use one of more than 200 plugins shared by the Sensu community.
 [Read more about plugins][6].
 
-#### Proxy entities
+## Proxy entities
 Components of your infrastructure that can’t run the agent locally (like a network switch or a website) but still need to be monitored.
 Agents create events with information about the proxy entity in place of the local entity when running checks with a specified proxy entity ID.
 [Read more about proxy entities][12].
 
-#### Role-based access control (RBAC)
+## Role-based access control (RBAC)
 Sensu’s local user management system.
 RBAC lets you manage users and permissions with namespaces, users, roles, and role bindings.
 [Read more about RBAC][13].
 
-#### Resources
+## Resources
 Objects within Sensu that you can use to specify access permissions in Sensu roles and cluster roles.
 Resources can be specific to a namespace (like checks and handlers) or cluster-wide (like users and cluster roles).
 [Read more about resources][18].
 
-#### Sensuctl
+## Sensuctl
 The Sensu command line tool that lets you interact with the backend.
 You can use sensuctl to create checks, view events, create users, manage clusters, and more.
 [Read more about sensuctl][14].
 
-#### Silencing
+## Silencing
 Entries that allow you to suppress execution of event handlers on an ad-hoc basis.
 Use silencing to schedule maintenance without being overloaded with alerts.
 [Read more about silencing][17].
 
-#### Token
+## Token
 A placeholder in a check definition that the agent replaces with local information before executing the check.
 Tokens let you fine-tune check attributes (like thresholds) on a per-entity level while reusing the check definition.
 [Read more about tokens][16].

--- a/content/sensu-go/5.19/learn/interactive-tutorials.md
+++ b/content/sensu-go/5.19/learn/interactive-tutorials.md
@@ -3,16 +3,13 @@ title: "Learn Sensu with interactive tutorials"
 linkTitle: "Interactive tutorials"
 description: "Learn Sensu using only your browser. These tutorials demonstrate how to use Sensu to automate your workflows, integrate with tools you're already using, and get complete control over your alerts."
 weight: 20
+toc: false
 version: "5.19"
 product: "Sensu Go"
 menu:
   sensu-go-5.19:
     parent: learn-sensu
 ---
-
-- [Learn Sensu in 15 minutes](#learn-sensu-in-15-minutes)
-- [Up and running with Sensu Go](#up-and-running-with-sensu-go)
-- [Send Sensu Go alerts to PagerDuty](#send-sensu-go-alerts-to-pagerduty)
 
 Sensu is the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
 

--- a/content/sensu-go/5.19/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/5.19/learn/learn-sensu-sandbox.md
@@ -7,13 +7,6 @@ product: "Sensu Go"
 
 In this tutorial, you'll download the Sensu sandbox and create a monitoring workflow with Sensu.
 
-- [Set up the sandbox](#set-up-the-sandbox)
-- [Lesson \#1: Create a monitoring event](#lesson-1-create-a-sensu-monitoring-event)
-- [Lesson \#2: Create an event pipeline](#lesson-2-pipe-keepalive-events-into-slack)
-- [Lesson \#3: Automate event production with the Sensu agent](#lesson-3-automate-event-production-with-the-sensu-agent)
-
----
-
 ## Set up the sandbox
 
 **1. Install Vagrant and VirtualBox**

--- a/content/sensu-go/5.19/learn/prometheus-metrics.md
+++ b/content/sensu-go/5.19/learn/prometheus-metrics.md
@@ -6,22 +6,6 @@ product: "Sensu Go"
 platformContent: false
 ---
 
-- [Set up](#set-up)
-  - [Install and configure Prometheus](#install-and-configure-prometheus)
-  - [Install and configure Sensu Go](#install-and-configure-sensu-go)
-  - [Install and configure InfluxDB](#install-and-configure-influxdb)
-  - [Install and configure Grafana](#install-and-configure-grafana)
-- [Create a Sensu InfluxDB pipeline](#create-a-sensu-influxdb-pipeline)
-  - [Create a Sensu InfluxDB handler asset](#create-a-sensu-influxdb-handler-asset)
-  - [Create a Sensu handler](#create-a-sensu-handler)
-- [Collect Prometheus metrics with Sensu](#collect-prometheus-metrics-with-sensu)
-  - [Create a Sensu Prometheus Collector asset](#create-a-sensu-prometheus-collector-asset)
-  - [Add a Sensu check to complete the pipeline](#add-a-sensu-check-to-complete-the-pipeline)
-- [Visualize metrics with Grafana](#visualize-metrics-with-grafana)
-  - [Configure a dashboard in Grafana](#configure-a-dashboard-in-grafana)
-  - [View metrics in Grafana](#view-metrics-in-grafana)
-- [Next steps](#next-steps)
-
 The [Sensu Prometheus Collector][1] is a check plugin that collects metrics from a [Prometheus exporter][2] or the [Prometheus query API][3].
 This allows Sensu to route the collected metrics to one or more time series databases, such as InfluxDB or Graphite.
 

--- a/content/sensu-go/5.19/learn/sample-app.md
+++ b/content/sensu-go/5.19/learn/sample-app.md
@@ -7,19 +7,6 @@ platformContent: true
 platforms: ["Linux/macOS", "Windows"]
 ---
 
-- [Prerequisites](#prerequisites)
-- [Set up](#set-up)
-- [Multitenancy](#multitenancy)
-- [Deploy Sensu agents and InfluxDB](#deploy-sensu-agents-and-influxdb)
-- [Monitor the app](#monitor-the-app)
-	- [Create a Sensu pipeline to Slack](#create-a-sensu-pipeline-to-slack)
-	- [Create a Sensu service check](#create-a-sensu-service-check-to-monitor-the-status-of-the-dummy-app)
-- [Collect app metrics](#collect-app-metrics)
-	- [Create a Sensu metric check to collect Prometheus metrics](#create-a-sensu-metric-check-to-collect-prometheus-metrics)
-	- [Visualize metrics with Grafana](#visualize-metrics-with-grafana)
-- [Collect Kubernetes metrics](#collect-kubernetes-metrics)
-- [Next steps](#next-steps)
-
 In this tutorial, you'll deploy a sample app with Kubernetes and monitor it with Sensu.
 In the sample app, `/` returns the local hostname.
 The sample app has three endpoints: `/metrics` returns Prometheus metric data, `/healthz` returns the Boolean health state, and `POST /healthz` toggles the health state.

--- a/content/sensu-go/5.19/platforms.md
+++ b/content/sensu-go/5.19/platforms.md
@@ -10,14 +10,6 @@ platformContent: true
 platforms: ["Linux", "Windows", "macOS", "FreeBSD", "Solaris"]
 ---
 
-- [Supported packages](#supported-packages)
-  - [Sensu backend](#sensu-backend) | [Sensu agent](#sensu-agent) | [Sensuctl command line tool](#sensuctl-command-line-tool)
-- [Docker images](#docker-images)
-- [Integrations](#integrations)
-- [Binary-only distributions](#binary-only-distributions)
-  - [Linux](#linux) | [Windows](#windows) | [macOS](#macos) | [FreeBSD](#freebsd) | [Solaris](#solaris)
-- [Build from source](#build-from-source)
-
 Sensu is available as [packages][1], [Docker images][2], and [binary-only distributions][4].
 We recommend [installing Sensu][5] with one of our supported packages, Docker images, or [configuration management][6] integrations.
 Sensu downloads are provided under the [Sensu commercial license][7].

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -12,20 +12,7 @@ menu:
     parent: reference
 ---
 
-- [Installation][1]
-- [Communication between the agent and backend](#communication-between-the-agent-and-backend)
-- [Create monitoring events using service checks](#create-monitoring-events-using-service-checks)
-- [Create monitoring events using the agent API](#create-monitoring-events-using-the-agent-api)
-- [Create monitoring events using the StatsD listener](#create-monitoring-events-using-the-statsd-listener)
-- [Create monitoring events using the agent TCP and UDP sockets](#create-monitoring-events-using-the-agent-tcp-and-udp-sockets) (deprecated)
-- [Keepalive monitoring](#keepalive-monitoring)
-- [Service management](#operation)
-  - [Start and stop the service](#start-the-service) | [Register and deregister](#registration) | [Cluster](#cluster) | [Synchronize time](#synchronize-time)
-- [Configuration via flags](#configuration-via-flags)
-  - [General configuration flags](#general-configuration-flags) | [API configuration flags](#api-configuration-flags) | [Ephemeral agent configuration flags](#ephemeral-agent-configuration-flags) | [Keepalive configuration flags](#keepalive-configuration-flags) | [Security configuration](#security-configuration-flags) | [Socket configuration flags](#socket-configuration-flags) | [StatsD configuration flags](#statsd-configuration-flags)
-  - [Allow list configuration commands](#allow-list-configuration-commands) and [example allow list configuration file](#example-allow-list-configuration-file)
-- [Configuration via environment variables](#configuration-via-environment-variables)
-- [Example Sensu agent configuration file](../../files/agent.yml) (download)
+[Example Sensu agent configuration file](../../files/agent.yml) (download)
 
 The Sensu agent is a lightweight client that runs on the infrastructure components you want to monitor.
 Agents register with the Sensu backend as [monitoring entities][3] with `type: "agent"`.

--- a/content/sensu-go/5.19/reference/apikeys.md
+++ b/content/sensu-go/5.19/reference/apikeys.md
@@ -9,12 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Authorization header format](#authorization-header-format)
-- [API key resource structure](#api-key-resource-structure)
-- [API key specification](#api-key-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-
 API keys are long-lived authentication tokens that make it more convenient for Sensu plugins and other Sensu-adjacent applications to authenticate with the Sensu API.
 Unlike [authentication tokens][2], API keys are persistent and do not need to be refreshed every 15 minutes.
 

--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -11,15 +11,6 @@ menu:
     parent: reference
 ---
 
-- [Asset builds](#asset-builds)
-- [Asset format specification](#asset-format-specification)
-- [Asset specification](#asset-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Asset filters based on entity.system attributes](#asset-filters-based-on-entity-system-attributes)
-- [Examples](#examples)
-- [Share an asset on Bonsai](#share-an-asset-on-bonsai)
-- [Delete assets](#delete-assets)
-
 You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
 Read [Install plugins with assets][23] to get started.
 

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -11,25 +11,14 @@ menu:
     parent: reference
 ---
 
-- [Installation][1]
-- [Create event pipelines](#create-event-pipelines)
-- [Schedule checks](#schedule-checks)
-- [Initialization](#initialization)
-- [Operation and service management](#operation)
-  - [Start and stop the service](#start-the-service) | [Cluster](#cluster) | [Synchronize time](#synchronize-time)
-- [Configuration](#configuration)
-  - [General configuration](#general-configuration-flags) | [Agent communication configuration](#agent-communication-configuration-flags) | [Security configuration](#security-configuration-flags) | [Web UI configuration](#web-ui-configuration-flags) | [Datastore and cluster configuration](#datastore-and-cluster-configuration-flags) | [Advanced configuration options](#advanced-configuration-options)
-  - [Configuration via environment variables](#configuration-via-environment-variables)
-- [Event logging](#event-logging)
-  - [Log rotation](#log-rotation)
-- [Example Sensu backend configuration file](../../files/backend.yml) (download)
+[Example Sensu backend configuration file](../../files/backend.yml) (download)
 
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, a [Sensu web UI][6], and the `sensu-backend` command line tool.
 The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
 See the [installation guide][1] to install the backend.
 
-### Create event pipelines
+## Create event pipelines
 
 The backend processes event data and executes filters, mutators, and handlers.
 These pipelines are powerful tools to automate your monitoring workflows.
@@ -41,7 +30,7 @@ To learn more about filters, mutators, and handlers, see:
 - [Mutators reference documentation][10]
 - [Handlers reference documentation][11]
 
-### Schedule checks
+## Schedule checks
 
 The backend is responsible for storing check definitions and scheduling check requests.
 Check scheduling is subscription-based: the backend sends check requests to subscriptions. where they're picked up by subscribing agents.

--- a/content/sensu-go/5.19/reference/checks.md
+++ b/content/sensu-go/5.19/reference/checks.md
@@ -10,16 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Check commands](#check-commands)
-- [Check result specification](#check-result-specification)
-- [Check scheduling](#check-scheduling): [Subscriptions](#subscriptions) | [Scheduling](#scheduling)
-- [Proxy checks](#proxy-checks)
-- [Check token substitution](#check-token-substitution)
-- [Check hooks](#check-hooks)
-- [Check specification](#check-specification)
-	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Proxy requests attributes](#proxy-requests-attributes) | [Check output truncation attributes](#check-output-truncation-attributes) | [`secrets` attributes](#secrets-attributes)
-- [Examples](#examples)
-
 Checks work with Sensu agents to produce monitoring events automatically.
 You can use checks to monitor server resources, services, and application health as well as collect and analyze metrics.
 Read [Monitor server resources][12] to get started.

--- a/content/sensu-go/5.19/reference/datastore.md
+++ b/content/sensu-go/5.19/reference/datastore.md
@@ -9,14 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Event storage](#event-storage)
-- [Scale event storage](#scale-event-storage) (commercial feature)
-  - [Requirements](#requirements)
-  - [Configuration](#configuration)
-  - [Datastore specification](#datastore-specification)
-
-## Event storage
-
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
 You can access event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
@@ -33,12 +25,12 @@ When configured with a PostgreSQL event store, Sensu connects to PostgreSQL to s
 Etcd continues to store Sensu entity and configuration data.
 You can access event data stored in PostgreSQL using the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
 
-### Requirements
+## Requirements
 
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-### Configuration
+## Configuration
 
 At the time when you enable the PostgreSQL event store, event data cuts over from etcd to PostgreSQL.
 This results in a loss of recent event history.
@@ -90,7 +82,7 @@ sensuctl create --file postgres.yml
 To update your Sensu PostgreSQL configuration, repeat the `sensuctl create` process.
 You can expect to see PostgreSQL status updates in the [Sensu backend logs][2] at the `warn` log level and PostgreSQL error messages in the [Sensu backend logs][2] at the `error` log level.
 
-#### Disable the PostgreSQL event store
+### Disable the PostgreSQL event store
 
 To disable the PostgreSQL event store, use `sensuctl delete` with your `PostgresConfig` resource definition:
 
@@ -107,9 +99,9 @@ Mar 10 17:35:04 sensu-centos sensu-backend[1365]: {"component":"store-providers"
 When you disable the PostgreSQL event store, event data cuts over from PostgreSQL to etcd, which results in a loss of recent event history.
 No restarts or Sensu backend configuration changes are required to disable the PostgreSQL event store.
 
-### Datastore specification
+## Datastore specification
 
-#### Top-level attributes
+### Top-level attributes
 
 type         |      |
 -------------|------
@@ -127,13 +119,12 @@ example      | {{< code shell >}}api_version: store/v1{{< /code >}}
 
 metadata     |      |
 -------------|------
-description  | Top-level scope that contains the PostgreSQL datastore `name` and `created_by` field.
+description  | Top-level scope that contains the PostgreSQL datastore `name`.
 required     | true
 type         | Map of key-value pairs
 example      | {{< code shell >}}
 metadata:
   name: my-postgres
-  created_by: admin
 {{< /code >}}
 
 spec         |      |
@@ -147,7 +138,7 @@ spec:
   pool_size: 20
 {{< /code >}}
 
-#### Metadata attributes
+### Metadata attributes
 
 name         |      |
 -------------|------
@@ -156,14 +147,7 @@ required     | true
 type         | String
 example      | {{< code shell >}}name: my-postgres{{< /code >}}
 
-| created_by |      |
--------------|------
-description  | Username of the Sensu user who created the datastore or last updated the datastore. Sensu automatically populates the `created_by` field when the datastore is created or updated.
-required     | false
-type         | String
-example      | {{< code shell >}}created_by: admin{{< /code >}}
-
-#### Spec attributes
+### Spec attributes
 
 dsn          |      |
 -------------|------
@@ -180,28 +164,9 @@ default      | `0` (unlimited)
 type         | Integer
 example      | {{< code shell >}}pool_size: 20{{< /code >}}
 
-<a name="max_conn_lifetime"></a>
-
-max_conn_lifetime    |      |
--------------|------
-description  | Available in [Sensu Go 5.19.2][4]. Maximum time a connection can persist before being destroyed. Specify values with a numeral and a letter indicator: `s` to indicate seconds, `m` to indicate minutes, and `h` to indicate hours. For example, `1m`, `2h`, and `2h1m3s` are valid. 
-required     | false
-type         | String
-example      | {{< code shell >}}max_conn_lifetime: 5m{{< /code >}}
-
-max_idle_conns    |      |
--------------|------
-description  | Available in [Sensu Go 5.19.2][4]. Maximum number of number of idle connections to retain. 
-required     | false
-default      | `2`
-type         | Integer
-example      | {{< code shell >}}max_idle_conns: 2{{< /code >}}
-
-
 [1]: ../../sensuctl/reference/#first-time-setup
 [2]: ../../guides/troubleshooting/
 [3]: https://aws.amazon.com/rds/
-[4]: ../../release-notes/#5-19-2-release-notes
 [8]: ../../guides/clustering/#use-an-external-etcd-cluster
 [9]: ../../web-ui/sign-in/
 [10]: ../../sensuctl/reference/#sensuctl-event

--- a/content/sensu-go/5.19/reference/entities.md
+++ b/content/sensu-go/5.19/reference/entities.md
@@ -10,13 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Usage limits](#usage-limits)
-- [Proxy entities](#proxy-entities)
-- [Manage entity labels](#manage-entity-labels): [Proxy entity labels](#proxy-entities-managed) | [Agent entity labels](#agent-entities-managed)
-- [Entities specification](#entities-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [System attributes](#system-attributes) | [Network attributes](#network-attributes) | [NetworkInterface attributes](#networkinterface-attributes) | [Deregistration attributes](#deregistration-attributes)
-- [Examples](#examples)
-
 An entity represents anything that needs to be monitored, such as a server, container, or network switch, including the full range of infrastructure, runtime, and application types that compose a complete monitoring environment (from server hardware to serverless functions).
 We call these monitored parts of an infrastructure "entities."
 

--- a/content/sensu-go/5.19/reference/etcdreplicators.md
+++ b/content/sensu-go/5.19/reference/etcdreplicators.md
@@ -10,13 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Create a replicator](#create-a-replicator)
-- [Delete a replicator](#delete-a-replicator)
-- [Replicator configuration](#replicator-configuration)
-- [etcd-replicators specification](#etcd-replicators-specification)
-- [Example EtcdReplicator resources](#example-etcdreplicator-resources)
-- [Critical success factors for etcd replication](#critical-success-factors-for-etcd-replication)
-
 **COMMERCIAL FEATURE**: Access the etcd-replicators datatype in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.19/reference/events.md
+++ b/content/sensu-go/5.19/reference/events.md
@@ -10,19 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Check-only events](#check-only-events)
-- [Metric-only events](#metric-only-events)
-- [Check and metric events](#check-and-metric-events)
-- [Create events using the Sensu agent](#create-events-using-the-sensu-agent)
-- [Create events using the events API](#create-events-using-the-events-api)
-- [Manage events](#manage-events): [View events](#view-events) | [Delete events](#delete-events) | [Resolve events](#resolve-events)
-- [Event format](#event-format)
-- [Use event data](#use-event-data)
-  - [Occurrences](#occurrences-and-occurrences-watermark)
-- [Events specification](#events-specification)
-	- [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [Check attributes](#check-attributes) | [Metric attributes](#metric-attributes)
-- [Examples](#examples)
-
 An event is a generic container used by Sensu to provide context to checks and metrics.
 The context, called event data, contains information about the originating entity and the corresponding check or metric result.
 An event must contain a check or metrics.
@@ -30,7 +17,7 @@ In certain cases, an event can contain both.
 These generic containers allow Sensu to handle different types of events in the pipeline.
 Because events are polymorphic in nature, it is important to never assume their contents (or lack of content).
 
-### Check-only events
+## Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu server, regardless of the status indicated by the check result.
 The agent creates an event upon receipt of the check execution result.
@@ -38,13 +25,13 @@ The agent will execute any configured [hooks][4] the check might have.
 From there, the result is forwarded to the Sensu backend for processing.
 Potentially noteworthy events may be processed by one or more event handlers, for example to send an email or invoke an automated action.
 
-### Metric-only events
+## Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the [StatsD listener][5].
 The agent will translate the StatsD metrics to Sensu metric format and place them inside an event.
 Because these events do not contain checks, they bypass the store and are sent to the event pipeline and corresponding event handlers.
 
-### Check and metric events
+## Check and metric events
 
 Events that contain _both_ a check and metrics most likely originated from [check output metric extraction][6].
 If a check is configured for metric extraction, the agent will parse the check output and transform it to Sensu metric format.

--- a/content/sensu-go/5.19/reference/filters.md
+++ b/content/sensu-go/5.19/reference/filters.md
@@ -10,19 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Inclusive and exclusive event filters](#inclusive-and-exclusive-event-filters)
-- [Built-in event filters](#built-in-event-filters)
-- [Build event filter expressions](#build-event-filter-expressions)
-- [Event filter specification](#event-filter-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Event filter examples](#event-filter-examples)
-	- [Handle production events](#handle-production-events)
-	- [Handle non-production events](#handle-non-production-events)
-	- [Handle state change only](#handle-state-change-only)
-	- [Handle repeated events](#handle-repeated-events)
-	- [Handle events during office hours only](#handle-events-during-office-hours-only)
-- [Use JavaScript libraries with Sensu filters](#use-javascript-libraries-with-sensu-filters)
-
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the event data.
 If the filters do not remove the event, the handler will be executed.

--- a/content/sensu-go/5.19/reference/handlers.md
+++ b/content/sensu-go/5.19/reference/handlers.md
@@ -10,14 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Pipe handlers](#pipe-handlers)
-- [TCP/UDP handlers](#tcp-udp-handlers)
-- [Handler sets](#handler-sets)
-- [Keepalive event handlers](#keepalive-event-handlers)
-- [Handler specification](#handler-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`socket` attributes](#socket-attributes) | [`secrets` attributes](#secrets-attributes)
-- [Examples](#handler-examples)
-
 Handlers are actions the Sensu backend executes on events.
 Several types of handlers are available.
 The most common are `pipe` handlers, which work similarly to [checks][1] and enable Sensu to interact with almost any computer program via [standard streams][2].

--- a/content/sensu-go/5.19/reference/health.md
+++ b/content/sensu-go/5.19/reference/health.md
@@ -9,10 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Health payload example](#health-payload-example)
-- [Health specification](#health-specification)
-  - [Top-level attributes](#top-level-attributes) | [ClusterHealth attributes](#clusterhealth-attributes) | [Header attributes](#header-attributes) | [PostgresHealth attributes](#postgreshealth-attributes)
-
 Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
 
 ## Health payload example

--- a/content/sensu-go/5.19/reference/hooks.md
+++ b/content/sensu-go/5.19/reference/hooks.md
@@ -10,15 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Check response types](#check-response-types)
-- [Check hooks](#check-hooks)
-- [Hook specification](#hook-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-  - [Rudimentary auto-rememdiation](#rudimentary-auto-remediation)
-  - [Capture the process tree](#capture-the-process-tree)
-  - [Check hook using token substitution](#check-hook-using-token-substitution)
-
 Hooks are reusable commands the agent executes in response to a check result before creating a monitoring event.
 You can create, manage, and reuse hooks independently of checks.
 Hooks enrich monitoring event context by gathering relevant information based on the exit status code of a check (ex: `1`).

--- a/content/sensu-go/5.19/reference/license.md
+++ b/content/sensu-go/5.19/reference/license.md
@@ -10,11 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Activate your commercial license](#activate-your-commercial-license)
-- [Entity limit](#entity-limit)
-- [License expiration](#license-expiration)
-- [Quick links](#quick-links)
-
 ## Activate your commercial license
 
 If you haven't already, [install the backend, agent, and sensuctl][2] and [configure sensuctl][3].

--- a/content/sensu-go/5.19/reference/mutators.md
+++ b/content/sensu-go/5.19/reference/mutators.md
@@ -10,12 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Commands](#commands)
-- [Built-in mutators](#built-in-mutators)
-- [Mutator specification](#mutator-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes) | [`secrets` attributes](#secrets-attributes)
-- [Examples](#examples)
-
 Handlers can specify a mutator to execute and transform event data before any handlers are applied.
 
 * When the Sensu backend processes an event, it checks the handler for the presence of a mutator and executes that mutator before executing the handler.

--- a/content/sensu-go/5.19/reference/rbac.md
+++ b/content/sensu-go/5.19/reference/rbac.md
@@ -10,23 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Namespaces](#namespaces)
-  - [Manage namespaces](#manage-namespaces) | [Namespace specification](#namespace-specification) | [Namespace example](#namespace-example)
-- [Resources](#resources)
-  - [Namespaced resource types](#namespaced-resource-types) | [Cluster-wide resource types](#cluster-wide-resource-types) | [Special resource types](#special-resource-types)
-- [Users](#users)
-  - [Manage users](#manage-users) | [User specification](#user-specification) | [User example](#user-example)
-- [Groups](#groups)
-  - [Manage groups](#manage-groups)
-- [Roles and cluster roles](#roles-and-cluster-roles)
-  - [Manage roles and cluster roles](#manage-roles-and-cluster-roles) | [Role and cluster role specification](#role-and-cluster-role-specification) | [Role and cluster role examples](#role-and-cluster-role-examples)
-- [Role bindings and cluster role bindings](#role-bindings-and-cluster-role-bindings)
-  - [Manage role bindings and cluster role bindings](#manage-role-bindings-and-cluster-role-bindings) | [Role binding and cluster role binding specification](#role-binding-and-cluster-role-binding-specification) | [Role binding and cluster role binding examples](#role-binding-and-cluster-role-binding-examples)
-- [Example workflows](#example-workflows)
-  - [Assign user permissions within a namespace](#assign-user-permissions-within-a-namespace)
-  - [Assign group permissions within a namespace](#assign-group-permissions-within-a-namespace)
-  - [Assign group permissions across all namespaces](#assign-group-permissions-across-all-namespaces)
-
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows you to manage user access and resources based on namespaces, groups, roles, and bindings.
 
@@ -276,7 +259,7 @@ A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
 **NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication).
-It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication). 
+It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication). 
 {{% /notice %}}
 
 To change the password for a user:
@@ -1274,8 +1257,8 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [40]: ../../reference/etcdreplicators/
 [41]: ../agent/#security-configuration-flags
 [42]: ../../installation/install-sensu/#install-the-sensu-backend
-[43]: ../../installation/auth#ldap-authentication
-[44]: ../../installation/auth/#ad-authentication
+[43]: ../../installation/auth#lightweight-directory-access-protocol-ldap-authentication
+[44]: ../../installation/auth/#active-directory-ad-authentication
 [45]: ../../sensuctl/reference/#change-admin-user-s-password
 [46]: ../secrets-providers/
 [47]: ../datastore/

--- a/content/sensu-go/5.19/reference/searches.md
+++ b/content/sensu-go/5.19/reference/searches.md
@@ -10,12 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Searches specification](#searches-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-	- [Search for events with any status except passing](#search-for-events-with-any-status-except-passing)
-  - [Search for published checks with a specific subscription and region ](#search-for-published-checks-with-a-specific-subscription-and-region)
-
 **COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.19/reference/secrets-providers.md
+++ b/content/sensu-go/5.19/reference/secrets-providers.md
@@ -10,11 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Secrets providers specification](#secrets-providers-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Secrets providers configuration](#secrets-providers-configuration)
-- [Secrets providers examples](#secrets-providers-examples)
-
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.19/reference/secrets.md
+++ b/content/sensu-go/5.19/reference/secrets.md
@@ -10,11 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Secret specification](#secret-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Secret configuration](#secret-configuration)
-- [Secret examples](#secret-examples)
-
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][1].
 

--- a/content/sensu-go/5.19/reference/sensu-query-expressions.md
+++ b/content/sensu-go/5.19/reference/sensu-query-expressions.md
@@ -11,11 +11,6 @@ menu:
     parent: reference
 ---
 
-- [Syntax quick reference](#syntax-quick-reference)
-- [Specification](#specification)
-  - [Custom functions](#custom-functions)
-- [Examples](#examples)
-
 Sensu query expressions (SQEs) are JavaScript-based expressions that provide additional functionality for using Sensu, like nested parameters and custom functions.
 
 SQEs are defined in [event filters][3], so they act in the context of determining whether a given event should be passed to the handler.

--- a/content/sensu-go/5.19/reference/silencing.md
+++ b/content/sensu-go/5.19/reference/silencing.md
@@ -10,16 +10,6 @@ menu:
     parent: reference
 ---
 
-- [Silencing specification](#silencing-specification)
-  - [Top-level attributes](#top-level-attributes) | [Metadata attributes](#metadata-attributes) | [Spec attributes](#spec-attributes)
-- [Examples](#examples)
-	- [Silence all checks on a specific entity](#silence-all-checks-on-a-specific-entity)
-	- [Silence a specific check on a specific entity](#silence-a-specific-check-on-a-specific-entity)
-	- [Silence all checks on entities with a specific subscription](#silence-all-checks-on-entities-with-a-specific-subscription)
-	- [Silence a specific check on entities with a specific subscription](#silence-a-specific-check-on-entities-with-a-specific-subscription)
-	- [Silence a specific check on every entity](#silence-a-specific-check-on-every-entity)
-	- [Delete a silence](#delete-a-silence)
-
 Sensu's silencing capability allows you to suppress event handler execution on an ad hoc basis so you can plan maintenance and reduce alert fatigue.
 Silences are created on an ad hoc basis using `sensuctl`.
 Successfully created silencing entries are assigned a `name` in the format `$SUBSCRIPTION:$CHECK`, where `$SUBSCRIPTION` is the name of a Sensu entity subscription and `$CHECK` is the name of a Sensu check.

--- a/content/sensu-go/5.19/reference/tessen.md
+++ b/content/sensu-go/5.19/reference/tessen.md
@@ -9,12 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Configure Tessen](#configure-tessen)
-- [Tessen specification](#tessen-specification)
-  - [Top-level attributes](#top-level-attributes) | [Spec attributes](#spec-attributes)
-- [Tessen configuration example](#tessen-configuration-example)
-- [Tessen metrics log examples](#tessen-metrics-log-examples)
-
 Tessen is the Sensu call-home service.
 It is enabled by default on Sensu backends.
 Tessen sends anonymized data about Sensu instances to Sensu Inc., including the version, cluster size, number of events processed, and number of resources created (like checks and handlers).

--- a/content/sensu-go/5.19/reference/tokens.md
+++ b/content/sensu-go/5.19/reference/tokens.md
@@ -9,12 +9,6 @@ menu:
     parent: reference
 ---
 
-- [Manage entity labels](#manage-entity-labels)
-- [Token specification](#token-specification)
-- [Unmatched tokens](#unmatched-tokens)
-- [Token data type limitations](#token-data-type-limitations)
-- [Examples](#examples)
-
 Tokens are placeholders in a check definition that the agent replaces with entity information before executing the check.
 You can use tokens to fine-tune check attributes (like alert thresholds) on a per-entity level while reusing the check definition.
 

--- a/content/sensu-go/5.19/sensuctl/quickstart.md
+++ b/content/sensu-go/5.19/sensuctl/quickstart.md
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-### Configure sensuctl and log in
+## Configure sensuctl and log in
 
 {{< code shell >}}
 sensuctl configure
@@ -20,25 +20,25 @@ sensuctl configure
 ? Password: YOUR_PASSWORD
 {{< /code >}}
 
-### Create resources from a file that contains JSON resource definitions
+## Create resources from a file that contains JSON resource definitions
 
 {{< code shell >}}
 sensuctl create --file filename.json
 {{< /code >}}
 
-### View monitored entities
+## View monitored entities
 
 {{< code shell >}}
 sensuctl entity list
 {{< /code >}}
 
-### View monitoring events
+## View monitoring events
 
 {{< code shell >}}
 sensuctl event list
 {{< /code >}}
 
-### Edit a check
+## Edit a check
 
 In this example, the check name is `check-cpu`:
 
@@ -46,7 +46,7 @@ In this example, the check name is `check-cpu`:
 sensuctl edit check check-cpu
 {{< /code >}}
 
-### View the JSON configuration for a check
+## View the JSON configuration for a check
 
 In this example, the check name is `check-cpu`:
 

--- a/content/sensu-go/5.19/sensuctl/reference.md
+++ b/content/sensu-go/5.19/sensuctl/reference.md
@@ -11,26 +11,6 @@ menu:
     parent: sensuctl
 ---
 
-- [First-time setup](#first-time-setup)
-- [Get help](#get-help)
-- [Manage sensuctl](#manage-sensuctl)
-- [Test a user password](#test-a-user-password)
-- [Create resources](#create-resources)
-- [Delete resources](#delete-resources)
-- [Update resources](#update-resources)
-- [Export resources](#export-resources)
-- [Manage resources](#manage-resources)
-  - [Subcommands](#subcommands): [sensuctl check](#sensuctl-check) | [sensuctl cluster](#sensuctl-cluster) | [sensuctl event](#sensuctl-event) | [sensuctl namespace](#sensuctl-namespace) | [sensuctl user](#sensuctl-user) | [sensuctl prune](#sensuctl-prune) (alpha feature)
-- [Response filtering](#response-filtering) (commercial feature)
-- [Time formats](#time-formats)
-- [Shell auto-completion](#shell-auto-completion)
-- [Environment variables](#environment-variables)
-- [Config files](#configuration-files)
-- [Interact with Bonsai](#interact-with-bonsai)
-  - [Install asset definitions](#install-asset-definitions)
-  - [Check your Sensu backend for outdated assets](#check-your-sensu-backend-for-outdated-assets)
-  - [Extend sensuctl with commands](#extend-sensuctl-with-commands)
-
 Sensuctl is a command line tool for managing resources within Sensu.
 It works by calling Sensu's underlying API to create, read, update, and delete resources, events, and entities.
 Sensuctl is available for Linux, macOS, and Windows.
@@ -218,7 +198,7 @@ A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
 **NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../../installation/auth#use-built-in-basic-authentication).
-It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#ldap-authentication) or [Active Directory (AD)](../../installation/auth/#ad-authentication). 
+It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../installation/auth/#lightweight-directory-access-protocol-ldap-authentication) or [Active Directory (AD)](../../installation/auth/#active-directory-ad-authentication). 
 {{% /notice %}}
 
 For example, if you test LDAP credentials with the `sensuctl user test-creds` command, the backend will log an error, even if you know the LDAP credentials are correct:
@@ -1216,7 +1196,7 @@ Flags are optional and apply only to the `delete` command.
 [23]: #subcommands
 [24]: #sensuctl-edit-resource-types
 [25]: ../../api/overview/
-[26]: ../../installation/auth/#ldap-authentication
+[26]: ../../installation/auth/#lightweight-directory-access-protocol-ldap-authentication
 [27]: ../../reference/tessen/
 [28]: ../../api/overview#response-filtering
 [29]: ../../api/overview#field-selector
@@ -1231,7 +1211,7 @@ Flags are optional and apply only to the `delete` command.
 [39]: #wrapped-json-format
 [40]: ../../installation/install-sensu/#install-the-sensu-backend
 [41]: ../../reference/secrets/
-[42]: ../../installation/auth/#ad-authentication
+[42]: ../../installation/auth/#active-directory-ad-authentication
 [43]: ../../reference/secrets-providers/
 [44]: ../../installation/auth#use-built-in-basic-authentication
 [45]: ../../installation/install-sensu/#2-configure-and-start

--- a/content/sensu-go/5.19/versions.md
+++ b/content/sensu-go/5.19/versions.md
@@ -4,6 +4,7 @@ linkTitle: "Supported Versions"
 description: "Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images. Read this article to learn about supported versions of Sensu."
 version: "5.19"
 weight: -40
+toc: false
 offline: false
 product: "Sensu Go"
 menu: "sensu-go-5.19"

--- a/content/sensu-go/5.19/web-ui/filter.md
+++ b/content/sensu-go/5.19/web-ui/filter.md
@@ -11,15 +11,6 @@ menu:
     parent: web-ui
 ---
 
-- [Basic filters](#basic-filters)
-- [Advanced filters](#advanced-filters)
-- [Create basic web UI filters](#create-basic-web-ui-filters)
-- [Create web UI filters based on label selectors or field selectors](#create-web-ui-filters-based-on-label-selectors-or-field-selectors)
-- [Web UI-specific syntax](#web-ui-specific-syntax)
-- [Operators quick reference](#operators-quick-reference)
-- [Examples](#examples)
-- [Save a filtered search](#save-a-filtered-search)
-
 The Sensu web UI includes basic filters you can use to build customized views of your Sensu resources.
 Sensu also supports advanced web UI filtering based on a wider range of resource attributes and custom labels as a [commercial feature][1].
 

--- a/content/sensu-go/5.19/web-ui/sign-in.md
+++ b/content/sensu-go/5.19/web-ui/sign-in.md
@@ -11,10 +11,6 @@ menu:
     parent: web-ui
 ---
 
-- [Access the web UI](#access-the-web-ui)
-- [Sign in](#sign-in)
-- [Themes](#themes)
-
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][6].

--- a/content/sensu-go/5.19/web-ui/view-manage-resources.md
+++ b/content/sensu-go/5.19/web-ui/view-manage-resources.md
@@ -11,12 +11,6 @@ menu:
     parent: web-ui
 ---
 
-- [Use the namespace switcher](#use-the-namespace-switcher)
-- [Manage events](#manage-events)
-- [Manage entities](#manage-entities)
-- [Manage silences](#manage-silences)
-- [Manage checks, handlers, event filters, and mutators](#manage-checks-handlers-event-filters-and-mutators)
-
 You can view and manage Sensu resources in the web UI, including events, entities, silences, checks, handlers, event filters, and mutators.
 
 ## Use the namespace switcher

--- a/content/sensu-go/5.20/guides/systemd-logs.md
+++ b/content/sensu-go/5.20/guides/systemd-logs.md
@@ -22,6 +22,8 @@ To configure journald to forward logging data to syslog, modify `/etc/systemd/jo
 ForwardToSyslog=yes
 {{< /code >}}
 
+## Configure rsyslog
+
 Next, set up rsyslog to write the logging data received from journald to `/var/log/sensu/servicename.log`.
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
 The `sensu-backend` is not required if you're only setting up log forwarding for the `sensu-agent` service.

--- a/content/sensu-go/5.20/installation/auth.md
+++ b/content/sensu-go/5.20/installation/auth.md
@@ -1276,7 +1276,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}"username_prefix": "okta"{{< /code >}}
 
-### Register an OIDC application
+## Register an OIDC application
 
 To use OIDC for authentication, register Sensu Go as an OIDC application.
 Use the instructions listed in this section to register an OIDC application for Sensu Go based on your OIDC provider.

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -12,6 +12,8 @@ menu:
     parent: reference
 ---
 
+[Example Sensu agent configuration file](../../files/agent.yml) (download)
+
 The Sensu agent is a lightweight client that runs on the infrastructure components you want to monitor.
 Agents register with the Sensu backend as [monitoring entities][3] with `type: "agent"`.
 Agent entities are responsible for creating [check and metrics events][7] to send to the [backend event pipeline][2].

--- a/content/sensu-go/5.20/reference/backend.md
+++ b/content/sensu-go/5.20/reference/backend.md
@@ -11,6 +11,8 @@ menu:
     parent: reference
 ---
 
+[Example Sensu backend configuration file](../../files/backend.yml) (download)
+
 The Sensu backend is a service that manages check requests and event data.
 Every Sensu backend includes an integrated transport for scheduling checks using subscriptions, an event processing pipeline that applies filters, mutators, and handlers, an embedded [etcd][2] datastore for storing configuration and state, a Sensu API, a [Sensu web UI][6], and the `sensu-backend` command line tool.
 The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.

--- a/content/sensu-go/5.20/reference/datastore.md
+++ b/content/sensu-go/5.20/reference/datastore.md
@@ -9,8 +9,6 @@ menu:
     parent: reference
 ---
 
-## Event storage
-
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
 You can access event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
@@ -27,12 +25,12 @@ When configured with a PostgreSQL event store, Sensu connects to PostgreSQL to s
 Etcd continues to store Sensu entity and configuration data.
 You can access event data stored in PostgreSQL using the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
 
-### Requirements
+## Requirements
 
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-### Configuration
+## Configuration
 
 At the time when you enable the PostgreSQL event store, event data cuts over from etcd to PostgreSQL.
 This results in a loss of recent event history.
@@ -88,7 +86,7 @@ sensuctl create --file postgres.yml
 To update your Sensu PostgreSQL configuration, repeat the `sensuctl create` process.
 You can expect to see PostgreSQL status updates in the [Sensu backend logs][2] at the `warn` log level and PostgreSQL error messages in the [Sensu backend logs][2] at the `error` log level.
 
-#### Disable the PostgreSQL event store
+### Disable the PostgreSQL event store
 
 To disable the PostgreSQL event store, use `sensuctl delete` with your `PostgresConfig` resource definition:
 
@@ -105,9 +103,9 @@ Mar 10 17:35:04 sensu-centos sensu-backend[1365]: {"component":"store-providers"
 When you disable the PostgreSQL event store, event data cuts over from PostgreSQL to etcd, which results in a loss of recent event history.
 No restarts or Sensu backend configuration changes are required to disable the PostgreSQL event store.
 
-### Datastore specification
+## Datastore specification
 
-#### Top-level attributes
+### Top-level attributes
 
 type         |      |
 -------------|------
@@ -147,7 +145,7 @@ spec:
   pool_size: 20
 {{< /code >}}
 
-#### Metadata attributes
+### Metadata attributes
 
 name         |      |
 -------------|------
@@ -163,7 +161,7 @@ required     | false
 type         | String
 example      | {{< code shell >}}created_by: admin{{< /code >}}
 
-#### Spec attributes
+### Spec attributes
 
 dsn          |      |
 -------------|------

--- a/content/sensu-go/5.20/reference/events.md
+++ b/content/sensu-go/5.20/reference/events.md
@@ -17,7 +17,7 @@ In certain cases, an event can contain both.
 These generic containers allow Sensu to handle different types of events in the pipeline.
 Because events are polymorphic in nature, it is important to never assume their contents (or lack of content).
 
-### Check-only events
+## Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu server, regardless of the status indicated by the check result.
 The agent creates an event upon receipt of the check execution result.
@@ -25,13 +25,13 @@ The agent will execute any configured [hooks][4] the check might have.
 From there, the result is forwarded to the Sensu backend for processing.
 Potentially noteworthy events may be processed by one or more event handlers, for example to send an email or invoke an automated action.
 
-### Metric-only events
+## Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the [StatsD listener][5].
 The agent will translate the StatsD metrics to Sensu metric format and place them inside an event.
 Because these events do not contain checks, they bypass the store and are sent to the event pipeline and corresponding event handlers.
 
-### Check and metric events
+## Check and metric events
 
 Events that contain _both_ a check and metrics most likely originated from [check output metric extraction][6].
 If a check is configured for metric extraction, the agent will parse the check output and transform it to Sensu metric format.

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -18,7 +18,7 @@ Every Sensu backend includes an integrated transport for scheduling checks using
 The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
 See the [installation guide][1] to install the backend.
 
-### Create event pipelines
+## Create event pipelines
 
 The backend processes event data and executes filters, mutators, and handlers.
 These pipelines are powerful tools to automate your monitoring workflows.
@@ -30,7 +30,7 @@ To learn more about filters, mutators, and handlers, see:
 - [Mutators reference documentation][10]
 - [Handlers reference documentation][11]
 
-### Schedule checks
+## Schedule checks
 
 The backend is responsible for storing check definitions and scheduling check requests.
 Check scheduling is subscription-based: the backend sends check requests to subscriptions. where they're picked up by subscribing agents.

--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -17,7 +17,7 @@ In certain cases, an event can contain both.
 These generic containers allow Sensu to handle different types of events in the pipeline.
 Because events are polymorphic in nature, it is important to never assume their contents (or lack of content).
 
-### Check-only events
+## Check-only events
 
 A Sensu event is created every time a check result is processed by the Sensu server, regardless of the status indicated by the check result.
 The agent creates an event upon receipt of the check execution result.
@@ -25,13 +25,13 @@ The agent will execute any configured [hooks][4] the check might have.
 From there, the result is forwarded to the Sensu backend for processing.
 Potentially noteworthy events may be processed by one or more event handlers, for example to send an email or invoke an automated action.
 
-### Metric-only events
+## Metric-only events
 
 Sensu events can also be created when the agent receives metrics through the [StatsD listener][5].
 The agent will translate the StatsD metrics to Sensu metric format and place them inside an event.
 Because these events do not contain checks, they bypass the store and are sent to the event pipeline and corresponding event handlers.
 
-### Check and metric events
+## Check and metric events
 
 Events that contain _both_ a check and metrics most likely originated from [check output metric extraction][6].
 If a check is configured for metric extraction, the agent will parse the check output and transform it to Sensu metric format.


### PR DESCRIPTION
## Description
Remove manual top-of-page TOCs in 5.18 and 5.19 docs in favor of automatically generated floating TOC at right side of each page, plus a bit of cleanup in 5.20 and 5.21 docs.

## Motivation and Context
Docs IA project
