### PR TITLE
Add line break in CentOS/RHEL headings to prevent awkward break

### DIFF
--- a/content/sensu-go/6.0/platforms.md
+++ b/content/sensu-go/6.0/platforms.md
@@ -26,7 +26,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu agent
 
-|  | CentOS/RHEL<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | CentOS/<br>RHEL<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -37,7 +37,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensuctl command line tool
 
-|  | CentOS/RHEL<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | CentOS/<br>RHEL<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |


### PR DESCRIPTION
Adds a forced line break `CentOS/<br>RHEL` in the agent and sensuctl package table headings to remove the awkward unforced line break