### PR TITLE
Fix links in Get Started doc

### DIFF
--- a/content/sensu-go/5.18/get-started.md
+++ b/content/sensu-go/5.18/get-started.md
@@ -59,9 +59,9 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../reference/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go#building-from-source
+[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
 [12]: ../learn/learn-in-15/
-[13]: ../installation/upgrade/#migrate-to-sensu-go-from-sensu-core-1x
+[13]: ../migrate/
 [14]: https://sensu.io/features#free-vs-paid
 [15]: #install-the-commercial-distribution-of-sensu-go
 [16]: #build-sensu-from-source-oss

--- a/content/sensu-go/5.19/get-started.md
+++ b/content/sensu-go/5.19/get-started.md
@@ -59,9 +59,9 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../reference/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go#building-from-source
+[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
 [12]: ../learn/learn-in-15/
-[13]: ../installation/upgrade/#migrate-to-sensu-go-from-sensu-core-1x
+[13]: ../migrate/
 [14]: https://sensu.io/features#free-vs-paid
 [15]: #install-the-commercial-distribution-of-sensu-go
 [16]: #build-sensu-from-source-oss

--- a/content/sensu-go/5.20/get-started.md
+++ b/content/sensu-go/5.20/get-started.md
@@ -59,9 +59,9 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../reference/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go#building-from-source
+[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
 [12]: ../learn/learn-in-15/
-[13]: ../installation/upgrade/#migrate-to-sensu-go-from-sensu-core-1x
+[13]: ../migrate/
 [14]: https://sensu.io/features#free-vs-paid
 [15]: #install-the-commercial-distribution-of-sensu-go
 [16]: #build-sensu-from-source-oss

--- a/content/sensu-go/5.21/get-started.md
+++ b/content/sensu-go/5.21/get-started.md
@@ -59,10 +59,10 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../reference/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go#building-from-source
+[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
 [12]: ../learn/learn-in-15/
-[13]: ../installation/upgrade/#migrate-to-sensu-go-from-sensu-core-1x
-[14]: https://sensu.io/features#free-vs-paid
+[13]: ../migrate/
+[14]: https://sensu.io/features#free-vs-paid/
 [15]: #install-the-commercial-distribution-of-sensu-go
 [16]: #build-sensu-from-source-oss
 [17]: #explore-monitoring-at-scale-with-sensu-go


### PR DESCRIPTION
## Description
Fixes a couple links in the Get Started with Sensu doc:
- Migrate
- Link to build from source

## Motivation and Context
facepalm
