### PR TITLE
Replace protocol HTTP/HTTPS with gRPC for ports 2379 and 2380

### DIFF
--- a/content/sensu-go/5.18/migrate.md
+++ b/content/sensu-go/5.18/migrate.md
@@ -53,8 +53,8 @@ Sensu checks and pipeline elements are configured via the API or sensuctl tool i
 The [**Sensu backend**][3] is powered by an embedded transport and [etcd][36] datastore and gives you flexible, automated workflows to route metrics and alerts.
 Sensu backends require persistent storage for their embedded database, disk space for local asset caching, and several exposed ports:
 
-- 2379 (HTTP/HTTPS) Sensu storage client: Required for Sensu backends using an external etcd instance
-- 2380 (HTTP/HTTPS) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
+- 2379 (gRPC) Sensu storage client: Required for Sensu backends using an external etcd instance
+- 2380 (gRPC) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
 - 3000 (HTTP/HTTPS) [Sensu web UI][29]: Required for all Sensu backends using a Sensu web UI
 - 8080 (HTTP/HTTPS) [Sensu API][40]: Required for all users accessing the Sensu API
 - 8081 (WS/WSS) Agent API: Required for all Sensu agents connecting to a Sensu backend

--- a/content/sensu-go/5.18/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.18/operations/deploy-sensu/install-sensu.md
@@ -46,8 +46,8 @@ Sensu backends require the following ports:
 
 Port | Protocol | Description |
 ---- | -------- | ----------- |
-2379 | HTTP/HTTPS | Sensu storage client: Required for Sensu backends using an external etcd instance |
-2380 | HTTP/HTTPS | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
+2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
+2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |

--- a/content/sensu-go/5.19/migrate.md
+++ b/content/sensu-go/5.19/migrate.md
@@ -53,8 +53,8 @@ Sensu checks and pipeline elements are configured via the API or sensuctl tool i
 The [**Sensu backend**][3] is powered by an embedded transport and [etcd][36] datastore and gives you flexible, automated workflows to route metrics and alerts.
 Sensu backends require persistent storage for their embedded database, disk space for local asset caching, and several exposed ports:
 
-- 2379 (HTTP/HTTPS) Sensu storage client: Required for Sensu backends using an external etcd instance
-- 2380 (HTTP/HTTPS) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
+- 2379 (gRPC) Sensu storage client: Required for Sensu backends using an external etcd instance
+- 2380 (gRPC) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
 - 3000 (HTTP/HTTPS) [Sensu web UI][29]: Required for all Sensu backends using a Sensu web UI
 - 8080 (HTTP/HTTPS) [Sensu API][40]: Required for all users accessing the Sensu API
 - 8081 (WS/WSS) Agent API: Required for all Sensu agents connecting to a Sensu backend

--- a/content/sensu-go/5.19/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.19/operations/deploy-sensu/install-sensu.md
@@ -46,8 +46,8 @@ Sensu backends require the following ports:
 
 Port | Protocol | Description |
 ---- | -------- | ----------- |
-2379 | HTTP/HTTPS | Sensu storage client: Required for Sensu backends using an external etcd instance |
-2380 | HTTP/HTTPS | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
+2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
+2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |

--- a/content/sensu-go/5.20/migrate.md
+++ b/content/sensu-go/5.20/migrate.md
@@ -53,8 +53,8 @@ Sensu checks and pipeline elements are configured via the API or sensuctl tool i
 The [**Sensu backend**][3] is powered by an embedded transport and [etcd][36] datastore and gives you flexible, automated workflows to route metrics and alerts.
 Sensu backends require persistent storage for their embedded database, disk space for local asset caching, and several exposed ports:
 
-- 2379 (HTTP/HTTPS) Sensu storage client: Required for Sensu backends using an external etcd instance
-- 2380 (HTTP/HTTPS) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
+- 2379 (gRPC) Sensu storage client: Required for Sensu backends using an external etcd instance
+- 2380 (gRPC) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
 - 3000 (HTTP/HTTPS) [Sensu web UI][29]: Required for all Sensu backends using a Sensu web UI
 - 8080 (HTTP/HTTPS) [Sensu API][40]: Required for all users accessing the Sensu API
 - 8081 (WS/WSS) Agent API: Required for all Sensu agents connecting to a Sensu backend

--- a/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
@@ -46,8 +46,8 @@ Sensu backends require the following ports:
 
 Port | Protocol | Description |
 ---- | -------- | ----------- |
-2379 | HTTP/HTTPS | Sensu storage client: Required for Sensu backends using an external etcd instance |
-2380 | HTTP/HTTPS | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
+2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
+2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |

--- a/content/sensu-go/5.21/migrate.md
+++ b/content/sensu-go/5.21/migrate.md
@@ -53,8 +53,8 @@ Sensu checks and pipeline elements are configured via the API or sensuctl tool i
 The [**Sensu backend**][3] is powered by an embedded transport and [etcd][36] datastore and gives you flexible, automated workflows to route metrics and alerts.
 Sensu backends require persistent storage for their embedded database, disk space for local asset caching, and several exposed ports:
 
-- 2379 (HTTP/HTTPS) Sensu storage client: Required for Sensu backends using an external etcd instance
-- 2380 (HTTP/HTTPS) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
+- 2379 (gRPC) Sensu storage client: Required for Sensu backends using an external etcd instance
+- 2380 (gRPC) Sensu storage peer: Required for other Sensu backends in a [cluster][37]
 - 3000 (HTTP/HTTPS) [Sensu web UI][29]: Required for all Sensu backends using a Sensu web UI
 - 8080 (HTTP/HTTPS) [Sensu API][40]: Required for all users accessing the Sensu API
 - 8081 (WS/WSS) Agent API: Required for all Sensu agents connecting to a Sensu backend

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
@@ -46,8 +46,8 @@ Sensu backends require the following ports:
 
 Port | Protocol | Description |
 ---- | -------- | ----------- |
-2379 | HTTP/HTTPS | Sensu storage client: Required for Sensu backends using an external etcd instance |
-2380 | HTTP/HTTPS | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
+2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
+2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |


### PR DESCRIPTION
## Description
Replaced protocol HTTP/HTTPS with gRPC for ports 2379 and 2380 in all versions of:
- https://docs.sensu.io/sensu-go/latest/migrate/
- https://docs.sensu.io/sensu-go/latest/installation/install-sensu/#ports

## Motivation and Context
https://sensu.slack.com/archives/C3MHLUP46/p1593714927236400

This PR replaces https://github.com/sensu/sensu-docs/pull/2587 to eliminate a file location conflict for install-sensu.md