### PR TITLE
Fix the description of spec.client.version attribute in VaultProvider reference

### DIFF
--- a/content/sensu-go/5.18/installation/install-sensu.md
+++ b/content/sensu-go/5.18/installation/install-sensu.md
@@ -470,7 +470,7 @@ If you're ready to see what Sensu can do, one of these pathways can get you star
 ### Deploy Sensu outside your local development environment
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to [run a Sensu cluster][22].
-A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared etcd cluster, using Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 
 Clustering allows you to absorb the loss of a backend node, prevent data loss, and distribute the network load of agents.
 However, scaling a single backend to a cluster or migrating a cluster from cleartext HTTP to encrypted HTTPS without downtime can require [a number of tedious steps][40].

--- a/content/sensu-go/5.18/reference/secrets-providers.md
+++ b/content/sensu-go/5.18/reference/secrets-providers.md
@@ -190,7 +190,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value engine version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -327,7 +327,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes

--- a/content/sensu-go/5.19/installation/install-sensu.md
+++ b/content/sensu-go/5.19/installation/install-sensu.md
@@ -470,7 +470,7 @@ If you're ready to see what Sensu can do, one of these pathways can get you star
 ### Deploy Sensu outside your local development environment
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to [run a Sensu cluster][22].
-A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared etcd cluster, using Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 
 Clustering allows you to absorb the loss of a backend node, prevent data loss, and distribute the network load of agents.
 However, scaling a single backend to a cluster or migrating a cluster from cleartext HTTP to encrypted HTTPS without downtime can require [a number of tedious steps][40].

--- a/content/sensu-go/5.19/reference/secrets-providers.md
+++ b/content/sensu-go/5.19/reference/secrets-providers.md
@@ -196,7 +196,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value engine version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -333,7 +333,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes

--- a/content/sensu-go/5.20/installation/install-sensu.md
+++ b/content/sensu-go/5.20/installation/install-sensu.md
@@ -470,7 +470,7 @@ If you're ready to see what Sensu can do, one of these pathways can get you star
 ### Deploy Sensu outside your local development environment
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to [run a Sensu cluster][22].
-A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared etcd cluster, using Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 
 Clustering allows you to absorb the loss of a backend node, prevent data loss, and distribute the network load of agents.
 However, scaling a single backend to a cluster or migrating a cluster from cleartext HTTP to encrypted HTTPS without downtime can require [a number of tedious steps][40].

--- a/content/sensu-go/5.20/reference/secrets-providers.md
+++ b/content/sensu-go/5.20/reference/secrets-providers.md
@@ -195,7 +195,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value engine version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -332,7 +332,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes

--- a/content/sensu-go/5.21/installation/install-sensu.md
+++ b/content/sensu-go/5.21/installation/install-sensu.md
@@ -470,7 +470,7 @@ If you're ready to see what Sensu can do, one of these pathways can get you star
 ### Deploy Sensu outside your local development environment
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to [run a Sensu cluster][22].
-A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared etcd cluster, using Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of three or more sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 
 Clustering allows you to absorb the loss of a backend node, prevent data loss, and distribute the network load of agents.
 However, scaling a single backend to a cluster or migrating a cluster from cleartext HTTP to encrypted HTTPS without downtime can require [a number of tedious steps][40].

--- a/content/sensu-go/5.21/reference/secrets-providers.md
+++ b/content/sensu-go/5.21/reference/secrets-providers.md
@@ -196,7 +196,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value engine version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -333,7 +333,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes


### PR DESCRIPTION
## Description

Makes the description of .spec.client.version attribute more accurate.

## Motivation and Context

In https://sensu.slack.com/archives/C60EEQFH8/p1593202372412800 we discussed the issue a customer was facing in getting VaultProvider working. Through this discussion we learned that the `spec.client.version` attribute is actually specifying the version of the key/value store engine, not the version of the Vault HTTP API. 
