### PR TITLE
Fix link to free vs paid in 5.21 Get Started doc

### DIFF
--- a/content/sensu-go/5.21/get-started.md
+++ b/content/sensu-go/5.21/get-started.md
@@ -62,7 +62,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
 [12]: ../learn/learn-in-15/
 [13]: ../migrate/
-[14]: https://sensu.io/features#free-vs-paid/
+[14]: https://sensu.io/features#free-vs-paid
 [15]: #install-the-commercial-distribution-of-sensu-go
 [16]: #build-sensu-from-source-oss
 [17]: #explore-monitoring-at-scale-with-sensu-go


### PR DESCRIPTION
Fixes link to https://sensu.io/features#free-vs-paid to compare OSS and Commercial versions in 5.21 Get Started doc