### PR TITLE
Add link to tutorial issue template in all scenarios

### DIFF
--- a/content/sensu-go/5.20/learn/learn-in-15.md
+++ b/content/sensu-go/5.20/learn/learn-in-15.md
@@ -28,4 +28,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.20/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/5.20/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/5.20/learn/sensu-pagerduty.md
+++ b/content/sensu-go/5.20/learn/sensu-pagerduty.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.20/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/5.20/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/5.20/learn/up-and-running.md
+++ b/content/sensu-go/5.20/learn/up-and-running.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.20/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/5.20/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/5.21/learn/learn-in-15.md
+++ b/content/sensu-go/5.21/learn/learn-in-15.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/5.21/learn/sensu-pagerduty.md
+++ b/content/sensu-go/5.21/learn/sensu-pagerduty.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/5.21/learn/up-and-running.md
+++ b/content/sensu-go/5.21/learn/up-and-running.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/6.0/learn/learn-in-15.md
+++ b/content/sensu-go/6.0/learn/learn-in-15.md
@@ -24,7 +24,7 @@ s.parentNode.insertBefore(b, s);})();
     data-katacoda-color="2c3458"
     data-katacoda-ctaurl="https://docs.sensu.io/sensu-go/latest/learn/sandbox/"
     data-katacoda-ctatext="Learn more in the Sensu Sandbox"
-    style="height: 800px; padding-top: 10px;" 
+    style="height: 800px; padding-top: 10px;"
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/6.0/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/6.0/learn/sensu-pagerduty.md
+++ b/content/sensu-go/6.0/learn/sensu-pagerduty.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/6.0/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/6.0/learn/up-and-running.md
+++ b/content/sensu-go/6.0/learn/up-and-running.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/6.0/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/6.1/learn/learn-in-15.md
+++ b/content/sensu-go/6.1/learn/learn-in-15.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/6.1/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/6.1/learn/sensu-pagerduty.md
+++ b/content/sensu-go/6.1/learn/sensu-pagerduty.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/6.1/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>

--- a/content/sensu-go/6.1/learn/up-and-running.md
+++ b/content/sensu-go/6.1/learn/up-and-running.md
@@ -27,4 +27,4 @@ s.parentNode.insertBefore(b, s);})();
     style="height: 800px; padding-top: 10px;" 
 ></div>
 <br><br>
-<a href="https://docs.sensu.io/sensu-go/5.21/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a>
+<a href="https://docs.sensu.io/sensu-go/6.1/learn/interactive-tutorials/"><-- Back to Learn Sensu with interactive training</a> or <a href="https://github.com/sensu/sensu-docs/issues/new?assignees=&labels=&template=tutorial-issue.md&title=">report an issue in this tutorial</a>


### PR DESCRIPTION
## Description
Adds link to https://github.com/sensu/sensu-docs/blob/master/.github/ISSUE_TEMPLATE/tutorial-issue.md in the footer of all Katacoda scenarios.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2233
