### PR TITLE
Update migrate note re: Core version required for concurrent Go instance

### DIFF
--- a/content/sensu-core/0.29/migration.md
+++ b/content/sensu-core/0.29/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.0/migration.md
+++ b/content/sensu-core/1.0/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.1/migration.md
+++ b/content/sensu-core/1.1/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.2/migration.md
+++ b/content/sensu-core/1.2/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.3/migration.md
+++ b/content/sensu-core/1.3/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.4/migration.md
+++ b/content/sensu-core/1.4/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.5/migration.md
+++ b/content/sensu-core/1.5/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.6/migration.md
+++ b/content/sensu-core/1.6/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.7/migration.md
+++ b/content/sensu-core/1.7/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.8/migration.md
+++ b/content/sensu-core/1.8/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-core/1.9/migration.md
+++ b/content/sensu-core/1.9/migration.md
@@ -58,7 +58,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 ### Sensu Go architecture
 
@@ -392,7 +392,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/2.6/migration.md
+++ b/content/sensu-enterprise/2.6/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/2.7/migration.md
+++ b/content/sensu-enterprise/2.7/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/2.8/migration.md
+++ b/content/sensu-enterprise/2.8/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.0/migration.md
+++ b/content/sensu-enterprise/3.0/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.1/migration.md
+++ b/content/sensu-enterprise/3.1/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.2/migration.md
+++ b/content/sensu-enterprise/3.2/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.3/migration.md
+++ b/content/sensu-enterprise/3.3/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.4/migration.md
+++ b/content/sensu-enterprise/3.4/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.5/migration.md
+++ b/content/sensu-enterprise/3.5/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.6/migration.md
+++ b/content/sensu-enterprise/3.6/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.7/migration.md
+++ b/content/sensu-enterprise/3.7/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-enterprise/3.8/migration.md
+++ b/content/sensu-enterprise/3.8/migration.md
@@ -44,7 +44,7 @@ This results in a fundamental change in Sensu terminology from Sensu Core 1.x: t
 
 “Clients” are now represented within Sensu Go as abstract “entities” that can describe a wider range of system components (network gear, web server, cloud resource, etc.) Entities include “agent entities” (entities running a Sensu agent) and familiar “proxy entities”.
 
-To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.7.0][34].
+_**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, first [upgrade][33] to at least [Sensu Core 1.9.0-2][34]._
 
 #### Sensu Go architecture
 
@@ -395,7 +395,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: /sensu-go/latest/getting-started/learn-sensu
 [33]: /sensu-core/latest/installation/upgrading/
-[34]: /sensu-core/1.8/changelog/#core-v1-7-0
+[34]: https://eol-repositories.sensuapp.org/
 [35]: /sensu-go/latest/installation/platforms
 [36]: /sensu-go/latest/installation/configuration-management
 [37]: /sensu-go/latest/installation/recommended-hardware

--- a/content/sensu-go/5.20/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.20/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The Sensu Go agent is also available for Windows.
 [Configuration management][44] integrations for Sensu Go are available for Ansible, Chef, and Puppet.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.7.0](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The Sensu Go agent is also available for Windows.
 [Configuration management][44] integrations for Sensu Go are available for Ansible, Chef, and Puppet.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.7.0](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The Sensu Go agent is also available for Windows.
 [Configuration management][44] integrations for Sensu Go are available for Ansible, Chef, and Puppet.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.7.0](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The Sensu Go agent is also available for Windows.
 [Configuration management][44] integrations for Sensu Go are available for Ansible, Chef, and Puppet.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.7.0](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:


### PR DESCRIPTION
## Description
Correct migrate note to say that Core 1.9.0-2 is required to run Core and Go side-by-side (instead of Core 1.7.0)

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2835
