### PR TITLE
Fix Authorization: KEY to Authorization: Key in API keys api doc

### DIFF
--- a/content/sensu-go/5.20/api/apikeys.md
+++ b/content/sensu-go/5.20/api/apikeys.md
@@ -24,7 +24,7 @@ The following example demonstrates a request to the `/apikeys` API endpoint, res
 {{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/apikeys \
--H "Authorization: KEY $SENSU_API_KEY"
+-H "Authorization: Key $SENSU_API_KEY"
 
 HTTP/1.1 200 OK
 

--- a/content/sensu-go/5.21/api/apikeys.md
+++ b/content/sensu-go/5.21/api/apikeys.md
@@ -24,7 +24,7 @@ The following example demonstrates a request to the `/apikeys` API endpoint, res
 {{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/apikeys \
--H "Authorization: KEY $SENSU_API_KEY"
+-H "Authorization: Key $SENSU_API_KEY"
 
 HTTP/1.1 200 OK
 

--- a/content/sensu-go/6.0/api/apikeys.md
+++ b/content/sensu-go/6.0/api/apikeys.md
@@ -24,7 +24,7 @@ The following example demonstrates a request to the `/apikeys` API endpoint, res
 {{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/core/v2/apikeys \
--H "Authorization: KEY $SENSU_API_KEY"
+-H "Authorization: Key $SENSU_API_KEY"
 
 HTTP/1.1 200 OK
 


### PR DESCRIPTION
## Description
In API doc for API keys, fixes `Authorization: KEY` to `Authorization: Key` so that the curl example will work.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2663
