### PR TITLE
Clarify purpose of agent entity decoupling

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -41,7 +41,7 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 When an agent connects to a backend, the agent entity definition is created from the information in the `agent.yml` configuration file.
 The default `agent.yml` file location [depends on your operating system][35].
 
-You can manage agent entity configuration via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
 This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 {{% notice note %}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -41,14 +41,15 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 When an agent connects to a backend, the agent entity definition is created from the information in the `agent.yml` configuration file.
 The default `agent.yml` file location [depends on your operating system][35].
 
-You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
-
-If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+You can manage agent entity configuration via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 {{% notice note %}}
 **NOTE**: You cannot modify an agent entity with the `agent.yml` configuration file unless you delete the entity.
 The entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
+
+If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
 
 To maintain agent entities based on `agent.yml`, create ephemeral agent entities with the [deregister attribute][34] set to `true`.
 With this setting, the agent entity will deregister every time the agent process stops and its keepalive expires.

--- a/content/sensu-go/6.0/release-notes.md
+++ b/content/sensu-go/6.0/release-notes.md
@@ -82,7 +82,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.0.0.
 As a result, after you complete the steps to [upgrade to Sensu 6.0][170] (including running the `sensu-backend upgrade` command), you will not be able to use your database with older versions of Sensu.
 - In [binary-only distributions][164], the web UI is now a standalone product that is no longer distributed inside the `sensu-backend` binary.
 See the [Sensu Go Web repository][163] for more information.
-- After initial creation, you cannot change your `sensu-agent` entity configuration by modifying the agent's configuration file.
+- After initial creation, you cannot change your [`sensu-agent` entity configuration][171] by modifying the agent's configuration file.
 
 **NEW FEATURES:**
 
@@ -1474,3 +1474,4 @@ To get started with Sensu Go:
 [168]: /sensu-go/6.0/observability-pipeline/observe-filter/sensu-query-expressions/#sensucheckdependencies
 [169]: /sensu-go/6.0/observability-pipeline/observe-filter/filters/#build-event-filter-expressions-with-javascript-execution-functions
 [170]: /sensu-go/6.0/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-60-from-a-5x-deployment
+[171]: /sensu-go/6.0/observability-pipeline/observe-entities/entities/#create-and-manage-agent-entities

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -41,14 +41,15 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 When an agent connects to a backend, the agent entity definition is created from the information in the `agent.yml` configuration file.
 The default `agent.yml` file location [depends on your operating system][35].
 
-You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
-
-If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 {{% notice note %}}
 **NOTE**: You cannot modify an agent entity with the `agent.yml` configuration file unless you delete the entity.
 The entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
+
+If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
 
 To maintain agent entities based on `agent.yml`, create ephemeral agent entities with the [deregister attribute][34] set to `true`.
 With this setting, the agent entity will deregister every time the agent process stops and its keepalive expires.

--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -82,7 +82,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.0.0.
 As a result, after you complete the steps to [upgrade to Sensu 6.0][170] (including running the `sensu-backend upgrade` command), you will not be able to use your database with older versions of Sensu.
 - In [binary-only distributions][164], the web UI is now a standalone product that is no longer distributed inside the `sensu-backend` binary.
 See the [Sensu Go Web repository][163] for more information.
-- After initial creation, you cannot change your `sensu-agent` entity configuration by modifying the agent's configuration file.
+- After initial creation, you cannot change your [`sensu-agent` entity configuration][171] by modifying the agent's configuration file.
 
 **NEW FEATURES:**
 
@@ -1474,3 +1474,4 @@ To get started with Sensu Go:
 [168]: /sensu-go/6.0/observability-pipeline/observe-filter/sensu-query-expressions/#sensucheckdependencies
 [169]: /sensu-go/6.0/observability-pipeline/observe-filter/filters/#build-event-filter-expressions-with-javascript-execution-functions
 [170]: /sensu-go/6.0/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-60-from-a-5x-deployment
+[171]: /sensu-go/6.0/observability-pipeline/observe-entities/entities/#create-and-manage-agent-entities


### PR DESCRIPTION
## Description
- Adds information about the reason for decoupling agent entity creation via agent.yml and agent entity modification via the backend in the entity reference
- Adds a link to the relevant section in the release notes to make it easier for users who learn about this change from the release notes to find more detailed information

## Motivation and Context
Customer question in Community Slack