### PR TITLE
Update resource names and lists for sensuctl dump and sensuctl prune

### DIFF
--- a/content/sensu-go/5.19/sensuctl/back-up-recover.md
+++ b/content/sensu-go/5.19/sensuctl/back-up-recover.md
@@ -24,13 +24,21 @@ sensuctl dump all --format yaml --file my-resources.yaml
 To export only checks to STDOUT in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump check --format yaml
+sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
 To export only handlers and filters to a file named `my-handlers-and-filters.yaml` in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump handler,filter --format yaml --file my-handlers-and-filters.yaml
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< /code >}}
+
+You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands:
+
+{{< code shell >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
@@ -51,21 +59,21 @@ mkdir backup
    
    {{< code shell >}}
 sensuctl dump all \
---omit entities,events,apikeys,users,roles,rolebindings,clusterroles,clusterrolebindings \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yaml
 {{< /code >}}
    
 3. Export your [RBAC][2] resources, except API keys and users.
    
    {{< code shell >}}
-sensuctl dump roles,rolebindings,clusterroles,clusterrolebindings
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding
 --format yaml > backup/rbac.yaml
 {{< /code >}}
 
 4. Export your API keys and users resources.
    
    {{< code shell >}}
-sensuctl dump apikeys,users
+sensuctl dump core/v2.APIKey,core/v2.User
 --format yaml > backup/cannotrestore.yaml
 {{< /code >}}
 
@@ -78,7 +86,7 @@ Because users require this additional configuration and API keys cannot be resto
 5. Export your entity resources (if desired).
      
    {{< code shell >}}
-sensuctl dump entities \
+sensuctl dump core/v2.Entity \
 --format yaml > backup/inventory.yaml
 {{< /code >}}
 
@@ -102,7 +110,7 @@ mkdir backup
 2. Back up your pipeline resources, stripping namespaces so that your resources are portable for reuse in any namespace.
    
    {{< code shell >}}
-sensuctl dump assets,checks,hooks,filters,mutators,handlers,silenced,secrets/v1.Secret,secrets/v1.Provider \
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
 {{< /code >}}
 
@@ -129,58 +137,30 @@ When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
 {{% /notice %}}
 
-## List types of supported resources
+## Supported resource types
 
-{{% notice important %}}
-**IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
-{{% /notice %}}
-
-Use `sensuctl describe-type` to list the types of supported resources.
-For example, to list all types:
-
-{{< code shell >}}
-sensuctl describe-type all
-{{< /code >}}
-
-You can also list specific resource types by fully qualified name or synonym:
-
-{{< code shell >}}
-sensuctl describe-type core/v2.CheckConfig
-sensuctl describe-type checks
-{{< /code >}}
-
-To list more than one type, use a comma-separated list:
-
-{{< code shell >}}
-sensuctl describe-type core/v2.CheckConfig,core/v2.EventFilter,core/v2.Handler
-sensuctl describe-type checks,filters,handlers
-{{< /code >}}
-
-<a name="resource-types"></a>
-
-The table below lists supported `sensuctl describe-type` resource types.
+The table below lists supported `sensuctl dump` resource types.
 
 {{% notice note %}}
-**NOTE**: The resource types with no synonym listed are [commercial features](../../commercial/).
+**NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
-Synonym | Fully qualified name 
+Short name | Fully qualified name 
 --------------------|---
 None | `authentication/v2.Provider`
 None | `licensing/v2.LicenseFile`
 None | `store/v1.PostgresConfig`
-None | `federation/v1.Replicator`
+None | `federation/v1.EtcdReplicator`
 None | `secrets/v1.Provider`
 None | `secrets/v1.Secret`
 None | `searches/v1.Search`
-None | `web/v1.GlobalConfig`
 `apikeys` | `core/v2.APIKey`
 `assets` | `core/v2.Asset`
 `checks` | `core/v2.CheckConfig`
 `clusterroles` | `core/v2.ClusterRole`
 `clusterrolebindings` | `core/v2.ClusterRoleBinding`
 `entities` | `core/v2.Entity`
-`events` | `core/v2.Event` 
+`events` | `core/v2.Event`
 `filters` | `core/v2.EventFilter`
 `handlers` | `core/v2.Handler`
 `hooks` | `core/v2.Hook`
@@ -192,20 +172,10 @@ None | `web/v1.GlobalConfig`
 `tessen` | `core/v2.TessenConfig`
 `users` | `core/v2.User`
 
-### Format the sensuctl describe-type response
-
-Add the `--format` flag to specify how the resources should be formatted in the `sensuctl describe-type` response.
-The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
-
-{{< code shell >}}
-sensuctl describe-type core/v2.CheckConfig --format yaml
-sensuctl describe-type core/v2.CheckConfig --format wrapped-json
-{{< /code >}}
-
 
 [1]: ../create-manage-resources/#create-resources
 [2]: ../../reference/rbac/
 [3]: #restore-resources-from-backup
 [4]: ../../operations/maintain-sensu/upgrade/
 [5]: ../create-manage-resources/#create-resources-across-namespaces
-[6]: #resource-types
+[6]: #supported-resource-types

--- a/content/sensu-go/5.19/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.19/sensuctl/create-manage-resources.md
@@ -395,7 +395,7 @@ sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... -f [FILE or URL] [-r] ... ] [-
 
 In this example `sensuctl prune` command:
 
-- Replace [RESOURCE TYPE] with the [synonym or fully qualified name][10] of the resource you want to prune.
+- Replace [RESOURCE TYPE] with the [fully qualified name or short name][10] of the resource you want to prune.
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE or URL] with the name of the file or the URL that contains the set of Sensu objects you want to keep (the configuration).
 - Replace [flags] with the flags you want to use, if any.
@@ -407,6 +407,8 @@ Use a comma separator to prune more than one resource in a single command.
 For example, to prune checks and assets from the file `checks.yaml` for the `dev` namespace and the `admin` and `ops` users:
 
 {{< code shell >}}
+sensuctl prune core/v2.CheckConfig,core/v2.Asset --file checks.yaml --namespace dev --users admin,ops
+
 sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
 {{< /code >}}
 
@@ -426,11 +428,15 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune resource types
+##### Supported resource types
 
 The table below lists supported `sensuctl prune` resource types.
 
-Synonym | Fully qualified name 
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
+
+Short name | Fully qualified name 
 --------------------|---
 None | `authentication/v2.Provider`
 None | `licensing/v2.LicenseFile`
@@ -438,12 +444,14 @@ None | `store/v1.PostgresConfig`
 None | `federation/v1.EtcdReplicator`
 None | `secrets/v1.Provider`
 None | `secrets/v1.Secret`
-`apikey` | `core/v2.APIKey`
+None | `searches/v1.Search`
+`apikeys` | `core/v2.APIKey`
 `assets` | `core/v2.Asset`
 `checks` | `core/v2.CheckConfig`
 `clusterroles` | `core/v2.ClusterRole`
 `clusterrolebindings` | `core/v2.ClusterRoleBinding`
 `entities` | `core/v2.Entity`
+`events` | `core/v2.Event`
 `filters` | `core/v2.EventFilter`
 `handlers` | `core/v2.Handler`
 `hooks` | `core/v2.Hook`
@@ -457,14 +465,12 @@ None | `secrets/v1.Secret`
 
 ##### sensuctl prune examples
 
-`sensuctl prune` supports pruning resources by their synonyms or fully qualified names:
-
-{{< code shell >}}
-sensuctl prune checks,entities
-{{< /code >}}
+`sensuctl prune` supports pruning resources by their fully qualified names or short names:
 
 {{< code shell >}}
 sensuctl prune core/v2.CheckConfig,core/v2.Entity
+
+sensuctl prune checks,entities
 {{< /code >}}
 
 Use the `all` qualifier to prune all supported resources:
@@ -506,7 +512,7 @@ Sensuctl supports the following formats:
 [7]: ../../operations/deploy-sensu/cluster-sensu/
 [8]: ../../reference/rbac/#user-specification
 [9]: #wrapped-json-format
-[10]: #sensuctl-prune-resource-types
+[10]: #supported-resource-types
 [11]: ../../reference/license/
 [12]: ../../reference/assets/
 [13]: ../../reference/checks/

--- a/content/sensu-go/5.20/sensuctl/back-up-recover.md
+++ b/content/sensu-go/5.20/sensuctl/back-up-recover.md
@@ -24,13 +24,21 @@ sensuctl dump all --format yaml --file my-resources.yaml
 To export only checks to STDOUT in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump check --format yaml
+sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
 To export only handlers and filters to a file named `my-handlers-and-filters.yaml` in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump handler,filter --format yaml --file my-handlers-and-filters.yaml
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< /code >}}
+
+You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands:
+
+{{< code shell >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
@@ -51,21 +59,21 @@ mkdir backup
    
    {{< code shell >}}
 sensuctl dump all \
---omit entities,events,apikeys,users,roles,rolebindings,clusterroles,clusterrolebindings \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yaml
 {{< /code >}}
    
 3. Export your [RBAC][2] resources, except API keys and users.
    
    {{< code shell >}}
-sensuctl dump roles,rolebindings,clusterroles,clusterrolebindings
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding
 --format yaml > backup/rbac.yaml
 {{< /code >}}
 
 4. Export your API keys and users resources.
    
    {{< code shell >}}
-sensuctl dump apikeys,users
+sensuctl dump core/v2.APIKey,core/v2.User
 --format yaml > backup/cannotrestore.yaml
 {{< /code >}}
 
@@ -78,7 +86,7 @@ Because users require this additional configuration and API keys cannot be resto
 5. Export your entity resources (if desired).
      
    {{< code shell >}}
-sensuctl dump entities \
+sensuctl dump core/v2.Entity \
 --format yaml > backup/inventory.yaml
 {{< /code >}}
 
@@ -102,7 +110,7 @@ mkdir backup
 2. Back up your pipeline resources, stripping namespaces so that your resources are portable for reuse in any namespace.
    
    {{< code shell >}}
-sensuctl dump assets,checks,hooks,filters,mutators,handlers,silenced,secrets/v1.Secret,secrets/v1.Provider \
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
 {{< /code >}}
 
@@ -129,23 +137,55 @@ When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
 {{% /notice %}}
 
-## List types of supported resources
+## Supported resource types
 
 {{% notice important %}}
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type` to list the types of supported resources.
-For example, to list all types:
+Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
 
 {{< code shell >}}
 sensuctl describe-type all
+
+      Fully Qualified Name           Short Name           API Version             Type          Namespaced  
+ ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
 
-You can also list specific resource types by fully qualified name or synonym:
+You can also list specific resource types by fully qualified name or short name:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig
+
 sensuctl describe-type checks
 {{< /code >}}
 
@@ -153,44 +193,9 @@ To list more than one type, use a comma-separated list:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig,core/v2.EventFilter,core/v2.Handler
+
 sensuctl describe-type checks,filters,handlers
 {{< /code >}}
-
-<a name="resource-types"></a>
-
-The table below lists supported `sensuctl describe-type` resource types.
-
-{{% notice note %}}
-**NOTE**: The resource types with no synonym listed are [commercial features](../../commercial/).
-{{% /notice %}}
-
-Synonym | Fully qualified name 
---------------------|---
-None | `authentication/v2.Provider`
-None | `licensing/v2.LicenseFile`
-None | `store/v1.PostgresConfig`
-None | `federation/v1.Replicator`
-None | `secrets/v1.Provider`
-None | `secrets/v1.Secret`
-None | `searches/v1.Search`
-None | `web/v1.GlobalConfig`
-`apikeys` | `core/v2.APIKey`
-`assets` | `core/v2.Asset`
-`checks` | `core/v2.CheckConfig`
-`clusterroles` | `core/v2.ClusterRole`
-`clusterrolebindings` | `core/v2.ClusterRoleBinding`
-`entities` | `core/v2.Entity`
-`events` | `core/v2.Event` 
-`filters` | `core/v2.EventFilter`
-`handlers` | `core/v2.Handler`
-`hooks` | `core/v2.Hook`
-`mutators` | `core/v2.Mutator`
-`namespaces` | `core/v2.Namespace`
-`roles` | `core/v2.Role`
-`rolebindings` | `core/v2.RoleBinding`
-`silenced` | `core/v2.Silenced`
-`tessen` | `core/v2.TessenConfig`
-`users` | `core/v2.User`
 
 ### Format the sensuctl describe-type response
 
@@ -199,6 +204,7 @@ The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig --format yaml
+
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
@@ -208,4 +214,4 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 [3]: #restore-resources-from-backup
 [4]: ../../operations/maintain-sensu/upgrade/
 [5]: ../create-manage-resources/#create-resources-across-namespaces
-[6]: #resource-types
+[6]: #supported-resource-types

--- a/content/sensu-go/5.20/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.20/sensuctl/create-manage-resources.md
@@ -395,7 +395,7 @@ sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... -f [FILE or URL] [-r] ... ] [-
 
 In this example `sensuctl prune` command:
 
-- Replace [RESOURCE TYPE] with the [synonym or fully qualified name][10] of the resource you want to prune.
+- Replace [RESOURCE TYPE] with the [fully qualified name or short name][10] of the resource you want to prune.
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE or URL] with the name of the file or the URL that contains the set of Sensu objects you want to keep (the configuration).
 - Replace [flags] with the flags you want to use, if any.
@@ -407,6 +407,8 @@ Use a comma separator to prune more than one resource in a single command.
 For example, to prune checks and assets from the file `checks.yaml` for the `dev` namespace and the `admin` and `ops` users:
 
 {{< code shell >}}
+sensuctl prune core/v2.CheckConfig,core/v2.Asset --file checks.yaml --namespace dev --users admin,ops
+
 sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
 {{< /code >}}
 
@@ -426,45 +428,54 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune resource types
+##### Supported resource types
 
-The table below lists supported `sensuctl prune` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
 
-Synonym | Fully qualified name 
---------------------|---
-None | `authentication/v2.Provider`
-None | `licensing/v2.LicenseFile`
-None | `store/v1.PostgresConfig`
-None | `federation/v1.EtcdReplicator`
-None | `secrets/v1.Provider`
-None | `secrets/v1.Secret`
-`apikey` | `core/v2.APIKey`
-`assets` | `core/v2.Asset`
-`checks` | `core/v2.CheckConfig`
-`clusterroles` | `core/v2.ClusterRole`
-`clusterrolebindings` | `core/v2.ClusterRoleBinding`
-`entities` | `core/v2.Entity`
-`filters` | `core/v2.EventFilter`
-`handlers` | `core/v2.Handler`
-`hooks` | `core/v2.Hook`
-`mutators` | `core/v2.Mutator`
-`namespaces` | `core/v2.Namespace`
-`roles` | `core/v2.Role`
-`rolebindings` | `core/v2.RoleBinding`
-`silenced` | `core/v2.Silenced`
-`tessen` | `core/v2.TessenConfig`
-`users` | `core/v2.User`
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
+
+{{< code shell >}}
+sensuctl describe-type all
+
+      Fully Qualified Name           Short Name           API Version             Type          Namespaced  
+ ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
+{{< /code >}}
 
 ##### sensuctl prune examples
 
-`sensuctl prune` supports pruning resources by their synonyms or fully qualified names:
-
-{{< code shell >}}
-sensuctl prune checks,entities
-{{< /code >}}
+`sensuctl prune` supports pruning resources by their fully qualified names or short names:
 
 {{< code shell >}}
 sensuctl prune core/v2.CheckConfig,core/v2.Entity
+
+sensuctl prune checks,entities
 {{< /code >}}
 
 Use the `all` qualifier to prune all supported resources:
@@ -506,7 +517,7 @@ Sensuctl supports the following formats:
 [7]: ../../operations/deploy-sensu/cluster-sensu/
 [8]: ../../reference/rbac/#user-specification
 [9]: #wrapped-json-format
-[10]: #sensuctl-prune-resource-types
+[10]: #supported-resource-types
 [11]: ../../reference/webconfig/
 [12]: ../../reference/assets/
 [13]: ../../reference/checks/
@@ -527,7 +538,7 @@ Sensuctl supports the following formats:
 [28]: ../../reference/secrets/
 [29]: ../../reference/etcdreplicators/
 [30]: ../../commercial/
-[31]: ..#manage-sensuctl
+[31]: ../#manage-sensuctl
 [32]: ../../reference/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../reference/license/

--- a/content/sensu-go/5.21/sensuctl/back-up-recover.md
+++ b/content/sensu-go/5.21/sensuctl/back-up-recover.md
@@ -24,13 +24,21 @@ sensuctl dump all --format yaml --file my-resources.yaml
 To export only checks to STDOUT in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump check --format yaml
+sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
 To export only handlers and filters to a file named `my-handlers-and-filters.yaml` in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump handler,filter --format yaml --file my-handlers-and-filters.yaml
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< /code >}}
+
+You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands:
+
+{{< code shell >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
@@ -51,21 +59,21 @@ mkdir backup
    
    {{< code shell >}}
 sensuctl dump all \
---omit entities,events,apikeys,users,roles,rolebindings,clusterroles,clusterrolebindings \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yaml
 {{< /code >}}
    
 3. Export your [RBAC][2] resources, except API keys and users.
    
    {{< code shell >}}
-sensuctl dump roles,rolebindings,clusterroles,clusterrolebindings
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding
 --format yaml > backup/rbac.yaml
 {{< /code >}}
 
 4. Export your API keys and users resources.
    
    {{< code shell >}}
-sensuctl dump apikeys,users
+sensuctl dump core/v2.APIKey,core/v2.User
 --format yaml > backup/cannotrestore.yaml
 {{< /code >}}
 
@@ -78,7 +86,7 @@ Because users require this additional configuration and API keys cannot be resto
 5. Export your entity resources (if desired).
      
    {{< code shell >}}
-sensuctl dump entities \
+sensuctl dump core/v2.Entity \
 --format yaml > backup/inventory.yaml
 {{< /code >}}
 
@@ -102,7 +110,7 @@ mkdir backup
 2. Back up your pipeline resources, stripping namespaces so that your resources are portable for reuse in any namespace.
    
    {{< code shell >}}
-sensuctl dump assets,checks,hooks,filters,mutators,handlers,silenced,secrets/v1.Secret,secrets/v1.Provider \
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
 {{< /code >}}
 
@@ -129,23 +137,55 @@ When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
 {{% /notice %}}
 
-## List types of supported resources
+## Supported resource types
 
 {{% notice important %}}
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type` to list the types of supported resources.
-For example, to list all types:
+Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
 
 {{< code shell >}}
 sensuctl describe-type all
+
+      Fully Qualified Name           Short Name           API Version             Type          Namespaced  
+ ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
 
-You can also list specific resource types by fully qualified name or synonym:
+You can also list specific resource types by fully qualified name or short name:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig
+
 sensuctl describe-type checks
 {{< /code >}}
 
@@ -153,44 +193,9 @@ To list more than one type, use a comma-separated list:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig,core/v2.EventFilter,core/v2.Handler
+
 sensuctl describe-type checks,filters,handlers
 {{< /code >}}
-
-<a name="resource-types"></a>
-
-The table below lists supported `sensuctl describe-type` resource types.
-
-{{% notice note %}}
-**NOTE**: The resource types with no synonym listed are [commercial features](../../commercial/).
-{{% /notice %}}
-
-Synonym | Fully qualified name 
---------------------|---
-None | `authentication/v2.Provider`
-None | `licensing/v2.LicenseFile`
-None | `store/v1.PostgresConfig`
-None | `federation/v1.Replicator`
-None | `secrets/v1.Provider`
-None | `secrets/v1.Secret`
-None | `searches/v1.Search`
-None | `web/v1.GlobalConfig`
-`apikeys` | `core/v2.APIKey`
-`assets` | `core/v2.Asset`
-`checks` | `core/v2.CheckConfig`
-`clusterroles` | `core/v2.ClusterRole`
-`clusterrolebindings` | `core/v2.ClusterRoleBinding`
-`entities` | `core/v2.Entity`
-`events` | `core/v2.Event` 
-`filters` | `core/v2.EventFilter`
-`handlers` | `core/v2.Handler`
-`hooks` | `core/v2.Hook`
-`mutators` | `core/v2.Mutator`
-`namespaces` | `core/v2.Namespace`
-`roles` | `core/v2.Role`
-`rolebindings` | `core/v2.RoleBinding`
-`silenced` | `core/v2.Silenced`
-`tessen` | `core/v2.TessenConfig`
-`users` | `core/v2.User`
 
 ### Format the sensuctl describe-type response
 
@@ -199,6 +204,7 @@ The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig --format yaml
+
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
@@ -208,4 +214,4 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 [3]: #restore-resources-from-backup
 [4]: ../../operations/maintain-sensu/upgrade/
 [5]: ../create-manage-resources/#create-resources-across-namespaces
-[6]: #resource-types
+[6]: #supported-resource-types

--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -395,7 +395,7 @@ sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... -f [FILE or URL] [-r] ... ] [-
 
 In this example `sensuctl prune` command:
 
-- Replace [RESOURCE TYPE] with the [synonym or fully qualified name][10] of the resource you want to prune.
+- Replace [RESOURCE TYPE] with the [fully qualified name or short name][10] of the resource you want to prune.
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE or URL] with the name of the file or the URL that contains the set of Sensu objects you want to keep (the configuration).
 - Replace [flags] with the flags you want to use, if any.
@@ -407,6 +407,8 @@ Use a comma separator to prune more than one resource in a single command.
 For example, to prune checks and assets from the file `checks.yaml` for the `dev` namespace and the `admin` and `ops` users:
 
 {{< code shell >}}
+sensuctl prune core/v2.CheckConfig,core/v2.Asset --file checks.yaml --namespace dev --users admin,ops
+
 sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
 {{< /code >}}
 
@@ -426,45 +428,54 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune resource types
+##### Supported resource types
 
-The table below lists supported `sensuctl prune` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
 
-Synonym | Fully qualified name 
---------------------|---
-None | `authentication/v2.Provider`
-None | `licensing/v2.LicenseFile`
-None | `store/v1.PostgresConfig`
-None | `federation/v1.EtcdReplicator`
-None | `secrets/v1.Provider`
-None | `secrets/v1.Secret`
-`apikey` | `core/v2.APIKey`
-`assets` | `core/v2.Asset`
-`checks` | `core/v2.CheckConfig`
-`clusterroles` | `core/v2.ClusterRole`
-`clusterrolebindings` | `core/v2.ClusterRoleBinding`
-`entities` | `core/v2.Entity`
-`filters` | `core/v2.EventFilter`
-`handlers` | `core/v2.Handler`
-`hooks` | `core/v2.Hook`
-`mutators` | `core/v2.Mutator`
-`namespaces` | `core/v2.Namespace`
-`roles` | `core/v2.Role`
-`rolebindings` | `core/v2.RoleBinding`
-`silenced` | `core/v2.Silenced`
-`tessen` | `core/v2.TessenConfig`
-`users` | `core/v2.User`
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
+
+{{< code shell >}}
+sensuctl describe-type all
+
+      Fully Qualified Name           Short Name           API Version             Type          Namespaced  
+ ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
+{{< /code >}}
 
 ##### sensuctl prune examples
 
-`sensuctl prune` supports pruning resources by their synonyms or fully qualified names:
-
-{{< code shell >}}
-sensuctl prune checks,entities
-{{< /code >}}
+`sensuctl prune` supports pruning resources by their fully qualified names or short names:
 
 {{< code shell >}}
 sensuctl prune core/v2.CheckConfig,core/v2.Entity
+
+sensuctl prune checks,entities
 {{< /code >}}
 
 Use the `all` qualifier to prune all supported resources:
@@ -506,7 +517,7 @@ Sensuctl supports the following formats:
 [7]: ../../operations/deploy-sensu/cluster-sensu/
 [8]: ../../reference/rbac/#user-specification
 [9]: #wrapped-json-format
-[10]: #sensuctl-prune-resource-types
+[10]: #supported-resource-types
 [11]: ../../reference/webconfig/
 [12]: ../../reference/assets/
 [13]: ../../reference/checks/

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -24,13 +24,13 @@ sensuctl dump all --format yaml --file my-resources.yaml
 To export only checks to STDOUT in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump check --format yaml
+sensuctl dump checks --format yaml
 {{< /code >}}
 
 To export only handlers and filters to a file named `my-handlers-and-filters.yaml` in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump handler,filter --format yaml --file my-handlers-and-filters.yaml
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
@@ -129,24 +129,55 @@ When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
 {{% /notice %}}
 
-## List types of supported resources
+## Sensuctl dump resource types
 
 {{% notice important %}}
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type` to list the types of supported resources.
-For example, to list all types:
+Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+
+{{% notice note %}}
+**NOTE**: The resource types with no short name listed are [commercial features](../../commercial/).
+{{% /notice %}}
 
 {{< code shell >}}
 sensuctl describe-type all
+
+      Fully Qualified Name           Short Name           API Version             Type          Namespaced  
+ ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
 
-You can also list specific resource types by fully qualified name or synonym:
+You can also list specific resource types by short name or fully qualified name:
 
 {{< code shell >}}
-sensuctl describe-type core/v2.CheckConfig
 sensuctl describe-type checks
+sensuctl describe-type core/v2.CheckConfig
 {{< /code >}}
 
 To list more than one type, use a comma-separated list:
@@ -156,50 +187,14 @@ sensuctl describe-type core/v2.CheckConfig,core/v2.EventFilter,core/v2.Handler
 sensuctl describe-type checks,filters,handlers
 {{< /code >}}
 
-<a name="resource-types"></a>
-
-The table below lists supported `sensuctl describe-type` resource types.
-
-{{% notice note %}}
-**NOTE**: The resource types with no synonym listed are [commercial features](../../commercial/).
-{{% /notice %}}
-
-Synonym | Fully qualified name 
---------------------|---
-None | `authentication/v2.Provider`
-None | `licensing/v2.LicenseFile`
-None | `store/v1.PostgresConfig`
-None | `federation/v1.Replicator`
-None | `secrets/v1.Provider`
-None | `secrets/v1.Secret`
-None | `searches/v1.Search`
-None | `web/v1.GlobalConfig`
-`apikeys` | `core/v2.APIKey`
-`assets` | `core/v2.Asset`
-`checks` | `core/v2.CheckConfig`
-`clusterroles` | `core/v2.ClusterRole`
-`clusterrolebindings` | `core/v2.ClusterRoleBinding`
-`entities` | `core/v2.Entity`
-`events` | `core/v2.Event` 
-`filters` | `core/v2.EventFilter`
-`handlers` | `core/v2.Handler`
-`hooks` | `core/v2.Hook`
-`mutators` | `core/v2.Mutator`
-`namespaces` | `core/v2.Namespace`
-`roles` | `core/v2.Role`
-`rolebindings` | `core/v2.RoleBinding`
-`silenced` | `core/v2.Silenced`
-`tessen` | `core/v2.TessenConfig`
-`users` | `core/v2.User`
-
 ### Format the sensuctl describe-type response
 
 Add the `--format` flag to specify how the resources should be formatted in the `sensuctl describe-type` response.
 The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 
 {{< code shell >}}
-sensuctl describe-type core/v2.CheckConfig --format yaml
-sensuctl describe-type core/v2.CheckConfig --format wrapped-json
+sensuctl describe-type checks --format yaml
+sensuctl describe-type checks --format wrapped-json
 {{< /code >}}
 
 
@@ -208,4 +203,4 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 [3]: #restore-resources-from-backup
 [4]: ../../operations/maintain-sensu/upgrade/
 [5]: ../create-manage-resources/#create-resources-across-namespaces
-[6]: #resource-types
+[6]: #sensuctl-dump-resource-types

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -33,6 +33,14 @@ To export only handlers and filters to a file named `my-handlers-and-filters.yam
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
+You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands:
+
+{{< code shell >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
+{{< /code >}}
+
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
 This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
 

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -129,7 +129,7 @@ When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
 {{% /notice %}}
 
-## Sensuctl dump resource types
+## Supported resource types
 
 {{% notice important %}}
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
@@ -203,4 +203,4 @@ sensuctl describe-type checks --format wrapped-json
 [3]: #restore-resources-from-backup
 [4]: ../../operations/maintain-sensu/upgrade/
 [5]: ../create-manage-resources/#create-resources-across-namespaces
-[6]: #sensuctl-dump-resource-types
+[6]: #supported-resource-types

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -24,13 +24,13 @@ sensuctl dump all --format yaml --file my-resources.yaml
 To export only checks to STDOUT in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump checks --format yaml
+sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
 To export only handlers and filters to a file named `my-handlers-and-filters.yaml` in `yaml` format:
 
 {{< code shell >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
@@ -51,21 +51,21 @@ mkdir backup
    
    {{< code shell >}}
 sensuctl dump all \
---omit entities,events,apikeys,users,roles,rolebindings,clusterroles,clusterrolebindings \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yaml
 {{< /code >}}
    
 3. Export your [RBAC][2] resources, except API keys and users.
    
    {{< code shell >}}
-sensuctl dump roles,rolebindings,clusterroles,clusterrolebindings
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding
 --format yaml > backup/rbac.yaml
 {{< /code >}}
 
 4. Export your API keys and users resources.
    
    {{< code shell >}}
-sensuctl dump apikeys,users
+sensuctl dump core/v2.APIKey,core/v2.User
 --format yaml > backup/cannotrestore.yaml
 {{< /code >}}
 
@@ -78,7 +78,7 @@ Because users require this additional configuration and API keys cannot be resto
 5. Export your entity resources (if desired).
      
    {{< code shell >}}
-sensuctl dump entities \
+sensuctl dump core/v2.Entity \
 --format yaml > backup/inventory.yaml
 {{< /code >}}
 
@@ -102,7 +102,7 @@ mkdir backup
 2. Back up your pipeline resources, stripping namespaces so that your resources are portable for reuse in any namespace.
    
    {{< code shell >}}
-sensuctl dump assets,checks,hooks,filters,mutators,handlers,silenced,secrets/v1.Secret,secrets/v1.Provider \
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
 {{< /code >}}
 
@@ -138,7 +138,7 @@ You must add a [`password_hash`](../#generate-a-password-hash) or `password` to 
 Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
 
 {{% notice note %}}
-**NOTE**: The resource types with no short name listed are [commercial features](../../commercial/).
+**NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
 {{< code shell >}}
@@ -173,17 +173,19 @@ sensuctl describe-type all
   core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
 
-You can also list specific resource types by short name or fully qualified name:
+You can also list specific resource types by fully qualified name or short name:
 
 {{< code shell >}}
-sensuctl describe-type checks
 sensuctl describe-type core/v2.CheckConfig
+
+sensuctl describe-type checks
 {{< /code >}}
 
 To list more than one type, use a comma-separated list:
 
 {{< code shell >}}
 sensuctl describe-type core/v2.CheckConfig,core/v2.EventFilter,core/v2.Handler
+
 sensuctl describe-type checks,filters,handlers
 {{< /code >}}
 
@@ -193,8 +195,9 @@ Add the `--format` flag to specify how the resources should be formatted in the 
 The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 
 {{< code shell >}}
-sensuctl describe-type checks --format yaml
-sensuctl describe-type checks --format wrapped-json
+sensuctl describe-type core/v2.CheckConfig --format yaml
+
+sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
 

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -395,7 +395,7 @@ sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... -f [FILE or URL] [-r] ... ] [-
 
 In this example `sensuctl prune` command:
 
-- Replace [RESOURCE TYPE] with the [synonym or fully qualified name][10] of the resource you want to prune.
+- Replace [RESOURCE TYPE] with the [short name or fully qualified name][10] of the resource you want to prune.
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE or URL] with the name of the file or the URL that contains the set of Sensu objects you want to keep (the configuration).
 - Replace [flags] with the flags you want to use, if any.
@@ -428,36 +428,47 @@ The following table describes the command-specific flags.
 
 ##### sensuctl prune resource types
 
-The table below lists supported `sensuctl prune` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
 
-Synonym | Fully qualified name 
---------------------|---
-None | `authentication/v2.Provider`
-None | `licensing/v2.LicenseFile`
-None | `store/v1.PostgresConfig`
-None | `federation/v1.EtcdReplicator`
-None | `secrets/v1.Provider`
-None | `secrets/v1.Secret`
-`apikey` | `core/v2.APIKey`
-`assets` | `core/v2.Asset`
-`checks` | `core/v2.CheckConfig`
-`clusterroles` | `core/v2.ClusterRole`
-`clusterrolebindings` | `core/v2.ClusterRoleBinding`
-`entities` | `core/v2.Entity`
-`filters` | `core/v2.EventFilter`
-`handlers` | `core/v2.Handler`
-`hooks` | `core/v2.Hook`
-`mutators` | `core/v2.Mutator`
-`namespaces` | `core/v2.Namespace`
-`roles` | `core/v2.Role`
-`rolebindings` | `core/v2.RoleBinding`
-`silenced` | `core/v2.Silenced`
-`tessen` | `core/v2.TessenConfig`
-`users` | `core/v2.User`
+{{% notice note %}}
+**NOTE**: The resource types with no short name listed are [commercial features](../../commercial/).
+{{% /notice %}}
+
+{{< code shell >}}
+sensuctl describe-type all
+
+      Fully Qualified Name           Short Name           API Version             Type          Namespaced  
+ ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
+{{< /code >}}
 
 ##### sensuctl prune examples
 
-`sensuctl prune` supports pruning resources by their synonyms or fully qualified names:
+`sensuctl prune` supports pruning resources by their short names or fully qualified names:
 
 {{< code shell >}}
 sensuctl prune checks,entities

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -395,7 +395,7 @@ sensuctl prune [RESOURCE TYPE],[RESOURCE TYPE]... -f [FILE or URL] [-r] ... ] [-
 
 In this example `sensuctl prune` command:
 
-- Replace [RESOURCE TYPE] with the [short name or fully qualified name][10] of the resource you want to prune.
+- Replace [RESOURCE TYPE] with the [fully qualified name or short name][10] of the resource you want to prune.
 You must specify at least one resource type or the `all` qualifier (to prune all resource types).
 - Replace [FILE or URL] with the name of the file or the URL that contains the set of Sensu objects you want to keep (the configuration).
 - Replace [flags] with the flags you want to use, if any.
@@ -407,7 +407,7 @@ Use a comma separator to prune more than one resource in a single command.
 For example, to prune checks and assets from the file `checks.yaml` for the `dev` namespace and the `admin` and `ops` users:
 
 {{< code shell >}}
-sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
+sensuctl prune core/v2.CheckConfig,core/v2.Asset --file checks.yaml --namespace dev --users admin,ops
 {{< /code >}}
 
 ##### sensuctl prune flags
@@ -431,7 +431,7 @@ The following table describes the command-specific flags.
 Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
 
 {{% notice note %}}
-**NOTE**: The resource types with no short name listed are [commercial features](../../commercial/).
+**NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
 {{< code shell >}}
@@ -468,14 +468,12 @@ sensuctl describe-type all
 
 ##### sensuctl prune examples
 
-`sensuctl prune` supports pruning resources by their short names or fully qualified names:
-
-{{< code shell >}}
-sensuctl prune checks,entities
-{{< /code >}}
+`sensuctl prune` supports pruning resources by their fully qualified names or short names:
 
 {{< code shell >}}
 sensuctl prune core/v2.CheckConfig,core/v2.Entity
+
+sensuctl prune checks,entities
 {{< /code >}}
 
 Use the `all` qualifier to prune all supported resources:
@@ -517,7 +515,7 @@ Sensuctl supports the following formats:
 [7]: ../../operations/deploy-sensu/cluster-sensu/
 [8]: ../../reference/rbac/#user-specification
 [9]: #wrapped-json-format
-[10]: #sensuctl-prune-resource-types
+[10]: #supported-resource-types
 [11]: ../../reference/webconfig/
 [12]: ../../reference/assets/
 [13]: ../../reference/checks/

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -408,6 +408,8 @@ For example, to prune checks and assets from the file `checks.yaml` for the `dev
 
 {{< code shell >}}
 sensuctl prune core/v2.CheckConfig,core/v2.Asset --file checks.yaml --namespace dev --users admin,ops
+
+sensuctl prune checks,assets --file checks.yaml --namespace dev --users admin,ops
 {{< /code >}}
 
 ##### sensuctl prune flags

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -426,7 +426,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune resource types
+##### Supported resource types
 
 Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
 


### PR DESCRIPTION
## Description
Corrects all sensuctl dump and sensuctl prune commands to use only the short names or fully qualified names listed when you run `sensuctl describe-type`.

Also updates the `sensuctl describe-type --all` list to reflect the response as displayed in terminal and explain how users can retrieve the current list rather than reproducing an edited list of resource types.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2692
