### PR TITLE
Add observability pipeline notice to Sensu Go 5.x 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,7 +4,7 @@
     <img alt="Sensu Go Lizy mascot image" title="404 Page Not Found" src="/images/idle-lizy.png">
     <h1>404</h1>
     <h2>Page Not Found</h2>
-    <p>Try searching the docs below, or visit the <a href="/">site directory</a>.<p>
+    <p id="instructions">Try searching the docs below, or visit the <a href="/">site directory</a>.<p>
 
     <div class="full-width-search">
       <input id="search" type="text" />
@@ -48,6 +48,12 @@
     document.querySelector(docsearchOptions.inputSelector).value = searchTerms.join(" ").match(/[a-zA-Z0-9.]+/g).join(" ");
     var search = docsearch(docsearchOptions);
     search.autocomplete.autocomplete.open();
+
+    // Add notice about new 6.x pages that aren't present in 5.x
+    // TODO: Remove after all 5.x content is archived
+    if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the main Sensu Go ${searchTerms[1]} page if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+    }
   </script>
   <body>
 </html>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -21,6 +21,12 @@
     var searchTerms = window.location.pathname.split("/");
     searchTerms.shift();
 
+    // Add notice about new 6.x pages that aren't present in 5.x
+    // TODO: Remove after all 5.x content is archived
+    if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the main Sensu Go ${searchTerms[1]} page if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+    }
+
     // Scope the search results to a product/version (dirty)
     // Versions
     if (searchTerms[1]) {
@@ -48,12 +54,6 @@
     document.querySelector(docsearchOptions.inputSelector).value = searchTerms.join(" ").match(/[a-zA-Z0-9.]+/g).join(" ");
     var search = docsearch(docsearchOptions);
     search.autocomplete.autocomplete.open();
-
-    // Add notice about new 6.x pages that aren't present in 5.x
-    // TODO: Remove after all 5.x content is archived
-    if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the main Sensu Go ${searchTerms[1]} page if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
-    }
   </script>
   <body>
 </html>

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -7,6 +7,7 @@
 (function () {
   // 1
   const $toc = document.getElementById('TableOfContents');
+  if (!$toc) return;
   const $tocElements = Array.from($toc.querySelectorAll('li')).filter($el => $el.innerHTML.trim());
   const tocLinks = $tocElements.map($li => (
     `#${CSS.escape($li.querySelector('a').getAttribute('href').replace('#', ''))}`


### PR DESCRIPTION
## Description

As above. On the 404 page, the following text...

> Try searching the docs below, or visit the site directory.

Is replaced with...

> We made some improvements in the version 6 docs that aren’t reflected in earlier versions. Try the main Sensu Go ${version} page if you need to use pre-6.0 docs. You can also search the docs below or visit the site directory.

Where `${version}` is replaced by whatever 5.x version the user attempted to navigate to.

## Motivation and Context

Resolves #2708