### PR TITLE
Add table with command-specific flags for sensuctl create

### DIFF
--- a/content/sensu-go/5.20/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.20/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in `wrapped-json` and `yaml`.
 Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
 See the [`wrapped-json`example][9] and [this table][3] for a list of supported types.
@@ -557,3 +557,4 @@ Sensuctl supports the following formats:
 [33]: #create-resources-across-namespaces
 [34]: ../../reference/license/
 [35]: ../../reference/rbac/#cluster-roles
+[36]: #sensuctl-create-flags

--- a/content/sensu-go/5.20/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.20/sensuctl/create-manage-resources.md
@@ -123,6 +123,17 @@ Or:
 cat my-resources.yml | sensuctl create
 {{< /code >}}
 
+### sensuctl create flags
+
+Run `sensuctl create -h` to view command-specific and global flags.
+The following table describes the command-specific flags.
+
+| Flag | Function and important notes
+| ---- | ----------------------------
+`-f` or `--file` | Files, URLs, or directories to create resources from. Strings.
+`-h` or `--help` | Help for the create command.
+`-r` or `--recursive` | Create command will follow subdirectories.
+
 ### sensuctl create resource types
 
 |sensuctl create types |   |   |   |

--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in `wrapped-json` and `yaml`.
 Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
 See the [`wrapped-json`example][9] and [this table][3] for a list of supported types.
@@ -557,3 +557,4 @@ Sensuctl supports the following formats:
 [33]: #create-resources-across-namespaces
 [34]: ../../reference/license/
 [35]: ../../reference/rbac/#cluster-roles
+[36]: #sensuctl-create-flags

--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -123,6 +123,17 @@ Or:
 cat my-resources.yml | sensuctl create
 {{< /code >}}
 
+### sensuctl create flags
+
+Run `sensuctl create -h` to view command-specific and global flags.
+The following table describes the command-specific flags.
+
+| Flag | Function and important notes
+| ---- | ----------------------------
+`-f` or `--file` | Files, URLs, or directories to create resources from. Strings.
+`-h` or `--help` | Help for the create command.
+`-r` or `--recursive` | Create command will follow subdirectories.
+
 ### sensuctl create resource types
 
 |sensuctl create types |   |   |   |

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in `wrapped-json` and `yaml`.
 Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
 See the [`wrapped-json`example][9] and [this table][3] for a list of supported types.
@@ -559,3 +559,4 @@ Sensuctl supports the following formats:
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
 [35]: ../../operations/control-access/rbac/#cluster-roles
+[36]: #sensuctl-create-flags

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -123,6 +123,17 @@ Or:
 cat my-resources.yml | sensuctl create
 {{< /code >}}
 
+### sensuctl create flags
+
+Run `sensuctl create -h` to view command-specific and global flags.
+The following table describes the command-specific flags.
+
+| Flag | Function and important notes
+| ---- | ----------------------------
+`-f` or `--file` | Files, URLs, or directories to create resources from. Strings.
+`-h` or `--help` | Help for the create command.
+`-r` or `--recursive` | Create command will follow subdirectories.
+
 ### sensuctl create resource types
 
 |sensuctl create types |   |   |   |

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in `wrapped-json` and `yaml`.
 Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
 See the [`wrapped-json`example][9] and [this table][3] for a list of supported types.
@@ -557,3 +557,4 @@ Sensuctl supports the following formats:
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
 [35]: ../../operations/control-access/rbac/#cluster-roles
+[36]: #sensuctl-create-flags

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -123,6 +123,17 @@ Or:
 cat my-resources.yml | sensuctl create
 {{< /code >}}
 
+### sensuctl create flags
+
+Run `sensuctl create -h` to view command-specific and global flags.
+The following table describes the command-specific flags.
+
+| Flag | Function and important notes
+| ---- | ----------------------------
+`-f` or `--file` | Files, URLs, or directories to create resources from. Strings.
+`-h` or `--help` | Help for the create command.
+`-r` or `--recursive` | Create command will follow subdirectories.
+
 ### sensuctl create resource types
 
 |sensuctl create types |   |   |   |


### PR DESCRIPTION
## Description
Adds table to document command-specific flags for sensuctl create in https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#create-resources

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2773
