### PR TITLE
replace envvar reference  with valid token substitution in example

### DIFF
--- a/content/sensu-go/5.19/reference/assets.md
+++ b/content/sensu-go/5.19/reference/assets.md
@@ -251,7 +251,6 @@ example (multiple builds)     | {{< code shell >}}"spec": {
       }
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -263,7 +262,6 @@ example (single build, deprecated)     | {{< code shell >}}"spec": {
     "entity.system.arch == 'amd64'"
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -373,7 +371,6 @@ required     | false
 type         | Map of key-value string pairs
 example      | {{< code shell >}}
 "headers": {
-  "Authorization": "Bearer $TOKEN",
   "X-Forwarded-For": "client1, proxy1, proxy2"
 }
 {{< /code >}}
@@ -499,7 +496,6 @@ spec:
   - entity.system.os == 'linux'
   - entity.system.arch == 'amd64'
   headers:
-    Authorization: Bearer $TOKEN
     X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -526,7 +522,6 @@ spec:
       "entity.system.arch == 'amd64'"
     ],
     "headers": {
-      "Authorization": "Bearer $TOKEN",
       "X-Forwarded-For": "client1, proxy1, proxy2"
     }
   }
@@ -558,7 +553,6 @@ spec:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz
     sha512: 70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b
@@ -567,7 +561,6 @@ spec:
     - entity.system.arch == 'arm'
     - entity.system.arm_version == 7
     headers:
-      Authorization: Bearer $TOKEN
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz
     sha512: 10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f
@@ -575,7 +568,6 @@ spec:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
       X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -604,7 +596,6 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -617,7 +608,6 @@ spec:
           "entity.system.arm_version == 7"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -629,7 +619,6 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       }

--- a/content/sensu-go/5.20/reference/assets.md
+++ b/content/sensu-go/5.20/reference/assets.md
@@ -251,7 +251,7 @@ example (multiple builds)     | {{< code shell >}}"spec": {
       }
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
+    "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -263,7 +263,7 @@ example (single build, deprecated)     | {{< code shell >}}"spec": {
     "entity.system.arch == 'amd64'"
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
+    "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -373,7 +373,7 @@ required     | false
 type         | Map of key-value string pairs
 example      | {{< code shell >}}
 "headers": {
-  "Authorization": "Bearer $TOKEN",
+  "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
   "X-Forwarded-For": "client1, proxy1, proxy2"
 }
 {{< /code >}}
@@ -499,7 +499,7 @@ spec:
   - entity.system.os == 'linux'
   - entity.system.arch == 'amd64'
   headers:
-    Authorization: Bearer $TOKEN
+    Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
     X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -526,7 +526,7 @@ spec:
       "entity.system.arch == 'amd64'"
     ],
     "headers": {
-      "Authorization": "Bearer $TOKEN",
+      "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
       "X-Forwarded-For": "client1, proxy1, proxy2"
     }
   }
@@ -558,7 +558,7 @@ spec:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz
     sha512: 70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b
@@ -567,7 +567,7 @@ spec:
     - entity.system.arch == 'arm'
     - entity.system.arm_version == 7
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz
     sha512: 10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f
@@ -575,7 +575,7 @@ spec:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -604,7 +604,7 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -617,7 +617,7 @@ spec:
           "entity.system.arm_version == 7"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -629,7 +629,7 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       }

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -339,7 +339,7 @@ example (multiple builds)     | {{< code shell >}}"spec": {
       }
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
+    "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -351,7 +351,7 @@ example (single build, deprecated)     | {{< code shell >}}"spec": {
     "entity.system.arch == 'amd64'"
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
+    "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -461,7 +461,7 @@ required     | false
 type         | Map of key-value string pairs
 example      | {{< code shell >}}
 "headers": {
-  "Authorization": "Bearer $TOKEN",
+  "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
   "X-Forwarded-For": "client1, proxy1, proxy2"
 }
 {{< /code >}}
@@ -587,7 +587,7 @@ spec:
   - entity.system.os == 'linux'
   - entity.system.arch == 'amd64'
   headers:
-    Authorization: Bearer $TOKEN
+    Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
     X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -614,7 +614,7 @@ spec:
       "entity.system.arch == 'amd64'"
     ],
     "headers": {
-      "Authorization": "Bearer $TOKEN",
+      "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
       "X-Forwarded-For": "client1, proxy1, proxy2"
     }
   }
@@ -646,7 +646,7 @@ spec:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz
     sha512: 70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b
@@ -655,7 +655,7 @@ spec:
     - entity.system.arch == 'arm'
     - entity.system.arm_version == 7
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz
     sha512: 10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f
@@ -663,7 +663,7 @@ spec:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -692,7 +692,7 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -705,7 +705,7 @@ spec:
           "entity.system.arm_version == 7"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -717,7 +717,7 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       }

--- a/content/sensu-go/6.0/reference/assets.md
+++ b/content/sensu-go/6.0/reference/assets.md
@@ -339,7 +339,7 @@ example (multiple builds)     | {{< code shell >}}"spec": {
       }
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
+    "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -351,7 +351,7 @@ example (single build, deprecated)     | {{< code shell >}}"spec": {
     "entity.system.arch == 'amd64'"
   ],
   "headers": {
-    "Authorization": "Bearer $TOKEN",
+    "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
     "X-Forwarded-For": "client1, proxy1, proxy2"
   }
 }{{< /code >}}
@@ -461,7 +461,7 @@ required     | false
 type         | Map of key-value string pairs
 example      | {{< code shell >}}
 "headers": {
-  "Authorization": "Bearer $TOKEN",
+  "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
   "X-Forwarded-For": "client1, proxy1, proxy2"
 }
 {{< /code >}}
@@ -587,7 +587,7 @@ spec:
   - entity.system.os == 'linux'
   - entity.system.arch == 'amd64'
   headers:
-    Authorization: Bearer $TOKEN
+    Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
     X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -614,7 +614,7 @@ spec:
       "entity.system.arch == 'amd64'"
     ],
     "headers": {
-      "Authorization": "Bearer $TOKEN",
+      "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
       "X-Forwarded-For": "client1, proxy1, proxy2"
     }
   }
@@ -646,7 +646,7 @@ spec:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz
     sha512: 70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b
@@ -655,7 +655,7 @@ spec:
     - entity.system.arch == 'arm'
     - entity.system.arm_version == 7
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
   - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz
     sha512: 10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f
@@ -663,7 +663,7 @@ spec:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
     headers:
-      Authorization: Bearer $TOKEN
+      Authorization: 'Bearer {{ .annotations.asset_token | default "N/A" }}'
       X-Forwarded-For: client1, proxy1, proxy2
 {{< /code >}}
 
@@ -692,7 +692,7 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -705,7 +705,7 @@ spec:
           "entity.system.arm_version == 7"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       },
@@ -717,7 +717,7 @@ spec:
           "entity.system.arch == 'amd64'"
         ],
         "headers": {
-          "Authorization": "Bearer $TOKEN",
+          "Authorization": "Bearer {{ .annotations.asset_token | default \"N/A\" }}",
           "X-Forwarded-For": "client1, proxy1, proxy2"
         }
       }


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
The use of envvar in the asset header examples is malformed and does not work in practice.
I've replaced them with a token substitution example that I have tested locally using 6.0

## Motivation and Context
Working examples are great

## Review Instructions
We need to figure out how far back in the docs versions this needs to be applied. 
Asset token substitution is somewhat new.. in that it was not a feature in 5.0. 
Need to find when it was added in the release notes.
