### PR TITLE
Add improved sensuctl asset add response with help usage

### DIFF
--- a/content/sensu-go/6.0/guides/contact-routing.md
+++ b/content/sensu-go/6.0/guides/contact-routing.md
@@ -50,6 +50,12 @@ To add the has-contact asset to Sensu, use [`sensuctl asset add`][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.2.0 -r contact-filter
+fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.2.0
+added asset: sensu/sensu-go-has-contact-filter:0.2.0
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["contact-filter"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `contact-filter`.
@@ -125,6 +131,12 @@ If you haven't already, add the [Slack handler asset][8] to Sensu with sensuctl:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
+added asset: sensu/sensu-slack-handler:1.0.3
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `sensu-slack-handler`.

--- a/content/sensu-go/6.0/guides/email-handler.md
+++ b/content/sensu-go/6.0/guides/email-handler.md
@@ -31,6 +31,13 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] a
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler -r email-handler
+no version specified, using latest: 0.6.0
+fetching bonsai asset: sensu/sensu-email-handler:0.6.0
+added asset: sensu/sensu-email-handler:0.6.0
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["email-handler"].
 {{< /code >}}
 
 The -r (rename) flag allows you to specify a shorter name for the asset (in this case, `email-handler`).

--- a/content/sensu-go/6.0/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/6.0/guides/influx-db-metric-handler.md
@@ -26,7 +26,7 @@ This example uses the [Sensu InfluxDB Handler][13] asset to power an `influx-db`
 Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] asset:
 
 {{< code shell >}}
-sensuctl asset add sensu/sensu-influxdb-handler:3.1.2
+sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
 added asset: sensu/sensu-influxdb-handler:3.1.2
 

--- a/content/sensu-go/6.0/guides/influx-db-metric-handler.md
+++ b/content/sensu-go/6.0/guides/influx-db-metric-handler.md
@@ -26,7 +26,13 @@ This example uses the [Sensu InfluxDB Handler][13] asset to power an `influx-db`
 Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] asset:
 
 {{< code shell >}}
-sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
+sensuctl asset add sensu/sensu-influxdb-handler:3.1.2
+fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
+added asset: sensu/sensu-influxdb-handler:3.1.2
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["influxdb-handler"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `influxdb-handler`.

--- a/content/sensu-go/6.0/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/6.0/guides/install-check-executables-with-assets.md
@@ -22,6 +22,12 @@ To add the [Sensu PagerDuty Handler asset][7] to Sensu, use [`sensuctl asset add
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler
+fetching bonsai asset: sensu/sensu-pagerduty-handler:1.2.0
+added asset: sensu/sensu-pagerduty-handler:1.2.0
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["pagerduty-handler"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.

--- a/content/sensu-go/6.0/guides/monitor-external-resources.md
+++ b/content/sensu-go/6.0/guides/monitor-external-resources.md
@@ -31,6 +31,12 @@ Use [`sensuctl asset add`][21] to register the `sensu-plugins-http` asset:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
+fetching bonsai asset: sensu-plugins/sensu-plugins-http:5.1.1
+added asset: sensu-plugins/sensu-plugins-http:5.1.1
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["sensu-plugins-http"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `sensu-plugins-http`.
@@ -41,6 +47,12 @@ Then, use the following sensuctl example to register the `sensu-ruby-runtime` as
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
+added asset: sensu/sensu-ruby-runtime:0.0.10
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 {{< /code >}}
 
 You can also download the asset definition from [Bonsai][17] and register the asset using `sensuctl create --file filename.yml`. 

--- a/content/sensu-go/6.0/guides/monitor-server-resources.md
+++ b/content/sensu-go/6.0/guides/monitor-server-resources.md
@@ -27,6 +27,12 @@ Use [`sensuctl asset add`][9] to register the `sensu-plugins-cpu-checks` asset:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
+fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
+added asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["cpu-checks-plugins"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `cpu-checks-plugins`.
@@ -37,6 +43,12 @@ Then, use the following sensuctl example to register the `sensu-ruby-runtime` as
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
+added asset: sensu/sensu-ruby-runtime:0.0.10
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 {{< /code >}}
 
 You can also download the asset definition from [Bonsai][7] and register the asset using `sensuctl create --file filename.yml`.

--- a/content/sensu-go/6.0/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.0/guides/reduce-alert-fatigue.md
@@ -64,6 +64,12 @@ Use [`sensuctl asset add`][5] to register the [fatigue check filter][9] asset:
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
+fetching bonsai asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
+added asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["fatigue-filter"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `fatigue-filter`.

--- a/content/sensu-go/6.0/guides/send-slack-alerts.md
+++ b/content/sensu-go/6.0/guides/send-slack-alerts.md
@@ -26,6 +26,12 @@ Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
+added asset: sensu/sensu-slack-handler:1.0.3
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 {{< /code >}}
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `sensu-slack-handler`.

--- a/content/sensu-go/6.0/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.0/sensuctl/sensuctl-bonsai.md
@@ -27,15 +27,22 @@ Replace `[NAMESPACE/NAME]` with the namespace and name of the asset from Bonsai:
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.1
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.1
 added asset: sensu/sensu-influxdb-handler:3.1.1
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["sensu/sensu-influxdb-handler"].
 {{< /code >}}
 
 You can also use the `--rename` flag to rename the asset on install:
 
 {{< code shell >}}
-sensuctl asset add sensu/sensu-slack-handler --rename slack-handler
-no version specified, using latest: 1.0.3
-fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
-added asset: sensu/sensu-slack-handler:1.0.3
+sensuctl asset add sensu/sensu-influxdb-handler:3.1.1 --rename influxdb-handler
+fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.1
+added asset: sensu/sensu-influxdb-handler:3.1.1
+
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with ["influxdb-handler"].
 {{< /code >}}
 
 {{% notice note %}}


### PR DESCRIPTION
## Description
Adds improved response for `sensuctl asset add` with help usage through the docs:
- https://docs.sensu.io/sensu-go/latest/sensuctl/sensuctl-bonsai/
- https://docs.sensu.io/sensu-go/latest/guides/monitor-server-resources/
- https://docs.sensu.io/sensu-go/latest/guides/monitor-external-resources/
- https://docs.sensu.io/sensu-go/latest/guides/influx-db-metric-handler/
- https://docs.sensu.io/sensu-go/latest/guides/send-slack-alerts/
- https://docs.sensu.io/sensu-go/latest/guides/email-handler/
- https://docs.sensu.io/sensu-go/latest/guides/install-check-executables-with-assets/
- https://docs.sensu.io/sensu-go/latest/guides/reduce-alert-fatigue/
- https://docs.sensu.io/sensu-go/latest/guides/contact-routing/

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2599