### PR TITLE
Fix HTTP response codes for create entities and events

### DIFF
--- a/content/sensu-go/5.19/api/entities.md
+++ b/content/sensu-go/5.19/api/entities.md
@@ -184,7 +184,7 @@ The `/entities` API endpoint provides HTTP POST access to create a Sensu entity.
 ### Example {#entities-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/entities` API endpoint to create a proxy entity named `sensu-centos`.
-The request includes the entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X POST \
@@ -207,7 +207,7 @@ curl -X POST \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entities-post-specification}
@@ -326,7 +326,7 @@ HTTP/1.1 200 OK
 description          | Returns the specified entity.
 example url          | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
 response type        | Map
-response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< code json >}}
 {
   "entity_class": "agent",
@@ -405,7 +405,7 @@ The `/entities/:entity` API endpoint provides HTTP PUT access to create or updat
 ### Example {#entitiesentity-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/entities/:entity` API endpoint to update the entity named `sensu-centos`.
-The request includes the updated entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the updated entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X PUT \
@@ -429,7 +429,7 @@ curl -X PUT \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/sensu-centos
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entitiesentity-put-specification}
@@ -458,7 +458,7 @@ payload         | {{< code shell >}}
   }
 }
 {{< /code >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete an entity
 

--- a/content/sensu-go/5.19/api/events.md
+++ b/content/sensu-go/5.19/api/events.md
@@ -172,7 +172,7 @@ The `/events` API endpoint provides HTTP POST access to create an event and send
 ### Example {#events-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/events` API endpoint to create an event.
-The request includes information about the check and entity represented by the event and returns a successful HTTP `200 OK` response and the event definition.
+The request includes information about the check and entity represented by the event and returns a successful HTTP `201 Created` response and the event definition.
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/5.20/api/entities.md
+++ b/content/sensu-go/5.20/api/entities.md
@@ -237,7 +237,7 @@ The `/entities` API endpoint provides HTTP POST access to create a Sensu entity.
 ### Example {#entities-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/entities` API endpoint to create a proxy entity named `sensu-centos`.
-The request includes the entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X POST \
@@ -260,7 +260,7 @@ curl -X POST \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entities-post-specification}
@@ -403,7 +403,7 @@ HTTP/1.1 200 OK
 description          | Returns the specified entity.
 example url          | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
 response type        | Map
-response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< code json >}}
 {
   "entity_class": "agent",
@@ -506,7 +506,7 @@ The `/entities/:entity` API endpoint provides HTTP PUT access to create or updat
 ### Example {#entitiesentity-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/entities/:entity` API endpoint to update the entity named `sensu-centos`.
-The request includes the updated entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the updated entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X PUT \
@@ -530,7 +530,7 @@ curl -X PUT \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/sensu-centos
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entitiesentity-put-specification}
@@ -559,7 +559,7 @@ payload         | {{< code shell >}}
   }
 }
 {{< /code >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete an entity {#entitiesentity-delete}
 

--- a/content/sensu-go/5.20/api/events.md
+++ b/content/sensu-go/5.20/api/events.md
@@ -177,7 +177,7 @@ The `/events` API endpoint provides HTTP POST access to create an event and send
 ### Example {#events-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/events` API endpoint to create an event.
-The request includes information about the check and entity represented by the event and returns a successful HTTP `200 OK` response and the event definition.
+The request includes information about the check and entity represented by the event and returns a successful HTTP `201 Created` response and the event definition.
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/5.21/api/entities.md
+++ b/content/sensu-go/5.21/api/entities.md
@@ -237,7 +237,7 @@ The `/entities` API endpoint provides HTTP POST access to create a Sensu entity.
 ### Example {#entities-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/entities` API endpoint to create a proxy entity named `sensu-centos`.
-The request includes the entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X POST \
@@ -260,7 +260,7 @@ curl -X POST \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entities-post-specification}
@@ -403,7 +403,7 @@ HTTP/1.1 200 OK
 description          | Returns the specified entity.
 example url          | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
 response type        | Map
-response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< code json >}}
 {
   "entity_class": "agent",
@@ -506,7 +506,7 @@ The `/entities/:entity` API endpoint provides HTTP PUT access to create or updat
 ### Example {#entitiesentity-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/entities/:entity` API endpoint to update the entity named `sensu-centos`.
-The request includes the updated entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the updated entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X PUT \
@@ -530,7 +530,7 @@ curl -X PUT \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/sensu-centos
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entitiesentity-put-specification}
@@ -559,7 +559,7 @@ payload         | {{< code shell >}}
   }
 }
 {{< /code >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete an entity {#entitiesentity-delete}
 

--- a/content/sensu-go/5.21/api/events.md
+++ b/content/sensu-go/5.21/api/events.md
@@ -177,7 +177,7 @@ The `/events` API endpoint provides HTTP POST access to create an event and send
 ### Example {#events-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/events` API endpoint to create an event.
-The request includes information about the check and entity represented by the event and returns a successful HTTP `200 OK` response and the event definition.
+The request includes information about the check and entity represented by the event and returns a successful HTTP `201 Created` response and the event definition.
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/6.0/api/entities.md
+++ b/content/sensu-go/6.0/api/entities.md
@@ -237,7 +237,7 @@ The `/entities` API endpoint provides HTTP POST access to create a Sensu entity.
 ### Example {#entities-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/entities` API endpoint to create a proxy entity named `sensu-centos`.
-The request includes the entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X POST \
@@ -260,7 +260,7 @@ curl -X POST \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entities-post-specification}
@@ -403,7 +403,7 @@ HTTP/1.1 200 OK
 description          | Returns the specified entity.
 example url          | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
 response type        | Map
-response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< code json >}}
 {
   "entity_class": "agent",
@@ -506,7 +506,7 @@ The `/entities/:entity` API endpoint provides HTTP PUT access to create or updat
 ### Example {#entitiesentity-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/entities/:entity` API endpoint to update the entity named `sensu-centos`.
-The request includes the updated entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the updated entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X PUT \
@@ -530,7 +530,7 @@ curl -X PUT \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/sensu-centos
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entitiesentity-put-specification}
@@ -559,7 +559,7 @@ payload         | {{< code shell >}}
   }
 }
 {{< /code >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete an entity {#entitiesentity-delete}
 

--- a/content/sensu-go/6.0/api/events.md
+++ b/content/sensu-go/6.0/api/events.md
@@ -185,7 +185,7 @@ The `/events` API endpoint provides HTTP POST access to create an event and send
 ### Example {#events-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/events` API endpoint to create an event.
-The request includes information about the check and entity represented by the event and returns a successful HTTP `200 OK` response and the event definition.
+The request includes information about the check and entity represented by the event and returns a successful HTTP `201 Created` response and the event definition.
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/6.1/api/entities.md
+++ b/content/sensu-go/6.1/api/entities.md
@@ -237,7 +237,7 @@ The `/entities` API endpoint provides HTTP POST access to create a Sensu entity.
 ### Example {#entities-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/entities` API endpoint to create a proxy entity named `sensu-centos`.
-The request includes the entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X POST \
@@ -260,7 +260,7 @@ curl -X POST \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entities-post-specification}
@@ -403,7 +403,7 @@ HTTP/1.1 200 OK
 description          | Returns the specified entity.
 example url          | http://hostname:8080/api/core/v2/namespaces/default/entities/sensu-centos
 response type        | Map
-response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< code json >}}
 {
   "entity_class": "agent",
@@ -506,7 +506,7 @@ The `/entities/:entity` API endpoint provides HTTP PUT access to create or updat
 ### Example {#entitiesentity-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/entities/:entity` API endpoint to update the entity named `sensu-centos`.
-The request includes the updated entity definition in the request body and returns a successful `HTTP 201 Created` response.
+The request includes the updated entity definition in the request body and returns a successful `HTTP 200 OK` response.
 
 {{< code shell >}}
 curl -X PUT \
@@ -530,7 +530,7 @@ curl -X PUT \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/entities/sensu-centos
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification {#entitiesentity-put-specification}
@@ -559,7 +559,7 @@ payload         | {{< code shell >}}
   }
 }
 {{< /code >}}
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete an entity {#entitiesentity-delete}
 

--- a/content/sensu-go/6.1/api/events.md
+++ b/content/sensu-go/6.1/api/events.md
@@ -185,7 +185,7 @@ The `/events` API endpoint provides HTTP POST access to create an event and send
 ### Example {#events-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/events` API endpoint to create an event.
-The request includes information about the check and entity represented by the event and returns a successful HTTP `200 OK` response and the event definition.
+The request includes information about the check and entity represented by the event and returns a successful HTTP `201 Created` response and the event definition.
 
 {{< code shell >}}
 curl -X POST \


### PR DESCRIPTION
## Description

https://docs.sensu.io/sensu-go/latest/api/entities/#create-a-new-entity: correct example text and example to use 200 instead of 201

https://docs.sensu.io/sensu-go/latest/api/entities/#entitiesentity-put: correct example text and example to use 200 instead of 201

https://docs.sensu.io/sensu-go/latest/api/events/#create-a-new-event: correct example text to use 201 instead of 200

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2693