### PR TITLE
Fix main version page link in 404 for observability pipeline

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -24,7 +24,7 @@
     // Add notice about new 6.x pages that aren't present in 5.x
     // TODO: Remove after all 5.x content is archived
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="docs.sensu.io/sensu-go/${searchTerms[1]}">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="docs.sensu.io/sensu-go/${searchTerms[1]}">main Sensu Go page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
     }
 
     // Scope the search results to a product/version (dirty)

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -24,7 +24,7 @@
     // Add notice about new 6.x pages that aren't present in 5.x
     // TODO: Remove after all 5.x content is archived
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="../../../">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
     }
 
     // Scope the search results to a product/version (dirty)

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -24,7 +24,7 @@
     // Add notice about new 6.x pages that aren't present in 5.x
     // TODO: Remove after all 5.x content is archived
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="../">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="docs.sensu.io/sensu-go/${searchTerms[1]}">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
     }
 
     // Scope the search results to a product/version (dirty)

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -24,7 +24,7 @@
     // Add notice about new 6.x pages that aren't present in 5.x
     // TODO: Remove after all 5.x content is archived
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="docs.sensu.io/sensu-go/${searchTerms[1]}">main Sensu Go page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="../../../">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
     }
 
     // Scope the search results to a product/version (dirty)


### PR DESCRIPTION
## Description
Fixes the link to the main version pages in the 404 content for the observability pipeline pages.

## Motivation and Context
Docs IA project
