### PR TITLE
Add agent flags re: backend handshake and heartbeat

### DIFF
--- a/content/sensu-go/5.19/reference/agent.md
+++ b/content/sensu-go/5.19/reference/agent.md
@@ -749,6 +749,9 @@ Flags:
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
       --assets-burst-limit int                asset fetch burst limit (default 100)
       --assets-rate-limit float               maximum number of assets fetched per second
+      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -854,6 +857,45 @@ sensu-agent start --assets-rate-limit 1.39
 
 # /etc/sensu/agent.yml example
 assets-rate-limit: 1.39{{< /code >}}
+
+
+| backend-handshake-timeout |      |
+----------------------------|------
+description   | Number of seconds the Sensu agent should wait when negotiating a new WebSocket connection.
+type          | Integer
+default       | `15`
+environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-handshake-timeout 20
+
+# /etc/sensu/agent.yml example
+backend-handshake-timeout: 20{{< /code >}}
+
+
+| backend-heartbeat-interval |      |
+-----------------------------|------
+description   | Interval at which the agent should send heartbeats to the Sensu backend. In seconds.
+type          | Integer
+default       | `30`
+environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-interval 45
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-interval: 45{{< /code >}}
+
+
+| backend-heartbeat-timeout |      |
+----------------------------|------
+description   | Number of seconds the agent should wait for a response to a hearbeat from the Sensu backend.
+type          | Integer
+default       | `45`
+environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-timeout 60
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-timeout: 60{{< /code >}}
 
 
 | backend-url |      |

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -755,6 +755,9 @@ Flags:
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
       --assets-burst-limit int                asset fetch burst limit (default 100)
       --assets-rate-limit float               maximum number of assets fetched per second
+      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -862,6 +865,45 @@ sensu-agent start --assets-rate-limit 1.39
 
 # /etc/sensu/agent.yml example
 assets-rate-limit: 1.39{{< /code >}}
+
+
+| backend-handshake-timeout |      |
+----------------------------|------
+description   | Number of seconds the Sensu agent should wait when negotiating a new WebSocket connection.
+type          | Integer
+default       | `15`
+environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-handshake-timeout 20
+
+# /etc/sensu/agent.yml example
+backend-handshake-timeout: 20{{< /code >}}
+
+
+| backend-heartbeat-interval |      |
+-----------------------------|------
+description   | Interval at which the agent should send heartbeats to the Sensu backend. In seconds.
+type          | Integer
+default       | `30`
+environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-interval 45
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-interval: 45{{< /code >}}
+
+
+| backend-heartbeat-timeout |      |
+----------------------------|------
+description   | Number of seconds the agent should wait for a response to a hearbeat from the Sensu backend.
+type          | Integer
+default       | `45`
+environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-timeout 60
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-timeout: 60{{< /code >}}
 
 
 | backend-url |      |

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -755,6 +755,9 @@ Flags:
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
       --assets-burst-limit int                asset fetch burst limit (default 100)
       --assets-rate-limit float               maximum number of assets fetched per second
+      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -864,6 +867,45 @@ sensu-agent start --assets-rate-limit 1.39
 
 # /etc/sensu/agent.yml example
 assets-rate-limit: 1.39{{< /code >}}
+
+
+| backend-handshake-timeout |      |
+----------------------------|------
+description   | Number of seconds the Sensu agent should wait when negotiating a new WebSocket connection.
+type          | Integer
+default       | `15`
+environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-handshake-timeout 20
+
+# /etc/sensu/agent.yml example
+backend-handshake-timeout: 20{{< /code >}}
+
+
+| backend-heartbeat-interval |      |
+-----------------------------|------
+description   | Interval at which the agent should send heartbeats to the Sensu backend. In seconds.
+type          | Integer
+default       | `30`
+environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-interval 45
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-interval: 45{{< /code >}}
+
+
+| backend-heartbeat-timeout |      |
+----------------------------|------
+description   | Number of seconds the agent should wait for a response to a hearbeat from the Sensu backend.
+type          | Integer
+default       | `45`
+environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-timeout 60
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-timeout: 60{{< /code >}}
 
 
 | backend-url |      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -755,6 +755,9 @@ Flags:
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
       --assets-burst-limit int                asset fetch burst limit (default 100)
       --assets-rate-limit float               maximum number of assets fetched per second
+      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -868,6 +871,45 @@ sensu-agent start --assets-rate-limit 1.39
 
 # /etc/sensu/agent.yml example
 assets-rate-limit: 1.39{{< /code >}}
+
+
+| backend-handshake-timeout |      |
+----------------------------|------
+description   | Number of seconds the Sensu agent should wait when negotiating a new WebSocket connection.
+type          | Integer
+default       | `15`
+environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-handshake-timeout 20
+
+# /etc/sensu/agent.yml example
+backend-handshake-timeout: 20{{< /code >}}
+
+
+| backend-heartbeat-interval |      |
+-----------------------------|------
+description   | Interval at which the agent should send heartbeats to the Sensu backend. In seconds.
+type          | Integer
+default       | `30`
+environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-interval 45
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-interval: 45{{< /code >}}
+
+
+| backend-heartbeat-timeout |      |
+----------------------------|------
+description   | Number of seconds the agent should wait for a response to a hearbeat from the Sensu backend.
+type          | Integer
+default       | `45`
+environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-timeout 60
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-timeout: 60{{< /code >}}
 
 
 | backend-url |      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -755,6 +755,9 @@ Flags:
       --api-port int                          port the Sensu client HTTP API listens on (default 3031)
       --assets-burst-limit int                asset fetch burst limit (default 100)
       --assets-rate-limit float               maximum number of assets fetched per second
+      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
       --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
       --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
       --cert-file string                      TLS certificate in PEM format
@@ -868,6 +871,45 @@ sensu-agent start --assets-rate-limit 1.39
 
 # /etc/sensu/agent.yml example
 assets-rate-limit: 1.39{{< /code >}}
+
+
+| backend-handshake-timeout |      |
+----------------------------|------
+description   | Number of seconds the Sensu agent should wait when negotiating a new WebSocket connection.
+type          | Integer
+default       | `15`
+environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-handshake-timeout 20
+
+# /etc/sensu/agent.yml example
+backend-handshake-timeout: 20{{< /code >}}
+
+
+| backend-heartbeat-interval |      |
+-----------------------------|------
+description   | Interval at which the agent should send heartbeats to the Sensu backend. In seconds.
+type          | Integer
+default       | `30`
+environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-interval 45
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-interval: 45{{< /code >}}
+
+
+| backend-heartbeat-timeout |      |
+----------------------------|------
+description   | Number of seconds the agent should wait for a response to a hearbeat from the Sensu backend.
+type          | Integer
+default       | `45`
+environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --backend-heartbeat-timeout 60
+
+# /etc/sensu/agent.yml example
+backend-heartbeat-timeout: 60{{< /code >}}
 
 
 | backend-url |      |

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,8 +3157,8 @@ yaml@^1.8.3:
   dependencies:
     "@babel/runtime" "^7.8.7"
 
-yargs-parser@^13.1.2:
-  version "13.1.2"
+yargs-parser@^5.0.0:
+  version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,8 +3157,8 @@ yaml@^1.8.3:
   dependencies:
     "@babel/runtime" "^7.8.7"
 
-yargs-parser@^5.0.0:
-  version "5.0.0"
+yargs-parser@^13.1.2:
+  version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:


### PR DESCRIPTION
## Description
Documents these config flags in the agent reference:
`--backend-handshake-timeout`
`--backend-heartbeat-interval`
`--backend-heartbeat-timeout`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2735
