### PR TITLE
Fix table markdown for occurrences in events reference

### DIFF
--- a/content/sensu-go/5.18/reference/events.md
+++ b/content/sensu-go/5.18/reference/events.md
@@ -157,17 +157,17 @@ The following table shows the occurrences attributes for a series of example eve
 
 | event sequence   | `occurrences`   | `occurrences_watermark` |
 | -----------------| --------------- | ----------------------- |
-1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
-2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
-3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
-4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
-5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
-6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
-7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
-8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
-9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
-10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
-11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
+|1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
+|2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
+|3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
+|4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
+|5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
+|6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
+|7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
+|8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
+|9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
+|10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
+|11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
 ## Events specification
 

--- a/content/sensu-go/5.19/reference/events.md
+++ b/content/sensu-go/5.19/reference/events.md
@@ -157,17 +157,17 @@ The following table shows the occurrences attributes for a series of example eve
 
 | event sequence   | `occurrences`   | `occurrences_watermark` |
 | -----------------| --------------- | ----------------------- |
-1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
-2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
-3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
-4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
-5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
-6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
-7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
-8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
-9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
-10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
-11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
+|1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
+|2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
+|3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
+|4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
+|5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
+|6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
+|7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
+|8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
+|9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
+|10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
+|11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
 ## Events specification
 

--- a/content/sensu-go/5.20/reference/events.md
+++ b/content/sensu-go/5.20/reference/events.md
@@ -157,17 +157,17 @@ The following table shows the occurrences attributes for a series of example eve
 
 | event sequence   | `occurrences`   | `occurrences_watermark` |
 | -----------------| --------------- | ----------------------- |
-1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
-2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
-3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
-4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
-5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
-6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
-7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
-8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
-9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
-10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
-11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
+|1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
+|2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
+|3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
+|4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
+|5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
+|6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
+|7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
+|8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
+|9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
+|10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
+|11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
 ## Events specification
 

--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -157,17 +157,17 @@ The following table shows the occurrences attributes for a series of example eve
 
 | event sequence   | `occurrences`   | `occurrences_watermark` |
 | -----------------| --------------- | ----------------------- |
-1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
-2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
-3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
-4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
-5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
-6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
-7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
-8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
-9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
-10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
-11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
+|1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
+|2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
+|3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`
+|4. WARNING event   | `occurrences: 2`| `occurrences_watermark: 2`
+|5. WARNING event   | `occurrences: 3`| `occurrences_watermark: 3`
+|6. CRITICAL event  | `occurrences: 1`| `occurrences_watermark: 3`
+|7. CRITICAL event  | `occurrences: 2`| `occurrences_watermark: 3`
+|8. CRITICAL event  | `occurrences: 3`| `occurrences_watermark: 3`
+|9. CRITICAL event  | `occurrences: 4`| `occurrences_watermark: 4`
+|10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
+|11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
 ## Events specification
 


### PR DESCRIPTION
## Description

Fixes markdown for [occurrences table in the event reference](https://docs.sensu.io/sensu-go/latest/reference/events/#occurrences-and-occurrences-watermark)

## Motivation and Context

I'm not sure if rendering this table broke when we upgraded Hugo, but here's what I'm seeing currently:

![2020-07-10 at 3 11 PM](https://user-images.githubusercontent.com/148017/87203396-bd60c800-c2bf-11ea-916e-6e5fc08fe64f.png)


## Review Instructions

Table should look more like this in the preview deployment:

![2020-07-10 at 3 13 PM](https://user-images.githubusercontent.com/148017/87203496-f5680b00-c2bf-11ea-86cc-cf7382356ce6.png)

