### PR TITLE
update the entities reference documentation

### DIFF
--- a/content/sensu-go/6.0/reference/entities.md
+++ b/content/sensu-go/6.0/reference/entities.md
@@ -73,7 +73,7 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 When an agent connects to a backend, the agent entity definition is created from the information in the `agent.yml` configuration file.
 The default `agent.yml` file location [depends on your operating system][35].
 
-You can manage agent entities via the backend with [sensuctl][32], the [entities API][31], and the [web UI][33].
+You can manage a subset of agent entity attributes via the backend with [sensuctl][32], the [entities API][31], and the [web UI][33]. The [entity metadata attributes][8] that can be centrally manage include: `labels` and `annotations`. The [entity spec attributes][13] that can be centrally managed include: `deregister`, `deregistration`, `redact`, `subscriptions`, and `keepalive_handlers`. When these attributes are updated via sensuctl, the entiteies API, or the web UI, the updated values will override the values present in the `agent.yml` file  
 
 If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
 
@@ -88,6 +88,7 @@ When it restarts, it will revert to the original configuration from `agent.yml`
 You must set `deregister: true` in `agent.yml` before the agent entity is created.
 
 If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
+
 
 ## Create and manage proxy entities
 
@@ -392,6 +393,8 @@ example      | {{< code shell >}}"created_by": "admin"{{< /code >}}
 | labels     |      |
 -------------|------
 description  | Custom attributes to include with event data that you can use for response and web UI view filtering.<br><br>If you include labels in your event data, you can filter [API responses][14], [sensuctl responses][15], and [web UI views][23] based on them. In other words, labels allow you to create meaningful groupings for your data.<br><br>Limit labels to metadata you need to use for response filtering. For complex, non-identifying metadata that you will *not* need to use in response filtering, use annotations rather than labels.
+**Note**: agent entity `labels` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
 required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
@@ -405,6 +408,8 @@ example      | {{< code shell >}}"labels": {
 | annotations |     |
 -------------|------
 description  | Non-identifying metadata to include with event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].
+**Note**: agent entity `annotations` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
@@ -425,6 +430,8 @@ example      | {{< code shell >}}"entity_class": "agent"{{< /code >}}
 subscriptions| 
 -------------|------ 
 description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
+**Note**: agent entity `subscriptions` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.
@@ -561,9 +568,21 @@ required     | false
 type         | Integer 
 example      | {{< code shell >}}"last_seen": 1522798317 {{< /code >}}
 
+keepalive_handlers   | 
+-------------|------ 
+description  | List of handler names to use for keepalive events issued by agent entities. If keepalive handlers are not specified, the Sensu backend will use the default keepalive handler and create an event in sensuctl and the Sensu web UI.
+**Note**: agent entity `keepalive_handlers` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+required     | false 
+type         | Array 
+default      | `keepalive`
+example      | {{< code shell >}}"keepalive_handlers": ["keeplive", "keepalive-aws"]{{< /code >}}
+
 deregister   | 
 -------------|------ 
 description  | `true` if the entity should be removed when it stops sending keepalive messages. Otherwise, `false`.
+**Note**: agent entity `deregister` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
 required     | false 
 type         | Boolean 
 default      | `false`
@@ -572,6 +591,8 @@ example      | {{< code shell >}}"deregister": false {{< /code >}}
 deregistration  | 
 -------------|------ 
 description  | Map that contains a handler name to use when an entity is deregistered. See [deregistration attributes][2] for more information.
+**Note**: agent entity `deregistration` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -593,6 +614,8 @@ deregistration:
 redact       | 
 -------------|------ 
 description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
+**Note**: agent entity `redact` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
+The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
 required     | false 
 type         | Array 
 default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]

--- a/content/sensu-go/6.0/reference/entities.md
+++ b/content/sensu-go/6.0/reference/entities.md
@@ -73,7 +73,13 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 When an agent connects to a backend, the agent entity definition is created from the information in the `agent.yml` configuration file.
 The default `agent.yml` file location [depends on your operating system][35].
 
-You can manage a subset of agent entity attributes via the backend with [sensuctl][32], the [entities API][31], and the [web UI][33]. The [entity metadata attributes][8] that can be centrally manage include: `labels` and `annotations`. The [entity spec attributes][13] that can be centrally managed include: `deregister`, `deregistration`, `redact`, `subscriptions`, and `keepalive_handlers`. When these attributes are updated via sensuctl, the entiteies API, or the web UI, the updated values will override the values present in the `agent.yml` file  
+You can centrally manage a subset of agent entity attributes via the backend with [sensuctl][32], the [entities API][31], and the [web UI][33].
+Specifically, these are the agent entity attributes you can centrally manage:
+
+- [Metadata attributes][8]: `labels` and `annotations`
+- [Spec attributes][13]: `deregister`, `deregistration`, `redact`, `subscriptions`, and `keepalive_handlers`
+
+When you update these attributes via sensuctl, the entities API, or the web UI, the updated values will override the values present in the `agent.yml` file.
 
 If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
 
@@ -88,7 +94,6 @@ When it restarts, it will revert to the original configuration from `agent.yml`
 You must set `deregister: true` in `agent.yml` before the agent entity is created.
 
 If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
-
 
 ## Create and manage proxy entities
 
@@ -348,6 +353,10 @@ example      | {{< code shell >}}
     "subscriptions": [
       "entity:webserver01"
     ],
+    "keepalive_handlers": [
+      "keepalive",
+      "keepalive-aws"
+    ],
     "last_seen": 1542667231,
     "deregister": false,
     "deregistration": {},
@@ -392,9 +401,10 @@ example      | {{< code shell >}}"created_by": "admin"{{< /code >}}
 
 | labels     |      |
 -------------|------
-description  | Custom attributes to include with event data that you can use for response and web UI view filtering.<br><br>If you include labels in your event data, you can filter [API responses][14], [sensuctl responses][15], and [web UI views][23] based on them. In other words, labels allow you to create meaningful groupings for your data.<br><br>Limit labels to metadata you need to use for response filtering. For complex, non-identifying metadata that you will *not* need to use in response filtering, use annotations rather than labels.
-**Note**: agent entity `labels` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | Custom attributes to include with event data that you can use for response and web UI view filtering.<br><br>If you include labels in your event data, you can filter [API responses][14], [sensuctl responses][15], and [web UI views][23] based on them. In other words, labels allow you to create meaningful groupings for your data.<br><br>Limit labels to metadata you need to use for response filtering. For complex, non-identifying metadata that you will *not* need to use in response filtering, use annotations rather than labels. {{% notice note %}}
+**NOTE**: You can centrally manage agent entity `labels` via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `labels` values in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}}
 required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
@@ -407,9 +417,10 @@ example      | {{< code shell >}}"labels": {
 
 | annotations |     |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].
-**Note**: agent entity `annotations` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | Non-identifying metadata to include with event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
+**NOTE**: You can centrally manage agent entity `annotations` via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `annotations` values in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}} 
 required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
@@ -429,9 +440,10 @@ example      | {{< code shell >}}"entity_class": "agent"{{< /code >}}
 
 subscriptions| 
 -------------|------ 
-description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.
-**Note**: agent entity `subscriptions` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | List of subscription names for the entity. The entity by default has an entity-specific subscription, in the format of `entity:{name}` where `name` is the entity's hostname.{{% notice note %}}
+**NOTE**: You can centrally manage agent entity `subscriptions` via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `subscriptions` values in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}}
 required     | false 
 type         | Array 
 default      | The entity-specific subscription.
@@ -568,21 +580,23 @@ required     | false
 type         | Integer 
 example      | {{< code shell >}}"last_seen": 1522798317 {{< /code >}}
 
-keepalive_handlers   | 
+keepalive_handlers | 
 -------------|------ 
-description  | List of handler names to use for keepalive events issued by agent entities. If keepalive handlers are not specified, the Sensu backend will use the default keepalive handler and create an event in sensuctl and the Sensu web UI.
-**Note**: agent entity `keepalive_handlers` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | List of handler names to use for keepalive events issued by agent entities. If no keepalive handlers are specified, the Sensu backend will use the default keepalive handler and create an event in sensuctl and the Sensu web UI.{{% notice note %}}
+**NOTE**: You can centrally manage agent entity `keepalive_handlers` via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `keepalive_handlers` values in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}}
 required     | false 
 type         | Array 
 default      | `keepalive`
-example      | {{< code shell >}}"keepalive_handlers": ["keeplive", "keepalive-aws"]{{< /code >}}
+example      | {{< code shell >}}"keepalive_handlers": ["keepalive", "keepalive-aws"]{{< /code >}}
 
 deregister   | 
 -------------|------ 
-description  | `true` if the entity should be removed when it stops sending keepalive messages. Otherwise, `false`.
-**Note**: agent entity `deregister` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | `true` if the entity should be removed when it stops sending keepalive messages. Otherwise, `false`.{{% notice note %}}
+**NOTE**: You can centrally manage the agent entity `deregister` value via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `deregister` value in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}}
 required     | false 
 type         | Boolean 
 default      | `false`
@@ -590,9 +604,10 @@ example      | {{< code shell >}}"deregister": false {{< /code >}}
 
 deregistration  | 
 -------------|------ 
-description  | Map that contains a handler name to use when an entity is deregistered. See [deregistration attributes][2] for more information.
-**Note**: agent entity `deregistration` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | Map that contains a handler name to use when an entity is deregistered. See [deregistration attributes][2] for more information.{{% notice note %}}
+**NOTE**: You can centrally manage agent entity `deregistration` values via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `deregistration` values in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}}
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -613,9 +628,10 @@ deregistration:
 
 redact       | 
 -------------|------ 
-description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
-**Note**: agent entity `redact` can be centrally managed using sensuctl, the web-ui, or the Sensu entities API. 
-The `agent.yaml` file values for this attribute are only used to bootstrap the entity record if it does not already exist.  
+description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.{{% notice note %}}
+**NOTE**: You can centrally manage agent entity `redact` values via the backend with [sensuctl](../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../api/entities/), and the [web UI](../../web-ui/view-manage-resources/#manage-entities). 
+The `redact` values in the `agent.yml` file are used only for initial entity creation (unless you delete the entity).
+{{% /notice %}}
 required     | false 
 type         | Array 
 default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
@@ -1019,6 +1035,8 @@ spec:
   - secret
   subscriptions:
   - entity:webserver01
+  keepalive_handlers:
+  - keepalive
   system:
     arch: amd64
     libc_type: glibc
@@ -1147,6 +1165,9 @@ spec:
     "sensu_agent_version": "1.0.0",
     "subscriptions": [
       "entity:webserver01"
+    ],
+    "keepalive_handlers": [
+      "keepalive"
     ],
     "last_seen": 1542667231,
     "deregister": false,


### PR DESCRIPTION


## Description
1. Update Entities reference to better clarify which attributes can not be safely managed in Sensu 6.0
2.  Add missing keepalive_handlers attribute in entities reference

## Motivation and Context
Just make it clear what portions of the agent attributes can be centrally managed now.

