### PR TITLE
Fix typo in handler template doc and add description

### DIFF
--- a/content/sensu-go/5.19/guides/handler-templates.md
+++ b/content/sensu-go/5.19/guides/handler-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Create handler templates"
 linkTitle: "Create Handler Templates"
-description: "PLACEHOLDER."
+description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
 weight: 95
 version: "5.19"
 product: "Sensu Go"

--- a/content/sensu-go/5.19/guides/handler-templates.md
+++ b/content/sensu-go/5.19/guides/handler-templates.md
@@ -21,7 +21,7 @@ For example, a template for a brief Slack alert might include information about 
 
 <html>
 The entity {{.Entity.Name}} has a status of {{.Check.State}}. The entity has reported the same status for {{.Check.Occurrences}} preceding events.<br>
-The playbook for managing this alert is availble at https://example.com/observability/alerts/playbook.
+The playbook for managing this alert is available at https://example.com/observability/alerts/playbook.
 </html>
 
 {{< /code >}}

--- a/content/sensu-go/5.20/guides/handler-templates.md
+++ b/content/sensu-go/5.20/guides/handler-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Create handler templates"
 linkTitle: "Create Handler Templates"
-description: "PLACEHOLDER."
+description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
 weight: 95
 version: "5.20"
 product: "Sensu Go"

--- a/content/sensu-go/5.20/guides/handler-templates.md
+++ b/content/sensu-go/5.20/guides/handler-templates.md
@@ -21,7 +21,7 @@ For example, a template for a brief Slack alert might include information about 
 
 <html>
 The entity {{.Entity.Name}} has a status of {{.Check.State}}. The entity has reported the same status for {{.Check.Occurrences}} preceding events.<br>
-The playbook for managing this alert is availble at https://example.com/observability/alerts/playbook.
+The playbook for managing this alert is available at https://example.com/observability/alerts/playbook.
 </html>
 
 {{< /code >}}

--- a/content/sensu-go/5.21/guides/handler-templates.md
+++ b/content/sensu-go/5.21/guides/handler-templates.md
@@ -21,7 +21,7 @@ For example, a template for a brief Slack alert might include information about 
 
 <html>
 The entity {{.Entity.Name}} has a status of {{.Check.State}}. The entity has reported the same status for {{.Check.Occurrences}} preceding events.<br>
-The playbook for managing this alert is availble at https://example.com/observability/alerts/playbook.
+The playbook for managing this alert is available at https://example.com/observability/alerts/playbook.
 </html>
 
 {{< /code >}}

--- a/content/sensu-go/5.21/guides/handler-templates.md
+++ b/content/sensu-go/5.21/guides/handler-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Create handler templates"
 linkTitle: "Create Handler Templates"
-description: "PLACEHOLDER."
+description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
 weight: 95
 version: "5.21"
 product: "Sensu Go"

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Create handler templates"
 linkTitle: "Create Handler Templates"
-description: "PLACEHOLDER."
+description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
 weight: 80
 version: "6.0"
 product: "Sensu Go"

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
@@ -20,7 +20,7 @@ For example, a template for a brief Slack alert might include information about 
 
 <html>
 The entity {{.Entity.Name}} has a status of {{.Check.State}}. The entity has reported the same status for {{.Check.Occurrences}} preceding events.<br>
-The playbook for managing this alert is availble at https://example.com/observability/alerts/playbook.
+The playbook for managing this alert is available at https://example.com/observability/alerts/playbook.
 </html>
 
 {{< /code >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
@@ -20,7 +20,7 @@ For example, a template for a brief Slack alert might include information about 
 
 <html>
 The entity {{.Entity.Name}} has a status of {{.Check.State}}. The entity has reported the same status for {{.Check.Occurrences}} preceding events.<br>
-The playbook for managing this alert is availble at https://example.com/observability/alerts/playbook.
+The playbook for managing this alert is available at https://example.com/observability/alerts/playbook.
 </html>
 
 {{< /code >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Create handler templates"
 linkTitle: "Create Handler Templates"
-description: "PLACEHOLDER."
+description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
 weight: 80
 version: "6.1"
 product: "Sensu Go"


### PR DESCRIPTION
## Description
Fix typo in basic slack example and adding description.