### PR TITLE
Fix/vault provider client version description

### DIFF
--- a/content/sensu-go/5.18/reference/secrets-providers.md
+++ b/content/sensu-go/5.18/reference/secrets-providers.md
@@ -190,7 +190,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -327,7 +327,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes

--- a/content/sensu-go/5.19/reference/secrets-providers.md
+++ b/content/sensu-go/5.19/reference/secrets-providers.md
@@ -196,7 +196,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -333,7 +333,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes

--- a/content/sensu-go/5.20/reference/secrets-providers.md
+++ b/content/sensu-go/5.20/reference/secrets-providers.md
@@ -332,7 +332,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes

--- a/content/sensu-go/5.20/reference/secrets-providers.md
+++ b/content/sensu-go/5.20/reference/secrets-providers.md
@@ -195,7 +195,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}

--- a/content/sensu-go/5.21/reference/secrets-providers.md
+++ b/content/sensu-go/5.21/reference/secrets-providers.md
@@ -196,7 +196,7 @@ example      | {{< code shell >}}"token": "VAULT_TOKEN"{{< /code >}}
 
 version      | 
 -------------|------ 
-description  | HashiCorp Vault [HTTP API version][14].
+description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
 example      | {{< code shell >}}"version": "v1"{{< /code >}}
@@ -333,7 +333,7 @@ spec: {}
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
 [13]: ../../guides/securing-sensu/#sensu-agent-mtls-authentication
-[14]: https://www.vaultproject.io/api-docs/
+[14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../../guides/secrets-management/
 [17]: #rate-limiter-attributes


### PR DESCRIPTION
## Description

Corrects the description of `spec.client.version` attribute in VaultProvider reference

## Motivation and Context

In https://sensu.slack.com/archives/C60EEQFH8/p1593202372412800 we discussed the issue a customer was facing in getting VaultProvider working. Through this discussion we learned that the `spec.client.version` attribute is actually specifying the version of the key/value store engine, not the version of the Vault HTTP API. 