### PR TITLE
Add notes and handlers attribute in agent /events API example

### DIFF
--- a/content/sensu-go/5.18/reference/agent.md
+++ b/content/sensu-go/5.18/reference/agent.md
@@ -87,6 +87,13 @@ The following example submits an HTTP POST request to the `/events` API.
 The request creates event for a check named `check-mysql-status` with the output `could not connect to mysql` and a status of `1` (warning).
 The agent responds with an HTTP `202 Accepted` response to indicate that the event has been added to the queue to be sent to the backend.
 
+The event will be handled according to an `email` handler definition.
+
+{{% notice note %}}
+**NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
+When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 {{< code shell >}}
 curl -X POST \
 -H 'Content-Type: application/json' \
@@ -95,6 +102,7 @@ curl -X POST \
     "metadata": {
       "name": "check-mysql-status"
     },
+    "handlers": ["email"],
     "status": 1,
     "output": "could not connect to mysql"
   }

--- a/content/sensu-go/5.18/reference/checks.md
+++ b/content/sensu-go/5.18/reference/checks.md
@@ -558,6 +558,11 @@ example      | {{< code shell >}}"annotations": {
 
 ### Spec attributes
 
+{{% notice note %}}
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
+When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 |command     |      |
 -------------|------
 description  | Check command to be executed.

--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -87,6 +87,13 @@ The following example submits an HTTP POST request to the `/events` API.
 The request creates event for a check named `check-mysql-status` with the output `could not connect to mysql` and a status of `1` (warning).
 The agent responds with an HTTP `202 Accepted` response to indicate that the event has been added to the queue to be sent to the backend.
 
+The event will be handled according to an `email` handler definition.
+
+{{% notice note %}}
+**NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
+When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 {{< code shell >}}
 curl -X POST \
 -H 'Content-Type: application/json' \
@@ -95,6 +102,7 @@ curl -X POST \
     "metadata": {
       "name": "check-mysql-status"
     },
+    "handlers": ["email"],
     "status": 1,
     "output": "could not connect to mysql"
   }

--- a/content/sensu-go/5.19/reference/checks.md
+++ b/content/sensu-go/5.19/reference/checks.md
@@ -570,6 +570,11 @@ example      | {{< code shell >}}"annotations": {
 
 ### Spec attributes
 
+{{% notice note %}}
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
+When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 |command     |      |
 -------------|------
 description  | Check command to be executed.

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -87,6 +87,13 @@ The following example submits an HTTP POST request to the `/events` API.
 The request creates event for a check named `check-mysql-status` with the output `could not connect to mysql` and a status of `1` (warning).
 The agent responds with an HTTP `202 Accepted` response to indicate that the event has been added to the queue to be sent to the backend.
 
+The event will be handled according to an `email` handler definition.
+
+{{% notice note %}}
+**NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
+When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 {{< code shell >}}
 curl -X POST \
 -H 'Content-Type: application/json' \
@@ -95,6 +102,7 @@ curl -X POST \
     "metadata": {
       "name": "check-mysql-status"
     },
+    "handlers": ["email"],
     "status": 1,
     "output": "could not connect to mysql"
   }

--- a/content/sensu-go/5.20/reference/checks.md
+++ b/content/sensu-go/5.20/reference/checks.md
@@ -570,6 +570,11 @@ example      | {{< code shell >}}"annotations": {
 
 ### Spec attributes
 
+{{% notice note %}}
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
+When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 |command     |      |
 -------------|------
 description  | Check command to be executed.

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -91,7 +91,7 @@ The event will be handled according to an `email` handler definition.
 
 {{% notice note %}}
 **NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
-In that case, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) instead, and there is no `spec` object in the check definition.
+When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) instead, and there is no `spec` object in the check definition.
 {{% /notice %}} 
 
 {{< code shell >}}

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -87,6 +87,13 @@ The following example submits an HTTP POST request to the `/events` API.
 The request creates event for a check named `check-mysql-status` with the output `could not connect to mysql` and a status of `1` (warning).
 The agent responds with an HTTP `202 Accepted` response to indicate that the event has been added to the queue to be sent to the backend.
 
+The event will be handled according to an `email` handler definition.
+
+{{% notice note %}}
+**NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
+In that case, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) instead, and there is no `spec` object in the check definition.
+{{% /notice %}} 
+
 {{< code shell >}}
 curl -X POST \
 -H 'Content-Type: application/json' \
@@ -95,6 +102,7 @@ curl -X POST \
     "metadata": {
       "name": "check-mysql-status"
     },
+    "handlers": ["email"],
     "status": 1,
     "output": "could not connect to mysql"
   }

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -92,7 +92,7 @@ The event will be handled according to an `email` handler definition.
 {{% notice note %}}
 **NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
 When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) in the check definition instead.
-{{% /notice %}} 
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -91,7 +91,7 @@ The event will be handled according to an `email` handler definition.
 
 {{% notice note %}}
 **NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
-When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) instead, and there is no `spec` object in the check definition.
+When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) in the check definition instead.
 {{% /notice %}} 
 
 {{< code shell >}}

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -570,6 +570,11 @@ example      | {{< code shell >}}"annotations": {
 
 ### Spec attributes
 
+{{% notice note %}}
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
+In that case, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) instead, and there is no `spec` object in the check definition.
+{{% /notice %}}
+
 |command     |      |
 -------------|------
 description  | Check command to be executed.

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -572,7 +572,7 @@ example      | {{< code shell >}}"annotations": {
 
 {{% notice note %}}
 **NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
-In that case, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) instead, and there is no `spec` object in the check definition.
+When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) instead, and there is no `spec` object in the check definition.
 {{% /notice %}}
 
 |command     |      |

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -572,7 +572,7 @@ example      | {{< code shell >}}"annotations": {
 
 {{% notice note %}}
 **NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
-When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) instead, and there is no `spec` object in the check definition.
+When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 
 |command     |      |

--- a/content/sensu-go/6.0/reference/agent.md
+++ b/content/sensu-go/6.0/reference/agent.md
@@ -87,6 +87,13 @@ The following example submits an HTTP POST request to the `/events` API.
 The request creates event for a check named `check-mysql-status` with the output `could not connect to mysql` and a status of `1` (warning).
 The agent responds with an HTTP `202 Accepted` response to indicate that the event has been added to the queue to be sent to the backend.
 
+The event will be handled according to an `email` handler definition.
+
+{{% notice note %}}
+**NOTE**: For HTTP `POST` requests to the agent /events API, check [spec attributes](../checks/#spec-attributes) are not required.
+When doing so, the spec attributes (including `handlers`) are listed as individual [top-level attributes](../checks/#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 {{< code shell >}}
 curl -X POST \
 -H 'Content-Type: application/json' \
@@ -95,6 +102,7 @@ curl -X POST \
     "metadata": {
       "name": "check-mysql-status"
     },
+    "handlers": ["email"],
     "status": 1,
     "output": "could not connect to mysql"
   }

--- a/content/sensu-go/6.0/reference/checks.md
+++ b/content/sensu-go/6.0/reference/checks.md
@@ -570,6 +570,11 @@ example      | {{< code shell >}}"annotations": {
 
 ### Spec attributes
 
+{{% notice note %}}
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../api/events/#create-a-new-event) /events API.
+When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
+{{% /notice %}}
+
 |command     |      |
 -------------|------
 description  | Check command to be executed.


### PR DESCRIPTION
## Description
- Adds note in https://docs.sensu.io/sensu-go/latest/reference/checks/#spec-attributes and https://docs.sensu.io/sensu-go/latest/reference/agent/#events-post-example to explain how agent and backend POST /events requests do not include spec attributes (i.e. lists them as top-level attributes instead)
- Adds `handlers` attribute to https://docs.sensu.io/sensu-go/latest/reference/agent/#events-post-example example to demonstrate position of would-be spec attributes in this case

When correct, I'll propagate to all docs versions.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2655
