### PR TITLE
Add is_silenced to event examples and spec

### DIFF
--- a/content/sensu-go/6.0/api/events.md
+++ b/content/sensu-go/6.0/api/events.md
@@ -59,6 +59,7 @@ HTTP/1.1 200 OK
       ],
       "high_flap_threshold": 0,
       "interval": 20,
+      "is_silenced": true,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [],
@@ -72,6 +73,9 @@ HTTP/1.1 200 OK
       "timeout": 0,
       "duration": 0.010849143,
       "output": "",
+      "silenced": [
+        "entity:gin:check-nginx"
+      ],
       "state": "failing",
       "status": 1,
       "total_state_change": 0,
@@ -136,6 +140,7 @@ output         | {{< code shell >}}
       ],
       "high_flap_threshold": 0,
       "interval": 20,
+      "is_silenced": true,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [],
@@ -149,6 +154,9 @@ output         | {{< code shell >}}
       "timeout": 0,
       "duration": 0.010849143,
       "output": "",
+      "silenced": [
+        "entity:gin:check-nginx"
+      ],
       "state": "failing",
       "status": 1,
       "total_state_change": 0,
@@ -193,10 +201,14 @@ curl -X POST \
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "state": "failing",
     "status": 2,
     "handlers": ["slack"],
     "interval": 60,
+    "is_silenced": true,
     "metadata": {
       "name": "server-health"
     }
@@ -225,10 +237,14 @@ payload         | {{< code shell >}}
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "state": "failing",
     "status": 2,
     "handlers": ["slack"],
     "interval": 60,
+    "is_silenced": true,
     "metadata": {
       "name": "server-health"
     }
@@ -285,6 +301,9 @@ HTTP/1.1 200 OK
       ],
       "issued": 1543871496,
       "output": "CPU OK - Usage:.50\n",
+      "silenced": [
+        "entity:gin:check-cpu"
+      ],
       "state": "passing",
       "status": 0,
       "total_state_change": 0,
@@ -334,6 +353,9 @@ HTTP/1.1 200 OK
       ],
       "issued": 1543871524,
       "output": "",
+      "silenced": [
+        "entity:gin:keepalive"
+      ],
       "state": "passing",
       "status": 0,
       "total_state_change": 0,
@@ -395,6 +417,9 @@ output               | {{< code json >}}
       ],
       "issued": 1543871524,
       "output": "",
+      "silenced": [
+        "entity:gin:keepalive"
+      ],
       "state": "passing",
       "status": 0,
       "total_state_change": 0,
@@ -453,6 +478,7 @@ HTTP/1.1 200 OK
         ],
         "high_flap_threshold": 0,
         "interval": 60,
+        "is_silenced": true,
         "low_flap_threshold": 0,
         "publish": false,
         "runtime_assets": null,
@@ -481,6 +507,9 @@ HTTP/1.1 200 OK
         ],
         "issued": 0,
         "output": "Server error",
+        "silenced": [
+          "entity:gin:server-health"
+        ],
         "state": "failing",
         "status": 1,
         "total_state_change": 0,
@@ -538,6 +567,7 @@ output               | {{< code json >}}
         ],
         "high_flap_threshold": 0,
         "interval": 60,
+        "is_silenced": true,
         "low_flap_threshold": 0,
         "publish": false,
         "runtime_assets": null,
@@ -566,6 +596,9 @@ output               | {{< code json >}}
         ],
         "issued": 0,
         "output": "Server error",
+        "silenced": [
+          "entity:gin:server-health"
+        ],
         "state": "failing",
         "status": 1,
         "total_state_change": 0,
@@ -608,9 +641,13 @@ curl -X POST \
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "status": 1,
     "handlers": ["slack"],
     "interval": 60,
+    "is_silenced": true,
     "metadata": {
       "name": "server-health"
     }
@@ -658,9 +695,13 @@ payload         | {{< code shell >}}
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "status": 1,
     "handlers": ["slack"],
     "interval": 60,
+    "is_silenced": true,
     "metadata": {
       "name": "server-health"
     }
@@ -692,9 +733,13 @@ curl -X PUT \
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "status": 1,
     "handlers": ["slack"],
     "interval": 60,
+    "is_silenced": true,
     "metadata": {
       "name": "server-health"
     }
@@ -742,9 +787,13 @@ payload         | {{< code shell >}}
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "status": 1,
     "handlers": ["slack"],
     "interval": 60,
+    "is_silenced": true,
     "metadata": {
       "name": "server-health"
     }
@@ -808,6 +857,9 @@ curl -X PUT \
   },
   "check": {
     "output": "Server error",
+    "silenced": [
+      "entity:gin:server-health"
+    ],
     "status": 1,
     "handlers": ["slack"],
     "interval": 60,

--- a/content/sensu-go/6.0/reference/events.md
+++ b/content/sensu-go/6.0/reference/events.md
@@ -223,6 +223,7 @@ example      | {{< code shell >}}
       }
     ],
     "interval": 10,
+    "is_silenced": true,
     "issued": 1552506033,
     "last_ok": 1552506033,
     "low_flap_threshold": 0,
@@ -451,6 +452,7 @@ example      | {{< code shell >}}
     }
   ],
   "interval": 10,
+  "is_silenced": true,
   "issued": 1552506033,
   "last_ok": 1552506033,
   "low_flap_threshold": 0,
@@ -577,6 +579,13 @@ description  | For incident and resolution events, the number of preceding event
 required     | false
 type         | Integer greater than 0
 example      | {{< code shell >}}"occurrences_watermark": 1{{< /code >}}
+
+is_silenced  | |
+-------------|------
+description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event.Check will also list the silenced entries that match the event in the `silenced` array.
+required     | false
+type         | Boolean
+example      | {{< code shell >}}"is_silenced": "true"{{< /code >}}
 
 silenced     | |
 -------------|------
@@ -739,6 +748,7 @@ spec:
     - executed: 1552594757
       status: 0
     interval: 60
+    is_silenced: true
     issued: 1552594757
     last_ok: 1552594758
     low_flap_threshold: 0
@@ -749,6 +759,8 @@ spec:
     occurrences_watermark: 1
     output: |
       CPU OK - Usage:3.96
+    silenced:
+      entity:gin:server-health
     output_metric_format: ""
     output_metric_handlers: []
     proxy_entity_name: ""
@@ -837,6 +849,7 @@ spec:
         }
       ],
       "interval": 60,
+      "is_silenced": true,
       "issued": 1552594757,
       "last_ok": 1552594758,
       "low_flap_threshold": 0,
@@ -847,6 +860,9 @@ spec:
       "occurrences": 1,
       "occurrences_watermark": 1,
       "output": "CPU OK - Usage:3.96\n",
+      "silenced": [
+        "entity:gin:scheck-cpu"
+      ],
       "output_metric_format": "",
       "output_metric_handlers": [],
       "proxy_entity_name": "",
@@ -958,6 +974,7 @@ spec:
     - executed: 1552505843
       status: 0
     interval: 10
+    is_silenced: false
     issued: 1552506033
     last_ok: 1552506033
     low_flap_threshold: 0
@@ -1068,6 +1085,7 @@ spec:
         }
       ],
       "interval": 10,
+      "is_silenced": false,
       "issued": 1552506033,
       "last_ok": 1552506033,
       "low_flap_threshold": 0,

--- a/content/sensu-go/6.0/reference/events.md
+++ b/content/sensu-go/6.0/reference/events.md
@@ -582,7 +582,7 @@ example      | {{< code shell >}}"occurrences_watermark": 1{{< /code >}}
 
 is_silenced  | |
 -------------|------
-description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event.Check will also list the silenced entries that match the event in the `silenced` array.
+description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event.Check definition will also list the silenced entries that match the event in the `silenced` array.
 required     | false
 type         | Boolean
 example      | {{< code shell >}}"is_silenced": "true"{{< /code >}}


### PR DESCRIPTION
## Description
- Adds `is_silenced` to examples in event API doc
- Adds `is_silenced` to examples and check attribute table in event reference doc

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2634
