### PR TITLE
Add support for multi-level navigation nesting

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -56,18 +56,37 @@
                     <!-- Loop through the child menu's pages -->
                     {{ range .Children.ByWeight }}
                       {{ if not (eq (lower .Parent) (lower .Name)) }}
-                        <!-- Determine if this children is active -->
-                        {{ $isCurrent := (eq $.Permalink (.URL | absURL | printf "%s")) }}
-                        <li><a class="{{ if $isCurrent }}current{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
-                      {{ end }}
+                        <!-- Determine if this child is active -->
+                        <li>
+                          {{ if .HasChildren }}
+                            <a class="accordion {{ if ($currentNode.HasMenuCurrent $k .) }}active current{{ end }}">
+                              {{ .Name }}
+                              <i class="fa fa-chevron-down" aria-hidden="true"></i>
+                            </a>
+                            <ul>
+                              {{ range .Children.ByWeight }}
+                                {{ if not (eq (lower .Parent) (lower .Name)) }}
+                                  <!-- Determine if this child is active -->
+                                  <li>
+                                    <a class="{{ if ($currentNode.IsMenuCurrent $k .) }}current{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a>
+                                  </li>
+                                {{ end }}
+                              {{ end }}
+                            </ul>
+                          {{ else }}
+                            {{ $isCurrent := (eq $.Permalink (.URL | absURL )) }}
+                            <a class="{{ if $isCurrent }}current{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a>
+                          {{ end }}
+                        </li>
                     {{ end }}
-                  </ul>
+                  {{ end }}
+                </ul>
                 </li>
               {{ end }}
             <!-- No children, this is top level menu items -->
             {{ else }}
               {{ if not (eq $.Params.product $x.Name) }}
-              <li><a class="strong" href="{{ .URL | absURL }}">{{ $x.Name }}</a></li>
+                <li><a class="strong" href="{{ .URL | absURL }}">{{ $x.Name }}</a></li>
               {{ end }}
             {{ end }}
           {{ end }}
@@ -83,7 +102,8 @@
   var acc = document.getElementsByClassName('accordion');
 
   for (var i = 0; i < acc.length; i++) {
-    acc[i].addEventListener('click', function() {
+    acc[i].addEventListener('click', function(e) {
+      e.preventDefault();
       this.classList.toggle('active');
     });
   }


### PR DESCRIPTION
## Description

Adds support for an additional level of menus/content nesting:

<img width="304" alt="image" src="https://user-images.githubusercontent.com/4516305/85283341-7b492100-b48d-11ea-873c-502da3cc19b3.png">

## Motivation and Context

Updates #2443 (resolves item #1)

## Review Instructions

To add additional levels of content (for example, at `https://docs.sensu.io/sensu-go/latest/sensuctl/reference/`), the process is similar to how we currently create menu items:

1. Create a new directory:

        content/sensu-go/5.21/sensuctl/reference

2. Create a top-level `_index.md` page in that directory, with front matter similar to the following. The important keys are `title`, `version`, and `menu`. The `menu` key must include both a `parent` (which it is to be nested under) and an `identifier` (which its child items will use):

        ---
        title: "Nested Reference Menu"
        description: "Nested menu description"
        weight: 70
        product: "Sensu Go"
        version: "5.21"
        layout: "base-for-directory-listing"
        menu:
          sensu-go-5.21:
            parent: sensuctl
            identifier: sensuctl-reference
        ---
        
        {{< directoryListing >}}

3. Create any number of child pages in the same directory (for example, `content/sensu-go/5.21/sensuctl/reference/subpage.md`), with front matter that includes the following:

        menu:
          sensu-go-5.21:
            parent: sensuctl-reference

Please let me know if you have any questions.