### PR TITLE
Remove config-file env var for agent and backend

### DIFF
--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -945,13 +945,11 @@ cache-dir: "/cache/sensu-agent"{{< /code >}}
 description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
-
-# /etc/sensu/agent.yml example
-config-file: "/sensu/agent.yml"{{< /code >}}
+{{< /code >}}
 
 <a name="disable-assets"></a>
 

--- a/content/sensu-go/5.20/reference/backend.md
+++ b/content/sensu-go/5.20/reference/backend.md
@@ -429,13 +429,11 @@ cache-dir: "/cache/sensu-backend"{{< /code >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_BACKEND_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
-
-# /etc/sensu/backend.yml example
-config-file: "/etc/sensu/backend.yml"{{< /code >}}
+{{< /code >}}
 
 
 | debug     |      |

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -947,13 +947,11 @@ cache-dir: "/cache/sensu-agent"{{< /code >}}
 description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
-
-# /etc/sensu/agent.yml example
-config-file: "/sensu/agent.yml"{{< /code >}}
+{{< /code >}}
 
 <a name="disable-assets"></a>
 

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -431,13 +431,11 @@ cache-dir: "/cache/sensu-backend"{{< /code >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_BACKEND_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
-
-# /etc/sensu/backend.yml example
-config-file: "/etc/sensu/backend.yml"{{< /code >}}
+{{< /code >}}
 
 
 | debug     |      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -955,13 +955,11 @@ cache-dir: "/cache/sensu-agent"{{< /code >}}
 description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
-
-# /etc/sensu/agent.yml example
-config-file: "/sensu/agent.yml"{{< /code >}}
+{{< /code >}}
 
 <a name="disable-assets"></a>
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -435,13 +435,11 @@ cache-dir: "/cache/sensu-backend"{{< /code >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_BACKEND_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
-
-# /etc/sensu/backend.yml example
-config-file: "/etc/sensu/backend.yml"{{< /code >}}
+{{< /code >}}
 
 
 | debug     |      |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -955,13 +955,11 @@ cache-dir: "/cache/sensu-agent"{{< /code >}}
 description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
-environment variable | `SENSU_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
-
-# /etc/sensu/agent.yml example
-config-file: "/sensu/agent.yml"{{< /code >}}
+{{< /code >}}
 
 <a name="disable-assets"></a>
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -450,13 +450,11 @@ cache-dir: "/cache/sensu-backend"{{< /code >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | `SENSU_BACKEND_CONFIG_FILE`
+environment variable | The config file path cannot be set by an environment variable.
 example       | {{< code shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
-
-# /etc/sensu/backend.yml example
-config-file: "/etc/sensu/backend.yml"{{< /code >}}
+{{< /code >}}
 
 
 | debug     |      |


### PR DESCRIPTION
## Description
In the agent and backend references:
- Replaces `config-file` flag env var with a message that the config file path cannot be set by env var
- Removes yaml example for setting config file path

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2813
