### PR TITLE
Add warning about configuring only one OIDC authentication provider

### DIFF
--- a/content/sensu-go/5.18/operations/control-access/auth.md
+++ b/content/sensu-go/5.18/operations/control-access/auth.md
@@ -1092,6 +1092,11 @@ Sensu offers [commercial support][6] for the OIDC provider for using the OpenID 
 
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
+{{% notice warning %}}
+**WARNING**: For proper OIDC authentication behavior, configure only **one** OIDC provider.
+Configuring more than one OIDC provider can result in undefined behavior.
+{{% /notice %}}
+
 ### OIDC configuration examples
 
 {{< language-toggle >}}

--- a/content/sensu-go/5.19/operations/control-access/auth.md
+++ b/content/sensu-go/5.19/operations/control-access/auth.md
@@ -1092,6 +1092,11 @@ Sensu offers [commercial support][6] for the OIDC provider for using the OpenID 
 
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
+{{% notice warning %}}
+**WARNING**: For proper OIDC authentication behavior, configure only **one** OIDC provider.
+Configuring more than one OIDC provider can result in undefined behavior.
+{{% /notice %}}
+
 ### OIDC configuration examples
 
 {{< language-toggle >}}

--- a/content/sensu-go/5.20/operations/control-access/auth.md
+++ b/content/sensu-go/5.20/operations/control-access/auth.md
@@ -1092,6 +1092,11 @@ Sensu offers [commercial support][6] for the OIDC provider for using the OpenID 
 
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
+{{% notice warning %}}
+**WARNING**: For proper OIDC authentication behavior, configure only **one** OIDC provider.
+Configuring more than one OIDC provider can result in undefined behavior.
+{{% /notice %}}
+
 ### OIDC configuration examples
 
 {{< language-toggle >}}

--- a/content/sensu-go/5.21/operations/control-access/auth.md
+++ b/content/sensu-go/5.21/operations/control-access/auth.md
@@ -1092,6 +1092,11 @@ Sensu offers [commercial support][6] for the OIDC provider for using the OpenID 
 
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
+{{% notice warning %}}
+**WARNING**: For proper OIDC authentication behavior, configure only **one** OIDC provider.
+Configuring more than one OIDC provider can result in undefined behavior.
+{{% /notice %}}
+
 ### OIDC configuration examples
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.0/operations/control-access/auth.md
+++ b/content/sensu-go/6.0/operations/control-access/auth.md
@@ -1142,6 +1142,11 @@ Sensu offers [commercial support][6] for the OIDC provider for using the OpenID 
 
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
+{{% notice warning %}}
+**WARNING**: For proper OIDC authentication behavior, configure only **one** OIDC provider.
+Configuring more than one OIDC provider can result in undefined behavior.
+{{% /notice %}}
+
 ### OIDC configuration examples
 
 {{< language-toggle >}}


### PR DESCRIPTION
## Description
Adds a warning about undefined behavior due to configuring more than one OIDC auth provider in https://docs.sensu.io/sensu-go/6.0/operations/control-access/auth/#openid-connect-10-protocol-oidc-authentication

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2644