### PR TITLE
Update the script for adding a new version to update interactive tutorial links

### DIFF
--- a/scripts/new-docs-version.sh
+++ b/scripts/new-docs-version.sh
@@ -38,6 +38,8 @@ find_and_replace() {
     echo "Renaming menu attribute in front matter"
     find "$DOCS_ROOT/content/sensu-go/$NEW_SENSU_VERSION" -iname '*.md' -exec sed -i "s/  sensu-go-${OLD_SENSU_VERSION}\:/  sensu-go-${NEW_SENSU_VERSION}\:/g" {} +
     find "$DOCS_ROOT/content/sensu-go/$NEW_SENSU_VERSION" -iname '*.md' -exec sed -i "s/menu: \"sensu-go-${OLD_SENSU_VERSION}\"/menu: \"sensu-go-${NEW_SENSU_VERSION}\"/g" {} +
+    echo "Updating version in interactive tutorial links"
+    sed -i "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/${NEW_SENSU_VERSION}/learn/learn-in-15.md content/sensu-go/${NEW_SENSU_VERSION}/learn/up-and-running.md content/sensu-go/${NEW_SENSU_VERSION}/learn/sensu-pagerduty.md
     return 0
     ;;
   "Darwin")
@@ -46,6 +48,8 @@ find_and_replace() {
     echo "Renaming menu attribute in front matter"
     find "$DOCS_ROOT/content/sensu-go/$NEW_SENSU_VERSION" -iname '*.md' -exec sed -i '' "s/  sensu-go-${OLD_SENSU_VERSION}\:/  sensu-go-${NEW_SENSU_VERSION}\:/g" {} +
     find "$DOCS_ROOT/content/sensu-go/$NEW_SENSU_VERSION" -iname '*.md' -exec sed -i '' "s/menu: \"sensu-go-${OLD_SENSU_VERSION}\"/menu: \"sensu-go-${NEW_SENSU_VERSION}\"/g" {} +
+    echo "Updating version in interactive tutorial links"
+    sed -i '' "s/${OLD_SENSU_VERSION}/${NEW_SENSU_VERSION}/g" content/sensu-go/${NEW_SENSU_VERSION}/learn/learn-in-15.md content/sensu-go/${NEW_SENSU_VERSION}/learn/up-and-running.md content/sensu-go/${NEW_SENSU_VERSION}/learn/sensu-pagerduty.md
     return 0
     ;;
   *)


### PR DESCRIPTION
## Description
Updates new-docs-version.sh so that it will also update the version numbers in the links in our Katacoda scenario wrappers.

## Motivation and Context
I realized we have a link back to the main interactive tutorials page (https://docs.sensu.io/sensu-go/latest/learn/interactive-tutorials/) at the bottom of the page in our Katacoda scenarios. This link wasn't getting updated by either of our scripts when we create a new docs version or update the version/build numbers. 