### PR TITLE
Change shortcode to important for backup note for 6.0 upgrade

### DIFF
--- a/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
@@ -13,7 +13,7 @@ menu:
 
 ## Upgrade to Sensu Go 6.0 from a 5.x deployment
 
-{{% notice warning %}}
+{{% notice important %}}
 **IMPORTANT**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/create-manage-resources/#export-resources) to create a backup of your existing installation.
 You will not be able to downgrade to a Sensu 5.x version after you upgrade your database to Sensu 6.0 in step 3 of this process.
 {{% /notice %}}


### PR DESCRIPTION
Change "warning" to "important" to get the correct shortcode formatting for the backup note at the top of the 6.0 upgrade section.