### PR TITLE
Add explanation for SENSU_HOSTNAME in flag defaults

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -808,6 +808,10 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 <a name="allow-list"></a>
 
 | allow-list |      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -344,6 +344,10 @@ discovery instead of the static `--initial-cluster method`
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with entity data for backend dynamic runtime assets (e.g. handler and mutator dynamic runtime assets).
@@ -765,6 +769,10 @@ dashboard-port: 4000{{< /code >}}
 
 
 ### Datastore and cluster configuration flags
+
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
 
 | etcd-advertise-client-urls |      |
 --------------|------

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -808,6 +808,10 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 <a name="allow-list"></a>
 
 | allow-list |      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -345,6 +345,10 @@ discovery instead of the static `--initial-cluster method`
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with entity data for backend dynamic runtime assets (e.g. handler and mutator dynamic runtime assets).
@@ -780,6 +784,10 @@ dashboard-port: 4000{{< /code >}}
 
 
 ### Datastore and cluster configuration flags
+
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
 
 | etcd-advertise-client-urls |      |
 --------------|------


### PR DESCRIPTION
## Description
Explains what we mean by `SENSU_HOSTNAME` in flag default values in agent and backend references.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2671