### PR TITLE
Fix edit this page link in new contribute section so it works for latest version

### DIFF
--- a/layouts/partials/contribute.html
+++ b/layouts/partials/contribute.html
@@ -3,7 +3,7 @@
     <h4>Contribute:</h4>
     <ul>
       <li>
-        <a href="https://github.com/sensu/sensu-docs/edit/master/content/{{ .Page.File.Path | urlize }}" target="_blank">
+        <a href="{{.Site.Params.repo_url}}/edit/master/content/{{replace .File.Path "latest" .Site.Params.products.sensu_go.latest}}" target="_blank">
           <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
           Edit this page
         </a>


### PR DESCRIPTION
## Description
Replace Edit this page link in new contribute item with:
`{{.Site.Params.repo_url}}/edit/master/content/{{replace .File.Path "latest" .Site.Params.products.sensu_go.latest}}`

## Motivation and Context
Link didn't work for `latest` docs in new contribute item.