### PR TITLE
Add layout for Uchiwa docs index pages

### DIFF
--- a/content/uchiwa/1.0/api/_index.md
+++ b/content/uchiwa/1.0/api/_index.md
@@ -3,6 +3,7 @@ title: "API"
 product: "Uchiwa"
 version: "1.0"
 weight: 20
+layout: "base-for-directory-listing"
 menu: 
   uchiwa-1.0:
     identifier: api

--- a/content/uchiwa/1.0/getting-started/_index.md
+++ b/content/uchiwa/1.0/getting-started/_index.md
@@ -3,6 +3,7 @@ title: "Getting Started"
 product: "Uchiwa"
 version: "1.0"
 weight: 1
+layout: "base-for-directory-listing"
 menu: 
   uchiwa-1.0:
     identifier: getting-started

--- a/content/uchiwa/1.0/guides/_index.md
+++ b/content/uchiwa/1.0/guides/_index.md
@@ -3,6 +3,7 @@ title: "Guides"
 product: "Uchiwa"
 version: "1.0"
 weight: 10
+layout: "base-for-directory-listing"
 menu: 
   uchiwa-1.0:
     identifier: guides

--- a/content/uchiwa/1.0/reference/_index.md
+++ b/content/uchiwa/1.0/reference/_index.md
@@ -3,6 +3,7 @@ title: "Reference"
 product: "Uchiwa"
 version: "1.0"
 weight: 30
+layout: "base-for-directory-listing"
 menu: 
   uchiwa-1.0:
     identifier: reference


### PR DESCRIPTION
## Description
Add `layout: "base-for-directory-listing"` to front matter for all index pages in the Uchiwa docs. With the layout added, the index pages will list a basic table of contents for the pages in each section.

## Motivation and Context
Cameron and I discovered the index pages for each category were blank in the Uchiwa docs while investigating a separate issue.
