### PR TITLE
Remove duplicate image caption for standalone arch

### DIFF
--- a/content/sensu-go/5.20/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/deployment-architecture.md
@@ -65,8 +65,6 @@ The single backend (standalone) with embedded etcd architecture requires minimal
 
 *<p style="text-align:center">Single Sensu Go backend or standalone architecture</p>*
 
-*Single Sensu Go backend or standalone architecture*
-
 You can reconfigure a single backend as a member of a cluster, but this operation is destructive: it requires destroying the existing database.
 
 The single backend (standalone) architecture may be a good fit for small- to medium-sized deployments (such as monitoring a remote office or datacenter), deploying alongside individual auto-scaling groups, or in various segments of a logical environment spanning multiple cloud providers.

--- a/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
@@ -65,8 +65,6 @@ The single backend (standalone) with embedded etcd architecture requires minimal
 
 *<p style="text-align:center">Single Sensu Go backend or standalone architecture</p>*
 
-*Single Sensu Go backend or standalone architecture*
-
 You can reconfigure a single backend as a member of a cluster, but this operation is destructive: it requires destroying the existing database.
 
 The single backend (standalone) architecture may be a good fit for small- to medium-sized deployments (such as monitoring a remote office or datacenter), deploying alongside individual auto-scaling groups, or in various segments of a logical environment spanning multiple cloud providers.

--- a/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
@@ -65,8 +65,6 @@ The single backend (standalone) with embedded etcd architecture requires minimal
 
 *<p style="text-align:center">Single Sensu Go backend or standalone architecture</p>*
 
-*Single Sensu Go backend or standalone architecture*
-
 You can reconfigure a single backend as a member of a cluster, but this operation is destructive: it requires destroying the existing database.
 
 The single backend (standalone) architecture may be a good fit for small- to medium-sized deployments (such as monitoring a remote office or datacenter), deploying alongside individual auto-scaling groups, or in various segments of a logical environment spanning multiple cloud providers.

--- a/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
@@ -65,8 +65,6 @@ The single backend (standalone) with embedded etcd architecture requires minimal
 
 *<p style="text-align:center">Single Sensu Go backend or standalone architecture</p>*
 
-*Single Sensu Go backend or standalone architecture*
-
 You can reconfigure a single backend as a member of a cluster, but this operation is destructive: it requires destroying the existing database.
 
 The single backend (standalone) architecture may be a good fit for small- to medium-sized deployments (such as monitoring a remote office or datacenter), deploying alongside individual auto-scaling groups, or in various segments of a logical environment spanning multiple cloud providers.


### PR DESCRIPTION
## Description
Removes duplicate image caption in standalone architecture section in https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/deployment-architecture/#single-backend-standalone

## Motivation and Context
Fix duplicate image caption
