### PR TITLE
Explain asset download timing in asset reference

### DIFF
--- a/content/sensu-go/5.18/reference/assets.md
+++ b/content/sensu-go/5.18/reference/assets.md
@@ -57,7 +57,7 @@ Sensu backends follow a similar process when pipeline elements (filters, mutator
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
+If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].

--- a/content/sensu-go/5.18/reference/assets.md
+++ b/content/sensu-go/5.18/reference/assets.md
@@ -43,14 +43,28 @@ For each build provided in an asset, Sensu will evaluate any defined filters to 
 If all filters specified on a build evaluate to `true`, that build is considered a match.
 For assets with multiple builds, only the first build which matches will be downloaded and installed.
 
-### Asset build installation
+### Asset build download
+
+Sensu downloads the asset build on the host system where the asset contents are needed to execute the requested command.
+For example, if a check definition references an asset, the Sensu agent that executes the check will download the asset the first time it executes the check.
+The asset build the agent downloads will depend on the filter rules associated with each build defined for the asset.
+
+Sensu backends follow a similar process when pipeline elements (filters, mutators, and handlers) request runtime asset installation as part of operation.
+
+{{% notice note %}}
+**NOTE**: Asset builds are not downloaded until they are needed for command execution.
+{{% /notice %}}
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
+If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
+
+{{% notice note %}}
+**NOTE**: Asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+{{% /notice %}}
 
 ### Asset build execution
 

--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -57,7 +57,7 @@ Sensu backends follow a similar process when pipeline elements (filters, mutator
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
+If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].

--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -43,14 +43,28 @@ For each build provided in an asset, Sensu will evaluate any defined filters to 
 If all filters specified on a build evaluate to `true`, that build is considered a match.
 For assets with multiple builds, only the first build which matches will be downloaded and installed.
 
-### Asset build installation
+### Asset build download
+
+Sensu downloads the asset build on the host system where the asset contents are needed to execute the requested command.
+For example, if a check definition references an asset, the Sensu agent that executes the check will download the asset the first time it executes the check.
+The asset build the agent downloads will depend on the filter rules associated with each build defined for the asset.
+
+Sensu backends follow a similar process when pipeline elements (filters, mutators, and handlers) request runtime asset installation as part of operation.
+
+{{% notice note %}}
+**NOTE**: Asset builds are not downloaded until they are needed for command execution.
+{{% /notice %}}
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
+If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
+
+{{% notice note %}}
+**NOTE**: Asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+{{% /notice %}}
 
 Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching assets (available in [Sensu Go 5.19.3][42]).
 

--- a/content/sensu-go/5.20/reference/assets.md
+++ b/content/sensu-go/5.20/reference/assets.md
@@ -57,7 +57,7 @@ Sensu backends follow a similar process when pipeline elements (filters, mutator
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
+If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].

--- a/content/sensu-go/5.20/reference/assets.md
+++ b/content/sensu-go/5.20/reference/assets.md
@@ -43,14 +43,28 @@ For each build provided in an asset, Sensu will evaluate any defined filters to 
 If all filters specified on a build evaluate to `true`, that build is considered a match.
 For assets with multiple builds, only the first build which matches will be downloaded and installed.
 
-### Asset build installation
+### Asset build download
+
+Sensu downloads the asset build on the host system where the asset contents are needed to execute the requested command.
+For example, if a check definition references an asset, the Sensu agent that executes the check will download the asset the first time it executes the check.
+The asset build the agent downloads will depend on the filter rules associated with each build defined for the asset.
+
+Sensu backends follow a similar process when pipeline elements (filters, mutators, and handlers) request runtime asset installation as part of operation.
+
+{{% notice note %}}
+**NOTE**: Asset builds are not downloaded until they are needed for command execution.
+{{% /notice %}}
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
+If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
+
+{{% notice note %}}
+**NOTE**: Asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+{{% /notice %}}
 
 Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching assets.
 

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -57,7 +57,7 @@ Sensu backends follow a similar process when pipeline elements (filters, mutator
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
+If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -43,14 +43,28 @@ For each build provided in an asset, Sensu will evaluate any defined filters to 
 If all filters specified on a build evaluate to `true`, that build is considered a match.
 For assets with multiple builds, only the first build which matches will be downloaded and installed.
 
-### Asset build installation
+### Asset build download
+
+Sensu downloads the asset build on the host system where the asset contents are needed to execute the requested command.
+For example, if a check definition references an asset, the Sensu agent that executes the check will download the asset the first time it executes the check.
+The asset build the agent downloads will depend on the filter rules associated with each build defined for the asset.
+
+Sensu backends follow a similar process when pipeline elements (filters, mutators, and handlers) request runtime asset installation as part of operation.
+
+{{% notice note %}}
+**NOTE**: Asset builds are not downloaded until they are needed for command execution.
+{{% /notice %}}
 
 When Sensu finds a matching build, it downloads the build artifact from the specified URL.
 If the asset definition includes headers, they are passed along as part of the HTTP request.
-If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
+If the downloaded artifact’s SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service’s local cache directory.
 
 Set the backend or agent's local cache path with the `--cache-dir` flag.
 Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
+
+{{% notice note %}}
+**NOTE**: Asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+{{% /notice %}}
 
 Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching assets.
 


### PR DESCRIPTION
## Description
- Adds suggested clarification re: asset download timing
- Changes heading to "download" instead of "installation" to be consistent with the explanation the section contains

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2588