### PR TITLE
Test authentication and authorization sub-categories

### DIFF
--- a/content/sensu-go/6.1/operations/control-access/authentication/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/authentication/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Authentication"
+description: "Set up access control for Sensu, the flexible observability pipeline. Read these documents to authenticate to Sensu and authorize access for Sensu users."
+product: "Sensu Go"
+version: "6.1"
+weight: 20
+layout: "single"
+toc: false
+menu:
+  sensu-go-6.1:
+    parent: control-access
+    identifier: authentication
+---
+
+Test for authentication subcategory
+

--- a/content/sensu-go/6.1/operations/control-access/authentication/apikeys.md
+++ b/content/sensu-go/6.1/operations/control-access/authentication/apikeys.md
@@ -9,7 +9,7 @@ version: "6.1"
 product: "Sensu Go"
 menu: 
   sensu-go-6.1:
-    parent: control-access
+    parent: authentication
 ---
 
 API keys are long-lived authentication tokens that make it more convenient for Sensu plugins and other Sensu-adjacent applications to authenticate with the Sensu API.

--- a/content/sensu-go/6.1/operations/control-access/authentication/auth.md
+++ b/content/sensu-go/6.1/operations/control-access/authentication/auth.md
@@ -7,7 +7,7 @@ version: "6.1"
 product: "Sensu Go"
 menu:
   sensu-go-6.1:
-    parent: control-access
+    parent: authentication
 ---
 
 Sensu requires username and password authentication to access the [Sensu web UI][1], [API][8], and command line tool ([sensuctl][2]).

--- a/content/sensu-go/6.1/operations/control-access/authentication/use-apikeys.md
+++ b/content/sensu-go/6.1/operations/control-access/authentication/use-apikeys.md
@@ -10,7 +10,7 @@ product: "Sensu Go"
 platformContent: False
 menu: 
   sensu-go-6.1:
-    parent: control-access
+    parent: authentication
 ---
 
 The Sensu API key feature (core/v2.APIKey) is a persistent UUID that maps to a stored Sensu username.

--- a/content/sensu-go/6.1/operations/control-access/authorization/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/authorization/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Authorization"
+description: "Set up access control for Sensu, the flexible observability pipeline. Read these documents to authenticate to Sensu and authorize access for Sensu users."
+product: "Sensu Go"
+version: "6.1"
+weight: 20
+layout: "single"
+toc: false
+menu:
+  sensu-go-6.1:
+    parent: control-access
+    identifier: authorization
+---
+
+Test for authorization sub-category.
+

--- a/content/sensu-go/6.1/operations/control-access/authorization/create-read-only-user.md
+++ b/content/sensu-go/6.1/operations/control-access/authorization/create-read-only-user.md
@@ -10,7 +10,7 @@ product: "Sensu Go"
 platformContent: false
 menu: 
   sensu-go-6.1:
-    parent: control-access
+    parent: authorization
 ---
 
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.

--- a/content/sensu-go/6.1/operations/control-access/authorization/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/authorization/rbac.md
@@ -9,7 +9,7 @@ version: "6.1"
 product: "Sensu Go"
 menu:
   sensu-go-6.1:
-    parent: control-access
+    parent: authorization
 ---
 
 Sensu role-based access control (RBAC) helps different teams and projects share a Sensu instance.


### PR DESCRIPTION
## Description
Tests whether our current docs arch can support a third nested level in the left nav. See Operations > Control Access -- the left nav menu does not accept a further nested level.

I will re-check this next week to make sure I haven't overlooked something.

## Motivation and Context
Investigate docs architecture options related to https://github.com/sensu/sensu-docs/issues/2811

## Additional Notes
The PR that added nested levels is https://github.com/sensu/sensu-docs/pull/2561