### PR TITLE
Fix grammar in SENSU_HOSTNAME notes

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -808,6 +808,10 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 <a name="allow-list"></a>
 
 | allow-list |      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -809,7 +809,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
 <a name="allow-list"></a>

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -809,7 +809,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
 {{% /notice %}}
 
 <a name="allow-list"></a>

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -771,7 +771,7 @@ dashboard-port: 4000{{< /code >}}
 ### Datastore and cluster configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
 | etcd-advertise-client-urls |      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -345,7 +345,7 @@ discovery instead of the static `--initial-cluster method`
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
 | annotations|      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -344,6 +344,10 @@ discovery instead of the static `--initial-cluster method`
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with entity data for backend dynamic runtime assets (e.g. handler and mutator dynamic runtime assets).
@@ -765,6 +769,10 @@ dashboard-port: 4000{{< /code >}}
 
 
 ### Datastore and cluster configuration flags
+
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
 
 | etcd-advertise-client-urls |      |
 --------------|------

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -345,7 +345,7 @@ discovery instead of the static `--initial-cluster method`
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
 {{% /notice %}}
 
 | annotations|      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -808,6 +808,10 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 <a name="allow-list"></a>
 
 | allow-list |      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -809,7 +809,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
 <a name="allow-list"></a>

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -809,7 +809,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
 {{% /notice %}}
 
 <a name="allow-list"></a>

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -786,7 +786,7 @@ dashboard-port: 4000{{< /code >}}
 ### Datastore and cluster configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
 | etcd-advertise-client-urls |      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -346,7 +346,7 @@ discovery instead of the static `--initial-cluster method`
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
 {{% /notice %}}
 
 | annotations|      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -345,6 +345,10 @@ discovery instead of the static `--initial-cluster method`
 
 ### General configuration flags
 
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with entity data for backend dynamic runtime assets (e.g. handler and mutator dynamic runtime assets).
@@ -780,6 +784,10 @@ dashboard-port: 4000{{< /code >}}
 
 
 ### Datastore and cluster configuration flags
+
+{{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostname of containers, which is represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+{{% /notice %}}
 
 | etcd-advertise-client-urls |      |
 --------------|------

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -346,7 +346,7 @@ discovery instead of the static `--initial-cluster method`
 ### General configuration flags
 
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in default flag values for Docker.
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
 | annotations|      |


### PR DESCRIPTION
## Description
Fixes grammar in notes re: `SENSU_HOSTNAME` added in https://github.com/sensu/sensu-docs/pull/2729

## Motivation and Context
Clean up additions from https://github.com/sensu/sensu-docs/pull/2729
