### PR TITLE
Add "Next" button to top-level operations pages

### DIFF
--- a/content/sensu-go/6.1/operations/_index.md
+++ b/content/sensu-go/6.1/operations/_index.md
@@ -19,6 +19,8 @@ The content in the Operations category walks you through each step in getting Se
 - [Monitor Sensu][4]
 - [Manage Secrets][5]
 
+**<button onclick="window.location.href='deploy-sensu';">Next</button>**
+
 
 [1]: deploy-sensu/
 [2]: control-access/

--- a/content/sensu-go/6.1/operations/control-access/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/_index.md
@@ -17,6 +17,8 @@ The Control Access section describes how to authenticate identities and authoriz
 [Configure authentication][1] to use Sensu's built-in basic authentication provider or external authentication providers to authenticate via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect.
 Then, use [role-based access control (RBAC)][2] to exercise fine-grained control over how Sensu users interact with Sensu resources.
 
+**<button onclick="window.location.href='auth';">Next</button>**
+
 
 [1]: auth/
 [2]: create-read-only-user/

--- a/content/sensu-go/6.1/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/_index.md
@@ -21,6 +21,8 @@ Follow our guides to achieve a production-ready installation: [generate certific
 
 You can also [scale your monitoring and observability workflows][8] to many thousands of events per second with Enterprise datastore.
 
+**<button onclick="window.location.href='hardware-requirements';">Next</button>**
+
 
 [1]: hardware-requirements/
 [2]: deployment-architecture/

--- a/content/sensu-go/6.1/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/_index.md
@@ -14,6 +14,8 @@ menu:
 
 Use the guides in the Maintain Sensu category to [upgrade][1] to the latest version of Sensu and [troubleshoot][2].
 
+**<button onclick="window.location.href='upgrade';">Next</button>**
+
 
 [1]: upgrade/
 [2]: troubleshoot/

--- a/content/sensu-go/6.1/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/_index.md
@@ -14,5 +14,7 @@ menu:
 
 Use Sensu’s [secrets management][1] to obtain secrets like usernames and passwords from external secrets providers so that you can both refer to external secrets and consume secrets via backend environment variables without exposing them in your Sensu configuration.
 
+**<button onclick="window.location.href='secrets-management';">Next</button>**
+
 
 [1]: secrets-management/

--- a/content/sensu-go/6.1/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/_index.md
@@ -14,5 +14,7 @@ menu:
 
 Add [log forwarding][1] from journald to syslog and set up log rotation to successfully monitor your Sensu installation.
 
+**<button onclick="window.location.href='log-sensu-systemd';">Next</button>**
+
 
 [1]: log-sensu-systemd/


### PR DESCRIPTION
## Description
Adds a "Next" button to the top-level index pages for each operations section and the operations category.

## Motivation and Context
Temporary measure to direct users from the section index pages onto the first page of content within each section while we're drafting more substantial content for the index pages.