### PR TITLE
Add content on Learn Sensu index page

### DIFF
--- a/content/sensu-go/5.20/learn/_index.md
+++ b/content/sensu-go/5.20/learn/_index.md
@@ -11,12 +11,27 @@ menu:
     identifier: learn-sensu
 ---
 
-Use the tools in this section to learn Sensu, the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
+The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
-This section includes a [glossary][1] of Sensu terminology, [interactive tutorials][2] that you can use to learn Sensu right in your browser, a [live demo][3] of the Sensu web UI, and a [sandbox][4] where you can build your first observability workflow.
+If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
+The glossary includes links to relevant reference documentation for more in-depth information.
+
+Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
+The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
+
+Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
+The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
+
+For further learning opportunities, download the [Sensu sandbox][4].
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
 [1]: glossary/
 [2]: interactive-tutorials/
 [3]: demo/
 [4]: sandbox/
+[5]: learn-sensu-sandbox/
+[6]: prometheus-metrics/
+[7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
+[8]: ../sensuctl/

--- a/content/sensu-go/5.21/learn/_index.md
+++ b/content/sensu-go/5.21/learn/_index.md
@@ -11,12 +11,27 @@ menu:
     identifier: learn-sensu
 ---
 
-Use the tools in this section to learn Sensu, the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
+The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
-This section includes a [glossary][1] of Sensu terminology, [interactive tutorials][2] that you can use to learn Sensu right in your browser, a [live demo][3] of the Sensu web UI, and a [sandbox][4] where you can build your first observability workflow.
+If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
+The glossary includes links to relevant reference documentation for more in-depth information.
+
+Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
+The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
+
+Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
+The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
+
+For further learning opportunities, download the [Sensu sandbox][4].
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
 [1]: glossary/
 [2]: interactive-tutorials/
 [3]: demo/
 [4]: sandbox/
+[5]: learn-sensu-sandbox/
+[6]: prometheus-metrics/
+[7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
+[8]: ../sensuctl/

--- a/content/sensu-go/6.0/learn/_index.md
+++ b/content/sensu-go/6.0/learn/_index.md
@@ -11,12 +11,31 @@ menu:
     identifier: learn-sensu
 ---
 
-Use the tools in this section to learn Sensu, the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
+The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
-This section includes a [glossary][1] of Sensu terminology, [interactive tutorials][2] that you can use to learn Sensu right in your browser, a [live demo][3] of the Sensu web UI, and a [sandbox][4] where you can build your first observability workflow.
+If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
+The glossary includes links to relevant reference documentation for more in-depth information.
+
+{{% notice protip %}}
+**PRO TIP**: To visualize how Sensu concepts work together in our observability pipeline, [take the tour](../observability-pipeline/) &mdash; follow the `Next` buttons on each page.
+{{% /notice %}}
+
+Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
+The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
+
+Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
+The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
+
+For further learning opportunities, download the [Sensu sandbox][4].
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
 [1]: glossary/
 [2]: interactive-tutorials/
 [3]: demo/
 [4]: sandbox/
+[5]: learn-sensu-sandbox/
+[6]: prometheus-metrics/
+[7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
+[8]: ../sensuctl/

--- a/content/sensu-go/6.1/learn/_index.md
+++ b/content/sensu-go/6.1/learn/_index.md
@@ -11,12 +11,31 @@ menu:
     identifier: learn-sensu
 ---
 
-Use the tools in this section to learn Sensu, the industry-leading telemetry and service health-checking solution for multi-cloud monitoring at scale.
+The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
-This section includes a [glossary][1] of Sensu terminology, [interactive tutorials][2] that you can use to learn Sensu right in your browser, a [live demo][3] of the Sensu web UI, and a [sandbox][4] where you can build your first observability workflow.
+If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
+The glossary includes links to relevant reference documentation for more in-depth information.
+
+{{% notice protip %}}
+**PRO TIP**: To visualize how Sensu concepts work together in our observability pipeline, [take the tour](../observability-pipeline/) &mdash; follow the `Next` buttons on each page.
+{{% /notice %}}
+
+Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
+The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
+
+Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
+The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
+
+For further learning opportunities, download the [Sensu sandbox][4].
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
 [1]: glossary/
 [2]: interactive-tutorials/
 [3]: demo/
 [4]: sandbox/
+[5]: learn-sensu-sandbox/
+[6]: prometheus-metrics/
+[7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
+[8]: ../sensuctl/


### PR DESCRIPTION
## Description
Adds explanation to frame the pages included in the Learn Sensu category, with links to individual pages within the category and other helpful information.

## Motivation and Context
Improve the basic placeholder content I added to the index pages in the course of the initial docs IA project work