### PR TITLE
[WIP] Add Plugins category and move plugins and asset content

### DIFF
--- a/content/sensu-go/5.21/plugins/_index.md
+++ b/content/sensu-go/5.21/plugins/_index.md
@@ -1,0 +1,98 @@
+---
+title: "Plugins"
+description: "Sensu plugins provide executables that extend Sensu's functionality. Use Sensu plugins to perform status or metric checks, change data to a desired format, and route Sensu events."
+product: "Sensu Go"
+version: "5.21"
+weight: 120
+layout: "single"
+menu:
+  sensu-go-5.21:
+    identifier: plugins
+---
+
+The goal of the Sensu Plugins project is to provide a set of community-driven, high-quality plugins, handlers and other code to maximize the effective use of Sensu in various types of auto-scaling and traditional environments. Much of the code is written in Ruby and uses the [`sensu-plugin` framework][1]; some also depend on additional gems or packages(e.g. `mysql2` or `libopenssl-devel`). Some are shell scripts! All languages are welcome but the preference is for pure Ruby when possible to ensure the broadest range of compatibility.
+
+Plugins are maintained by volunteers and do **not** have an SLA or similar.
+Visit the [contributing guide][2] to learn more about contributing to the Sensu plugins project.
+
+## Plugins vs Assets
+
+Sensu plugins provide executable scripts or other programs that can be used as [Sensu checks][1] (i.e. to monitor server resources, services, and application health, or collect & analyze metrics), [Sensu handlers][2] (i.e. to send notifications or perform other actions based on [Sensu events][3]), or [Sensu mutators][3] (i.e. to modify [event data][4] prior to handling).
+
+Assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
+You can use assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
+
+You don't need an asset to use a plugin, but you do need a plugin to create an asset.
+
+## Nagios plugins and the Nagios Exchange
+
+The [Sensu Plugin specification][16] is 100% compatible with the [Nagios plugin specification][17]; as a result, **Nagios plugins may be used with Sensu without any modification**. Sensu allows you to bring new life to the 50+ plugins in the official [Nagios Plugins project][18] (which [began life in 1999][19], making it a very mature source for monitoring plugins), and
+over 4000 plugins available in the [Nagios Exchange][20].
+
+## Plugin execution
+
+All plugins are executed by the Sensu agent or backend as the `sensu` user.
+Plugins must be executable files that are discoverable on the Sensu system (i.e. installed in a
+system `$PATH` directory), or they must be referenced with an absolute path
+(e.g. `/opt/path/to/my/plugin`).
+
+{{% notice note %}}
+**NOTE**: By default, the Sensu installer packages will modify the system `$PATH`
+for the Sensu processes to include `/etc/sensu/plugins`. As a result, executable
+scripts (e.g. plugins) located in `/etc/sensu/plugins` will be valid commands.
+This allows command attributes to use "relative paths" for Sensu plugin
+commands;<br><br>e.g.: `"command": "check-http.rb -u https://sensuapp.org"`.
+{{% /notice %}}
+
+## Asset execution
+
+The directory path of each asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
+Subsequent handler, filter, mutator, or check executions look for the asset in the local cache and ensure that the contents match the configured checksum.
+
+See the [example asset with a check][31] for a use case with a Sensu resource (a check) and an asset.
+
+### Asset builds
+
+An asset build is the combination of an artifact URL, SHA512 checksum, and optional [Sensu query expression][1] filters.
+Each asset definition may describe one or more builds.
+
+{{% notice note %}}
+**NOTE**: Assets that provide `url` and `sha512` attributes at the top level of the `spec` scope are [single-build assets](#asset-definition-single-build-deprecated), and this form of asset defintion is deprecated.
+We recommend using [multiple-build asset defintions](#asset-definition-multiple-builds), which specify one or more `builds` under the `spec` scope.
+{{% /notice %}}
+
+### Asset build evaluation
+
+For each build provided in an asset, Sensu will evaluate any defined filters to determine whether any build matches the agent or backend service's environment.
+If all filters specified on a build evaluate to `true`, that build is considered a match.
+For assets with multiple builds, only the first build which matches will be downloaded and installed.
+
+### Asset build download
+
+Sensu downloads the asset build on the host system where the asset contents are needed to execute the requested command.
+For example, if a check definition references an asset, the Sensu agent that executes the check will download the asset the first time it executes the check.
+The asset build the agent downloads will depend on the filter rules associated with each build defined for the asset.
+
+Sensu backends follow a similar process when pipeline elements (filters, mutators, and handlers) request runtime asset installation as part of operation.
+
+{{% notice note %}}
+**NOTE**: Asset builds are not downloaded until they are needed for command execution.
+{{% /notice %}}
+
+When Sensu finds a matching build, it downloads the build artifact from the specified URL.
+If the asset definition includes headers, they are passed along as part of the HTTP request.
+If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
+
+Set the backend or agent's local cache path with the `--cache-dir` flag.
+Disable assets for an agent with the agent `--disable-assets` [configuration flag][30].
+
+{{% notice note %}}
+**NOTE**: Asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+{{% /notice %}}
+
+Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching assets.
+
+
+[1]: https://github.com/sensu-plugins/sensu-plugin
+[2]: https://github.com/sensu-plugins/community/blob/master/CONTRIBUTING.md
+[3]: install-plugins/

--- a/content/sensu-go/5.21/plugins/install-plugins.md
+++ b/content/sensu-go/5.21/plugins/install-plugins.md
@@ -2,24 +2,143 @@
 title: "Install Sensu plugins"
 linkTitle: "Install Plugins"
 description: "Sensu plugins provide executables for performing status or metric checks, mutators for changing data to a desired format, and handlers for performing an action on a Sensu event. Read this plugin installation guide to learn how to install plugins with assets and use Sensu Community plugins with Sensu Go."
-weight: 100
+weight: 10
 version: "5.21"
 product: "Sensu Go"
 platformContent: true
 platforms: ["Ubuntu/Debian", "RHEL/CentOS"]
 menu:
   sensu-go-5.21:
-    parent: deploy-sensu
+    parent: plugins
 ---
 
 Extend Sensu's functionality with [plugins][10], which provide executables for performing status or metric checks, mutators for changing data to a desired format, and handlers for performing an action on a Sensu event.
 
+You can install plugins with assets, via Bonsai, or with the `sensu-install` command.
+
 ## Install plugins with assets
 
 Assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
-To start using and deploying assets, read [Install plugins with assets][7] to become familiar with workflows that involve assets. 
+This guide uses the [Sensu PagerDuty Handler asset][7] as an example to help you use and deploy plugins with assets.
 
-## Use Bonsai, the Sensu asset index
+### Register the Sensu PagerDuty Handler asset
+
+To add the [Sensu PagerDuty Handler asset][7] to Sensu, use [`sensuctl asset add`][6]:
+
+{{< code shell >}}
+sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler
+{{< /code >}}
+
+This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
+
+You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
+
+{{% notice note %}}
+**NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
+Read [the asset reference](../../reference/assets#asset-builds) for more information about asset builds.
+{{% /notice %}}
+
+### Adjust the asset definition
+
+Asset definitions tell Sensu how to download and verify the asset when required by a check, filter, mutator, or handler.
+
+After you add or download the asset definition, open the file and adjust the `namespace` and `filters` for your Sensu instance.
+Here's the asset definition for version 1.2.0 of the [Sensu PagerDuty Handler][7] asset for Linux AMD64:
+
+{{< code yml >}}
+---
+type: Asset
+api_version: core/v2
+metadata:
+  name: pagerduty-handler
+  namespace: default
+  labels: {}
+  annotations: {}
+spec:
+  url: https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_linux_amd64.tar.gz
+  sha512: 5be236b5b9ccceb10920d3a171ada4ac4f4caaf87f822475cd48bd7f2fab3235fa298f79ef6f97b0eb6498205740bb1af1120ca036fd3381edfebd9fb15aaa99
+  filters:
+  - entity.system.os == 'linux'
+  - entity.system.arch == 'amd64'
+{{< /code >}}
+
+Filters for _check_ assets should match entity platforms.
+Filters for _handler and filter_ assets should match your Sensu backend platform.
+If the provided filters are too restrictive for your platform, replace `os` and `arch` with any supported [entity system attributes][4] (for example, `entity.system.platform_family == 'rhel'`).
+You may also want to customize the asset `name` to reflect the supported platform (for example, `pagerduty-handler-linux`) and add custom attributes with [`labels` and `annotations`][5].
+
+**Enterprise-tier assets** (like the [ServiceNow][10] and [Jira][11] event handlers) require a Sensu commercial license.
+For more information about commercial features and to activate your license, see [Get started with commercial features][12].
+
+Use sensuctl to verify that the asset is registered and ready to use:
+
+{{< code shell >}}
+sensuctl asset list --format yaml
+{{< /code >}}
+
+### Create a workflow
+
+With the asset downloaded and registered, you can use it in a monitoring workflow.
+Assets may provide executable plugins intended for use with a Sensu check, handler, mutator, or hook, or JavaScript libraries intended to provide functionality for use in event filters.
+The details in Bonsai are the best resource for information about each asset's capabilities and configuration.
+
+For example, to use the [Sensu PagerDuty Handler][7] asset, you would create a `pagerduty` handler that includes your PagerDuty service API key in place of `SECRET` and `pagerduty-handler` as a runtime asset:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: Handler
+api_version: core/v2
+metadata:
+  name: pagerduty
+  namespace: default
+spec:
+  command: sensu-pagerduty-handler
+  env_vars:
+  - PAGERDUTY_TOKEN=SECRET
+  filters:
+  - is_incident
+  runtime_assets:
+  - pagerduty-handler
+  timeout: 10
+  type: pipe
+{{< /code >}}
+
+{{< code json >}}
+{
+    "api_version": "core/v2",
+    "type": "Handler",
+    "metadata": {
+        "namespace": "default",
+        "name": "pagerduty"
+    },
+    "spec": {
+        "type": "pipe",
+        "command": "sensu-pagerduty-handler",
+        "env_vars": [
+          "PAGERDUTY_TOKEN=SECRET"
+        ],
+        "runtime_assets": ["pagerduty-handler"],
+        "timeout": 10,
+        "filters": [
+            "is_incident"
+        ]
+    }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Save the definition to a file (for example, `pagerduty-handler.json`), and add it to Sensu with sensuctl:
+
+{{< code shell >}}
+sensuctl create --file pagerduty-handler.json
+{{< /code >}}
+
+Now that Sensu can create incidents in PagerDuty, you can automate this workflow by adding the `pagerduty` handler to your Sensu service check definitions.
+See [Monitor server resources][13] to learn more.
+
+## Install plugins via Bonsai, the Sensu asset index
 
 [Bonsai, the Sensu asset index][8], is a centralized place for downloading and sharing plugin assets.
 Make Bonsai your first stop when you need to find an asset.
@@ -82,7 +201,7 @@ We recommend using a configuration management tool or using [Sensu assets][5] to
 Follow [this discourse.sensu.io guide](https://discourse.sensu.io/t/contributing-assets-for-existing-ruby-sensu-plugins/1165) to walk through the process.
 {{% /notice %}}
 
-## Troubleshoot the sensu-install tool
+## Troubleshoot plugins installation
 
 Some plugins require additional tools to install them successfully.
 An example is the [Sensu disk checks plugin][3].

--- a/content/sensu-go/5.21/plugins/plugins-reference.md
+++ b/content/sensu-go/5.21/plugins/plugins-reference.md
@@ -1,0 +1,148 @@
+---
+title: "Plugins reference"
+linkTitle: "Plugins Reference"
+description: "Read this reference doc to learn about plugins."
+weight: 30
+version: "5.21"
+product: "Sensu Go"
+platformContent: false 
+menu:
+  sensu-go-5.21:
+    parent: plugins
+---
+
+## Sensu plugin specification
+
+Sensu plugins must comply with this specification:
+
+- Accept input/data via `STDIN` (handler and mutator plugins only)
+  - Optionally able to parse a JSON data payload (i.e. [event data][4])
+- Output data to `STDOUT` or `STDERR`
+- Produce an exit status code to indicate state:
+  - `0` indicates `OK`
+  - `1` indicates `WARNING`
+  - `2` indicates `CRITICAL`
+  - Exit status codes other than `0`, `1`, or `2` indicate an unknown or custom
+    status
+- Able to parse command line arguments to modify plugin behavior (optional)
+
+## Supported programming languages
+
+Any programming language that can satisfy the [Sensu plugin specification][16]
+requirements &ndash; which is nearly any programming language in the world
+&ndash; can be used to write Sensu plugins. One of the primary advantages of
+writing Sensu plugins in the Ruby programming language is that Sensu itself is
+written in Ruby, [and all Sensu installer packages provide an embedded
+Ruby][25], eliminating the need to install or depend on a separate runtime.
+
+{{% notice note %}}
+**NOTE**: Plugins written in programming languages other than Ruby will require the
+corresponding runtime to be installed in order for the plugin to run.
+{{% /notice %}}
+
+## Plugin definition specification
+
+{{% notice note %}}
+**NOTE**: Plugins based on the `sensu-plugin` gem derive configuration from [custom check definition attributes][28]. The configuration example(s) provided above, and the specification" provided here are for clarification and convenience only (i.e. this "specification" is just an extension of the [check definition specification][29], and not a definition of a distinct Sensu primitive).
+{{% /notice %}}
+
+### Check definition attributes
+
+occurrences |
+------------|------
+description | The number of event occurrences that must occur before an event is handled for the check.
+required    | false
+type        | Integer
+default     | `1`
+example     | {{< code shell >}}"occurrences": 3{{< /code >}}
+
+refresh     |
+------------|------
+description | Time in seconds until the event occurrence count is considered reset for the purpose of counting `occurrences`, to allow an event for the check to be handled again. For example, a check with a refresh of `1800` will have its events (recurrences) handled every 30 minutes, to remind users of the issue.
+required    | false
+type        | Integer
+default     | `1800`
+example     | {{< code shell >}}"refresh": 3600{{< /code >}}                                    
+
+dependencies | 
+-------------|------
+description  | An array of check dependencies. Events for the check will not be handled if events exist for one or more of the check dependencies. A check dependency can be a check executed by the same Sensu client (eg. `check_app`), or a client/check pair (eg.`db-01/check_mysql`).
+required     | false
+type         | String
+example      | {{< code shell >}}"dependencies": [
+  "check_app",
+  "db-01/check_mysql"
+]{{< /code >}}
+
+notification | 
+-------------|------
+description  | The notification message used for events created by the check, instead of the commonly used check output. This attribute is used by most notification event handlers that use the sensu-plugin library.
+required     | false
+type         | String
+example      | {{< code shell >}}"notification": "the shopping cart application is not responding to requests"{{< /code >}}
+
+## Basic plugin example
+
+The following example demonstrates how to write a basic Sensu plugin in the Ruby programming language.
+
+{{< code ruby >}}
+#!/usr/bin/env ruby
+#
+# A simple example handler plugin.
+
+require 'json'
+
+# Read the incoming JSON data from STDIN.
+event = JSON.parse(STDIN.read, :symbolize_names => true)
+
+# Create an output object using Ruby string interpolation
+output = "The check named #{event[:check][:name]} generated the following output: #{event[:output]}"
+
+# Convert the mutated event data back to JSON and output it to STDOUT.
+puts output
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: This example doesn't provide much in terms of functionality (it would simply be logged to the [Sensu server][23] log file), but it does provide a starting point for a simple custom plugin.
+{{% /notice %}}
+
+
+[1]: ../sensu-query-expressions/
+[2]: ../rbac#namespaces
+[3]: ../tokens/#manage-assets
+[4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
+[5]: #metadata-attributes
+[6]: ../checks/
+[7]: ../filters/
+[8]: ../mutators/
+[9]: ../handlers/
+[10]: ../entities#system-attributes
+[11]: ../../sensuctl/create-manage-resources/#create-resources
+[12]: #spec-attributes
+[13]: https://github.com/sensu/sensu/issues/1919
+[14]: #environment-variables-for-asset-paths
+[15]: #example-asset-structure
+[16]: https://bonsai.sensu.io/
+[17]: #token-substitution-for-asset-paths
+[18]: https://discourse.sensu.io/t/the-hello-world-of-sensu-assets/1422
+[19]: https://regex101.com/r/zo9mQU/2
+[20]: ../../api#response-filtering
+[21]: ../../sensuctl/filter-responses/
+[23]: ../../guides/install-check-executables-with-assets/
+[24]: https://github.com
+[25]: https://help.github.com/articles/about-releases/
+[26]: #bonsaiyml-example
+[27]: https://goreleaser.com/
+[28]: https://github.com/sensu/sensu-go-plugin/
+[29]: /plugins/latest/reference/
+[30]: ../agent#disable-assets
+[31]: #example-asset-with-a-check
+[34]: #asset-definition-single-build-deprecated
+[35]: #asset-definition-multiple-builds
+[37]: https://bonsai.sensu.io/sign-in
+[38]: https://bonsai.sensu.io/new
+[39]: ../../web-ui/filter#filter-with-label-selectors
+[40]: ../../reference/agent/#configuration-via-flags
+[41]: ../../reference/backend/#configuration
+[42]: #filters
+[43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime

--- a/content/sensu-go/5.21/plugins/share-assets-bonsai.md
+++ b/content/sensu-go/5.21/plugins/share-assets-bonsai.md
@@ -1,0 +1,153 @@
+---
+title: "Share assets on Bonsai"
+linkTitle: "Share assets on Bonsai"
+description: "Assets are shareable, reusable packages that make it easier to deploy Sensu plugins. You can use assets to provide the plugins, libraries, and runtimes you need to create automated monitoring workflows. Read this reference doc to learn about assets."
+weight: 70
+version: "5.21"
+product: "Sensu Go"
+platformContent: false 
+menu:
+  sensu-go-5.21:
+    parent: plugins
+---
+
+Share your open-source assets on [Bonsai][16] and connect with the Sensu community.
+Bonsai supports assets hosted on [GitHub][24] and released using [GitHub releases][25].
+For more information about creating Sensu Plugins, see the [Sensu Plugin specification][29].
+
+Bonsai requires a [`bonsai.yml` configuration file][26] in the root directory of your repository that includes the project description, platforms, asset filenames, and SHA-512 checksums.
+For a Bonsai-compatible asset template using Go and [GoReleaser][27], see the [Sensu Go plugin skeleton][28].
+
+To share your asset on Bonsai, [log in to Bonsai][37] with your GitHub account and authorize Sensu.
+After you are logged in, you can [register your asset on Bonsai][38] by adding the GitHub repository, a description, and tags.
+Make sure to provide a helpful README for your asset with configuration examples.
+
+## `bonsai.yml` example
+
+{{< code yml >}}
+---
+description: "#{repo}"
+builds:
+- platform: "linux"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+
+- platform: "Windows"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_windows_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'windows'"
+  -  "entity.system.arch == 'amd64'"
+{{< /code >}}
+
+## `bonsai.yml` specification
+
+ description | 
+-------------|------
+description  | Project description.
+required     | true
+type         | String
+example      | {{< code yml >}}description: "#{repo}"{{< /code >}}
+
+ builds      | 
+-------------|------
+description  | Array of asset details per platform.
+required     | true
+type         | Array
+example      | {{< code yml >}}
+builds:
+- platform: "linux"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+{{< /code >}}
+
+## Builds specification
+
+ platform    | 
+-------------|------
+description  | Platform supported by the asset.
+required     | true
+type         | String
+example      | {{< code yml >}}- platform: "linux"{{< /code >}}
+
+ arch        | 
+-------------|------
+description  | Architecture supported by the asset.
+required     | true
+type         | String
+example      | {{< code yml >}}  arch: "amd64"{{< /code >}}
+
+asset_filename | 
+-------------|------
+description  | File name of the archive that contains the asset.
+required     | true
+type         | String
+example      | {{< code yml >}}asset_filename: "#{repo}_#{version}_linux_amd64.tar.gz"{{< /code >}}
+
+sha_filename | 
+-------------|------
+description  | SHA-512 checksum for the asset archive.
+required     | true
+type         | String
+example      | {{< code yml >}}sha_filename: "#{repo}_#{version}_sha512-checksums.txt"{{< /code >}}
+
+ filter      | 
+-------------|------
+description  | Filter expressions that describe the operating system and architecture supported by the asset.
+required     | false
+type         | Array
+example      | {{< code yml >}}
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+{{< /code >}}
+
+
+[1]: ../sensu-query-expressions/
+[2]: ../rbac#namespaces
+[3]: ../tokens/#manage-assets
+[4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
+[5]: #metadata-attributes
+[6]: ../checks/
+[7]: ../filters/
+[8]: ../mutators/
+[9]: ../handlers/
+[10]: ../entities#system-attributes
+[11]: ../../sensuctl/create-manage-resources/#create-resources
+[12]: #spec-attributes
+[13]: https://github.com/sensu/sensu/issues/1919
+[14]: #environment-variables-for-asset-paths
+[15]: #example-asset-structure
+[16]: https://bonsai.sensu.io/
+[17]: #token-substitution-for-asset-paths
+[18]: https://discourse.sensu.io/t/the-hello-world-of-sensu-assets/1422
+[19]: https://regex101.com/r/zo9mQU/2
+[20]: ../../api#response-filtering
+[21]: ../../sensuctl/filter-responses/
+[23]: ../../guides/install-check-executables-with-assets/
+[24]: https://github.com
+[25]: https://help.github.com/articles/about-releases/
+[26]: #bonsaiyml-example
+[27]: https://goreleaser.com/
+[28]: https://github.com/sensu/sensu-go-plugin/
+[29]: /plugins/latest/reference/
+[30]: ../agent#disable-assets
+[31]: #example-asset-with-a-check
+[34]: #asset-definition-single-build-deprecated
+[35]: #asset-definition-multiple-builds
+[37]: https://bonsai.sensu.io/sign-in
+[38]: https://bonsai.sensu.io/new
+[39]: ../../web-ui/filter#filter-with-label-selectors
+[40]: ../../reference/agent/#configuration-via-flags
+[41]: ../../reference/backend/#configuration
+[42]: #filters
+[43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime


### PR DESCRIPTION
## Description
Creates a Plugins category and moves content from plugins and Sensu Go docs into it.

Go docs moved:
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/
- https://docs.sensu.io/sensu-go/latest/reference/assets/
- https://docs.sensu.io/sensu-go/latest/guides/install-check-executables-with-assets/ (moved into Install plugins)

Plugins docs moved (note that not all content was moved):
- https://docs.sensu.io/plugins/latest/
- https://docs.sensu.io/plugins/latest/reference/

Unsure about moving:
- https://docs.sensu.io/sensu-go/latest/sensuctl/sensuctl-bonsai/ (unsure whether it makes more sense in plugins docs or where it currently sits in sensuctl category)
- https://docs.sensu.io/plugins/latest/faq/ (need to pick through for relevance)
- https://docs.sensu.io/plugins/latest/installation/ (may conflict with install content from Go docs)
- https://docs.sensu.io/plugins/latest/roadmap/ (not sure if this is still relevant)
- https://docs.sensu.io/plugins/latest/developer-guidelines/ (might want to link to this if it's hosted elsewhere on GitHub)
- https://docs.sensu.io/plugins/latest/getting-started/ (not sure if this is still relevant)
- https://docs.sensu.io/plugins/latest/release-process/ (not sure if this is still relevant)
- https://docs.sensu.io/plugins/latest/history/ (not sure if this is still relevant)
- https://docs.sensu.io/plugins/latest/testing/ (not sure if this is still relevant)

## Motivation and Context
Docs IA project
