### PR TITLE
Add subscriptions reference doc

### DIFF
--- a/content/sensu-go/6.0/reference/agent.md
+++ b/content/sensu-go/6.0/reference/agent.md
@@ -29,41 +29,6 @@ For optimal network throughput, agents will attempt to negotiate the use of [Pro
 This communication is via clear text by default.
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
-## Create monitoring events using service checks
-
-Sensu uses the [publish/subscribe pattern of communication][15], which allows automated registration and deregistration of ephemeral systems.
-At the core of this model are Sensu agent subscriptions.
-
-Each Sensu agent has a defined set of [`subscriptions`][28]: a list of roles and responsibilities assigned to the system (for example, a webserver or database).
-These subscriptions determine which [monitoring checks][14] the agent will execute.
-Agent subscriptions allow Sensu to request check executions on a group of systems at a time instead of a traditional 1:1 mapping of configured hosts to monitoring checks.
-For an agent to execute a service check, you must specify the same subscription in the [agent configuration][28] and the [check definition][32].
-
-After receiving a check request from the Sensu backend, the agent:
-
-1. Applies any [tokens][27] that match attribute values in the check definition.
-2. Fetches [assets][29] and stores them in its local cache.
-By default, agents cache asset data at `/var/cache/sensu/sensu-agent` (`C:\ProgramData\sensu\cache\sensu-agent` on Windows systems) or as specified by the the [`cache-dir` flag][30].
-3. Executes the [check `command`][14].
-4. Executes any [hooks][31] specified by the check based on the exit status.
-5. Creates an [event][7] that contains information about the applicable entity, check, and metric.
-
-### Subscription configuration
-
-To configure subscriptions for an agent, set [the `subscriptions` flag][28].
-To configure subscriptions for a check, set the [check definition attribute `subscriptions`][14].
-
-In addition to the subscriptions defined in the agent configuration, Sensu agent entities also subscribe automatically to subscriptions that match their [entity `name`][38].
-For example, an agent entity with `name: "i-424242"` subscribes to check requests with the subscription `entity:i-424242`.
-This makes it possible to generate ad hoc check requests that target specific entities via the API.
-
-### Proxy entities
-
-Sensu proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed (such a network switch).
-The [Sensu backend][2] stores proxy entity definitions (unlike agent entities, which the agent stores).
-When the backend requests a check that includes a [`proxy_entity_name`][14], the agent includes the provided entity information in the event data in place of the agent entity data.
-See the [entity reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
-
 ## Create monitoring events using the agent API
 
 The Sensu agent API allows external sources to send monitoring data to Sensu without requiring the external sources to know anything about Sensu's internal implementation.
@@ -1635,7 +1600,6 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [12]: https://www.servicenow.com/products/it-operations-management.html
 [13]: #ephemeral-agent-configuration-flags
 [14]: ../checks/
-[15]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [16]: #general-configuration-flags
 [17]: #socket-configuration-flags
 [18]: #api-configuration-flags
@@ -1648,16 +1612,10 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [25]: ../../api#response-filtering
 [26]: ../../sensuctl/filter-responses/
 [27]: ../tokens/
-[28]: #subscriptions-flag
 [29]: ../assets/
-[30]: #cache-dir
-[31]: ../hooks/
-[32]: ../checks/
-[33]: ../../guides/monitor-external-resources/
 [35]: ../backend#datastore-and-cluster-configuration-flags
 [36]: ../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags
-[38]: #name
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
 [41]: ../handlers/#send-registration-events

--- a/content/sensu-go/6.0/reference/agent.md
+++ b/content/sensu-go/6.0/reference/agent.md
@@ -29,6 +29,19 @@ For optimal network throughput, agents will attempt to negotiate the use of [Pro
 This communication is via clear text by default.
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
+## Create monitoring events using service checks
+
+Sensu uses the [publish/subscribe pattern of communication][15], which allows automated registration and deregistration of ephemeral systems.
+Sensu agent subscriptions determine which checks the agent will execute.
+Read the [subscriptions reference][28] for more information.
+
+### Proxy entities
+
+Sensu proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed (such a network switch).
+The [Sensu backend][2] stores proxy entity definitions (unlike agent entities, which the agent stores).
+When the backend requests a check that includes a [`proxy_entity_name`][15], the agent includes the provided entity information in the event data in place of the agent entity data.
+See the [entity reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
+
 ## Create monitoring events using the agent API
 
 The Sensu agent API allows external sources to send monitoring data to Sensu without requiring the external sources to know anything about Sensu's internal implementation.
@@ -1599,7 +1612,8 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [11]: https://en.wikipedia.org/wiki/Configuration_management_database
 [12]: https://www.servicenow.com/products/it-operations-management.html
 [13]: #ephemeral-agent-configuration-flags
-[14]: ../checks/
+[14]: ../checks/#check-specification
+[15]: ../checks/#proxy-entity-name-attribute
 [16]: #general-configuration-flags
 [17]: #socket-configuration-flags
 [18]: #api-configuration-flags
@@ -1612,7 +1626,9 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 [25]: ../../api#response-filtering
 [26]: ../../sensuctl/filter-responses/
 [27]: ../tokens/
+[28]: ../../reference/subscriptions/
 [29]: ../assets/
+[33]: ../../guides/monitor-external-resources/
 [35]: ../backend#datastore-and-cluster-configuration-flags
 [36]: ../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags

--- a/content/sensu-go/6.0/reference/checks.md
+++ b/content/sensu-go/6.0/reference/checks.md
@@ -59,26 +59,12 @@ At every execution of a check command, regardless of success or failure, the Sen
 
 The Sensu backend schedules checks and publishes check execution requests to entities via a [publish-subscribe model][2].
 
-### Subscriptions
+You can schedule checks using the [`interval`][18], [`cron`][19], and [`publish`][38] attributes.
+Sensu requires that checks include either an `interval` attribute (interval scheduling) or a `cron` attribute (cron scheduling).
 
-Checks have a defined set of subscriptions: transport topics to which the Sensu backend publishes check requests.
-Sensu entities become subscribers to these topics (called subscriptions) via their individual `subscriptions` attribute. 
-Subscriptions typically correspond to a specific role or responsibility (for example. a webserver or database).
+### Round robin checks
 
-Subscriptions are powerful primitives in the monitoring context because they allow you to effectively monitor for specific behaviors or characteristics that correspond to the function provided by a particular system.
-For example, disk capacity thresholds might be more important (or at least different) on a database server than on a webserver.
-Conversely, CPU or memory usage thresholds might be more important on a caching system than on a file server.
-
-Subscriptions also allow you to configure check requests for an entire group or subgroup of systems rather than requiring a traditional one-to-one mapping.
-
-To configure subscriptions for a check, use the `subscriptions` attribute to specify an array of one or more subscription names.
-Sensu schedules checks once per interval for each agent with a matching subscription.
-For example, if we have three agents configured with the `system` subscription, a check configured with the `system` subscription results in three monitoring events per interval: one check execution per agent per interval.
-For Sensu to execute a check, the check definition must include a subscription that matches the subscription of at least one Sensu agent.
-
-#### Round robin checks
-
-By default, Sensu schedules checks once per interval for each agent with a matching subscription: one check execution per agent per interval.
+By default, Sensu schedules checks once per interval for each agent with a matching [subscription][45]: one check execution per agent per interval.
 Sensu also supports deduplicated check execution when configured with the `round_robin` check attribute.
 For checks with `round_robin` set to `true`, Sensu executes the check once per interval, cycling through the available agents alphabetically according to agent name.
 
@@ -97,12 +83,7 @@ If you do not specify a `proxy_entity_name` when using check `ttl` and `round_ro
 **PRO TIP**: Use round robin to distribute check execution workload across multiple agents when using [proxy checks](#proxy-checks).
 {{% /notice %}}
 
-### Scheduling
-
-You can schedule checks using the `interval`, `cron`, and `publish` attributes.
-Sensu requires that checks include either an `interval` attribute (interval scheduling) or a `cron` attribute (cron scheduling).
-
-#### Interval scheduling
+### Interval scheduling
 
 You can schedule a check to be executed at regular intervals using the `interval` and `publish` check attributes.
 For example, to schedule a check to execute every 60 seconds, set the `interval` attribute to `60` and the `publish` attribute to `true`.
@@ -112,7 +93,7 @@ For example, to schedule a check to execute every 60 seconds, set the `interval`
 This helps balance the load of both the backend and the agent and may result in a delay before initial check execution.
 {{% /notice %}}
 
-**Example interval check**
+#### Example interval check
 
 {{< language-toggle >}}
 
@@ -152,7 +133,7 @@ spec:
 
 {{< /language-toggle >}}
 
-#### Cron scheduling
+### Cron scheduling
 
 You can also schedule checks using [cron syntax][14].
 
@@ -166,7 +147,7 @@ Examples of valid cron values include:
 **NOTE**: If you're using YAML to create a check that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (e.g. `cron: '* * * * *'`).
 {{% /notice %}}
 
-**Example cron checks**
+#### Example cron checks
 
 To schedule a check to execute once a minute at the start of the minute, set the `cron` attribute to `* * * * *` and the `publish` attribute to `true`:
 
@@ -278,12 +259,12 @@ spec:
 
 {{< /language-toggle >}}
 
-#### Ad hoc scheduling
+### Ad hoc scheduling
 
 In addition to automatic execution, you can create checks to be scheduled manually using the [checks API][34].
 To create a check with ad-hoc scheduling, set the `publish` attribute to `false` in addition to an `interval` or `cron` schedule.
 
-**Example ad hoc check**
+#### Example ad hoc check
 
 {{< language-toggle >}}
 
@@ -581,6 +562,8 @@ description  | Check command to be executed.
 required     | true
 type         | String
 example      | {{< code shell >}}"command": "/etc/sensu/plugins/check-chef-client.go"{{< /code >}}
+
+<a name="check-subscriptions"></a>
 
 |subscriptions|     |
 -------------|------
@@ -1070,6 +1053,8 @@ The asset reference includes an [example check definition that uses the asset pa
 [15]: https://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules
 [16]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/flapping.html
 [17]: #subdue-attributes
+[18]: #interval-scheduling
+[19]: #cron-scheduling
 [20]: ../entities/#proxy-entities
 [21]: ../entities/#spec-attributes
 [22]: ../../reference/sensuctl/#time-windows
@@ -1089,12 +1074,14 @@ The asset reference includes an [example check definition that uses the asset pa
 [35]: #use-a-proxy-check-to-monitor-a-proxy-entity
 [36]: #use-a-proxy-check-to-monitor-multiple-proxy-entities
 [37]: #proxy-requests-top-level
+[38]: #ad-hoc-scheduling
 [39]: #check-token-substitution
 [40]: ../entities#manage-entity-labels
 [41]: ../../sensuctl/create-manage-resources/#create-resources
 [42]: #spec-attributes
 [43]: #round-robin-attribute
 [44]: #proxy-entity-name-attribute
+[45]: ../subscriptions/
 [46]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [47]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement

--- a/content/sensu-go/6.0/reference/subscriptions.md
+++ b/content/sensu-go/6.0/reference/subscriptions.md
@@ -12,12 +12,21 @@ menu:
 ---
 
 Sensu uses the [publish/subscribe pattern of communication][1], which allows automated registration and deregistration of ephemeral systems.
-At the core of this model are Sensu agent subscriptions.
+At the core of this model are Sensu agent and check [subscriptions][2]: transport topics to which the Sensu [backend][4] publishes check requests.
 
-Each Sensu agent has a defined set of [`subscriptions`][2]: a list of roles and responsibilities assigned to the system (for example, a webserver or database).
-These subscriptions determine which [checks][3] the agent will execute.
-Agent subscriptions allow Sensu to request check executions on a group of systems at a time instead of a traditional 1:1 mapping of configured hosts to monitoring checks.
-For an agent to execute a service check, you must specify the same subscription in the [agent configuration][2] and the [check definition][3].
+Sensu entities become subscribers to these topics via their individual `subscriptions` attribute. 
+Subscriptions typically correspond to a specific role or responsibility (for example. a webserver or database).
+
+Subscriptions are powerful primitives in the monitoring context because they allow you to effectively monitor for specific behaviors or characteristics that correspond to the function provided by a particular system.
+For example, disk capacity thresholds might be more important (or at least different) on a database server than on a webserver.
+Conversely, CPU or memory usage thresholds might be more important on a caching system than on a file server.
+
+Subscriptions allow you to configure check requests for an entire group or subgroup of systems rather than requiring a traditional one-to-one mapping of configured hosts or observability checks.
+
+## Agent subscriptions
+
+The subscriptions you specify in an agent's definition will determine which [checks][3] the agent will execute.
+For an agent to execute a service check, you must specify the same subscription in the [agent configuration][11] and the [check definition][12].
 
 After receiving a check request from the Sensu backend, the agent:
 
@@ -28,32 +37,39 @@ By default, agents cache asset data at `/var/cache/sensu/sensu-agent` (`C:\Progr
 4. Executes any [hooks][8] specified by the check based on the exit status.
 5. Creates an [event][9] that contains information about the applicable entity, check, and metric.
 
-## Subscription configuration
+### Agent subscription configuration
 
-To configure subscriptions for an agent, set [the `subscriptions` flag][2].
-To configure subscriptions for a check, set the [check definition attribute `subscriptions`][3].
+To configure subscriptions for an agent, set the [`subscriptions` flag][2].
 
 In addition to the subscriptions defined in the agent configuration, Sensu agent entities also subscribe automatically to subscriptions that match their [entity `name`][10].
 For example, an agent entity with `name: "i-424242"` subscribes to check requests with the subscription `entity:i-424242`.
 This makes it possible to generate ad hoc check requests that target specific entities via the API.
 
-## Proxy entities
+## Check subscriptions
 
-Sensu proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed (such a network switch).
-The [Sensu backend][11] stores proxy entity definitions (unlike agent entities, which the agent stores).
-When the backend requests a check that includes a [`proxy_entity_name`][3], the agent includes the provided entity information in the event data in place of the agent entity data.
-See the [entity reference][12] and [Monitor external resources][13] for more information about monitoring proxy entities.
+The subscriptions you specify in a check's definition determine which [agents][14] will execute the checks.
+
+Sensu [schedules][13] checks once per interval for each agent with a matching subscription.
+For example, if you have three agents configured with the `system` subscription, a check configured with the `system` subscription results in three monitoring events per interval: one check execution per agent per interval.
+For Sensu to execute a check, the check definition must include a subscription that matches the subscription of at least one Sensu agent.
+
+### Check subscription configuration
+
+To configure subscriptions for a check, set the [check definition attribute `subscriptions`][15] to specify an array of one or more subscription names.
 
 
 [1]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [2]: ../agent/#subscriptions-flag
 [3]: ../checks/
+[4]: ../backend/
 [5]: ../tokens/
 [6]: ../assets/
 [7]: ../agent/#cache-dir
 [8]: ../hooks/
 [9]: ../events/
 [10]: ../agent/#name
-[11]: ../backend/
-[12]: ../entities/
-[13]: ../../guides/monitor-external-resources/
+[11]: #agent-subscription-configuration
+[12]: #check-subscription-configuration
+[13]: ../checks/#check-scheduling
+[14]: ../agent/
+[15]: ../checks/#check-subscriptions

--- a/content/sensu-go/6.0/reference/subscriptions.md
+++ b/content/sensu-go/6.0/reference/subscriptions.md
@@ -1,0 +1,59 @@
+---
+title: "Subscriptions"
+reference_title: "Subscriptions"
+type: "reference"
+description: "The Sensu agent is a lightweight client that runs on the infrastructure components you want to monitor. Read the reference doc to use the Sensu agent to create monitoring events."
+weight: 170
+version: "6.0"
+product: "Sensu Go"
+menu:
+  sensu-go-6.0:
+    parent: reference
+---
+
+Sensu uses the [publish/subscribe pattern of communication][1], which allows automated registration and deregistration of ephemeral systems.
+At the core of this model are Sensu agent subscriptions.
+
+Each Sensu agent has a defined set of [`subscriptions`][2]: a list of roles and responsibilities assigned to the system (for example, a webserver or database).
+These subscriptions determine which [checks][3] the agent will execute.
+Agent subscriptions allow Sensu to request check executions on a group of systems at a time instead of a traditional 1:1 mapping of configured hosts to monitoring checks.
+For an agent to execute a service check, you must specify the same subscription in the [agent configuration][2] and the [check definition][3].
+
+After receiving a check request from the Sensu backend, the agent:
+
+1. Applies any [tokens][5] that match attribute values in the check definition.
+2. Fetches [assets][6] and stores them in its local cache.
+By default, agents cache asset data at `/var/cache/sensu/sensu-agent` (`C:\ProgramData\sensu\cache\sensu-agent` on Windows systems) or as specified by the the [`cache-dir` flag][7].
+3. Executes the [check `command`][3].
+4. Executes any [hooks][8] specified by the check based on the exit status.
+5. Creates an [event][9] that contains information about the applicable entity, check, and metric.
+
+## Subscription configuration
+
+To configure subscriptions for an agent, set [the `subscriptions` flag][2].
+To configure subscriptions for a check, set the [check definition attribute `subscriptions`][3].
+
+In addition to the subscriptions defined in the agent configuration, Sensu agent entities also subscribe automatically to subscriptions that match their [entity `name`][10].
+For example, an agent entity with `name: "i-424242"` subscribes to check requests with the subscription `entity:i-424242`.
+This makes it possible to generate ad hoc check requests that target specific entities via the API.
+
+## Proxy entities
+
+Sensu proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed (such a network switch).
+The [Sensu backend][11] stores proxy entity definitions (unlike agent entities, which the agent stores).
+When the backend requests a check that includes a [`proxy_entity_name`][3], the agent includes the provided entity information in the event data in place of the agent entity data.
+See the [entity reference][12] and [Monitor external resources][13] for more information about monitoring proxy entities.
+
+
+[1]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
+[2]: ../agent/#subscriptions-flag
+[3]: ../checks/
+[5]: ../tokens/
+[6]: ../assets/
+[7]: ../agent/#cache-dir
+[8]: ../hooks/
+[9]: ../events/
+[10]: ../agent/#name
+[11]: ../backend/
+[12]: ../entities/
+[13]: ../../guides/monitor-external-resources/

--- a/content/sensu-go/6.0/reference/tessen.md
+++ b/content/sensu-go/6.0/reference/tessen.md
@@ -3,7 +3,7 @@ title: "Tessen"
 reference_title: "Tessen"
 type: "reference"
 description: "Tessen sends anonymized data about Sensu instances to Sensu Inc. You can use sensuctl to view and manage Tessen configuration. Read this document to configure Tessen."
-weight: 170
+weight: 180
 version: "6.0"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.0/reference/tokens.md
+++ b/content/sensu-go/6.0/reference/tokens.md
@@ -3,7 +3,7 @@ title: "Tokens"
 reference_title: "Tokens"
 type: "reference"
 description: "Tokens are placeholders in a check definition that the agent replaces with entity information before executing the check. You can use tokens to fine-tune check attributes (like alert thresholds) on a per-entity level while reusing check definitions. Read the reference doc to learn about tokens."
-weight: 180
+weight: 190
 version: "6.0"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.0/reference/webconfig.md
+++ b/content/sensu-go/6.0/reference/webconfig.md
@@ -4,7 +4,7 @@ linkTitle: "Web UI Configuration"
 reference_title: "Web UI configuration"
 type: "reference"
 description: "Sensu's web UI configuration feature allows you to customize your web UI displays. Read the reference to create and update web UI configurations."
-weight: 190
+weight: 200
 version: "6.0"
 product: "Sensu Go"
 menu: 


### PR DESCRIPTION
## Description
Drafts a subscriptions reference doc using content from the agent and check references.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2679
Supports the observability pipeline docs IA work.