### PR TITLE
Updating the http check for /health to use the ruby check

### DIFF
--- a/content/sensu-go/5.19/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.19/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -51,14 +51,15 @@ metadata:
   namespace: default
   name: check_beta_backend_health
 spec:
-  command: check_http -H sensu-backend-beta -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_alpha
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< code yml "Backend Beta">}}
@@ -68,14 +69,15 @@ metadata:
   namespace: default
   name: check_alpha_backend_health
 spec:
-  command: check_http -H sensu-backend-alpha -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_beta
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/5.20/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.20/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -51,14 +51,15 @@ metadata:
   namespace: default
   name: check_beta_backend_health
 spec:
-  command: check_http -H sensu-backend-beta -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_alpha
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< code yml "Backend Beta">}}
@@ -68,14 +69,15 @@ metadata:
   namespace: default
   name: check_alpha_backend_health
 spec:
-  command: check_http -H sensu-backend-alpha -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_beta
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/5.21/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.21/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -51,14 +51,15 @@ metadata:
   namespace: default
   name: check_beta_backend_health
 spec:
-  command: check_http -H sensu-backend-beta -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_alpha
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< code yml "Backend Beta">}}
@@ -68,14 +69,15 @@ metadata:
   namespace: default
   name: check_alpha_backend_health
 spec:
-  command: check_http -H sensu-backend-alpha -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_beta
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -51,14 +51,15 @@ metadata:
   namespace: default
   name: check_beta_backend_health
 spec:
-  command: check_http -H sensu-backend-beta -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_alpha
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< code yml "Backend Beta">}}
@@ -68,14 +69,15 @@ metadata:
   namespace: default
   name: check_alpha_backend_health
 spec:
-  command: check_http -H sensu-backend-alpha -p 8080 -u /health
+  command: check-http.rb -u http://sensu-backend-beta:8080/health -n false
   subscriptions:
     - backend_beta
   interval: 10
   publish: true
   timeout: 10
   runtime_assets:
-    - monitoring-plugins
+    - sensu-ruby-runtime
+    - sensu-plugins-http
 {{< /code >}}
 
 {{< /language-toggle >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Addresses the issue where regardless of what check is used, the `/health` endpoint won't return anything other than a 200. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->

## Review Instructions
<!--- Optional -->
