### PR TITLE
Notes to clarify assets are not required

### DIFF
--- a/content/sensu-go/5.20/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.20/guides/install-check-executables-with-assets.md
@@ -16,6 +16,11 @@ You can use assets to provide the plugins, libraries, and runtimes you need to a
 See the [asset reference][1] for more information about assets.
 This guide uses the [Sensu PagerDuty Handler asset][7] as an example.
 
+{{% notice note %}}
+**NOTE**: Assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](../../operations/deploy-sensu/install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../../operations/deploy-sensu/configuration-management/) solution.
+{{% /notice %}}
+
 ## Register the Sensu PagerDuty Handler asset
 
 To add the [Sensu PagerDuty Handler asset][7] to Sensu, use [`sensuctl asset add`][6]:

--- a/content/sensu-go/5.20/learn/glossary.md
+++ b/content/sensu-go/5.20/learn/glossary.md
@@ -18,6 +18,7 @@ An agent can run checks on the entity it’s installed on or connect to a remote
 [Read more about the Sensu agent][1].
 
 ## Asset
+
 An executable that a check, handler, or mutator can specify as a dependency.
 Assets must be a tar archive (optionally gzipped) with scripts or executables within a bin folder.
 At runtime, the backend or agent installs required assets using the specified URL.

--- a/content/sensu-go/5.20/learn/glossary.md
+++ b/content/sensu-go/5.20/learn/glossary.md
@@ -18,7 +18,6 @@ An agent can run checks on the entity it’s installed on or connect to a remote
 [Read more about the Sensu agent][1].
 
 ## Asset
-
 An executable that a check, handler, or mutator can specify as a dependency.
 Assets must be a tar archive (optionally gzipped) with scripts or executables within a bin folder.
 At runtime, the backend or agent installs required assets using the specified URL.

--- a/content/sensu-go/5.20/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-plugins.md
@@ -17,7 +17,12 @@ Extend Sensu's functionality with [plugins][10], which provide executables for p
 ## Install plugins with assets
 
 Assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
-To start using and deploying assets, read [Install plugins with assets][7] to become familiar with workflows that involve assets. 
+To start using and deploying assets, read [Install plugins with assets][7] to become familiar with workflows that involve assets.
+
+{{% notice note %}}
+**NOTE**: Assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
+{{% /notice %}}
 
 ## Use Bonsai, the Sensu asset index
 

--- a/content/sensu-go/5.20/reference/assets.md
+++ b/content/sensu-go/5.20/reference/assets.md
@@ -21,7 +21,7 @@ You can use assets to provide the plugins, libraries, and runtimes you need to a
 Sensu supports runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
 
 {{% notice note %}}
-**NOTE**: Assets are not required to use Sensu Go in production.
+**NOTE**: Assets are not required to use Sensu Go.
 You can install Sensu plugins using the [sensu-install](../../operations/deploy-sensu/install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../../operations/deploy-sensu/configuration-management/) solution.
 {{% /notice %}}
 

--- a/content/sensu-go/5.21/guides/install-check-executables-with-assets.md
+++ b/content/sensu-go/5.21/guides/install-check-executables-with-assets.md
@@ -16,6 +16,11 @@ You can use assets to provide the plugins, libraries, and runtimes you need to a
 See the [asset reference][1] for more information about assets.
 This guide uses the [Sensu PagerDuty Handler asset][7] as an example.
 
+{{% notice note %}}
+**NOTE**: Assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](../../operations/deploy-sensu/install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../../operations/deploy-sensu/configuration-management/) solution.
+{{% /notice %}}
+
 ## Register the Sensu PagerDuty Handler asset
 
 To add the [Sensu PagerDuty Handler asset][7] to Sensu, use [`sensuctl asset add`][6]:

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-plugins.md
@@ -17,7 +17,12 @@ Extend Sensu's functionality with [plugins][10], which provide executables for p
 ## Install plugins with assets
 
 Assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
-To start using and deploying assets, read [Install plugins with assets][7] to become familiar with workflows that involve assets. 
+To start using and deploying assets, read [Install plugins with assets][7] to become familiar with workflows that involve assets.
+
+{{% notice note %}}
+**NOTE**: Assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](../install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
+{{% /notice %}}
 
 ## Use Bonsai, the Sensu asset index
 

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -21,7 +21,7 @@ You can use assets to provide the plugins, libraries, and runtimes you need to a
 Sensu supports runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
 
 {{% notice note %}}
-**NOTE**: Assets are not required to use Sensu Go in production.
+**NOTE**: Assets are not required to use Sensu Go.
 You can install Sensu plugins using the [sensu-install](../../operations/deploy-sensu/install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../../operations/deploy-sensu/configuration-management/) solution.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/assets.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/assets.md
@@ -21,7 +21,7 @@ You can use dynamic runtime assets to provide the plugins, libraries, and runtim
 Sensu supports dynamic runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
 
 {{% notice note %}}
-**NOTE**: Dynamic runtime assets are not required to use Sensu Go in production.
+**NOTE**: Dynamic runtime assets are not required to use Sensu Go.
 You can install Sensu plugins using the [sensu-install](../install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-plugins.md
@@ -17,7 +17,12 @@ Extend Sensu's functionality with [plugins][10], which provide executables for p
 ## Install plugins with dynamic runtime assets
 
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
-To start using and deploying assets, read [Use dynamic runtime assets to install plugins][7] to become familiar with workflows that involve assets. 
+To start using and deploying assets, read [Use dynamic runtime assets to install plugins][7] to become familiar with workflows that involve assets.
+
+{{% notice note %}}
+**NOTE**: Dynamic runtime assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
+{{% /notice %}}
 
 ## Use Bonsai, the Sensu asset index
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/use-assets-to-install-plugins.md
@@ -18,6 +18,11 @@ You can use assets to provide the plugins, libraries, and runtimes you need to a
 See the [asset reference][1] for more information about dynamic runtime assets.
 This guide uses the [Sensu PagerDuty Handler dynamic runtime asset][7] as an example.
 
+{{% notice note %}}
+**NOTE**: Dynamic runtime assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](../install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
+{{% /notice %}}
+
 ## Register the Sensu PagerDuty Handler asset
 
 To add the [Sensu PagerDuty Handler dynamic runtime asset][7] to Sensu, use [`sensuctl asset add`][6]:

--- a/content/sensu-go/6.1/operations/deploy-sensu/assets.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/assets.md
@@ -21,7 +21,7 @@ You can use dynamic runtime assets to provide the plugins, libraries, and runtim
 Sensu supports dynamic runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
 
 {{% notice note %}}
-**NOTE**: Dynamic runtime assets are not required to use Sensu Go in production.
+**NOTE**: Dynamic runtime assets are not required to use Sensu Go.
 You can install Sensu plugins using the [sensu-install](../install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-plugins.md
@@ -17,7 +17,12 @@ Extend Sensu's functionality with [plugins][10], which provide executables for p
 ## Install plugins with dynamic runtime assets
 
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
-To start using and deploying assets, read [Use dynamic runtime assets to install plugins][7] to become familiar with workflows that involve assets. 
+To start using and deploying assets, read [Use dynamic runtime assets to install plugins][7] to become familiar with workflows that involve assets.
+
+{{% notice note %}}
+**NOTE**: Dynamic runtime assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](#install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
+{{% /notice %}}
 
 ## Use Bonsai, the Sensu asset index
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/use-assets-to-install-plugins.md
@@ -18,6 +18,11 @@ You can use assets to provide the plugins, libraries, and runtimes you need to a
 See the [asset reference][1] for more information about dynamic runtime assets.
 This guide uses the [Sensu PagerDuty Handler dynamic runtime asset][7] as an example.
 
+{{% notice note %}}
+**NOTE**: Dynamic runtime assets are not required to use Sensu Go.
+You can install Sensu plugins using the [sensu-install](../install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
+{{% /notice %}}
+
 ## Register the Sensu PagerDuty Handler asset
 
 To add the [Sensu PagerDuty Handler dynamic runtime asset][7] to Sensu, use [`sensuctl asset add`][6]:


### PR DESCRIPTION
## Description
- Updates the first note in the assets reference to remove "in production"
- Adds the note re: assets not required in the plugins reference and guide to using assets to install plugins

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2831