### PR TITLE
Document PATCH capabilities for API docs

### DIFF
--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -305,10 +305,47 @@ Content-Length: 54
 ## Etag response headers
 
 All GET and PATCH requests return an [Etag HTTP response header][10] that identifies a specific version of the resource.
-
 Use the Etag value from the response header to conditionally execute PATCH requests that use the [If-Match][22] and [If-None-Match][23] headers.
 
 If Sensu cannot execute a PATCH request because one of the conditions failed, the request will return the HTTP response code `412 Precondition Failed`.
+
+### If-Match example
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-H 'If-Match: "drrn157624731797"' \
+-d '{
+  "metadata": {
+    "labels": {
+      "region": "us-west-1"
+    }
+  }
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### If-None-Match example
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-H 'If-None-Match: "drrn157624731797", "reew237527931897"' \
+-d '{
+  "metadata": {
+    "labels": {
+      "region": "us-west-1"
+    }
+  }
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
+
+HTTP/1.1 200 OK
+{{< /code >}}
 
 ## Response filtering
 

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -302,6 +302,14 @@ Content-Length: 54
 ]
 {{< /code >}}
 
+## Etag response headers
+
+All GET and PATCH requests return an [Etag HTTP response header][10] that identifies a specific version of the resource.
+
+Use the Etag value from the response header to conditionally execute PATCH requests that use the [If-Match][22] and [If-None-Match][23] headers.
+
+If Sensu cannot execute a PATCH request because one of the conditions failed, the request will return the HTTP response code `412 Precondition Failed`.
+
 ## Response filtering
 
 **COMMERCIAL FEATURE**: Access API response filtering in the packaged Sensu Go distribution.
@@ -689,6 +697,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [7]: ../sensuctl/environment-variables/
 [8]: ../commercial/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
+[10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
 [11]: auth/#authtoken-post
 [12]: auth/
 [13]: #operators
@@ -700,3 +709,5 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [19]: apikeys/
 [20]: #authenticate-with-the-authentication-api
 [21]: ../observability-pipeline/observe-schedule/backend/#api-request-limit
+[22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
+[23]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match

--- a/content/sensu-go/6.1/api/apikeys.md
+++ b/content/sensu-go/6.1/api/apikeys.md
@@ -139,7 +139,7 @@ output               | {{< code json >}}
 }
 {{< /code >}}
 
-## Update an API key
+## Update an API key with PATCH
 
 The `/apikeys/:apikey` PATCH endpoint updates the specified API key.
 

--- a/content/sensu-go/6.1/api/apikeys.md
+++ b/content/sensu-go/6.1/api/apikeys.md
@@ -139,6 +139,46 @@ output               | {{< code json >}}
 }
 {{< /code >}}
 
+## Update an API key
+
+The `/apikeys/:apikey` PATCH endpoint updates the specified API key.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+{{% /notice %}}
+
+### Example
+
+In the following example, querying the `/apikeys/:apikey` API updates the username for the specified `:apikey` definition.
+
+We support [JSON merge patches][2], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+{
+  "username": "devteam"
+} \
+http://127.0.0.1:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/apikeys/:apikey (PATCH) | 
+---------------------|------
+description          | Updates the specified API key.
+example url          | http://hostname:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
+response type        | Map
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output               | {{< code json >}}
+{
+  "username": "devteam"
+}
+{{< /code >}}
+
 ## Delete an API key {#apikeysapikey-delete}
 
 The `/apikeys/:apikey` API endpoint provides HTTP DELETE access to remove an API key.
@@ -163,4 +203,6 @@ description     | Revokes the specified API key.
 example URL     | http://hostname:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
 response codes  | <ul><li>**Success**: 204 (No Content)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../#pagination
+[2]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/assets.md
+++ b/content/sensu-go/6.1/api/assets.md
@@ -305,6 +305,49 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a dynamic runtime asset with PATCH
+
+The `/assets/:asset` API endpoint provides HTTP PATCH access to update `:asset` definitions, specified by asset name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#assetsasset-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/assets/:asset` API endpoint to add a label for the `sensu-slack-handler` asset, resulting in an HTTP `200 OK` response and the updated asset definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "labels": {
+    "region": "us-west-1"
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/assets/:asset (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu asset.
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
+payload         | {{< code shell >}}
+{
+  "labels": {
+    "region": "us-west-1"
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a dynamic runtime asset {#assetsasset-delete}
 
 The `/assets/:asset` API endpoint provides HTTP DELETE access so you can delete a dynamic runtime assets.
@@ -331,6 +374,8 @@ description     | Deletes the specified Sensu dynamic runtime asset.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
 response codes  | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../operations/deploy-sensu/assets/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[6]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/assets.md
+++ b/content/sensu-go/6.1/api/assets.md
@@ -326,8 +326,11 @@ curl -X PATCH \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/merge-patch+json' \
 -d '{
-  "labels": {
-    "region": "us-west-1"
+  "metadata": {
+    "labels": {
+      "region": "us-west-1"
+    }
+  }
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
 
@@ -342,8 +345,11 @@ description     | Updates the specified Sensu asset.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
 payload         | {{< code shell >}}
 {
-  "labels": {
-    "region": "us-west-1"
+  "metadata": {
+    "labels": {
+      "region": "us-west-1"
+    }
+  }
 }
 {{< /code >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/6.1/api/checks.md
+++ b/content/sensu-go/6.1/api/checks.md
@@ -310,6 +310,93 @@ payload         | {{< code shell >}}
 payload parameters | Required check attributes: `interval` (integer) or `cron` (string) and a `metadata` scope that contains `name` (string) and `namespace` (string). For more information about creating checks, see the [check reference][1].
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a check with PATCH
+
+The `/checks/:check` API endpoint provides HTTP PATCH access to update `:check` definitions, specified by check name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [`/checks/:check` PUT request](#checkscheck-put) instead.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/checks/:check` API endpoint to update the `check-cpu` check, resulting in an HTTP `200 OK` response and the updated check definition.
+
+We support [JSON merge patches][2], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "subscriptions": [
+    "linux",
+    "health"
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/checks/check-cpu
+
+HTTP/1.1 201 Created
+{{< /code >}}
+
+### API Specification
+
+/checks/:check (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu check.
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/checks/check-cpu
+payload         | {{< code shell >}}
+{
+  "subscriptions": [
+    "linux",
+    "health"
+  ]
+}
+{{< /code >}}
+payload parameters | Required check attributes: `interval` (integer) or `cron` (string) and a `metadata` scope that contains `name` (string) and `namespace` (string). For more information about creating checks, see the [check reference][1].
+response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+## Update an API key
+
+The `/apikeys/:apikey` PATCH endpoint updates the specified API key.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+{{% /notice %}}
+
+### Example {#apikeysapikey-patch-example}
+
+In the following example, querying the `/apikeys/:apikey` API updates the username for the specified `:apikey` definition.
+
+We support [JSON merge patches][2], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+{
+  "username": "devteam"
+} \
+http://127.0.0.1:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification {#apikeysapikey-patch-specification}
+
+/apikeys/:apikey (PATCH) | 
+---------------------|------
+description          | Updates the specified API key.
+example url          | http://hostname:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
+response type        | Map
+response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output               | {{< code json >}}
+{
+  "username": "devteam"
+}
+{{< /code >}}
+
 ## Delete a check {#checkscheck-delete}
 
 The `/checks/:check` API endpoint provides HTTP DELETE access to delete a check from Sensu, specified by the check name.

--- a/content/sensu-go/6.1/api/checks.md
+++ b/content/sensu-go/6.1/api/checks.md
@@ -316,14 +316,15 @@ The `/checks/:check` API endpoint provides HTTP PATCH access to update `:check` 
 
 {{% notice note %}}
 **NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
-Use a [`/checks/:check` PUT request](#checkscheck-put) instead.
+Use a [PUT request](#checkscheck-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
 {{% /notice %}}
 
 ### Example
 
-In the following example, an HTTP PATCH request is submitted to the `/checks/:check` API endpoint to update the `check-cpu` check, resulting in an HTTP `200 OK` response and the updated check definition.
+In the following example, an HTTP PATCH request is submitted to the `/checks/:check` API endpoint to update the subscriptions array for the `check-cpu` check, resulting in an HTTP `200 OK` response and the updated check definition.
 
-We support [JSON merge patches][2], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+We support [JSON merge patches][6], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
 
 {{< code shell >}}
 curl -X PATCH \
@@ -337,7 +338,7 @@ curl -X PATCH \
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/checks/check-cpu
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 {{< /code >}}
 
 ### API Specification
@@ -355,47 +356,7 @@ payload         | {{< code shell >}}
 }
 {{< /code >}}
 payload parameters | Required check attributes: `interval` (integer) or `cron` (string) and a `metadata` scope that contains `name` (string) and `namespace` (string). For more information about creating checks, see the [check reference][1].
-response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-
-## Update an API key
-
-The `/apikeys/:apikey` PATCH endpoint updates the specified API key.
-
-{{% notice note %}}
-**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
-{{% /notice %}}
-
-### Example {#apikeysapikey-patch-example}
-
-In the following example, querying the `/apikeys/:apikey` API updates the username for the specified `:apikey` definition.
-
-We support [JSON merge patches][2], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
-
-{{< code shell >}}
-curl -X PATCH \
--H "Authorization: Key $SENSU_API_KEY" \
--H 'Content-Type: application/merge-patch+json' \
-{
-  "username": "devteam"
-} \
-http://127.0.0.1:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
-
-HTTP/1.1 200 OK
-{{< /code >}}
-
-### API Specification {#apikeysapikey-patch-specification}
-
-/apikeys/:apikey (PATCH) | 
----------------------|------
-description          | Updates the specified API key.
-example url          | http://hostname:8080/api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
-response type        | Map
-response codes       | <ul><li>**Success**: 200 (OK)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
-output               | {{< code json >}}
-{
-  "username": "devteam"
-}
-{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete a check {#checkscheck-delete}
 
@@ -530,8 +491,10 @@ description               | Removes a single hook from a check (specified by the
 example url               | http://hostname:8080/api/core/v2/namespaces/default/checks/check-cpu/hooks/critical/hook/process_tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../observability-pipeline/observe-schedule/checks/
 [2]: ../../observability-pipeline/observe-schedule/hooks/
 [3]: ../../observability-pipeline/observe-schedule/checks#check-hooks-attribute
 [4]: ../#pagination
 [5]: ../#response-filtering
+[6]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/checks.md
+++ b/content/sensu-go/6.1/api/checks.md
@@ -355,7 +355,6 @@ payload         | {{< code shell >}}
   ]
 }
 {{< /code >}}
-payload parameters | Required check attributes: `interval` (integer) or `cron` (string) and a `metadata` scope that contains `name` (string) and `namespace` (string). For more information about creating checks, see the [check reference][1].
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Delete a check {#checkscheck-delete}

--- a/content/sensu-go/6.1/api/cluster-role-bindings.md
+++ b/content/sensu-go/6.1/api/cluster-role-bindings.md
@@ -285,6 +285,65 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a cluster role binding with PATCH
+
+The `/clusterrolebindings/:clusterrolebinding` API endpoint provides HTTP PATCH access to update `:clusterrolebinding` definitions, specified by cluster role binding name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#clusterrolebindingsclusterrolebinding-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/clusterrolebindings/:clusterrolebinding` API endpoint to update the subjects array for the `ops-group-binder` cluster role binding, resulting in an HTTP `200 OK` response and the updated cluster role binding definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "subjects": [
+    {
+      "type": "Group",
+      "name": "ops_team_1"
+    },
+    {
+      "type": "Group",
+      "name": "ops_team_2"
+    }
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/clusterrolebindings/ops-group-binder
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/clusterrolebindings/:clusterrolebinding (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu cluster role binding.
+example URL     | http://hostname:8080/api/core/v2/clusterrolebindings/ops-group-binder
+payload         | {{< code shell >}}
+{
+  "subjects": [
+    {
+      "type": "Group",
+      "name": "ops_team_1"
+    },
+    {
+      "type": "Group",
+      "name": "ops_team_2"
+    }
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a cluster role binding {#clusterrolebindingsclusterrolebinding-delete}
 
 The `/clusterrolebindings/:clusterrolebinding` API endpoint provides HTTP DELETE access to delete a cluster role binding from Sensu (specified by the cluster role binding name).
@@ -309,6 +368,8 @@ description               | Removes a cluster role binding from Sensu (specified
 example url               | http://hostname:8080/api/core/v2/clusterrolebindings/ops-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../operations/control-access/rbac/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/cluster-roles.md
+++ b/content/sensu-go/6.1/api/cluster-roles.md
@@ -306,6 +306,67 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a cluster role with PATCH
+
+The `/clusterroles/:clusterrole` API endpoint provides HTTP PATCH access to update `:clusterrole` definitions, specified by cluster role name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#clusterrolesclusterrole-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/clusterroles/:clusterrole` API endpoint to update the verbs array within the rules array for the `global-event-admin` cluster role, resulting in an HTTP `200 OK` response and the updated cluster role definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "rules": [
+    {
+      "verbs": [
+        "*"
+      ],
+      "resources": [
+        "events"
+      ],
+      "resource_names": null
+    }
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/clusterroles/global-event-admin
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/clusterroles/:clusterrole (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu cluster role.
+example URL     | http://hostname:8080/api/core/v2/clusterroles/global-event-admin
+payload         | {{< code shell >}}
+{
+  "rules": [
+    {
+      "verbs": [
+        "*"
+      ],
+      "resources": [
+        "events"
+      ],
+      "resource_names": null
+    }
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a cluster role {#clusterrolesclusterrole-delete}
 
 The `/clusterroles/:clusterrole` API endpoint provides HTTP DELETE access to delete a cluster role from Sensu (specified by the cluster role name).
@@ -330,6 +391,8 @@ description               | Removes a cluster role from Sensu (specified by the 
 example url               | http://hostname:8080/api/core/v2/clusterroles/global-event-reader
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../operations/control-access/rbac/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/entities.md
+++ b/content/sensu-go/6.1/api/entities.md
@@ -565,11 +565,16 @@ response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad 
 
 The `/entities/:entity` API endpoint provides HTTP PATCH access to update **entity configuration attributes** in `:entity` definitions, specified by entity name:
 
+- `labels`
+- `annotations`
+- `created_by`
 - `entity_class`
 - `user`
 - `subscriptions`
 - `deregister`
+- `deregistration`
 - `redact`
+- `keepalive_handler`
 
 {{% notice note %}}
 **NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
@@ -579,7 +584,7 @@ Also, you cannot add elements to an array with a PATCH request &mdash; you must 
 
 ### Example
 
-In the following example, an HTTP PATCH request is submitted to the `/entities/:entity` API endpoint to update the subscriptions array within the rules array for the `sensu-centos` entity, resulting in an HTTP `200 OK` response and the updated entity definition.
+In the following example, an HTTP PATCH request is submitted to the `/entities/:entity` API endpoint to add a label for the `sensu-centos` entity, resulting in an HTTP `200 OK` response and the updated entity definition.
 
 We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
 
@@ -588,10 +593,11 @@ curl -X PATCH \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/merge-patch+json' \
 -d '{
-  "subscriptions": [
-    "webserver",
-    "system"
-  ]
+  "metadata": {
+    "labels": {
+      "region": "us-west-1"
+    }
+  }
 }' \
 http://127.0.0.1:8080/api/core/v2/entities/sensu-centos
 
@@ -606,10 +612,11 @@ description     | Updates the specified Sensu entity.
 example URL     | http://hostname:8080/api/core/v2/entities/sensu-centos
 payload         | {{< code shell >}}
 {
-  "subscriptions": [
-    "webserver",
-    "system"
-  ]
+  "metadata": {
+    "labels": {
+      "region": "us-west-1"
+    }
+  }
 }
 {{< /code >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/6.1/api/entities.md
+++ b/content/sensu-go/6.1/api/entities.md
@@ -561,6 +561,59 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update an entity with PATCH
+
+The `/entities/:entity` API endpoint provides HTTP PATCH access to update **entity configuration attributes** in `:entity` definitions, specified by entity name:
+
+- `entity_class`
+- `user`
+- `subscriptions`
+- `deregister`
+- `redact`
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#entitiesentity-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/entities/:entity` API endpoint to update the subscriptions array within the rules array for the `sensu-centos` entity, resulting in an HTTP `200 OK` response and the updated entity definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "subscriptions": [
+    "webserver",
+    "system"
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/entities/sensu-centos
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/entities/:entity (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu entity.
+example URL     | http://hostname:8080/api/core/v2/entities/sensu-centos
+payload         | {{< code shell >}}
+{
+  "subscriptions": [
+    "webserver",
+    "system"
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete an entity {#entitiesentity-delete}
 
 The `/entities/:entity` API endpoint provides HTTP DELETE access to delete an entity from Sensu (specified by the entity name).
@@ -585,6 +638,8 @@ description               | Removes a entity from Sensu (specified by the entity
 example url               | http://hostname:8080/api/core/v2/namespaces/default/entities/server1
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../observability-pipeline/observe-entities/entities/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/filters.md
+++ b/content/sensu-go/6.1/api/filters.md
@@ -251,6 +251,51 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a filter with PATCH
+
+The `/filters/:filter` API endpoint provides HTTP PATCH access to update `:filter` definitions, specified by filter name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#filtersfilter-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/filters/:filter` API endpoint to update the expressions array for the `us-west` filter, resulting in an HTTP `200 OK` response and the updated filter definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "expressions": [
+    "event.check.occurrences == 3"
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/filter/us-west
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/filters/:filter (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu filter.
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/filter/us-west
+payload         | {{< code shell >}}
+{
+  "expressions": [
+    "event.check.occurrences == 3"
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete an event filter {#filtersfilter-delete}
 
 The `/filters/:filter` API endpoint provides HTTP DELETE access to delete an event filter from Sensu (specified by the filter name).
@@ -275,6 +320,8 @@ description               | Removes the specified event filter from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/filters/development_filter
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../observability-pipeline/observe-filter/filters/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/handlers.md
+++ b/content/sensu-go/6.1/api/handlers.md
@@ -320,6 +320,53 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a handler with PATCH
+
+The `/handlers/:handler` API endpoint provides HTTP PATCH access to update `:handler` definitions, specified by handler name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#handlershandler-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/handlers/:handler` API endpoint to update the filters array for the `influx-db` handler, resulting in an HTTP `200 OK` response and the updated handler definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "filters": [
+    "us-west",
+    "is_incident"
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers/influx-db
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/handlers/:handler (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu handler.
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/handlers/influx-db
+payload         | {{< code shell >}}
+{
+  "filters": [
+    "us-west",
+    "is_incident"
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a handler {#handlershandler-delete}
 
 The `/handlers/:handler` API endpoint provides HTTP DELETE access to delete a handler from Sensu (specified by the handler name).
@@ -347,3 +394,4 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 [1]: ../../observability-pipeline/observe-process/handlers/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/hooks.md
+++ b/content/sensu-go/6.1/api/hooks.md
@@ -241,6 +241,47 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a hook with PATCH
+
+The `/hooks/:hook` API endpoint provides HTTP PATCH access to update `:hook` definitions, specified by hook name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#hookshook-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/hooks/:hook` API endpoint to update the timeout for the `process-tree` hook, resulting in an HTTP `200 OK` response and the updated hook definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "timeout": 20
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/hook/process-tree
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/hooks/:hook (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu hook.
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
+payload         | {{< code shell >}}
+{
+  "timeout": 20
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a hook {#hookshook-delete}
 
 The `/hooks/:hook` API endpoint provides HTTP DELETE access to delete a check hook from Sensu (specified by the hook name).
@@ -265,6 +306,8 @@ description               | Removes the specified hook from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../observability-pipeline/observe-schedule/hooks/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/mutators.md
+++ b/content/sensu-go/6.1/api/mutators.md
@@ -158,7 +158,7 @@ HTTP/1.1 200 OK
 /mutators/:mutator (GET) | 
 ---------------------|------
 description          | Returns the specified mutator.
-example url          | http://hostname:8080/api/core/v2/namespaces/default/mutators/mutator-name
+example url          | http://hostname:8080/api/core/v2/namespaces/default/mutators/example-mutator
 response type        | Map
 response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output               | {{< code json >}}
@@ -229,6 +229,47 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a mutator with PATCH
+
+The `/mutators/:mutator` API endpoint provides HTTP PATCH access to update `:mutator` definitions, specified by mutator name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#mutatorsmutator-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/mutators/:mutator` API endpoint to update the timeout for the `example-mutator` mutator, resulting in an HTTP `200 OK` response and the updated mutator definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "timeout": 10
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/mutators/:mutator (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu mutator.
+example URL     | http://hostname:8080/api/core/v2/namespaces/default/mutators/process-tree
+payload         | {{< code shell >}}
+{
+  "timeout": 10
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a mutator {#mutatorsmutator-delete}
 
 The `/mutators/:mutator` API endpoint provides HTTP DELETE access to delete a mutator from Sensu (specified by the mutator name).
@@ -252,6 +293,8 @@ description               | Removes the specified mutator from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/mutators/example-mutator
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../observability-pipeline/observe-transform/mutators/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/role-bindings.md
+++ b/content/sensu-go/6.1/api/role-bindings.md
@@ -95,7 +95,20 @@ curl -X POST \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/json' \
 -d '{
-  "name": "development"
+  "subjects": [
+    {
+      "type": "Group",
+      "name": "readers"
+    }
+  ],
+  "role_ref": {
+    "type": "Role",
+    "name": "read-only"
+  },
+  "metadata": {
+    "name": "readers-group-binding",
+    "namespace": "default"
+  }
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/rolebindings
 
@@ -249,6 +262,65 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a role binding with PATCH
+
+The `/rolebindings/:rolebinding` API endpoint provides HTTP PATCH access to update `:rolebinding` definitions, specified by role binding name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#rolebindingsrolebinding-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/rolebindings/:rolebinding` API endpoint to add a group to the subjects array for the `dev-binding` role binding, resulting in an HTTP `200 OK` response and the updated role binding definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "subjects": [
+    {
+      "type": "Group",
+      "name": "dev_team_1"
+    },
+    {
+      "type": "Group",
+      "name": "dev_team_2"
+    }
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/rolebindings/dev-binding
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/rolebindings/:rolebinding (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu role binding.
+example URL     | http://hostname:8080/api/core/v2/rolebindings/dev-binding
+payload         | {{< code shell >}}
+{
+  "subjects": [
+    {
+      "type": "Group",
+      "name": "dev_team_1"
+    },
+    {
+      "type": "Group",
+      "name": "dev_team_2"
+    }
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a role binding {#rolebindingsrolebinding-delete}
 
 The `/rolebindings/:rolebinding` API endpoint provides HTTP DELETE access to delete a role binding from Sensu (specified by the role binding name).
@@ -273,6 +345,8 @@ description               | Removes the specified role binding from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/rolebindings/dev-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../operations/control-access/rbac/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396

--- a/content/sensu-go/6.1/api/roles.md
+++ b/content/sensu-go/6.1/api/roles.md
@@ -51,7 +51,7 @@ HTTP/1.1 200 OK
     "rules": [
       {
         "verbs": [
-          "read"
+          "get"
         ],
         "resources": [
           "*"
@@ -103,7 +103,7 @@ output         | {{< code shell >}}
     "rules": [
       {
         "verbs": [
-          "read"
+          "get"
         ],
         "resources": [
           "*"
@@ -309,6 +309,69 @@ payload         | {{< code shell >}}
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Update a role with PATCH
+
+The `/roles/:role` API endpoint provides HTTP PATCH access to update `:role` definitions, specified by role name.
+
+{{% notice note %}}
+**NOTE**: You cannot change a resource's `name` or `namespace` with a PATCH request.
+Use a [PUT request](#rolesrole-put) instead.<br><br>
+Also, you cannot add elements to an array with a PATCH request &mdash; you must replace the entire array.
+{{% /notice %}}
+
+### Example
+
+In the following example, an HTTP PATCH request is submitted to the `/roles/:role` API endpoint to update the verbs array within the rules array for the `global-event-admin` role, resulting in an HTTP `200 OK` response and the updated role definition.
+
+We support [JSON merge patches][4], so you must set the `Content-Type` header to `application/merge-patch+json` for PATCH requests.
+
+{{< code shell >}}
+curl -X PATCH \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/merge-patch+json' \
+-d '{
+  "rules": [
+    {
+      "verbs": [
+        "get",
+        "list"
+      ],
+      "resources": [
+        "events"
+      ],
+      "resource_names": null
+    }
+  ]
+}' \
+http://127.0.0.1:8080/api/core/v2/roles/event-reader
+
+HTTP/1.1 200 OK
+{{< /code >}}
+
+### API Specification
+
+/roles/:role (PATCH) | 
+----------------|------
+description     | Updates the specified Sensu role.
+example URL     | http://hostname:8080/api/core/v2/roles/event-reader
+payload         | {{< code shell >}}
+{
+  "rules": [
+    {
+      "verbs": [
+        "get",
+        "list"
+      ],
+      "resources": [
+        "events"
+      ],
+      "resource_names": null
+    }
+  ]
+}
+{{< /code >}}
+response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
 ## Delete a role {#rolesrole-delete}
 
 The `/roles/:role` API endpoint provides HTTP DELETE access to delete a role from Sensu (specified by the role name).
@@ -333,6 +396,8 @@ description               | Removes the specified role from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+
 [1]: ../../operations/control-access/rbac/
 [2]: ../#pagination
 [3]: ../#response-filtering
+[4]: https://tools.ietf.org/html/rfc7396


### PR DESCRIPTION
## Description
Work in progress

Adds PATCH sections to API docs:
- APIKeys
- Assets
- Checks
- Cluster role bindings
- Cluster roles
- Entities
- Filters
- Handlers
- Hooks
- Mutators
- Role bindings
- Roles

Adds Etag information to API overview.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2755