### PR TITLE
Add information about certificate bundles/chains

### DIFF
--- a/content/sensu-go/5.18/reference/agent.md
+++ b/content/sensu-go/5.18/reference/agent.md
@@ -715,6 +715,14 @@ Specify the agent configuration with either a `.yml` file or `sensu-agent start`
 Configuration via command line flags overrides attributes specified in a configuration file.
 See the [Example Sensu agent configuration file][5] for flags and defaults.
 
+### Certificate bundles or chains
+
+The Sensu agent supports all types of certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the leaf certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the leaf certificate alone instead of sending the whole bundle with the leaf certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the presented certificate through the chain.
+
 #### Configuration summary
 
 {{< code text >}}
@@ -811,7 +819,7 @@ annotations:
 
 | backend-url |      |
 --------------|------
-description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times.<br>{{% notice note %}}
+description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times. {{% notice note %}}
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
@@ -1144,7 +1152,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication.
+description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`

--- a/content/sensu-go/5.18/reference/backend.md
+++ b/content/sensu-go/5.18/reference/backend.md
@@ -250,6 +250,14 @@ All other required flags have default values.
 See the [example backend configuration file][17] for flags and defaults.
 The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
 
+### Certificate bundles or chains
+
+The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -438,7 +446,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
 | agent-auth-cert-file |      |
 -------------|------
-description  | TLS certificate in PEM format for agent certificate authentication.
+description  | TLS certificate in PEM format for agent certificate authentication. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
@@ -518,7 +526,7 @@ agent-port: 8081{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -607,7 +615,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
@@ -678,7 +686,7 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -896,7 +904,7 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< code shell >}}# Command line example

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -715,6 +715,14 @@ Specify the agent configuration with either a `.yml` file or `sensu-agent start`
 Configuration via command line flags overrides attributes specified in a configuration file.
 See the [Example Sensu agent configuration file][5] for flags and defaults.
 
+### Certificate bundles or chains
+
+The Sensu agent supports all types of certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the leaf certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the leaf certificate alone instead of sending the whole bundle with the leaf certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the presented certificate through the chain.
+
 #### Configuration summary
 
 {{< code text >}}
@@ -840,7 +848,7 @@ assets-rate-limit: 1.39{{< /code >}}
 
 | backend-url |      |
 --------------|------
-description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times.<br>{{% notice note %}}
+description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times. {{% notice note %}}
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
@@ -1188,7 +1196,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication.
+description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`

--- a/content/sensu-go/5.19/reference/backend.md
+++ b/content/sensu-go/5.19/reference/backend.md
@@ -250,6 +250,14 @@ All other required flags have default values.
 See the [example backend configuration file][17] for flags and defaults.
 The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
 
+### Certificate bundles or chains
+
+The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -466,7 +474,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
 | agent-auth-cert-file |      |
 -------------|------
-description  | TLS certificate in PEM format for agent certificate authentication.
+description  | TLS certificate in PEM format for agent certificate authentication. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
@@ -546,7 +554,7 @@ agent-port: 8081{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -635,7 +643,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
@@ -706,7 +714,7 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -924,7 +932,7 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< code shell >}}# Command line example

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -715,6 +715,14 @@ Specify the agent configuration with either a `.yml` file or `sensu-agent start`
 Configuration via command line flags overrides attributes specified in a configuration file.
 See the [Example Sensu agent configuration file][5] for flags and defaults.
 
+### Certificate bundles or chains
+
+The Sensu agent supports all types of certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the leaf certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the leaf certificate alone instead of sending the whole bundle with the leaf certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the presented certificate through the chain.
+
 #### Configuration summary
 
 {{% notice important %}}
@@ -847,7 +855,7 @@ assets-rate-limit: 1.39{{< /code >}}
 
 | backend-url |      |
 --------------|------
-description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times.<br>{{% notice note %}}
+description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times. {{% notice note %}}
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
@@ -1212,7 +1220,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication.
+description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`

--- a/content/sensu-go/5.20/reference/backend.md
+++ b/content/sensu-go/5.20/reference/backend.md
@@ -250,6 +250,14 @@ All other required flags have default values.
 See the [example backend configuration file][17] for flags and defaults.
 The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
 
+### Certificate bundles or chains
+
+The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -502,7 +510,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
 | agent-auth-cert-file |      |
 -------------|------
-description  | TLS certificate in PEM format for agent certificate authentication.
+description  | TLS certificate in PEM format for agent certificate authentication. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
@@ -582,7 +590,7 @@ agent-port: 8081{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -671,7 +679,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
@@ -742,7 +750,7 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -960,7 +968,7 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< code shell >}}# Command line example

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -717,11 +717,11 @@ See the [Example Sensu agent configuration file][5] for flags and defaults.
 
 ### Certificate bundles or chains
 
-The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
-This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
+The Sensu agent supports all types of certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the leaf certificate &mdash; the certificate that the program will use to show its own identity.
 
-If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
-You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
+If you send the leaf certificate alone instead of sending the whole bundle with the leaf certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the presented certificate through the chain.
 
 ### Configuration summary
 
@@ -1223,7 +1223,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -715,7 +715,15 @@ Specify the agent configuration with either a `.yml` file or `sensu-agent start`
 Configuration via command line flags overrides attributes specified in a configuration file.
 See the [Example Sensu agent configuration file][5] for flags and defaults.
 
-#### Configuration summary
+### Certificate bundles or chains
+
+The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
+
+### Configuration summary
 
 {{% notice important %}}
 **IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../release-notes/#5202-release-notes).
@@ -1215,7 +1223,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication.
+description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -857,7 +857,7 @@ assets-rate-limit: 1.39{{< /code >}}
 
 | backend-url |      |
 --------------|------
-description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times.<br>{{% notice note %}}
+description   | ws or wss URL of the Sensu backend server. To specify multiple backends with `sensu-agent start`, use this flag multiple times. {{% notice note %}}
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
@@ -1279,7 +1279,7 @@ insecure-skip-tls-verify: true{{< /code >}}
 
 | require-fips |      |
 ------------------|------
-description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode.<br>{{% notice note %}}
+description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
 **NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
@@ -1294,7 +1294,7 @@ require-fips: true{{< /code >}}
 
 | require-openssl |      |
 ------------------|------
-description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded.<br>{{% notice note %}}
+description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
 **NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -592,7 +592,7 @@ agent-port: 8081{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -622,7 +622,7 @@ insecure-skip-tls-verify: true{{< /code >}}
 
 | jwt-private-key-file |      |
 -------------|------
-description  | Path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs).<br>{{% notice note %}}
+description  | Path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs). {{% notice note %}}
 **NOTE**: The internal symmetric secret key is used by default to sign all JWTs unless a private key is specified via this attribute.
 {{% /notice %}}
 type         | String
@@ -637,7 +637,7 @@ jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
 
 | jwt-public-key-file |      |
 -------------|------
-description  | Path to the PEM-encoded public key to use to verify JSON Web Token (JWT) signatures.<br>{{% notice note %}}
+description  | Path to the PEM-encoded public key to use to verify JSON Web Token (JWT) signatures. {{% notice note %}}
 **NOTE**: JWTs signed with the internal symmetric secret key will continue to be verified with that key.
 {{% /notice %}}
 type         | String
@@ -667,7 +667,7 @@ key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
 | require-fips |      |
 ------------------|------
-description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode.<br>{{% notice note %}}
+description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
 **NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
@@ -682,7 +682,7 @@ require-fips: true{{< /code >}}
 
 | require-openssl |      |
 ------------------|------
-description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded.<br>{{% notice note %}}
+description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
 **NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
@@ -712,7 +712,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
@@ -783,7 +783,7 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -1001,7 +1001,7 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< code shell >}}# Command line example

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -250,6 +250,14 @@ All other required flags have default values.
 See the [example backend configuration file][17] for flags and defaults.
 The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
 
+### Certificate bundles or chains
+
+The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
+
+If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
+You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -504,7 +512,7 @@ state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
 | agent-auth-cert-file |      |
 -------------|------
-description  | TLS certificate in PEM format for agent certificate authentication.
+description  | TLS certificate in PEM format for agent certificate authentication. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
@@ -584,7 +592,7 @@ agent-port: 8081{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -704,7 +712,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
@@ -775,7 +783,7 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -993,7 +1001,7 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file.
+description           | Path to the peer server TLS certificate file.  Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< code shell >}}# Command line example


### PR DESCRIPTION
## Description
- Adds "Certificate bundles or chains" section to https://docs.sensu.io/sensu-go/latest/reference/agent/#configuration-via-flags and https://docs.sensu.io/sensu-go/latest/reference/backend/#configuration
- Adds note about order in certificate bundles to the description for all flags that include `cert-file` in https://docs.sensu.io/sensu-go/latest/reference/agent/#configuration-via-flags and https://docs.sensu.io/sensu-go/latest/reference/backend/#configuration

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2585

## Review Instructions
Should this information appear in any of these docs also?
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/generate-certificates/
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/cluster-sensu/