### PR TITLE
Fix link in 5.21 Learn in 15 scenario

### DIFF
--- a/content/sensu-go/5.21/learn/learn-in-15.md
+++ b/content/sensu-go/5.21/learn/learn-in-15.md
@@ -27,6 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-[**<-- Back to Learn Sensu with interactive training**][1]
-
-[1]: ../interactive-tutorials/
+<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>


### PR DESCRIPTION
Link to https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/ in https://docs.sensu.io/sensu-go/latest/learn/learn-in-15/ was broken (needs to be html rather than markdown).