### PR TITLE
Add link to Azure AD LDAP setup tutorial in auth doc

### DIFF
--- a/content/sensu-go/5.20/operations/control-access/auth.md
+++ b/content/sensu-go/5.20/operations/control-access/auth.md
@@ -622,6 +622,8 @@ For example:
 Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication to the Sensu web UI, API, and sensuctl.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
+To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
+
 ### AD configuration examples
 
 **Example AD configuration: Minimum required attributes**
@@ -1353,6 +1355,7 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 [7]: https://www.openldap.org/
 [8]: ../../../api/
 [9]: ../../../api/auth/
+[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: ../../../reference/rbac#roles-and-cluster-roles
 [13]: ../../../reference/rbac#role-bindings-and-cluster-role-bindings
 [17]: ../../../reference/rbac#namespaced-resource-types

--- a/content/sensu-go/5.21/operations/control-access/auth.md
+++ b/content/sensu-go/5.21/operations/control-access/auth.md
@@ -622,6 +622,8 @@ For example:
 Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication to the Sensu web UI, API, and sensuctl.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
+To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
+
 ### AD configuration examples
 
 **Example AD configuration: Minimum required attributes**
@@ -1353,6 +1355,7 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 [7]: https://www.openldap.org/
 [8]: ../../../api/
 [9]: ../../../api/auth/
+[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: ../../../reference/rbac#roles-and-cluster-roles
 [13]: ../../../reference/rbac#role-bindings-and-cluster-role-bindings
 [17]: ../../../reference/rbac#namespaced-resource-types

--- a/content/sensu-go/6.0/operations/control-access/auth.md
+++ b/content/sensu-go/6.0/operations/control-access/auth.md
@@ -622,6 +622,8 @@ For example:
 Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication to the Sensu web UI, API, and sensuctl.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
+To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
+
 ### AD configuration examples
 
 **Example AD configuration: Minimum required attributes**
@@ -1403,6 +1405,7 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 [7]: https://www.openldap.org/
 [8]: ../../../api/
 [9]: ../../../api/auth/
+[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: ../rbac#roles-and-cluster-roles
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [17]: ../rbac#namespaced-resource-types

--- a/content/sensu-go/6.1/operations/control-access/auth.md
+++ b/content/sensu-go/6.1/operations/control-access/auth.md
@@ -622,6 +622,8 @@ For example:
 Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication to the Sensu web UI, API, and sensuctl.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
+To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
+
 ### AD configuration examples
 
 **Example AD configuration: Minimum required attributes**
@@ -1414,6 +1416,7 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 [7]: https://www.openldap.org/
 [8]: ../../../api/
 [9]: ../../../api/auth/
+[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: ../rbac#roles-and-cluster-roles
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [17]: ../rbac#namespaced-resource-types


### PR DESCRIPTION
## Description
Adds link to https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps in AD authentication section of auth doc.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2694
