### PR TITLE
Restore updated commercial features page

### DIFF
--- a/content/sensu-go/5.20/commercial.md
+++ b/content/sensu-go/5.20/commercial.md
@@ -9,39 +9,49 @@ product: "Sensu Go"
 ---
 
 Sensu Go offers commercial features designed for monitoring at scale.
-[Contact the Sensu sales team][1] for a personalized demo and free trial.
-All commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100.
-See the [announcement on our blog][7] for more information.
+All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
+
+If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
 
 ## Commercial features in Sensu Go
 
+- **Protect your sensitive information** with [secrets management][19].
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+- **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
+Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
+- **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and filters using the Sensu [web UI][8], and access the Sensu web UI homepage.
-- **Authentication providers**: Scale Sensu role-based access control (RBAC) with [LDAP and Active Directory integrations][9].
-- **Scalable resource filtering** designed for large installations: Use label and field selectors to filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes.
-- **Event logging**: Log event data to a file you can use as an input source for your favorite data lake solution.
-The [event logging][10] functionality provides better performance and reliability than event handlers.
-- **Enterprise-tier assets**: Connect your monitoring event pipelines to industry-standard tools like ServiceNow and Jira with [enterprise-tier assets][11].
-- **Enterprise-scale event storage**: Scale your Sensu instance and handle high volumes of events with a [PostgreSQL event store][12].
-- **Enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
+- **Control permissions with Sensu role-based access control (RBAC)**, with the option of using [Lightweight Directory Access Protocol (LDAP) and Active Directory (AD)][9] for authentication.
+- **Use powerful filtering capabilities** designed for large installations. With label and field selectors, you can filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes.
+- **Log event data** [to a file][10] you can use as an input to your favorite data lake solution.
+- **Connect your monitoring event pipelines to industry-standard tools** like ServiceNow and Jira with [enterprise-tier assets][11].
+- **Achieve enterprise-scale event handling** for your Sensu instance with a [PostgreSQL event store][12].
+Access the PostgreSQL event datastore with the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
+- **Get enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
 Our expert in-house team offers best-in-class support to get you up and running smoothly.
 
 Review a [complete comparison of OSS and commercial features][3].
 
 ## Contact us for a free trial
 
-For a personalized demo and free trial of commercial features at scale in Sensu Go, [contact the Sensu sales team][1].
-Manage your Sensu account and contact support through [account.sensu.io][2].
+Sensu's commercial features are [free for your first 100 entities][7].
+If your Sensu installation includes more than 100 entities, [contact the Sensu sales team][1] for a free trial of commercial features at scale in Sensu Go.
 
-- [Contact the Sensu sales team][1]
-- [Log in to your Sensu account][2]
-- [Contact Sensu support][14]
+Manage your Sensu account and contact support through [account.sensu.io][2].
 
 ## Get started with commercial features in Sensu Go
 
 If you haven't already, [install the Sensu Go backend, agent, and sensuctl tool][15] and [configure sensuctl][16].
 
-Log in to your Sensu account at [account.sensu.io][2] and download your commercial license file.
-Click **Download license**.
+You will need a commercial license if your Sensu installation includes more than 100 entities.
+To download your commercial license file:
+
+1. Log in to your Sensu account at [account.sensu.io][2].
+2. Click **Download license**.
+
+{{% notice note %}}
+**NOTE**: In some cases, you may need to click **Generate license** before you can download your license.
+{{% /notice %}}
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
@@ -65,6 +75,7 @@ These resources will help you get started with commercial features in Sensu Go:
 - [Log in to your Sensu account][2]
 - [Contact Sensu support][14]
 
+
 [1]: https://sensu.io/contact?subject=contact-sales/
 [2]: https://account.sensu.io/
 [3]: https://sensu.io/features#free-vs-paid
@@ -83,3 +94,6 @@ These resources will help you get started with commercial features in Sensu Go:
 [16]: ../sensuctl/#first-time-setup
 [17]: ../guides/install-check-executables-with-assets/
 [18]: ../reference/license/
+[19]: ../operations/manage-secrets/secrets-management/
+[20]: ../operations/deploy-sensu/use-federation/
+[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication

--- a/content/sensu-go/5.21/commercial.md
+++ b/content/sensu-go/5.21/commercial.md
@@ -9,39 +9,49 @@ product: "Sensu Go"
 ---
 
 Sensu Go offers commercial features designed for monitoring at scale.
-[Contact the Sensu sales team][1] for a personalized demo and free trial.
-All commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100.
-See the [announcement on our blog][7] for more information.
+All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
+
+If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
 
 ## Commercial features in Sensu Go
 
+- **Protect your sensitive information** with [secrets management][19].
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+- **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
+Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
+- **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and filters using the Sensu [web UI][8], and access the Sensu web UI homepage.
-- **Authentication providers**: Scale Sensu role-based access control (RBAC) with [LDAP and Active Directory integrations][9].
-- **Scalable resource filtering** designed for large installations: Use label and field selectors to filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes.
-- **Event logging**: Log event data to a file you can use as an input source for your favorite data lake solution.
-The [event logging][10] functionality provides better performance and reliability than event handlers.
-- **Enterprise-tier assets**: Connect your monitoring event pipelines to industry-standard tools like ServiceNow and Jira with [enterprise-tier assets][11].
-- **Enterprise-scale event storage**: Scale your Sensu instance and handle high volumes of events with a [PostgreSQL event store][12].
-- **Enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
+- **Control permissions with Sensu role-based access control (RBAC)**, with the option of using [Lightweight Directory Access Protocol (LDAP) and Active Directory (AD)][9] for authentication.
+- **Use powerful filtering capabilities** designed for large installations. With label and field selectors, you can filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes.
+- **Log event data** [to a file][10] you can use as an input to your favorite data lake solution.
+- **Connect your monitoring event pipelines to industry-standard tools** like ServiceNow and Jira with [enterprise-tier assets][11].
+- **Achieve enterprise-scale event handling** for your Sensu instance with a [PostgreSQL event store][12].
+Access the PostgreSQL event datastore with the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
+- **Get enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
 Our expert in-house team offers best-in-class support to get you up and running smoothly.
 
 Review a [complete comparison of OSS and commercial features][3].
 
 ## Contact us for a free trial
 
-For a personalized demo and free trial of commercial features at scale in Sensu Go, [contact the Sensu sales team][1].
-Manage your Sensu account and contact support through [account.sensu.io][2].
+Sensu's commercial features are [free for your first 100 entities][7].
+If your Sensu installation includes more than 100 entities, [contact the Sensu sales team][1] for a free trial of commercial features at scale in Sensu Go.
 
-- [Contact the Sensu sales team][1]
-- [Log in to your Sensu account][2]
-- [Contact Sensu support][14]
+Manage your Sensu account and contact support through [account.sensu.io][2].
 
 ## Get started with commercial features in Sensu Go
 
 If you haven't already, [install the Sensu Go backend, agent, and sensuctl tool][15] and [configure sensuctl][16].
 
-Log in to your Sensu account at [account.sensu.io][2] and download your commercial license file.
-Click **Download license**.
+You will need a commercial license if your Sensu installation includes more than 100 entities.
+To download your commercial license file:
+
+1. Log in to your Sensu account at [account.sensu.io][2].
+2. Click **Download license**.
+
+{{% notice note %}}
+**NOTE**: In some cases, you may need to click **Generate license** before you can download your license.
+{{% /notice %}}
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
@@ -65,6 +75,7 @@ These resources will help you get started with commercial features in Sensu Go:
 - [Log in to your Sensu account][2]
 - [Contact Sensu support][14]
 
+
 [1]: https://sensu.io/contact?subject=contact-sales/
 [2]: https://account.sensu.io/
 [3]: https://sensu.io/features#free-vs-paid
@@ -83,3 +94,6 @@ These resources will help you get started with commercial features in Sensu Go:
 [16]: ../sensuctl/#first-time-setup
 [17]: ../guides/install-check-executables-with-assets/
 [18]: ../reference/license/
+[19]: ../operations/manage-secrets/secrets-management/
+[20]: ../operations/deploy-sensu/use-federation/
+[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication

--- a/content/sensu-go/6.0/commercial.md
+++ b/content/sensu-go/6.0/commercial.md
@@ -9,39 +9,49 @@ product: "Sensu Go"
 ---
 
 Sensu Go offers commercial features designed for monitoring at scale.
-[Contact the Sensu sales team][1] for a personalized demo and free trial.
-All commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100.
-See the [announcement on our blog][7] for more information.
+All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
+
+If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
 
 ## Commercial features in Sensu Go
 
-- **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and filters using the Sensu [web UI][8], and access the Sensu web UI homepage.
-- **Authentication providers**: Scale Sensu role-based access control (RBAC) with [LDAP and Active Directory integrations][9].
-- **Scalable resource filtering** designed for large installations: Use label and field selectors to filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes. Build event filter expressions with [JavaScript execution functions][19].
-- **Event logging**: Log observation data to a file you can use as an input source for your favorite data lake solution.
-The [event logging][10] functionality provides better performance and reliability than event handlers.
-- **Enterprise-tier dynamic runtime assets**: Connect your observability pipelines to industry-standard tools like ServiceNow and Jira with [enterprise-tier dynamic runtime assets][11].
-- **Enterprise-scale event storage**: Scale your Sensu instance and handle high volumes of events with a [PostgreSQL event store][12].
-- **Enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
+- **Protect your sensitive information** with [secrets management][22].
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+- **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
+Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
+- **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
+- **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and event filters using the Sensu [web UI][8], and access the Sensu web UI homepage.
+- **Control permissions with Sensu role-based access control (RBAC)**, with the option of using [Lightweight Directory Access Protocol (LDAP) and Active Directory (AD)][9] for authentication.
+- **Use powerful filtering capabilities** designed for large installations. With label and field selectors, you can filter [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wider range of resource attributes. Build event filter expressions with [JavaScript execution functions][19].
+- **Log observation data** [to a file][10] you can use as an input to your favorite data lake solution.
+- **Connect your observability pipelines to industry-standard tools** like ServiceNow and Jira with [enterprise-tier dynamic runtime assets][11].
+- **Achieve enterprise-scale event handling** for your Sensu instance with a [PostgreSQL event store][12].
+Access the PostgreSQL event datastore with the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
+- **Get enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
 Our expert in-house team offers best-in-class support to get you up and running smoothly.
 
 Review a [complete comparison of OSS and commercial features][3].
 
 ## Contact us for a free trial
 
-For a personalized demo and free trial of commercial features at scale in Sensu Go, [contact the Sensu sales team][1].
-Manage your Sensu account and contact support through [account.sensu.io][2].
+Sensu's commercial features are [free for your first 100 entities][7].
+If your Sensu installation includes more than 100 entities, [contact the Sensu sales team][1] for a free trial of commercial features at scale in Sensu Go.
 
-- [Contact the Sensu sales team][1]
-- [Log in to your Sensu account][2]
-- [Contact Sensu support][14]
+Manage your Sensu account and contact support through [account.sensu.io][2].
 
 ## Get started with commercial features in Sensu Go
 
 If you haven't already, [install the Sensu Go backend, agent, and sensuctl tool][15] and [configure sensuctl][16].
 
-Log in to your Sensu account at [account.sensu.io][2] and download your commercial license file.
-Click **Download license**.
+You will need a commercial license if your Sensu installation includes more than 100 entities.
+To download your commercial license file:
+
+1. Log in to your Sensu account at [account.sensu.io][2].
+2. Click **Download license**.
+
+{{% notice note %}}
+**NOTE**: In some cases, you may need to click **Generate license** before you can download your license.
+{{% /notice %}}
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
@@ -65,6 +75,7 @@ These resources will help you get started with commercial features in Sensu Go:
 - [Log in to your Sensu account][2]
 - [Contact Sensu support][14]
 
+
 [1]: https://sensu.io/contact?subject=contact-sales/
 [2]: https://account.sensu.io/
 [3]: https://sensu.io/features#free-vs-paid
@@ -84,3 +95,6 @@ These resources will help you get started with commercial features in Sensu Go:
 [17]: ../operations/deploy-sensu/use-assets-to-install-plugins/
 [18]: ../operations/maintain-sensu/license/
 [19]: ../observability-pipeline/observe-filter/filters#build-event-filter-expressions-with-javascript-execution-functions
+[20]: ../operations/deploy-sensu/use-federation/	
+[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[22]: ../operations/manage-secrets/secrets-management/

--- a/content/sensu-go/6.1/commercial.md
+++ b/content/sensu-go/6.1/commercial.md
@@ -9,39 +9,49 @@ product: "Sensu Go"
 ---
 
 Sensu Go offers commercial features designed for monitoring at scale.
-[Contact the Sensu sales team][1] for a personalized demo and free trial.
-All commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100.
-See the [announcement on our blog][7] for more information.
+All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
+
+If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
 
 ## Commercial features in Sensu Go
 
+- **Protect your sensitive information** with [secrets management][22].
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+- **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
+Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
+- **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Manage resources from your browser**: Create, edit, and delete checks, handlers, mutators, and event filters using the Sensu [web UI][8], and access the Sensu web UI homepage.
-- **Authentication providers**: Scale Sensu role-based access control (RBAC) with [LDAP and Active Directory integrations][9].
-- **Scalable resource selectors** designed for large installations: Search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes. Build event filter expressions with [JavaScript execution functions][19].
-- **Event logging**: Log observation data to a file you can use as an input source for your favorite data lake solution.
-The [event logging][10] functionality provides better performance and reliability than event handlers.
-- **Enterprise-tier dynamic runtime assets**: Connect your observability pipelines to industry-standard tools like ServiceNow and Jira with [enterprise-tier dynamic runtime assets][11].
-- **Enterprise-scale event storage**: Scale your Sensu instance and handle high volumes of events with a [PostgreSQL event store][12].
-- **Enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
+- **Control permissions with Sensu role-based access control (RBAC)**, with the option of using [Lightweight Directory Access Protocol (LDAP) and Active Directory (AD)][9] for authentication.
+- **Use powerful search capabilities** designed for large installations to search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes. Build event filter expressions with [JavaScript execution functions][19].
+- **Log observation data** [to a file][10] you can use as an input to your favorite data lake solution.
+- **Connect your observability pipelines to industry-standard tools** like ServiceNow and Jira with [enterprise-tier dynamic runtime assets][11].
+- **Achieve enterprise-scale event handling** for your Sensu instance with a [PostgreSQL event store][12].
+Access the PostgreSQL event datastore with the same Sensu web UI, API, and sensuctl processes as etcd-stored events.
+- **Get enterprise-class support**: Rest assured that with [Sensu support][13], help is available if you need it.
 Our expert in-house team offers best-in-class support to get you up and running smoothly.
 
 Review a [complete comparison of OSS and commercial features][3].
 
 ## Contact us for a free trial
 
-For a personalized demo and free trial of commercial features at scale in Sensu Go, [contact the Sensu sales team][1].
-Manage your Sensu account and contact support through [account.sensu.io][2].
+Sensu's commercial features are [free for your first 100 entities][7].
+If your Sensu installation includes more than 100 entities, [contact the Sensu sales team][1] for a free trial of commercial features at scale in Sensu Go.
 
-- [Contact the Sensu sales team][1]
-- [Log in to your Sensu account][2]
-- [Contact Sensu support][14]
+Manage your Sensu account and contact support through [account.sensu.io][2].
 
 ## Get started with commercial features in Sensu Go
 
 If you haven't already, [install the Sensu Go backend, agent, and sensuctl tool][15] and [configure sensuctl][16].
 
-Log in to your Sensu account at [account.sensu.io][2] and download your commercial license file.
-Click **Download license**.
+You will need a commercial license if your Sensu installation includes more than 100 entities.
+To download your commercial license file:
+
+1. Log in to your Sensu account at [account.sensu.io][2].
+2. Click **Download license**.
+
+{{% notice note %}}
+**NOTE**: In some cases, you may need to click **Generate license** before you can download your license.
+{{% /notice %}}
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
@@ -65,6 +75,7 @@ These resources will help you get started with commercial features in Sensu Go:
 - [Log in to your Sensu account][2]
 - [Contact Sensu support][14]
 
+
 [1]: https://sensu.io/contact?subject=contact-sales/
 [2]: https://account.sensu.io/
 [3]: https://sensu.io/features#free-vs-paid
@@ -84,3 +95,6 @@ These resources will help you get started with commercial features in Sensu Go:
 [17]: ../operations/deploy-sensu/use-assets-to-install-plugins/
 [18]: ../operations/maintain-sensu/license/
 [19]: ../observability-pipeline/observe-filter/filters#build-event-filter-expressions-with-javascript-execution-functions
+[20]: ../operations/deploy-sensu/use-federation/	
+[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[22]: ../operations/manage-secrets/secrets-management/


### PR DESCRIPTION
## Description
Restores changes to the commercial features page made in https://github.com/sensu/sensu-docs/pull/2235

## Motivation and Context
I must have overwritten the updates at some point when I was moving things around for the docs IA project.
