### PR TITLE
Add note about using Okta Classic UI to create Okta app

### DIFF
--- a/content/sensu-go/5.20/operations/control-access/auth.md
+++ b/content/sensu-go/5.20/operations/control-access/auth.md
@@ -1299,6 +1299,11 @@ Use the instructions listed in this section to register an OIDC application for 
 
 #### Create an Okta application
 
+{{% notice note %}}
+**NOTE**: These instructions are based on the Okta Classic UI.
+The steps may be different if you are using the Okta Developer Console.
+{{% /notice %}}
+
 1. In the Okta Administrator Dashboard, start the wizard:<br>select `Applications` > `Add Application` > `Create New App`.
 2. In the *Platform* dropdown, select `Web`.
 3. In the *Sign on method* section, select `OpenID Connect`.

--- a/content/sensu-go/5.21/operations/control-access/auth.md
+++ b/content/sensu-go/5.21/operations/control-access/auth.md
@@ -1299,6 +1299,11 @@ Use the instructions listed in this section to register an OIDC application for 
 
 #### Create an Okta application
 
+{{% notice note %}}
+**NOTE**: These instructions are based on the Okta Classic UI.
+The steps may be different if you are using the Okta Developer Console.
+{{% /notice %}}
+
 1. In the Okta Administrator Dashboard, start the wizard:<br>select `Applications` > `Add Application` > `Create New App`.
 2. In the *Platform* dropdown, select `Web`.
 3. In the *Sign on method* section, select `OpenID Connect`.

--- a/content/sensu-go/6.0/operations/control-access/auth.md
+++ b/content/sensu-go/6.0/operations/control-access/auth.md
@@ -1349,6 +1349,11 @@ Use the instructions listed in this section to register an OIDC application for 
 
 #### Create an Okta application
 
+{{% notice note %}}
+**NOTE**: These instructions are based on the Okta Classic UI.
+The steps may be different if you are using the Okta Developer Console.
+{{% /notice %}}
+
 1. In the Okta Administrator Dashboard, start the wizard:<br>select `Applications` > `Add Application` > `Create New App`.
 2. In the *Platform* dropdown, select `Web`.
 3. In the *Sign on method* section, select `OpenID Connect`.

--- a/content/sensu-go/6.1/operations/control-access/auth.md
+++ b/content/sensu-go/6.1/operations/control-access/auth.md
@@ -1360,6 +1360,11 @@ Use the instructions listed in this section to register an OIDC application for 
 
 #### Create an Okta application
 
+{{% notice note %}}
+**NOTE**: These instructions are based on the Okta Classic UI.
+The steps may be different if you are using the Okta Developer Console.
+{{% /notice %}}
+
 1. In the Okta Administrator Dashboard, start the wizard:<br>select `Applications` > `Add Application` > `Create New App`.
 2. In the *Platform* dropdown, select `Web`.
 3. In the *Sign on method* section, select `OpenID Connect`.


### PR DESCRIPTION
## Description
Adds note before https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#create-an-okta-application steps re: instructions are based on Classic UI, not developer console.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2803