### PR TITLE
Change do something new heading to get started in install-sensu

### DIFF
--- a/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
@@ -479,7 +479,7 @@ You can change the `output` value to `connected to mysql` to see a different mes
 Now that you have installed Sensu, you’re ready to build your observability pipelines!
 Here are some ideas for next steps.
 
-### Do something new with Sensu
+### Get started with Sensu
 
 If you're ready to see what Sensu can do, one of these pathways can get you started:
 

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
@@ -479,7 +479,7 @@ You can change the `output` value to `connected to mysql` to see a different mes
 Now that you have installed Sensu, you’re ready to build your observability pipelines!
 Here are some ideas for next steps.
 
-### Do something new with Sensu
+### Get started with Sensu
 
 If you're ready to see what Sensu can do, one of these pathways can get you started:
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -479,7 +479,7 @@ You can change the `output` value to `connected to mysql` to see a different mes
 Now that you have installed Sensu, you’re ready to build your observability pipelines!
 Here are some ideas for next steps.
 
-### Do something new with Sensu
+### Get started with Sensu
 
 If you're ready to see what Sensu can do, one of these pathways can get you started:
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -479,7 +479,7 @@ You can change the `output` value to `connected to mysql` to see a different mes
 Now that you have installed Sensu, you’re ready to build your observability pipelines!
 Here are some ideas for next steps.
 
-### Do something new with Sensu
+### Get started with Sensu
 
 If you're ready to see what Sensu can do, one of these pathways can get you started:
 


### PR DESCRIPTION
## Description
Change "Do something new with Sensu" to "Get started with Sensu" in Next steps section of install-sensu doc.

## Motivation and Context
Suggested by Sales team -- "Do something new" heading was not quite right in conjunction with the other next steps heading, which involves deploying Sensu in production. Changing this heading makes more sense -- presents the options more like beginner next steps and more advanced next steps.
