### PR TITLE
Fix redirects for create-a-read-only-user

### DIFF
--- a/static.json
+++ b/static.json
@@ -463,15 +463,15 @@
             "url": "/sensu-go/latest/operations/control-access/use-apikeys",
             "status": 301
         },
-        "~ ^/sensu-go/latest/guides/create-a-read-only-user/?$": {
+        "~ ^/sensu-go/latest/guides/create-read-only-user/?$": {
             "url": "/sensu-go/latest/operations/control-access/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/5.2[0-9]/?((?<=\/).*)?/guides/create-a-read-only-user/?$": {
+        "~ ^/sensu-go/5.2[0-9]/?((?<=\/).*)?/guides/create-read-only-user/?$": {
             "url": "/sensu-go/latest/operations/control-access/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/5.1[0-9]/?((?<=\/).*)?/guides/create-a-read-only-user/?$": {
+        "~ ^/sensu-go/5.1[0-9]/?((?<=\/).*)?/guides/create-read-only-user/?$": {
             "url": "/sensu-go/latest/operations/control-access/create-read-only-user",
             "status": 301
         },


### PR DESCRIPTION
## Description
Corrects redirects in static.json: changes `create-a-read-only-user` to `create-read-only-user`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2685
