### PR TITLE
Document known caveats for sensuctl prune and the prune API

### DIFF
--- a/content/sensu-go/5.19/api/prune.md
+++ b/content/sensu-go/5.19/api/prune.md
@@ -12,11 +12,15 @@ menu:
 **IMPORTANT**: The prune API is an alpha feature in release 5.19.0 and may include breaking changes.
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
+
+{{% notice note %}}
+**NOTE**: The prune API requires [cluster-level privileges](../../reference/rbac/#cluster-roles), even when all resources belong to the same namespace.
+{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/5.19/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.19/sensuctl/create-manage-resources.md
@@ -381,11 +381,14 @@ For more information, see [Get started with commercial features][30].
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
+{{% /notice %}}
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
+In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 ##### sensuctl prune usage
 
@@ -536,3 +539,4 @@ Sensuctl supports the following formats:
 [31]: ..#manage-sensuctl
 [32]: ../../reference/datastore/
 [33]: #create-resources-across-namespaces
+[35]: ../../reference/rbac/#cluster-roles

--- a/content/sensu-go/5.20/api/prune.md
+++ b/content/sensu-go/5.20/api/prune.md
@@ -12,7 +12,7 @@ menu:
 **IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
 {{% notice note %}}
 **NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -22,6 +22,10 @@ The code examples in this document use the [environment variable](../#configure-
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
+
+{{% notice note %}}
+**NOTE**: The prune API requires [cluster-level privileges](../../reference/rbac/#cluster-roles), even when all resources belong to the same namespace.
+{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/5.20/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.20/sensuctl/create-manage-resources.md
@@ -381,11 +381,14 @@ For more information, see [Get started with commercial features][30].
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
+{{% /notice %}}
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
+In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 ##### sensuctl prune usage
 
@@ -542,3 +545,4 @@ Sensuctl supports the following formats:
 [32]: ../../reference/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../reference/license/
+[35]: ../../reference/rbac/#cluster-roles

--- a/content/sensu-go/5.21/api/prune.md
+++ b/content/sensu-go/5.21/api/prune.md
@@ -12,7 +12,7 @@ menu:
 **IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
 {{% notice note %}}
 **NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -22,6 +22,10 @@ The code examples in this document use the [environment variable](../#configure-
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
+
+{{% notice note %}}
+**NOTE**: The prune API requires [cluster-level privileges](../../reference/rbac/#cluster-roles), even when all resources belong to the same namespace.
+{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -381,11 +381,14 @@ For more information, see [Get started with commercial features][30].
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
+{{% /notice %}}
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
+In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 ##### sensuctl prune usage
 
@@ -542,3 +545,4 @@ Sensuctl supports the following formats:
 [32]: ../../reference/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../reference/license/
+[35]: ../../reference/rbac/#cluster-roles

--- a/content/sensu-go/6.0/api/prune.md
+++ b/content/sensu-go/6.0/api/prune.md
@@ -12,7 +12,7 @@ menu:
 **IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
 {{% notice note %}}
 **NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -22,6 +22,10 @@ The code examples in this document use the [environment variable](../#configure-
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
+
+{{% notice note %}}
+**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#cluster-roles), even when all resources belong to the same namespace.
+{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -381,28 +381,14 @@ For more information, see [Get started with commercial features][30].
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
-For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
-In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
-
 {{% notice note %}}
 **NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}
 
-To delete resources that do not include a label, use [`sensuctl dump`](../back-up-recover/) with `sensuctl delete`.
-For example, to delete all checks:
-
-{{< code shell >}}
-sensuctl dump core/v2.CheckConfig | sensuctl delete
-{{< /code >}}
-
-To dump the checks to a yaml file and then delete them:
-
-{{< code shell >}}
-sensuctl dump core/v2.CheckConfig --format yaml --file dumpedchecks.yaml
-sensuctl delete -f dumpedchecks.yaml
-{{< /code >}}
+The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
+For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
+In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 ##### sensuctl prune usage
 

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -381,11 +381,28 @@ For more information, see [Get started with commercial features][30].
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
-This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
-
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
+In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
+
+{{% notice note %}}
+**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
+{{% /notice %}}
+
+To delete resources that do not include a label, use [`sensuctl dump`](../back-up-recover/) with `sensuctl delete`.
+For example, to delete all checks:
+
+{{< code shell >}}
+sensuctl dump core/v2.CheckConfig | sensuctl delete
+{{< /code >}}
+
+To dump the checks to a yaml file and then delete them:
+
+{{< code shell >}}
+sensuctl dump core/v2.CheckConfig --format yaml --file dumpedchecks.yaml
+sensuctl delete -f dumpedchecks.yaml
+{{< /code >}}
 
 ##### sensuctl prune usage
 
@@ -484,6 +501,8 @@ Use the `all` qualifier to prune all supported resources:
 sensuctl prune all
 {{< /code >}}
 
+
+
 ## Time formats
 
 Sensuctl supports multiple time formats depending on the manipulated resource.
@@ -542,3 +561,4 @@ Sensuctl supports the following formats:
 [32]: ../../operations/deploy-sensu/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
+[35]: ../../operations/control-access/rbac/#cluster-roles

--- a/content/sensu-go/6.1/api/prune.md
+++ b/content/sensu-go/6.1/api/prune.md
@@ -12,7 +12,7 @@ menu:
 **IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][1].
 
 {{% notice note %}}
 **NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -22,6 +22,10 @@ The code examples in this document use the [environment variable](../#configure-
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
+
+{{% notice note %}}
+**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#cluster-roles), even when all resources belong to the same namespace.
+{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -381,11 +381,14 @@ For more information, see [Get started with commercial features][30].
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
-`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
+{{% /notice %}}
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
+In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 ##### sensuctl prune usage
 
@@ -542,3 +545,4 @@ Sensuctl supports the following formats:
 [32]: ../../operations/deploy-sensu/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
+[35]: ../../operations/control-access/rbac/#cluster-roles


### PR DESCRIPTION
## Description
- Adds note formatting to the caveat that sensuctl prune can only delete resources with the label `sensu.io/managed_by: sensuctl` in https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#sensuctl-prune
- Adds note that pruning requires cluster-level privileges in https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#sensuctl-prune and https://docs.sensu.io/sensu-go/latest/api/prune/#create-a-new-pruning-command

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2753