### PR TITLE
Updated: Add read/write and grant config info for external etcd in cluster guide

### DIFF
--- a/content/sensu-go/5.20/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/cluster-sensu.md
@@ -262,11 +262,44 @@ See [Secure Sensu][16] for information about cluster security.
 
 ## Use an external etcd cluster
 
-To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
-To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer but is not compatible with etcd 3.4.0 or newer.
+Follow etcd's [clustering guide][2] using the same store configuration to stand up an external etcd cluster.
 
-In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
-To start etcd for `backend-1` based on the [three-node configuration example][19]:
+To initialize a backend that uses etcd authentication, configure read and write access to the `/sensu.io/` key space for your users:
+
+{{< highlight shell >}}
+# Add the sensu user (you will receive an interactive prompt for the password)
+etcdctl user add sensu
+# Create a role
+etcdctl role add sensu_readwrite
+# Give that role permission to read and write under the /sensu.io/ keyspace
+etcdctl role grant-permission sensu_readwrite readwrite --from-key '/sensu.io/'
+# Grant the sensu user the role
+etcdctl user grant-role sensu sensu_readwrite
+{{< /highlight >}}
+
+To double-check that the grant is configured correctly, run:
+
+{{< highlight shell >}}
+/opt/etcd/etcdctl user get USERNAME --detail
+{{< /highlight >}}
+
+The output should be:
+
+{{< highlight shell >}}
+User: USERNAME
+
+Role sensu_readwrite
+KV Read:
+	[/sensu.io/, <open ended>
+KV Write:
+	[/sensu.io/, <open ended>
+{{< /highlight >}}
+
+Etcd does not enable authentication by default, so additional configuration may be needed before etcd will enforce these controls.
+See the [etcd operators documentation][12] for details.
+
+To enable client-to-server and peer communication authentication [using self-signed TLS certificates][13], start etcd for `backend-1` based on the [three-node configuration example][19]:
 
 {{< code shell >}}
 etcd \
@@ -290,11 +323,10 @@ etcd \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `auto-compaction-mode` and `auto-compaction-retention` flags are important.
-Without these settings, your database may quickly reach etcd's maximum database size limit.
+**NOTE**: Without the `auto-compaction-mode` and `auto-compaction-retention` flags, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using your CA:
+Next, tell Sensu to use this external etcd data source by adding the `sensu-backend` flag `--no-embed-etcd` to the original configuration and the path to a client certificate created using your CA:
 
 {{< code shell >}}
 sensu-backend start \
@@ -319,18 +351,18 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 
 See the [etcd recovery guide][9] for disaster recovery information.
 
-[1]: https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.4.0/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.4.0/op-guide/configuration/
+[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
 [4]: https://etcd.io/docs/
-[5]: https://etcd.io/docs/v3.4.0/platforms/
+[5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.4.0/op-guide/failures/
-[9]: https://etcd.io/docs/v3.4.0/op-guide/recovery/
+[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
+[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.4.0/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.4.0/op-guide/
+[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/v3.3.13/op-guide/
 [13]: ../generate-certificates/
 [14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [15]: ../../../reference/backend/

--- a/content/sensu-go/5.20/reference/datastore.md
+++ b/content/sensu-go/5.20/reference/datastore.md
@@ -12,6 +12,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer but is not compatible with etcd 3.4.0 or newer.
+Follow etcd's [clustering guide][5] using the same store configuration to stand up an external etcd cluster.
+
 You can access event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -199,6 +202,7 @@ example      | {{< code shell >}}pool_size: 20{{< /code >}}
 [2]: ../../operations/maintain-sensu/troubleshoot/
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
+[5]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../web-ui/
 [10]: ../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
@@ -262,11 +262,44 @@ See [Secure Sensu][16] for information about cluster security.
 
 ## Use an external etcd cluster
 
-To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
-To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer but is not compatible with etcd 3.4.0 or newer.
+Follow etcd's [clustering guide][2] using the same store configuration to stand up an external etcd cluster.
 
-In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
-To start etcd for `backend-1` based on the [three-node configuration example][19]:
+To initialize a backend that uses etcd authentication, configure read and write access to the `/sensu.io/` key space for your users:
+
+{{< highlight shell >}}
+# Add the sensu user (you will receive an interactive prompt for the password)
+etcdctl user add sensu
+# Create a role
+etcdctl role add sensu_readwrite
+# Give that role permission to read and write under the /sensu.io/ keyspace
+etcdctl role grant-permission sensu_readwrite readwrite --from-key '/sensu.io/'
+# Grant the sensu user the role
+etcdctl user grant-role sensu sensu_readwrite
+{{< /highlight >}}
+
+To double-check that the grant is configured correctly, run:
+
+{{< highlight shell >}}
+/opt/etcd/etcdctl user get USERNAME --detail
+{{< /highlight >}}
+
+The output should be:
+
+{{< highlight shell >}}
+User: USERNAME
+
+Role sensu_readwrite
+KV Read:
+	[/sensu.io/, <open ended>
+KV Write:
+	[/sensu.io/, <open ended>
+{{< /highlight >}}
+
+Etcd does not enable authentication by default, so additional configuration may be needed before etcd will enforce these controls.
+See the [etcd operators documentation][12] for details.
+
+To enable client-to-server and peer communication authentication [using self-signed TLS certificates][13], start etcd for `backend-1` based on the [three-node configuration example][19]:
 
 {{< code shell >}}
 etcd \
@@ -290,11 +323,10 @@ etcd \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `auto-compaction-mode` and `auto-compaction-retention` flags are important.
-Without these settings, your database may quickly reach etcd's maximum database size limit.
+**NOTE**: Without the `auto-compaction-mode` and `auto-compaction-retention` flags, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using your CA:
+Next, tell Sensu to use this external etcd data source by adding the `sensu-backend` flag `--no-embed-etcd` to the original configuration and the path to a client certificate created using your CA:
 
 {{< code shell >}}
 sensu-backend start \
@@ -319,18 +351,18 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 
 See the [etcd recovery guide][9] for disaster recovery information.
 
-[1]: https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.4.0/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.4.0/op-guide/configuration/
+[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
 [4]: https://etcd.io/docs/
-[5]: https://etcd.io/docs/v3.4.0/platforms/
+[5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.4.0/op-guide/failures/
-[9]: https://etcd.io/docs/v3.4.0/op-guide/recovery/
+[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
+[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.4.0/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.4.0/op-guide/
+[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/v3.3.13/op-guide/
 [13]: ../generate-certificates/
 [14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [15]: ../../../reference/backend/

--- a/content/sensu-go/5.21/reference/datastore.md
+++ b/content/sensu-go/5.21/reference/datastore.md
@@ -12,6 +12,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer but is not compatible with etcd 3.4.0 or newer.
+Follow etcd's [clustering guide][5] using the same store configuration to stand up an external etcd cluster.
+
 You can access event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -199,6 +202,7 @@ example      | {{< code shell >}}pool_size: 20{{< /code >}}
 [2]: ../../operations/maintain-sensu/troubleshoot/
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
+[5]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../web-ui/
 [10]: ../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
@@ -13,6 +13,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer but is not compatible with etcd 3.4.0 or newer.
+Follow etcd's [clustering guide][5] using the same store configuration to stand up an external etcd cluster.
+
 You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of observability event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -200,6 +203,7 @@ example      | {{< code shell >}}pool_size: 20{{< /code >}}
 [2]: ../../maintain-sensu/troubleshoot/
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
+[5]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -13,6 +13,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an embedded etcd (default) or an [external etcd][8] instance.
+Using Sensu with an external etcd cluster requires etcd 3.3.2 or newer but is not compatible with etcd 3.4.0 or newer.
+Follow etcd's [clustering guide][5] using the same store configuration to stand up an external etcd cluster.
+
 You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of observability event data, integrate Sensu with a time series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -253,6 +256,7 @@ example      | {{< code shell >}}strict: true{{< /code >}}
 [2]: ../../maintain-sensu/troubleshoot/
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
+[5]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event


### PR DESCRIPTION
## Description
- Adds information about configuring read/write access and grant permission for etcd auth.
- Adds etcd compatibility info to datastore reference.
- Updates etcd links to use 3.3.13 docs.
- Propagates changes to all currently published docs versions.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2184
