### PR TITLE
Add 'filter' in web UI search page to help docs users find it

### DIFF
--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -11,7 +11,7 @@ menu:
     parent: web-ui
 ---
 
-The Sensu web UI includes basic search functions you can use to build customized views of your Sensu resources.
+The Sensu web UI includes basic search and filtering functions you can use to build customized views of your Sensu resources.
 Sensu also supports advanced web UI searches based on a wider range of resource attributes and custom labels as a [commercial feature][1].
 
 When you apply a search to a web UI page, it creates a unique link for the page of search results.
@@ -35,7 +35,7 @@ For details about operators, see [API response filtering operators][7].
 
 ## Use quick search
 
-The web UI quick search allows you to query Sensu resources without using search syntax.
+The web UI quick search allows you to query and filter Sensu resources without using search syntax.
 Type your search term into the search field on any page of the web UI and press `Enter`.
 Sensu will auto-complete a simple search statement for the resources on that page using substring matching.
 

--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -1,7 +1,7 @@
 ---
 title: "Search in the web UI"
 linkTitle: "Search in the Web UI"
-description: "The Sensu web UI supports searching the Events, Entities, Silences, Checks, Handlers, Filters, and Mutators pages. Learn more about searches in the Sensu web UI."
+description: "The Sensu web UI supports searching and filtering the Events, Entities, Silences, Checks, Handlers, Filters, and Mutators pages. Learn more about searches in the Sensu web UI."
 weight: 30
 version: "6.1"
 product: "Sensu Go"


### PR DESCRIPTION
## Description
Adds "filter" terminology in content and frontmatter description in the web UI search page (6.1 only).

## Motivation and Context
Top search for the past couple weeks has been `web ui filter` -- we changed the terminology from "filter" to "search" re: web UI in 6.1. This change may help support better search results for users while I check whether there is a better solution.