### PR TITLE
6.1.1: Update sensuctl dump and prune hook FQN and type

### DIFF
--- a/content/sensu-go/6.1/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.1/sensuctl/back-up-recover.md
@@ -182,7 +182,7 @@ sensuctl describe-type all
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In Sensu 6.1.0, for hooks, the fully qualified name is `core/v2.Hook` and the type is `Hook`.
+**NOTE**: In Sensu 6.1.0, `sensuctl dump` does not work with hooks.
 {{% /notice %}}
 
 You can also list specific resource types by fully qualified name or short name:

--- a/content/sensu-go/6.1/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.1/sensuctl/back-up-recover.md
@@ -110,7 +110,7 @@ mkdir backup
 2. Back up your pipeline resources, stripping namespaces so that your resources are portable for reuse in any namespace.
    
    {{< code shell >}}
-sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
 {{< /code >}}
 
@@ -174,12 +174,16 @@ sensuctl describe-type all
   core/v2.Event                  events                core/v2             Event                true
   core/v2.EventFilter            filters               core/v2             EventFilter          true
   core/v2.Handler                handlers              core/v2             Handler              true
-  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.HookConfig             hooks                 core/v2             HookConfig           true
   core/v2.Mutator                mutators              core/v2             Mutator              true
   core/v2.Role                   roles                 core/v2             Role                 true
   core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
   core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: In Sensu 6.1.0, for hooks, the fully qualified name is `core/v2.Hook` and the type is `Hook`.
+{{% /notice %}}
 
 You can also list specific resource types by fully qualified name or short name:
 

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -483,7 +483,7 @@ sensuctl describe-type all
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In Sensu 6.1.0, for hooks, the fully qualified name is `core/v2.Hook` and the type is `Hook`.
+**NOTE**: In Sensu 6.1.0, `sensuctl prune` does not work with hooks.
 {{% /notice %}}
 
 ##### sensuctl prune examples

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -475,12 +475,16 @@ sensuctl describe-type all
   core/v2.Event                  events                core/v2             Event                true
   core/v2.EventFilter            filters               core/v2             EventFilter          true
   core/v2.Handler                handlers              core/v2             Handler              true
-  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.HookConfig             hooks                 core/v2             HookConfig           true
   core/v2.Mutator                mutators              core/v2             Mutator              true
   core/v2.Role                   roles                 core/v2             Role                 true
   core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
   core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: In Sensu 6.1.0, for hooks, the fully qualified name is `core/v2.Hook` and the type is `Hook`.
+{{% /notice %}}
 
 ##### sensuctl prune examples
 


### PR DESCRIPTION
## Description
- Updates hook fully qualified name and type in supported resource types tables in https://docs.sensu.io/sensu-go/latest/sensuctl/back-up-recover/#supported-resource-types and https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#supported-resource-types
- Adds notes after the supported resource types tables to identify the different fully qualified name and type for hooks for 6.1.0.

## Motivation and Context
Support 6.1.1 release based on changes in https://github.com/sensu/sensu-go/pull/4057