### PR TITLE
Fixes for Deploy Sensu and Learn Sensu index pages

### DIFF
--- a/content/sensu-go/5.20/learn/_index.md
+++ b/content/sensu-go/5.20/learn/_index.md
@@ -5,7 +5,7 @@ product: "Sensu Go"
 version: "5.20"
 weight: 110
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-5.20:
     identifier: learn-sensu
@@ -13,17 +13,26 @@ menu:
 
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
+## Glossary
+
 If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
 The glossary includes links to relevant reference documentation for more in-depth information.
+
+## Interactive tutorials
 
 Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
 The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
 
+## Live demo
+
 Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
 The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
 
+## Sensu sandbox
+
 For further learning opportunities, download the [Sensu sandbox][4].
 Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 

--- a/content/sensu-go/5.20/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/_index.md
@@ -36,8 +36,6 @@ To deploy Sensu for use outside of a local development environment, [install Sen
 3. [Run a Sensu cluster][6], a group of three or more sensu-backend nodes connected to a shared database, to improve Sensu's availability, reliability, and durability.
 4. [Reach multi-cluster visibility][7] with federation so you can gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI and mirror your changes in one cluster to follower clusters.
 
-Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the federation API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
-
 ## Scale your Sensu implementation
 
 As the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore.
@@ -45,8 +43,6 @@ In clustered etcd deployments, each event must be replicated to each cluster mem
 
 Sensu's Enterprise datastore allows you to configure an external PostgreSQL instance for event storage so you can [scale your monitoring and observability workflows][13] beyond etcd’s 8-GB limit.
 Scale your Sensu implementation to many thousands of events per second, achieve much higher rates of event processing, and minimize the replication communication between etcd peers.
-
-Read the [datastore reference][14] for the Enterprise datastore requirements and specifications.
 
 For deployments at scale, [configuration management tools][12] can help ensure repeatable Sensu deployments and consistent configuration among Sensu backends.
 Ansible, Chef, and Puppet have well-defined Sensu modules to help you get started.
@@ -60,7 +56,5 @@ Ansible, Chef, and Puppet have well-defined Sensu modules to help you get starte
 [6]: cluster-sensu/
 [7]: use-federation/
 [8]: scale-event-storage/
-[9]: ../../reference/etcdreplicators/
 [12]: configuration-management/
 [13]: scale-event-storage/
-[14]: ../../reference/datastore/

--- a/content/sensu-go/5.21/learn/_index.md
+++ b/content/sensu-go/5.21/learn/_index.md
@@ -5,7 +5,7 @@ product: "Sensu Go"
 version: "5.21"
 weight: 110
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-5.21:
     identifier: learn-sensu
@@ -13,17 +13,26 @@ menu:
 
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
+## Glossary
+
 If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
 The glossary includes links to relevant reference documentation for more in-depth information.
+
+## Interactive tutorials
 
 Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
 The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
 
+## Live demo
+
 Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
 The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
 
+## Sensu sandbox
+
 For further learning opportunities, download the [Sensu sandbox][4].
 Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 

--- a/content/sensu-go/5.21/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/_index.md
@@ -36,8 +36,6 @@ To deploy Sensu for use outside of a local development environment, [install Sen
 3. [Run a Sensu cluster][6], a group of three or more sensu-backend nodes connected to a shared database, to improve Sensu's availability, reliability, and durability.
 4. [Reach multi-cluster visibility][7] with federation so you can gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI and mirror your changes in one cluster to follower clusters.
 
-Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the federation API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
-
 ## Scale your Sensu implementation
 
 As the number of entities and checks in your Sensu implementation grows, so does the rate of events being written to the datastore.
@@ -45,8 +43,6 @@ In clustered etcd deployments, each event must be replicated to each cluster mem
 
 Sensu's Enterprise datastore allows you to configure an external PostgreSQL instance for event storage so you can [scale your monitoring and observability workflows][13] beyond etcd’s 8-GB limit.
 Scale your Sensu implementation to many thousands of events per second, achieve much higher rates of event processing, and minimize the replication communication between etcd peers.
-
-Read the [datastore reference][14] for the Enterprise datastore requirements and specifications.
 
 For deployments at scale, [configuration management tools][12] can help ensure repeatable Sensu deployments and consistent configuration among Sensu backends.
 Ansible, Chef, and Puppet have well-defined Sensu modules to help you get started.
@@ -60,7 +56,5 @@ Ansible, Chef, and Puppet have well-defined Sensu modules to help you get starte
 [6]: cluster-sensu/
 [7]: use-federation/
 [8]: scale-event-storage/
-[9]: ../../reference/etcdreplicators/
 [12]: configuration-management/
 [13]: scale-event-storage/
-[14]: ../../reference/datastore/

--- a/content/sensu-go/6.0/learn/_index.md
+++ b/content/sensu-go/6.0/learn/_index.md
@@ -5,13 +5,15 @@ product: "Sensu Go"
 version: "6.0"
 weight: 110
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-6.0:
     identifier: learn-sensu
 ---
 
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
+
+## Glossary
 
 If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
 The glossary includes links to relevant reference documentation for more in-depth information.
@@ -20,14 +22,21 @@ The glossary includes links to relevant reference documentation for more in-dept
 **PRO TIP**: To visualize how Sensu concepts work together in our observability pipeline, [take the tour](../observability-pipeline/) &mdash; follow the `Next` buttons on each page.
 {{% /notice %}}
 
+## Interactive tutorials
+
 Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
 The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
+
+## Live demo
 
 Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
 The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
 
+## Sensu sandbox
+
 For further learning opportunities, download the [Sensu sandbox][4].
 Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 

--- a/content/sensu-go/6.1/learn/_index.md
+++ b/content/sensu-go/6.1/learn/_index.md
@@ -5,13 +5,15 @@ product: "Sensu Go"
 version: "6.1"
 weight: 110
 layout: "single"
-toc: false
+toc: true
 menu:
   sensu-go-6.1:
     identifier: learn-sensu
 ---
 
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
+
+## Glossary
 
 If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms.
 The glossary includes links to relevant reference documentation for more in-depth information.
@@ -20,14 +22,21 @@ The glossary includes links to relevant reference documentation for more in-dept
 **PRO TIP**: To visualize how Sensu concepts work together in our observability pipeline, [take the tour](../observability-pipeline/) &mdash; follow the `Next` buttons on each page.
 {{% /notice %}}
 
+## Interactive tutorials
+
 Discover what you can do with Sensu in our [interactive tutorials][2], which you can use to learn Sensu right in your browser.
 The tutorials demonstrate how to deploy a Sensu stack, log in to the Sensu web UI, create observability events, add Sensu assets and create event filters and handlers, and use Sensu to send incident alerts to services like Slack and PagerDuty or to monitor a local Nginx service.
+
+## Live demo
 
 Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
 The live demo also gives you a chance to try commands with [sensuctl][8], the Sensu command line tool.
 
+## Sensu sandbox
+
 For further learning opportunities, download the [Sensu sandbox][4].
 Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 


### PR DESCRIPTION
## Description
- Removes reference links for 5.21 and 5.20 Deploy Sensu index pages (references are in a separate section in the 5.x docs)
- Adds subheadings to divide the page for Learn Sensu index

## Motivation and Context
Minor improvements after initial index page updates in https://github.com/sensu/sensu-docs/pull/2823 and https://github.com/sensu/sensu-docs/pull/2826