### PR TITLE
Add top-level and deeply-nested section support to offline docs

### DIFF
--- a/offline/partials/toc.html
+++ b/offline/partials/toc.html
@@ -1,4 +1,4 @@
-{{ if .Sections }}
+{{ if and .Sections (eq .Parent .FirstSection) }}
   <div id="toc">
     <h2>Contents</h2>
     {{ range .Sections }}
@@ -32,19 +32,34 @@
                     {{ $niceName := title $niceName }}
 
                     <li>
-                      <span class="strong">
-                        {{ if or (eq $niceName "Api") (eq $niceName "Rbac") }}
-                          {{ upper $niceName }}
-                        <!-- render the title normally if not API -->
-                        {{ else }}
-                          {{ $niceName }}
-                        {{ end }}
-                      </span>
+                      {{ if and (ne .Page.Params.offline false) (ne $.Params.product $x.Name) }}
+                        <a class="strong" href="{{ .URL | absURL }}">
+                          {{ if or (eq $niceName "Api") (eq $niceName "Rbac") }}
+                            {{ upper $niceName }}
+                          <!-- render the title normally if not API -->
+                          {{ else }}
+                            {{ $niceName }}
+                          {{ end }}
+                        </a>
+                      {{ end }}
                       <ul>
                         <!-- Loop through the child menu's pages -->
                         {{ range .Children.ByWeight }}
                           {{ if and (ne .Page.Params.offline false) (ne (lower .Parent) (lower .Name)) }}
-                            <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+                            <li>
+                              <a href="{{ .URL | absURL }}">{{ .Name }}</a>
+                              {{ if .HasChildren }}
+                                <ul>
+                                  {{ range .Children.ByWeight }}
+                                    {{ if and (ne .Page.Params.offline false) (ne (lower .Parent) (lower .Name)) }}
+                                      <li>
+                                        <a href="{{ .URL | absURL }}">{{ .Name }}</a>
+                                      </li>
+                                    {{ end }}
+                                  {{ end }}
+                                </ul>
+                              {{ end }}
+                            </li>
                           {{ end }}
                         {{ end }}
                       </ul>

--- a/offline/shortcodes/directoryListing.html
+++ b/offline/shortcodes/directoryListing.html
@@ -1,5 +1,4 @@
-{{ $path := .Get 0 }}
-{{ $files := readDir $path }}
+{{ $files := readDir (path.Join "content" $.Page.File.Dir) }}
 
 <!-- Loop through all files in dir -->
 <ul>


### PR DESCRIPTION
## Description

Updates the offline table of contents so that top-level and deeply-nested section content is included/linked to. This should also fix the ordering issue mentioned in the linked issue.

## Motivation and Context

Resolves #2661