### PR TITLE
Add oidc to list of sensuctl create resource types

### DIFF
--- a/content/sensu-go/5.20/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.20/sensuctl/create-manage-resources.md
@@ -148,7 +148,7 @@ The following table describes the command-specific flags.
 `namespace` | `Role` | `role` | `RoleBinding`
 `role_binding` | [`Secret`][28] | `Silenced` | `silenced`
 [`User`][8] | `user` | [`VaultProvider`][24] | [`ldap`][26]
-[`ad`][25] | [`TessenConfig`][27] | [`PostgresConfig`][32]
+[`ad`][25] | [`oidc`][37] | [`TessenConfig`][27] | [`PostgresConfig`][32]
 
 ### Create resources across namespaces
 
@@ -558,3 +558,4 @@ Sensuctl supports the following formats:
 [34]: ../../reference/license/
 [35]: ../../reference/rbac/#cluster-roles
 [36]: #sensuctl-create-flags
+[37]: ../../operations/control-access/auth/#openid-connect-10-protocol-oidc-authentication

--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -148,7 +148,7 @@ The following table describes the command-specific flags.
 `namespace` | `Role` | `role` | `RoleBinding`
 `role_binding` | [`Secret`][28] | `Silenced` | `silenced`
 [`User`][8] | `user` | [`VaultProvider`][24] | [`ldap`][26]
-[`ad`][25] | [`TessenConfig`][27] | [`PostgresConfig`][32]
+[`ad`][25] | [`oidc`][37] | [`TessenConfig`][27] | [`PostgresConfig`][32]
 
 ### Create resources across namespaces
 
@@ -558,3 +558,4 @@ Sensuctl supports the following formats:
 [34]: ../../reference/license/
 [35]: ../../reference/rbac/#cluster-roles
 [36]: #sensuctl-create-flags
+[37]: ../../operations/control-access/auth/#openid-connect-10-protocol-oidc-authentication

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -148,7 +148,7 @@ The following table describes the command-specific flags.
 `namespace` | `Role` | `role` | `RoleBinding`
 `role_binding` | [`Secret`][28] | `Silenced` | `silenced`
 [`User`][8] | `user` | [`VaultProvider`][24] | [`ldap`][26]
-[`ad`][25] | [`TessenConfig`][27] | [`PostgresConfig`][32]
+[`ad`][25] | [`oidc`][37] | [`TessenConfig`][27] | [`PostgresConfig`][32]
 
 ### Create resources across namespaces
 
@@ -560,3 +560,4 @@ Sensuctl supports the following formats:
 [34]: ../../operations/maintain-sensu/license/
 [35]: ../../operations/control-access/rbac/#cluster-roles
 [36]: #sensuctl-create-flags
+[37]: ../../operations/control-access/auth/#openid-connect-10-protocol-oidc-authentication

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -148,7 +148,7 @@ The following table describes the command-specific flags.
 `namespace` | `Role` | `role` | `RoleBinding`
 `role_binding` | [`Secret`][28] | `Silenced` | `silenced`
 [`User`][8] | `user` | [`VaultProvider`][24] | [`ldap`][26]
-[`ad`][25] | [`TessenConfig`][27] | [`PostgresConfig`][32]
+[`ad`][25] | [`oidc`][37] | [`TessenConfig`][27] | [`PostgresConfig`][32]
 
 ### Create resources across namespaces
 
@@ -562,3 +562,4 @@ Sensuctl supports the following formats:
 [34]: ../../operations/maintain-sensu/license/
 [35]: ../../operations/control-access/rbac/#cluster-roles
 [36]: #sensuctl-create-flags
+[37]: ../../operations/control-access/auth/#openid-connect-10-protocol-oidc-authentication


### PR DESCRIPTION
## Description
Adds `oidc` to list of sensuctl create resource types at https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#sensuctl-create-resource-types

## Motivation and Context
Simon [confirmed](https://sensu.slack.com/archives/C60EEQFH8/p1603993273430400) OIDC is missing from the list