### PR TITLE
Correct password hash content in 5.21 docs

### DIFF
--- a/content/sensu-go/5.21/reference/rbac.md
+++ b/content/sensu-go/5.21/reference/rbac.md
@@ -322,9 +322,13 @@ required     | true
 type         | String
 example      | {{< code shell >}}"username": "alice"{{< /code >}}
 
+<a name="password"></a>
+
 password     | 
 -------------|------ 
-description  | User's password. Passwords must have at least eight characters.
+description  | User's password. Passwords must have at least eight characters.{{% notice note %}}
+You only need to set either the `password` or the [`password_hash`](#password-hash) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+{{% /notice %}}
 required     | true
 type         | String
 example      | {{< code shell >}}"password": "USER_PASSWORD"{{< /code >}}
@@ -344,9 +348,12 @@ type         | Boolean
 default      | `false`
 example      | {{< code shell >}}"disabled": false{{< /code >}}
 
+<a name="password-hash"></a>
+
 password_hash | 
 --------------|------ 
-description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords.
+description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords.{{% notice note %}}
+You only need to set either the [`password`](#password) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 required      | false
 type          | String
 example       | {{< code shell >}}"password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm"{{< /code >}}

--- a/content/sensu-go/5.21/reference/rbac.md
+++ b/content/sensu-go/5.21/reference/rbac.md
@@ -344,6 +344,13 @@ type         | Boolean
 default      | `false`
 example      | {{< code shell >}}"disabled": false{{< /code >}}
 
+password_hash | 
+--------------|------ 
+description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords.
+required      | false
+type          | String
+example       | {{< code shell >}}"password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm"{{< /code >}}
+
 ### User example
 
 The following example is in `yml` and `wrapped-json` formats for use with [`sensuctl create`][31].
@@ -360,6 +367,7 @@ spec:
   - ops
   - dev
   password: USER_PASSWORD
+  password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
   username: alice
 {{< /code >}}
 
@@ -371,6 +379,7 @@ spec:
   "spec": {
     "username": "alice",
     "password": "USER_PASSWORD",
+    "password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm",
     "disabled": false,
     "groups": ["ops", "dev"]
   }
@@ -1254,6 +1263,7 @@ You can add these resources to Sensu using [`sensuctl create`][31].
 [32]: ../../installation/auth#use-an-authentication-provider
 [33]: ../../commercial/
 [34]: ../../installation/auth#use-built-in-basic-authentication
+[35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../license/
 [38]: ../../installation/auth/#groups-prefix
 [39]: ../../installation/auth/#ad-groups-prefix

--- a/content/sensu-go/5.21/release-notes.md
+++ b/content/sensu-go/5.21/release-notes.md
@@ -69,7 +69,7 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 **June 15, 2020** &mdash; The latest release of Sensu Go, version 5.21.0, is now available for download.
 
-The latest release of Sensu Go, version 5.21.0, is now available for download! This release delivers several enhancements and fixes. The most significant enhancements involve user management: you can now back up users via `sensuctl dump`, restore users via `sensuctl create`, and reset user passwords via the backend API. We also tuned Sensu Go agent logging and changed the default log level from warning to info. Plus, we crushed a number of nasty bugs: checks configured with missing hooks can no longer crash the agent, proxy check request errors do not block scheduling for other entities, and more!
+The latest release of Sensu Go, version 5.21.0, is now available for download! This release delivers several enhancements and fixes. The most significant enhancements involve user management: you can now generate a password hash, specify the resulting hash in your user definitions without having to store cleartext passwords, and create and update these users using `sensuctl create`. You can also reset user passwords via the backend API. We also tuned Sensu Go agent logging and changed the default log level from warning to info. Plus, we crushed a number of nasty bugs: checks configured with missing hooks can no longer crash the agent, proxy check request errors do not block scheduling for other entities, and more!
 
 See the [upgrade guide][1] to upgrade Sensu to version 5.21.0.
 

--- a/content/sensu-go/5.21/sensuctl/reference.md
+++ b/content/sensu-go/5.21/sensuctl/reference.md
@@ -84,7 +84,7 @@ sensuctl user hash-password PASSWORD
 {{< /code >}}
 
 The `sensuctl user hash-password` command creates a [bcrypt hash][54] of the specified password.
-You can use this hash instead of the password when you use sensuctl to [create][8], [edit][51], or [dump][52] users.
+You can use this hash instead of the cleartext password when you use sensuctl to [create][8] and [edit][51] users.
 
 ### Preferred output format
 


### PR DESCRIPTION
## Description
- Corrects password hash information in 5.21 release notes and sensuctl reference
- Adds `password_hash` field to user attributes in RBAC reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2554
