### PR TITLE
Fix link to OIDC spec attributes

### DIFF
--- a/content/sensu-go/5.18/operations/control-access/auth.md
+++ b/content/sensu-go/5.18/operations/control-access/auth.md
@@ -1172,7 +1172,7 @@ example      | {{< code shell >}}"metadata": {
 
 spec         | 
 -------------|------
-description  | Top-level map that includes the OIDC [spec attributes][39]
+description  | Top-level map that includes the OIDC [spec attributes][25].
 required     | true
 type         | Map of key-value pairs
 example      | {{< code shell >}}"spec": {

--- a/content/sensu-go/5.19/operations/control-access/auth.md
+++ b/content/sensu-go/5.19/operations/control-access/auth.md
@@ -1172,7 +1172,7 @@ example      | {{< code shell >}}"metadata": {
 
 spec         | 
 -------------|------
-description  | Top-level map that includes the OIDC [spec attributes][39]
+description  | Top-level map that includes the OIDC [spec attributes][25].
 required     | true
 type         | Map of key-value pairs
 example      | {{< code shell >}}"spec": {

--- a/content/sensu-go/5.20/operations/control-access/auth.md
+++ b/content/sensu-go/5.20/operations/control-access/auth.md
@@ -1172,7 +1172,7 @@ example      | {{< code shell >}}"metadata": {
 
 spec         | 
 -------------|------
-description  | Top-level map that includes the OIDC [spec attributes][39]
+description  | Top-level map that includes the OIDC [spec attributes][25].
 required     | true
 type         | Map of key-value pairs
 example      | {{< code shell >}}"spec": {

--- a/content/sensu-go/5.21/operations/control-access/auth.md
+++ b/content/sensu-go/5.21/operations/control-access/auth.md
@@ -1172,7 +1172,7 @@ example      | {{< code shell >}}"metadata": {
 
 spec         | 
 -------------|------
-description  | Top-level map that includes the OIDC [spec attributes][39]
+description  | Top-level map that includes the OIDC [spec attributes][25].
 required     | true
 type         | Map of key-value pairs
 example      | {{< code shell >}}"spec": {

--- a/content/sensu-go/6.0/operations/control-access/auth.md
+++ b/content/sensu-go/6.0/operations/control-access/auth.md
@@ -1222,7 +1222,7 @@ example      | {{< code shell >}}"metadata": {
 
 spec         | 
 -------------|------
-description  | Top-level map that includes the OIDC [spec attributes][39]
+description  | Top-level map that includes the OIDC [spec attributes][25].
 required     | true
 type         | Map of key-value pairs
 example      | {{< code shell >}}"spec": {


### PR DESCRIPTION
## Description
Fixes link in `spec` description in https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#oidc-top-level-attributes to direct to https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#oidc-spec-attributes instead of https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#ldap-spec-attributes

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2648
