### PR TITLE
Remove note about subscription matching for proxy entities in Entities reference

### DIFF
--- a/content/sensu-go/5.18/reference/entities.md
+++ b/content/sensu-go/5.18/reference/entities.md
@@ -122,11 +122,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice note %}}
-**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes](../checks#proxy-requests-attributes).
-If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run.
-{{% /notice %}}
-
 Then run `sensuctl create` to create the entity based on the definition:
 
 {{< code shell >}}
@@ -353,7 +348,7 @@ example      | {{< code shell >}}"entity_class": "agent"{{< /code >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.

--- a/content/sensu-go/5.19/reference/entities.md
+++ b/content/sensu-go/5.19/reference/entities.md
@@ -122,11 +122,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice note %}}
-**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes](../checks#proxy-requests-attributes).
-If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run.
-{{% /notice %}}
-
 Then run `sensuctl create` to create the entity based on the definition:
 
 {{< code shell >}}
@@ -365,7 +360,7 @@ example      | {{< code shell >}}"entity_class": "agent"{{< /code >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.

--- a/content/sensu-go/5.20/reference/entities.md
+++ b/content/sensu-go/5.20/reference/entities.md
@@ -133,11 +133,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice note %}}
-**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes](../checks#proxy-requests-attributes).
-If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run.
-{{% /notice %}}
-
 Then run `sensuctl create` to create the entity based on the definition:
 
 {{< code shell >}}
@@ -400,7 +395,7 @@ example      | {{< code shell >}}"entity_class": "agent"{{< /code >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.

--- a/content/sensu-go/5.21/reference/entities.md
+++ b/content/sensu-go/5.21/reference/entities.md
@@ -133,11 +133,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice note %}}
-**NOTE**: The proxy entity definition must include the same subscriptions as the sensu-agent to work with round robin scheduling **and** [proxy requests attributes](../checks#proxy-requests-attributes).
-If more than one sensu-agent will execute a proxy check and you did not configure the proxy entity with the same subscriptions as the sensu-agent, the sensu-backend will log an error and the proxy check will not be scheduled for agents to run.
-{{% /notice %}}
-
 Then run `sensuctl create` to create the entity based on the definition:
 
 {{< code shell >}}
@@ -400,7 +395,7 @@ example      | {{< code shell >}}"entity_class": "agent"{{< /code >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname. If you are using round robin scheduling **and** [proxy requests attributes][24], the proxy entity definition must include the same subscriptions as the sensu-agent.
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.


### PR DESCRIPTION
## Description
Removes note and description table info about requiring proxy entity definitions to include the same subscriptions as the sensu-agent to work with round robin scheduling and proxy requests attributes.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2475
