### PR TITLE
Add content to index pages for maintain and monitor categories

### DIFF
--- a/content/sensu-go/5.20/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/5.20/operations/maintain-sensu/_index.md
@@ -5,17 +5,38 @@ product: "Sensu Go"
 version: "5.20"
 weight: 30
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-5.20:
     parent: operations
     identifier: maintain-sensu
 ---
 
-Use the guides in the Maintain Sensu category to [upgrade][1] to the latest version of Sensu and [troubleshoot][2].
+The Maintain Sensu category includes information to keep your Sensu installation up-to-date and running smoothly.
 
-**<button onclick="window.location.href='upgrade';">Next</button>**
+## Upgrade or migrate
+
+Follow the [upgrade guide][1] for step-by-step instructions to upgrade to the latest version of Sensu from any earlier version.
+The upgrade instructions include details about important changes between versions that could affect your upgrade and any special requirements to make sure your upgrade is successful.
+
+If you are still using Sensu Core 1.x, follow the [migrate guide][2] to upgrade to Sensu Go.
+The migrate guide includes links to Sensu's migration resources and Core configuration translation tools, as well as instructions for [installing Sensu Go alongside your existing Sensu Core instance][3].
+
+## Troubleshoot
+
+Use the Sensu [troubleshooting guide][4] to diagnose and resolve common issues.
+Learn how to read, configure, and find the [logs produced by Sensu services][6].
+Sensu log messages can help you identify and solve [backend startup errors][7] and [permissions issues][8].
+
+The troubleshooting guide also describes how to [use Sensu handlers and filters to test and debug your observability pipeline][9] and diagnose problems related to [assets][10].
 
 
 [1]: upgrade/
-[2]: troubleshoot/
+[2]: migrate/
+[3]: migrate/#step-by-step-migration-instructions
+[4]: troubleshoot/
+[6]: troubleshoot/#service-logging
+[7]: troubleshoot/#sensu-backend-startup-errors
+[8]: troubleshoot/#permission-issues
+[9]: troubleshoot/#handlers-and-event-filters
+[10]: troubleshoot/#assets

--- a/content/sensu-go/5.20/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/5.20/operations/monitor-sensu/_index.md
@@ -12,9 +12,12 @@ menu:
     identifier: monitor-sensu
 ---
 
-Add [log forwarding][1] from journald to syslog and set up log rotation to successfully monitor your Sensu installation.
+Use the guides in the Monitor Sensu category to successfully monitor your Sensu installation.
 
-**<button onclick="window.location.href='log-sensu-systemd';">Next</button>**
+Learn how to [log Sensu services with systemd][1], including adding log forwarding from journald to syslog, using rsyslog to write logging data to disk, and setting up log rotation.
+
+Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sensu backend or cluster: use a secondary Sensu instance to notify you when your primary Sensu instance is down (and vice versa).
 
 
 [1]: log-sensu-systemd/
+[2]: monitor-sensu-with-sensu/

--- a/content/sensu-go/5.21/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/_index.md
@@ -5,17 +5,38 @@ product: "Sensu Go"
 version: "5.21"
 weight: 30
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-5.21:
     parent: operations
     identifier: maintain-sensu
 ---
 
-Use the guides in the Maintain Sensu category to [upgrade][1] to the latest version of Sensu and [troubleshoot][2].
+The Maintain Sensu category includes information to keep your Sensu installation up-to-date and running smoothly.
 
-**<button onclick="window.location.href='upgrade';">Next</button>**
+## Upgrade or migrate
+
+Follow the [upgrade guide][1] for step-by-step instructions to upgrade to the latest version of Sensu from any earlier version.
+The upgrade instructions include details about important changes between versions that could affect your upgrade and any special requirements to make sure your upgrade is successful.
+
+If you are still using Sensu Core 1.x, follow the [migrate guide][2] to upgrade to Sensu Go.
+The migrate guide includes links to Sensu's migration resources and Core configuration translation tools, as well as instructions for [installing Sensu Go alongside your existing Sensu Core instance][3].
+
+## Troubleshoot
+
+Use the Sensu [troubleshooting guide][4] to diagnose and resolve common issues.
+Learn how to read, configure, and find the [logs produced by Sensu services][6].
+Sensu log messages can help you identify and solve [backend startup errors][7] and [permissions issues][8].
+
+The troubleshooting guide also describes how to [use Sensu handlers and filters to test and debug your observability pipeline][9] and diagnose problems related to [assets][10].
 
 
 [1]: upgrade/
-[2]: troubleshoot/
+[2]: migrate/
+[3]: migrate/#step-by-step-migration-instructions
+[4]: troubleshoot/
+[6]: troubleshoot/#service-logging
+[7]: troubleshoot/#sensu-backend-startup-errors
+[8]: troubleshoot/#permission-issues
+[9]: troubleshoot/#handlers-and-event-filters
+[10]: troubleshoot/#assets

--- a/content/sensu-go/5.21/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/5.21/operations/monitor-sensu/_index.md
@@ -12,9 +12,12 @@ menu:
     identifier: monitor-sensu
 ---
 
-Add [log forwarding][1] from journald to syslog and set up log rotation to successfully monitor your Sensu installation.
+Use the guides in the Monitor Sensu category to successfully monitor your Sensu installation.
 
-**<button onclick="window.location.href='log-sensu-systemd';">Next</button>**
+Learn how to [log Sensu services with systemd][1], including adding log forwarding from journald to syslog, using rsyslog to write logging data to disk, and setting up log rotation.
+
+Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sensu backend or cluster: use a secondary Sensu instance to notify you when your primary Sensu instance is down (and vice versa).
 
 
 [1]: log-sensu-systemd/
+[2]: monitor-sensu-with-sensu/

--- a/content/sensu-go/6.0/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/_index.md
@@ -5,17 +5,44 @@ product: "Sensu Go"
 version: "6.0"
 weight: 30
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-6.0:
     parent: operations
     identifier: maintain-sensu
 ---
 
-Use the guides in the Maintain Sensu category to [upgrade][1] to the latest version of Sensu and [troubleshoot][2].
+The Maintain Sensu category includes information to keep your Sensu installation up-to-date and running smoothly.
 
-**<button onclick="window.location.href='upgrade';">Next</button>**
+## Upgrade or migrate
+
+Follow the [upgrade guide][1] for step-by-step instructions to upgrade to the latest version of Sensu from any earlier version.
+The upgrade instructions include details about important changes between versions that could affect your upgrade and any special requirements to make sure your upgrade is successful.
+
+If you are still using Sensu Core 1.x, follow the [migrate guide][2] to upgrade to Sensu Go.
+The migrate guide includes links to Sensu's migration resources and Core configuration translation tools, as well as instructions for [installing Sensu Go alongside your existing Sensu Core instance][3].
+
+## Troubleshoot
+
+Use the Sensu [troubleshooting guide][4] to diagnose and resolve common issues.
+Learn how to read, configure, and find the [logs produced by Sensu services][6].
+Sensu log messages can help you identify and solve [backend startup errors][7] and [permissions issues][8].
+
+The troubleshooting guide also describes how to [use Sensu handlers and filters to test and debug your observability pipeline][9] and diagnose problems related to [dynamic runtime assets][10].
+
+## Manage license
+
+Read the [license reference][5] to learn how to activate your commercial license.
+The license reference also explains how to view your license details and expiration date and find your current entity count and limits.
 
 
 [1]: upgrade/
-[2]: troubleshoot/
+[2]: migrate/
+[3]: migrate/#step-by-step-migration-instructions
+[4]: troubleshoot/
+[5]: license/
+[6]: troubleshoot/#service-logging
+[7]: troubleshoot/#sensu-backend-startup-errors
+[8]: troubleshoot/#permission-issues
+[9]: troubleshoot/#handlers-and-event-filters
+[10]: troubleshoot/#dynamic-runtime-assets

--- a/content/sensu-go/6.0/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/_index.md
@@ -5,16 +5,33 @@ product: "Sensu Go"
 version: "6.0"
 weight: 40
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-6.0:
     parent: operations
     identifier: monitor-sensu
 ---
 
-Add [log forwarding][1] from journald to syslog and set up log rotation to successfully monitor your Sensu installation.
+Use the guides and references in the Monitor Sensu category to successfully monitor your Sensu installation.
 
-**<button onclick="window.location.href='log-sensu-systemd';">Next</button>**
+## Log Sensu services and monitor with Sensu
+
+Learn how to [log Sensu services with systemd][1], including adding log forwarding from journald to syslog, using rsyslog to write logging data to disk, and setting up log rotation.
+
+Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sensu backend or cluster: use a secondary Sensu instance to notify you when your primary Sensu instance is down (and vice versa).
+
+## Retrieve cluster health data
+
+The [health reference][3] explains how to use Sensu’s health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
+Learn how to read the JSON response for health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
+
+## Learn about Tessen
+
+The [Tessen reference][4] explains the Sensu call-home service, which is enabled by default on Sensu backends and required for licensed Sensu instances.
+We rely on anonymized Tessen data to understand how Sensu is being used and make informed decisions about product improvements.
 
 
 [1]: log-sensu-systemd/
+[2]: monitor-sensu-with-sensu/
+[3]: health/
+[4]: tessen/

--- a/content/sensu-go/6.1/operations/maintain-sensu/_index.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/_index.md
@@ -5,17 +5,44 @@ product: "Sensu Go"
 version: "6.1"
 weight: 30
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-6.1:
     parent: operations
     identifier: maintain-sensu
 ---
 
-Use the guides in the Maintain Sensu category to [upgrade][1] to the latest version of Sensu and [troubleshoot][2].
+The Maintain Sensu category includes information to keep your Sensu installation up-to-date and running smoothly.
 
-**<button onclick="window.location.href='upgrade';">Next</button>**
+## Upgrade or migrate
+
+Follow the [upgrade guide][1] for step-by-step instructions to upgrade to the latest version of Sensu from any earlier version.
+The upgrade instructions include details about important changes between versions that could affect your upgrade and any special requirements to make sure your upgrade is successful.
+
+If you are still using Sensu Core 1.x, follow the [migrate guide][2] to upgrade to Sensu Go.
+The migrate guide includes links to Sensu's migration resources and Core configuration translation tools, as well as instructions for [installing Sensu Go alongside your existing Sensu Core instance][3].
+
+## Troubleshoot
+
+Use the Sensu [troubleshooting guide][4] to diagnose and resolve common issues.
+Learn how to read, configure, and find the [logs produced by Sensu services][6].
+Sensu log messages can help you identify and solve [backend startup errors][7] and [permissions issues][8].
+
+The troubleshooting guide also describes how to [use Sensu handlers and filters to test and debug your observability pipeline][9] and diagnose problems related to [dynamic runtime assets][10].
+
+## Manage license
+
+Read the [license reference][5] to learn how to activate your commercial license.
+The license reference also explains how to view your license details and expiration date and find your current entity count and limits.
 
 
 [1]: upgrade/
-[2]: troubleshoot/
+[2]: migrate/
+[3]: migrate/#step-by-step-migration-instructions
+[4]: troubleshoot/
+[5]: license/
+[6]: troubleshoot/#service-logging
+[7]: troubleshoot/#sensu-backend-startup-errors
+[8]: troubleshoot/#permission-issues
+[9]: troubleshoot/#handlers-and-event-filters
+[10]: troubleshoot/#dynamic-runtime-assets

--- a/content/sensu-go/6.1/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/_index.md
@@ -5,16 +5,33 @@ product: "Sensu Go"
 version: "6.1"
 weight: 40
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-6.1:
     parent: operations
     identifier: monitor-sensu
 ---
 
-Add [log forwarding][1] from journald to syslog and set up log rotation to successfully monitor your Sensu installation.
+Use the guides and references in the Monitor Sensu category to successfully monitor your Sensu installation.
 
-**<button onclick="window.location.href='log-sensu-systemd';">Next</button>**
+## Log Sensu services and monitor with Sensu
+
+Learn how to [log Sensu services with systemd][1], including adding log forwarding from journald to syslog, using rsyslog to write logging data to disk, and setting up log rotation.
+
+Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sensu backend or cluster: use a secondary Sensu instance to notify you when your primary Sensu instance is down (and vice versa).
+
+## Retrieve cluster health data
+
+The [health reference][3] explains how to use Sensu’s health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
+Learn how to read the JSON response for health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
+
+## Learn about Tessen
+
+The [Tessen reference][4] explains the Sensu call-home service, which is enabled by default on Sensu backends and required for licensed Sensu instances.
+We rely on anonymized Tessen data to understand how Sensu is being used and make informed decisions about product improvements.
 
 
 [1]: log-sensu-systemd/
+[2]: monitor-sensu-with-sensu/
+[3]: health/
+[4]: tessen/


### PR DESCRIPTION
## Description
Adds explanation to frame the pages included in the Maintain Sensu and Monitor Sensu categories, with links to individual pages within the categories and other helpful information.

## Motivation and Context
Improve the basic placeholder content I added to the index pages in the course of the initial docs IA project work