### PR TITLE
Add asset build download note in all docs that involve adding an asset

### DIFF
--- a/content/sensu-go/5.18/guides/contact-routing.md
+++ b/content/sensu-go/5.18/guides/contact-routing.md
@@ -58,6 +58,11 @@ You can also download the latest asset definition from [Bonsai][12].
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### 2. Create contact filters
 
 The [Bonsai][1] documentation for the asset explains that the has-contact asset supports two functions:

--- a/content/sensu-go/5.18/guides/email-handler.md
+++ b/content/sensu-go/5.18/guides/email-handler.md
@@ -52,6 +52,11 @@ sensuctl asset info email-handler
 
 The asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Add an event filter
 
 Event filters allow you to fine-tune how your events are handled and [reduce alert fatigue][7].

--- a/content/sensu-go/5.18/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.18/guides/influx-db-metric-handler.md
@@ -41,6 +41,11 @@ Created
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create the handler
 
 Now that you have registered the asset, you'll use sensuctl to create a handler called `influx-db` that pipes event data to InfluxDB with the `sensu-influxdb-handler` asset.

--- a/content/sensu-go/5.18/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.18/guides/install-check-executables-with-assets.md
@@ -28,6 +28,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Adjust the asset definition
 
 Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.

--- a/content/sensu-go/5.18/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.18/guides/monitor-external-resources.md
@@ -55,6 +55,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### Create the check
 
 Now that the assets are registered, you can create a check named `check-sensu-site` to run the command `check-http.rb -u https://sensu.io` with the `sensu-plugins-http` and `sensu-ruby-runtime` assets, at an interval of 60 seconds, for all agents subscribed to the `proxy` subscription, using the `sensu-site` proxy entity name.

--- a/content/sensu-go/5.18/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.18/guides/monitor-server-resources.md
@@ -51,6 +51,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create a check
 
 Now that the assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.

--- a/content/sensu-go/5.18/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.18/guides/reduce-alert-fatigue.md
@@ -70,6 +70,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset directly from [Bonsai, the Sensu asset index][9].
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 You've registered the asset, but you still need to create the filter.
 To do this, use the following configuration:
 

--- a/content/sensu-go/5.18/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.18/guides/send-slack-alerts.md
@@ -38,6 +38,11 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Get a Slack webhook
 
 If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.

--- a/content/sensu-go/5.18/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/5.18/sensuctl/sensuctl-bonsai.md
@@ -38,6 +38,11 @@ fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Check your Sensu backend for outdated assets
 
 To check your Sensu backend for assets that have newer versions available on Bonsai, use `sensuctl asset outdated`.

--- a/content/sensu-go/5.19/guides/contact-routing.md
+++ b/content/sensu-go/5.19/guides/contact-routing.md
@@ -58,6 +58,11 @@ You can also download the latest asset definition from [Bonsai][12].
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### 2. Create contact filters
 
 The [Bonsai][1] documentation for the asset explains that the has-contact asset supports two functions:

--- a/content/sensu-go/5.19/guides/email-handler.md
+++ b/content/sensu-go/5.19/guides/email-handler.md
@@ -52,6 +52,11 @@ sensuctl asset info email-handler
 
 The asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Add an event filter
 
 Event filters allow you to fine-tune how your events are handled and [reduce alert fatigue][7].

--- a/content/sensu-go/5.19/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.19/guides/influx-db-metric-handler.md
@@ -41,6 +41,11 @@ Created
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create the handler
 
 Now that you have registered the asset, you'll use sensuctl to create a handler called `influx-db` that pipes event data to InfluxDB with the `sensu-influxdb-handler` asset.

--- a/content/sensu-go/5.19/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.19/guides/install-check-executables-with-assets.md
@@ -28,6 +28,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Adjust the asset definition
 
 Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.

--- a/content/sensu-go/5.19/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.19/guides/monitor-external-resources.md
@@ -55,6 +55,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### Create the check
 
 Now that the assets are registered, you can create a check named `check-sensu-site` to run the command `check-http.rb -u https://sensu.io` with the `sensu-plugins-http` and `sensu-ruby-runtime` assets, at an interval of 60 seconds, for all agents subscribed to the `proxy` subscription, using the `sensu-site` proxy entity name.

--- a/content/sensu-go/5.19/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.19/guides/monitor-server-resources.md
@@ -51,6 +51,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create a check
 
 Now that the assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.

--- a/content/sensu-go/5.19/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.19/guides/reduce-alert-fatigue.md
@@ -70,6 +70,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset directly from [Bonsai, the Sensu asset index][9].
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 You've registered the asset, but you still need to create the filter.
 To do this, use the following configuration:
 

--- a/content/sensu-go/5.19/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.19/guides/send-slack-alerts.md
@@ -38,6 +38,11 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Get a Slack webhook
 
 If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.

--- a/content/sensu-go/5.19/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/5.19/sensuctl/sensuctl-bonsai.md
@@ -38,6 +38,11 @@ fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Check your Sensu backend for outdated assets
 
 To check your Sensu backend for assets that have newer versions available on Bonsai, use `sensuctl asset outdated`.

--- a/content/sensu-go/5.20/guides/contact-routing.md
+++ b/content/sensu-go/5.20/guides/contact-routing.md
@@ -58,6 +58,11 @@ You can also download the latest asset definition from [Bonsai][12].
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### 2. Create contact filters
 
 The [Bonsai][1] documentation for the asset explains that the has-contact asset supports two functions:

--- a/content/sensu-go/5.20/guides/email-handler.md
+++ b/content/sensu-go/5.20/guides/email-handler.md
@@ -52,6 +52,11 @@ sensuctl asset info email-handler
 
 The asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Add an event filter
 
 Event filters allow you to fine-tune how your events are handled and [reduce alert fatigue][7].

--- a/content/sensu-go/5.20/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.20/guides/influx-db-metric-handler.md
@@ -41,6 +41,11 @@ Created
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create the handler
 
 Now that you have registered the asset, you'll use sensuctl to create a handler called `influx-db` that pipes event data to InfluxDB with the `sensu-influxdb-handler` asset.

--- a/content/sensu-go/5.20/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.20/guides/install-check-executables-with-assets.md
@@ -28,6 +28,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Adjust the asset definition
 
 Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.

--- a/content/sensu-go/5.20/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.20/guides/monitor-external-resources.md
@@ -55,6 +55,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### Create the check
 
 Now that the assets are registered, you can create a check named `check-sensu-site` to run the command `check-http.rb -u https://sensu.io` with the `sensu-plugins-http` and `sensu-ruby-runtime` assets, at an interval of 60 seconds, for all agents subscribed to the `proxy` subscription, using the `sensu-site` proxy entity name.

--- a/content/sensu-go/5.20/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.20/guides/monitor-server-resources.md
@@ -51,6 +51,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create a check
 
 Now that the assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.

--- a/content/sensu-go/5.20/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.20/guides/reduce-alert-fatigue.md
@@ -70,6 +70,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset directly from [Bonsai, the Sensu asset index][9].
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 You've registered the asset, but you still need to create the filter.
 To do this, use the following configuration:
 

--- a/content/sensu-go/5.20/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.20/guides/send-slack-alerts.md
@@ -38,6 +38,11 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Get a Slack webhook
 
 If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.

--- a/content/sensu-go/5.20/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/5.20/sensuctl/sensuctl-bonsai.md
@@ -38,6 +38,11 @@ fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Check your Sensu backend for outdated assets
 
 To check your Sensu backend for assets that have newer versions available on Bonsai, use `sensuctl asset outdated`.

--- a/content/sensu-go/5.21/guides/contact-routing.md
+++ b/content/sensu-go/5.21/guides/contact-routing.md
@@ -58,6 +58,11 @@ You can also download the latest asset definition from [Bonsai][12].
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### 2. Create contact filters
 
 The [Bonsai][1] documentation for the asset explains that the has-contact asset supports two functions:

--- a/content/sensu-go/5.21/guides/email-handler.md
+++ b/content/sensu-go/5.21/guides/email-handler.md
@@ -52,6 +52,11 @@ sensuctl asset info email-handler
 
 The asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Add an event filter
 
 Event filters allow you to fine-tune how your events are handled and [reduce alert fatigue][7].

--- a/content/sensu-go/5.21/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/5.21/guides/influx-db-metric-handler.md
@@ -41,6 +41,11 @@ Created
 
 Run `sensuctl asset list --format yaml` to confirm that the asset is ready to use.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create the handler
 
 Now that you have registered the asset, you'll use sensuctl to create a handler called `influx-db` that pipes event data to InfluxDB with the `sensu-influxdb-handler` asset.

--- a/content/sensu-go/5.21/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.21/guides/install-check-executables-with-assets.md
@@ -28,6 +28,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Adjust the asset definition
 
 Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.

--- a/content/sensu-go/5.21/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.21/guides/monitor-external-resources.md
@@ -55,6 +55,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ### Create the check
 
 Now that the assets are registered, you can create a check named `check-sensu-site` to run the command `check-http.rb -u https://sensu.io` with the `sensu-plugins-http` and `sensu-ruby-runtime` assets, at an interval of 60 seconds, for all agents subscribed to the `proxy` subscription, using the `sensu-site` proxy entity name.

--- a/content/sensu-go/5.21/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.21/guides/monitor-server-resources.md
@@ -51,6 +51,11 @@ sensuctl asset list
  sensu-ruby-runtime         //assets.bonsai.sensu.io/.../sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz     338b88b 
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Create a check
 
 Now that the assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.

--- a/content/sensu-go/5.21/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.21/guides/reduce-alert-fatigue.md
@@ -70,6 +70,11 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset directly from [Bonsai, the Sensu asset index][9].
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 You've registered the asset, but you still need to create the filter.
 To do this, use the following configuration:
 

--- a/content/sensu-go/5.21/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.21/guides/send-slack-alerts.md
@@ -38,6 +38,11 @@ You should see a confirmation message from sensuctl:
 Created
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Get a Slack webhook
 
 If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.

--- a/content/sensu-go/5.21/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/5.21/sensuctl/sensuctl-bonsai.md
@@ -38,6 +38,11 @@ fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
 ## Check your Sensu backend for outdated assets
 
 To check your Sensu backend for assets that have newer versions available on Bonsai, use `sensuctl asset outdated`.


### PR DESCRIPTION
## Description
Adds note about just-in-time asset build download with link to asset reference in all versions of the following docs:
- https://docs.sensu.io/sensu-go/latest/guides/monitor-server-resources/
- https://docs.sensu.io/sensu-go/latest/guides/monitor-external-resources/
- https://docs.sensu.io/sensu-go/latest/guides/influx-db-metric-handler/
- https://docs.sensu.io/sensu-go/latest/guides/send-slack-alerts/
- https://docs.sensu.io/sensu-go/latest/guides/email-handler/
- https://docs.sensu.io/sensu-go/latest/guides/install-check-executables-with-assets/
- https://docs.sensu.io/sensu-go/latest/guides/contact-routing/
- https://docs.sensu.io/sensu-go/latest/sensuctl/sensuctl-bonsai/

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2595