### PR TITLE
Add api-request-limit backend flag

### DIFF
--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -47,7 +47,8 @@ Beta APIs are more stable than alpha versions, but they offer similarly short-li
 
 ## Request size limit
 
-API request bodies are limited to 0.512 MB in size.
+The default limit for API request body size is 0.512 MB.
+Use the [`--api-request-limit` backend configuration flag][21] to customize the API request body size limit if needed.
 
 ## Access control
 
@@ -697,3 +698,4 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
 [19]: apikeys/
 [20]: #authenticate-with-the-authentication-api
+[21]: ../observability-pipeline/observe-schedule/backend/#api-request-limit

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -381,7 +381,7 @@ api-listen-address: "[::]:8080"{{< /code >}}
 -------------|------
 description  | Maximum size for API request bodies. In bytes.
 type         | Integer
-default      | `1024000`
+default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
 example      | {{< code shell >}}# Command line example
 sensu-backend start --api-request-limit 1024000

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -279,7 +279,7 @@ General Flags:
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --annotations stringToString          entity annotations map (default [])
       --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
-      --api-request-limit                   maximum API request body size, in bytes
+      --api-request-limit                   maximum API request body size, in bytes (default 512000)
       --api-url string                      URL of the API to connect to (default "http://localhost:8080")
       --assets-burst-limit int              asset fetch burst limit (default 100)
       --assets-rate-limit float             maximum number of assets fetched per second

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -279,6 +279,7 @@ General Flags:
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --annotations stringToString          entity annotations map (default [])
       --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
+      --api-request-limit                   maximum API request body size, in bytes
       --api-url string                      URL of the API to connect to (default "http://localhost:8080")
       --assets-burst-limit int              asset fetch burst limit (default 100)
       --assets-rate-limit float             maximum number of assets fetched per second
@@ -373,6 +374,20 @@ sensu-backend start --api-listen-address [::]:8080
 # /etc/sensu/backend.yml example
 api-listen-address: "[::]:8080"{{< /code >}}
 
+
+<a name="api-request-limit"></a>
+
+| api-request-limit |      |
+-------------|------
+description  | Maximum size for API request bodies. In bytes.
+type         | Integer
+default      | `1024000`
+environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
+example      | {{< code shell >}}# Command line example
+sensu-backend start --api-request-limit 1024000
+
+# /etc/sensu/backend.yml example
+api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
 -------------|------


### PR DESCRIPTION
## Description
- Adds api-request-limit flag to backend reference
- Updates default API request size limit information in API index page

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2705
