### PR TITLE
Add issue template for interactive tutorials

### DIFF
--- a/.github/ISSUE_TEMPLATE/tutorial-issue.md
+++ b/.github/ISSUE_TEMPLATE/tutorial-issue.md
@@ -1,0 +1,42 @@
+---
+name: Interactive tutorial issue
+about: Report a tutorial content or functionality problem or suggest an improvement
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Description
+<!--- Summarize the problem or your suggestion -->
+
+### Category
+
+This is an issue with:
+
+- [ ] bug (bug in tutorial build, layout, or functionality)
+- [ ] errata (error in tutorial content)
+- [ ] update (add missing or refresh existing content)
+- [ ] improvement (improve tutorial content or format)
+- [ ] new tutorial (requires a completely new tutorial)
+
+### Affected tutorial
+<!--- List the tutorial that needs to be updated to resolve this issue -->
+
+### Expected behavior
+<!--- Explain what should happen (for a bug or error) or suggest a change or improvement -->
+
+### Current behavior
+<!--- Explain what currently happens (for a bug or error) or what is missing (for a suggested improvement) -->
+
+### Changes needed
+<!--- Identify the information that needs to be corrected, if known -->
+
+### Screenshots
+<!--- If applicable, add screenshots to help explain the problem or suggestion -->
+
+### Additional context
+<!--- Add any other context about the issue here -->
+
+* Browser(s) and version(s): 
+* OS:


### PR DESCRIPTION
## Description
Adds an issue template for the interactive tutorials (Katacoda).

## Motivation and Context
Begin addressing https://github.com/sensu/sensu-docs/issues/2233
