### PR TITLE
Update template toolkit to use Sensu org link

### DIFF
--- a/content/sensu-go/5.19/guides/handler-templates.md
+++ b/content/sensu-go/5.19/guides/handler-templates.md
@@ -208,7 +208,7 @@ See the [Sensu PagerDuty Handler Bonsai page][10] for details.
 [5]: https://golang.org/pkg/time/#Time.Format
 [6]: https://yourbasic.org/golang/format-parse-string-time-date-example/
 [7]: https://bonsai.sensu.io/
-[8]: https://bonsai.sensu.io/assets/jspaleta/template-toolkit-command
+[8]: https://bonsai.sensu.io/assets/sensu/template-toolkit-command
 [9]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [11]: #print-available-event-attributes

--- a/content/sensu-go/5.20/guides/handler-templates.md
+++ b/content/sensu-go/5.20/guides/handler-templates.md
@@ -208,7 +208,7 @@ See the [Sensu PagerDuty Handler Bonsai page][10] for details.
 [5]: https://golang.org/pkg/time/#Time.Format
 [6]: https://yourbasic.org/golang/format-parse-string-time-date-example/
 [7]: https://bonsai.sensu.io/
-[8]: https://bonsai.sensu.io/assets/jspaleta/template-toolkit-command
+[8]: https://bonsai.sensu.io/assets/sensu/template-toolkit-command
 [9]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [11]: #print-available-event-attributes

--- a/content/sensu-go/5.21/guides/handler-templates.md
+++ b/content/sensu-go/5.21/guides/handler-templates.md
@@ -208,7 +208,7 @@ See the [Sensu PagerDuty Handler Bonsai page][10] for details.
 [5]: https://golang.org/pkg/time/#Time.Format
 [6]: https://yourbasic.org/golang/format-parse-string-time-date-example/
 [7]: https://bonsai.sensu.io/
-[8]: https://bonsai.sensu.io/assets/jspaleta/template-toolkit-command
+[8]: https://bonsai.sensu.io/assets/sensu/template-toolkit-command
 [9]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [11]: #print-available-event-attributes

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
@@ -207,7 +207,7 @@ See the [Sensu PagerDuty Handler Bonsai page][10] for details.
 [5]: https://golang.org/pkg/time/#Time.Format
 [6]: https://yourbasic.org/golang/format-parse-string-time-date-example/
 [7]: https://bonsai.sensu.io/
-[8]: https://bonsai.sensu.io/assets/jspaleta/template-toolkit-command
+[8]: https://bonsai.sensu.io/assets/sensu/template-toolkit-command
 [9]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [11]: #print-available-event-attributes

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
@@ -207,7 +207,7 @@ See the [Sensu PagerDuty Handler Bonsai page][10] for details.
 [5]: https://golang.org/pkg/time/#Time.Format
 [6]: https://yourbasic.org/golang/format-parse-string-time-date-example/
 [7]: https://bonsai.sensu.io/
-[8]: https://bonsai.sensu.io/assets/jspaleta/template-toolkit-command
+[8]: https://bonsai.sensu.io/assets/sensu/template-toolkit-command
 [9]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler
 [10]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [11]: #print-available-event-attributes


### PR DESCRIPTION
Change from jspaleta/ to sensu/ in Bonsai link in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/