### PR TITLE
Specify single layout formatting in frontmatter for all index pages

### DIFF
--- a/content/sensu-go/5.18/guides/_index.md
+++ b/content/sensu-go/5.18/guides/_index.md
@@ -4,7 +4,8 @@ description: "Sensu is the flexible monitoring event pipeline built to reduce op
 product: "Sensu Go"
 version: "5.18"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     identifier: guides

--- a/content/sensu-go/5.18/operations/_index.md
+++ b/content/sensu-go/5.18/operations/_index.md
@@ -4,7 +4,8 @@ description: "Follow the instructions in the Operations category to install, dep
 product: "Sensu Go"
 version: "5.18"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     identifier: operations

--- a/content/sensu-go/5.18/operations/control-access/_index.md
+++ b/content/sensu-go/5.18/operations/control-access/_index.md
@@ -4,7 +4,8 @@ description: "Set up access control for Sensu, the flexible observability pipeli
 product: "Sensu Go"
 version: "5.18"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     parent: operations

--- a/content/sensu-go/5.18/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/5.18/operations/deploy-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Deploy Sensu, the flexible observability pipeline built to reduce 
 product: "Sensu Go"
 version: "5.18"
 weight: 10
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     parent: operations

--- a/content/sensu-go/5.18/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/5.18/operations/maintain-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Read about how to maintain and troubleshoot your Sensu installatio
 product: "Sensu Go"
 version: "5.18"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     parent: operations

--- a/content/sensu-go/5.18/operations/manage-secrets/_index.md
+++ b/content/sensu-go/5.18/operations/manage-secrets/_index.md
@@ -4,7 +4,8 @@ description: "Sensu's secrets management allows you to avoid exposing secrets li
 product: "Sensu Go"
 version: "5.18"
 weight: 50
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     parent: operations

--- a/content/sensu-go/5.18/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/5.18/operations/monitor-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Log Sensu services and maintain visibility into your monitoring wo
 product: "Sensu Go"
 version: "5.18"
 weight: 40
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     parent: operations

--- a/content/sensu-go/5.18/reference/_index.md
+++ b/content/sensu-go/5.18/reference/_index.md
@@ -4,7 +4,8 @@ description: "Read the reference documentation for information about Sensu resou
 product: "Sensu Go"
 version: "5.18"
 weight: 100
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.18:
     identifier: reference

--- a/content/sensu-go/5.19/guides/_index.md
+++ b/content/sensu-go/5.19/guides/_index.md
@@ -4,7 +4,8 @@ description: "Sensu is the flexible monitoring event pipeline built to reduce op
 product: "Sensu Go"
 version: "5.19"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     identifier: guides

--- a/content/sensu-go/5.19/operations/_index.md
+++ b/content/sensu-go/5.19/operations/_index.md
@@ -4,7 +4,8 @@ description: "Follow the instructions in the Operations category to install, dep
 product: "Sensu Go"
 version: "5.19"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     identifier: operations

--- a/content/sensu-go/5.19/operations/control-access/_index.md
+++ b/content/sensu-go/5.19/operations/control-access/_index.md
@@ -4,7 +4,8 @@ description: "Set up access control for Sensu, the flexible observability pipeli
 product: "Sensu Go"
 version: "5.19"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     parent: operations

--- a/content/sensu-go/5.19/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/5.19/operations/deploy-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Deploy Sensu, the flexible observability pipeline built to reduce 
 product: "Sensu Go"
 version: "5.19"
 weight: 10
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     parent: operations

--- a/content/sensu-go/5.19/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/5.19/operations/maintain-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Read about how to maintain and troubleshoot your Sensu installatio
 product: "Sensu Go"
 version: "5.19"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     parent: operations

--- a/content/sensu-go/5.19/operations/manage-secrets/_index.md
+++ b/content/sensu-go/5.19/operations/manage-secrets/_index.md
@@ -4,7 +4,8 @@ description: "Sensu's secrets management allows you to avoid exposing secrets li
 product: "Sensu Go"
 version: "5.19"
 weight: 50
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     parent: operations

--- a/content/sensu-go/5.19/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/5.19/operations/monitor-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Log Sensu services and maintain visibility into your monitoring wo
 product: "Sensu Go"
 version: "5.19"
 weight: 40
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     parent: operations

--- a/content/sensu-go/5.19/reference/_index.md
+++ b/content/sensu-go/5.19/reference/_index.md
@@ -4,7 +4,8 @@ description: "Read the reference documentation for information about Sensu resou
 product: "Sensu Go"
 version: "5.19"
 weight: 100
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.19:
     identifier: reference

--- a/content/sensu-go/5.20/guides/_index.md
+++ b/content/sensu-go/5.20/guides/_index.md
@@ -4,7 +4,8 @@ description: "Sensu is the flexible monitoring event pipeline built to reduce op
 product: "Sensu Go"
 version: "5.20"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     identifier: guides

--- a/content/sensu-go/5.20/operations/_index.md
+++ b/content/sensu-go/5.20/operations/_index.md
@@ -4,7 +4,8 @@ description: "Follow the instructions in the Operations category to install, dep
 product: "Sensu Go"
 version: "5.20"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     identifier: operations

--- a/content/sensu-go/5.20/operations/control-access/_index.md
+++ b/content/sensu-go/5.20/operations/control-access/_index.md
@@ -4,7 +4,8 @@ description: "Set up access control for Sensu, the flexible observability pipeli
 product: "Sensu Go"
 version: "5.20"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     parent: operations

--- a/content/sensu-go/5.20/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Deploy Sensu, the flexible observability pipeline built to reduce 
 product: "Sensu Go"
 version: "5.20"
 weight: 10
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     parent: operations

--- a/content/sensu-go/5.20/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/5.20/operations/maintain-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Read about how to maintain and troubleshoot your Sensu installatio
 product: "Sensu Go"
 version: "5.20"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     parent: operations

--- a/content/sensu-go/5.20/operations/manage-secrets/_index.md
+++ b/content/sensu-go/5.20/operations/manage-secrets/_index.md
@@ -4,7 +4,8 @@ description: "Sensu's secrets management allows you to avoid exposing secrets li
 product: "Sensu Go"
 version: "5.20"
 weight: 50
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     parent: operations

--- a/content/sensu-go/5.20/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/5.20/operations/monitor-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Log Sensu services and maintain visibility into your monitoring wo
 product: "Sensu Go"
 version: "5.20"
 weight: 40
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     parent: operations

--- a/content/sensu-go/5.20/reference/_index.md
+++ b/content/sensu-go/5.20/reference/_index.md
@@ -4,7 +4,8 @@ description: "Read the reference documentation for information about Sensu resou
 product: "Sensu Go"
 version: "5.20"
 weight: 100
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.20:
     identifier: reference

--- a/content/sensu-go/5.21/guides/_index.md
+++ b/content/sensu-go/5.21/guides/_index.md
@@ -4,7 +4,8 @@ description: "Sensu is the flexible monitoring event pipeline built to reduce op
 product: "Sensu Go"
 version: "5.21"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     identifier: guides

--- a/content/sensu-go/5.21/operations/_index.md
+++ b/content/sensu-go/5.21/operations/_index.md
@@ -4,7 +4,8 @@ description: "Follow the instructions in the Operations category to install, dep
 product: "Sensu Go"
 version: "5.21"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     identifier: operations

--- a/content/sensu-go/5.21/operations/control-access/_index.md
+++ b/content/sensu-go/5.21/operations/control-access/_index.md
@@ -4,7 +4,8 @@ description: "Set up access control for Sensu, the flexible observability pipeli
 product: "Sensu Go"
 version: "5.21"
 weight: 20
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     parent: operations

--- a/content/sensu-go/5.21/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Deploy Sensu, the flexible observability pipeline built to reduce 
 product: "Sensu Go"
 version: "5.21"
 weight: 10
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     parent: operations

--- a/content/sensu-go/5.21/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Read about how to maintain and troubleshoot your Sensu installatio
 product: "Sensu Go"
 version: "5.21"
 weight: 30
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     parent: operations

--- a/content/sensu-go/5.21/operations/manage-secrets/_index.md
+++ b/content/sensu-go/5.21/operations/manage-secrets/_index.md
@@ -4,7 +4,8 @@ description: "Sensu's secrets management allows you to avoid exposing secrets li
 product: "Sensu Go"
 version: "5.21"
 weight: 50
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     parent: operations

--- a/content/sensu-go/5.21/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/5.21/operations/monitor-sensu/_index.md
@@ -4,7 +4,8 @@ description: "Log Sensu services and maintain visibility into your monitoring wo
 product: "Sensu Go"
 version: "5.21"
 weight: 40
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     parent: operations

--- a/content/sensu-go/5.21/reference/_index.md
+++ b/content/sensu-go/5.21/reference/_index.md
@@ -4,7 +4,8 @@ description: "Read the reference documentation for information about Sensu resou
 product: "Sensu Go"
 version: "5.21"
 weight: 100
-layout: "base-for-directory-listing"
+layout: "single"
+toc: false
 menu:
   sensu-go-5.21:
     identifier: reference


### PR DESCRIPTION
## Description
Specifies "single" layout for all index pages throughout the Sensu Go documentation.

## Motivation and Context
This change will make sure all of our pages include the new Contribute sidebar item (https://github.com/sensu/sensu-docs/pull/2613)