### PR TITLE
Update silence API and reference examples

### DIFF
--- a/content/sensu-go/5.20/api/silenced.md
+++ b/content/sensu-go/5.20/api/silenced.md
@@ -134,6 +134,31 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
 HTTP/1.1 201 Created
 {{< /code >}}
 
+Here's another example that shows an HTTP POST request to the `/silenced` API endpoint to create the silencing entry `*:http`, which will create a silence for any event with the check name `http`, regardless of the originating entities’ subscriptions.
+The request returns a successful HTTP `201 Created` response.
+
+{{< code shell >}}
+curl -X POST \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "*:http",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "expire": -1,
+  "expire_on_resolve": false,
+  "creator": "admin",
+  "check": "http",
+  "reason": "Testing"
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
+
+HTTP/1.1 201 Created
+{{< /code >}}
+
 ### API Specification {#silenced-post-specification}
 
 /silenced (POST) | 

--- a/content/sensu-go/5.20/api/silenced.md
+++ b/content/sensu-go/5.20/api/silenced.md
@@ -30,18 +30,31 @@ HTTP/1.1 200 OK
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}
@@ -60,18 +73,31 @@ output         | {{< code shell >}}
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}

--- a/content/sensu-go/5.20/reference/silencing.md
+++ b/content/sensu-go/5.20/reference/silencing.md
@@ -25,10 +25,10 @@ If there are one or more matching entries, the event is updated with a list of s
 The presence of silences indicates that the event is silenced.
 
 When creating a silencing entry, you can specify a combination of checks and subscriptions, but only one or the other is strictly required.
-For example, if you create a silencing entry specifying only a check, its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
+For example, if you create a silencing entry [specifying only a check][12], its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
 This indicates that any event with a matching check name will be marked as silenced, regardless of the originating entities’ subscriptions.
 
-Conversely, a silencing entry that specifies only a subscription will have a name with an asterisk in the `$CHECK` position.
+Conversely, a silencing entry that [specifies only a subscription][11] will have a name with an asterisk in the `$CHECK` position.
 This indicates that any event where the originating entities’ subscriptions match the subscription specified in the entry will be marked as silenced, regardless of the check name.
 
 ## Silencing specification
@@ -245,16 +245,34 @@ To continue the previous example, here's how to silence a check named `check_ntp
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: check_ntp
-expire_on_resolve: true
-subscription: entity:i-424242
+type: Silenced
+api_version: core/v2
+metadata:
+  name: entity:i-424242:check_ntp
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: entity:i-424242
+  check: check_ntp
+  expire_on_resolve: true
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "entity:i-424242", 
-  "check": "check_ntp", 
-  "expire_on_resolve": true 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "entity:i-424242:check_ntp",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "entity:i-424242",
+    "check": "check_ntp",
+    "expire_on_resolve": true
+  }
 }
 {{< /code >}}
 
@@ -272,12 +290,30 @@ Just as in the example of silencing all checks on a specific entity, you’ll cr
 {{< language-toggle >}}
 
 {{< code yml >}}
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver" 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver"
+  }
 }
 {{< /code >}}
 
@@ -290,14 +326,32 @@ To silence a check `mysql_status` that is running on Sensu entities with the sub
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver:mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver", 
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver:mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver",
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -310,12 +364,30 @@ To silence the check `mysql_status` on every entity in your infrastructure, rega
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
+type: Silenced
+api_version: core/v2
+metadata:
+  name: mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -325,7 +397,7 @@ check: mysql_status
 
 To delete a silencing entry, you must provide its name.
 
-Subscription-only silencing entry names will be similar to this example:
+Subscription-only silencing entry names will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -341,7 +413,7 @@ name: appserver:*
 
 {{< /language-toggle >}}
 
-Check-only silencing entry names will be similar to this example:
+Check-only silencing entry names will contain an asterisk (or wildcard) in the `$CHECK` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -357,6 +429,7 @@ name: '*:mysql_status'
 
 {{< /language-toggle >}}
 
+
 [1]: ../events/#attributes
 [2]: ../rbac#namespaces
 [3]: #metadata-attributes
@@ -367,3 +440,5 @@ name: '*:mysql_status'
 [8]: ../filters/
 [9]: ../../web-ui/filter#filter-with-label-selectors
 [10]: ../../web-ui/filter/
+[11]: #silence-all-checks-on-entities-with-a-specific-subscription
+[12]: #silence-a-specific-check-on-every-entity

--- a/content/sensu-go/5.21/api/silenced.md
+++ b/content/sensu-go/5.21/api/silenced.md
@@ -134,6 +134,31 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
 HTTP/1.1 201 Created
 {{< /code >}}
 
+Here's another example that shows an HTTP POST request to the `/silenced` API endpoint to create the silencing entry `*:http`, which will create a silence for any event with the check name `http`, regardless of the originating entities’ subscriptions.
+The request returns a successful HTTP `201 Created` response.
+
+{{< code shell >}}
+curl -X POST \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "*:http",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "expire": -1,
+  "expire_on_resolve": false,
+  "creator": "admin",
+  "check": "http",
+  "reason": "Testing"
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
+
+HTTP/1.1 201 Created
+{{< /code >}}
+
 ### API Specification {#silenced-post-specification}
 
 /silenced (POST) | 

--- a/content/sensu-go/5.21/api/silenced.md
+++ b/content/sensu-go/5.21/api/silenced.md
@@ -30,18 +30,31 @@ HTTP/1.1 200 OK
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}
@@ -60,18 +73,31 @@ output         | {{< code shell >}}
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}

--- a/content/sensu-go/5.21/reference/silencing.md
+++ b/content/sensu-go/5.21/reference/silencing.md
@@ -25,10 +25,10 @@ If there are one or more matching entries, the event is updated with a list of s
 The presence of silences indicates that the event is silenced.
 
 When creating a silencing entry, you can specify a combination of checks and subscriptions, but only one or the other is strictly required.
-For example, if you create a silencing entry specifying only a check, its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
+For example, if you create a silencing entry [specifying only a check][12], its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
 This indicates that any event with a matching check name will be marked as silenced, regardless of the originating entities’ subscriptions.
 
-Conversely, a silencing entry that specifies only a subscription will have a name with an asterisk in the `$CHECK` position.
+Conversely, a silencing entry that [specifies only a subscription][11] will have a name with an asterisk in the `$CHECK` position.
 This indicates that any event where the originating entities’ subscriptions match the subscription specified in the entry will be marked as silenced, regardless of the check name.
 
 ## Silencing specification
@@ -245,16 +245,34 @@ To continue the previous example, here's how to silence a check named `check_ntp
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: check_ntp
-expire_on_resolve: true
-subscription: entity:i-424242
+type: Silenced
+api_version: core/v2
+metadata:
+  name: entity:i-424242:check_ntp
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: entity:i-424242
+  check: check_ntp
+  expire_on_resolve: true
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "entity:i-424242", 
-  "check": "check_ntp", 
-  "expire_on_resolve": true 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "entity:i-424242:check_ntp",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "entity:i-424242",
+    "check": "check_ntp",
+    "expire_on_resolve": true
+  }
 }
 {{< /code >}}
 
@@ -272,12 +290,30 @@ Just as in the example of silencing all checks on a specific entity, you’ll cr
 {{< language-toggle >}}
 
 {{< code yml >}}
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver" 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver"
+  }
 }
 {{< /code >}}
 
@@ -290,14 +326,32 @@ To silence a check `mysql_status` that is running on Sensu entities with the sub
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver:mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver", 
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver:mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver",
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -310,12 +364,30 @@ To silence the check `mysql_status` on every entity in your infrastructure, rega
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
+type: Silenced
+api_version: core/v2
+metadata:
+  name: mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -325,7 +397,7 @@ check: mysql_status
 
 To delete a silencing entry, you must provide its name.
 
-Subscription-only silencing entry names will be similar to this example:
+Subscription-only silencing entry names will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -341,7 +413,7 @@ name: appserver:*
 
 {{< /language-toggle >}}
 
-Check-only silencing entry names will be similar to this example:
+Check-only silencing entry names will contain an asterisk (or wildcard) in the `$CHECK` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -357,6 +429,7 @@ name: '*:mysql_status'
 
 {{< /language-toggle >}}
 
+
 [1]: ../events/#attributes
 [2]: ../rbac#namespaces
 [3]: #metadata-attributes
@@ -366,4 +439,6 @@ name: '*:mysql_status'
 [7]: ../../sensuctl/filter-responses/
 [8]: ../filters/
 [9]: ../../web-ui/filter#filter-with-label-selectors
-[10]: ../../web-ui/filter
+[10]: ../../web-ui/filter/
+[11]: #silence-all-checks-on-entities-with-a-specific-subscription
+[12]: #silence-a-specific-check-on-every-entity

--- a/content/sensu-go/6.0/api/silenced.md
+++ b/content/sensu-go/6.0/api/silenced.md
@@ -134,6 +134,31 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
 HTTP/1.1 201 Created
 {{< /code >}}
 
+Here's another example that shows an HTTP POST request to the `/silenced` API endpoint to create the silencing entry `*:http`, which will create a silence for any event with the check name `http`, regardless of the originating entities’ subscriptions.
+The request returns a successful HTTP `201 Created` response.
+
+{{< code shell >}}
+curl -X POST \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "*:http",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "expire": -1,
+  "expire_on_resolve": false,
+  "creator": "admin",
+  "check": "http",
+  "reason": "Testing"
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
+
+HTTP/1.1 201 Created
+{{< /code >}}
+
 ### API Specification {#silenced-post-specification}
 
 /silenced (POST) | 

--- a/content/sensu-go/6.0/api/silenced.md
+++ b/content/sensu-go/6.0/api/silenced.md
@@ -30,18 +30,31 @@ HTTP/1.1 200 OK
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}
@@ -60,18 +73,31 @@ output         | {{< code shell >}}
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/silencing.md
@@ -26,10 +26,10 @@ If there are one or more matching entries, the event is updated with a list of s
 The presence of silences indicates that the event is silenced.
 
 When creating a silencing entry, you can specify a combination of checks and subscriptions, but only one or the other is strictly required.
-For example, if you create a silencing entry specifying only a check, its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
+For example, if you create a silencing entry [specifying only a check][12], its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
 This indicates that any event with a matching check name will be marked as silenced, regardless of the originating entities’ subscriptions.
 
-Conversely, a silencing entry that specifies only a subscription will have a name with an asterisk in the `$CHECK` position.
+Conversely, a silencing entry that [specifies only a subscription][11] will have a name with an asterisk in the `$CHECK` position.
 This indicates that any event where the originating entities’ subscriptions match the subscription specified in the entry will be marked as silenced, regardless of the check name.
 
 ## Silencing specification
@@ -246,16 +246,34 @@ To continue the previous example, here's how to silence a check named `check_ntp
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: check_ntp
-expire_on_resolve: true
-subscription: entity:i-424242
+type: Silenced
+api_version: core/v2
+metadata:
+  name: entity:i-424242:check_ntp
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: entity:i-424242
+  check: check_ntp
+  expire_on_resolve: true
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "entity:i-424242", 
-  "check": "check_ntp", 
-  "expire_on_resolve": true 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "entity:i-424242:check_ntp",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "entity:i-424242",
+    "check": "check_ntp",
+    "expire_on_resolve": true
+  }
 }
 {{< /code >}}
 
@@ -273,12 +291,30 @@ Just as in the example of silencing all checks on a specific entity, you’ll cr
 {{< language-toggle >}}
 
 {{< code yml >}}
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver" 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver"
+  }
 }
 {{< /code >}}
 
@@ -291,14 +327,32 @@ To silence a check `mysql_status` that is running on Sensu entities with the sub
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver:mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver", 
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver:mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver",
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -311,12 +365,30 @@ To silence the check `mysql_status` on every entity in your infrastructure, rega
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
+type: Silenced
+api_version: core/v2
+metadata:
+  name: mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -326,7 +398,7 @@ check: mysql_status
 
 To delete a silencing entry, you must provide its name.
 
-Subscription-only silencing entry names will be similar to this example:
+Subscription-only silencing entry names will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -342,7 +414,7 @@ name: appserver:*
 
 {{< /language-toggle >}}
 
-Check-only silencing entry names will be similar to this example:
+Check-only silencing entry names will contain an asterisk (or wildcard) in the `$CHECK` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -358,6 +430,7 @@ name: '*:mysql_status'
 
 {{< /language-toggle >}}
 
+
 [1]: ../../observe-events/events/#attributes
 [2]: ../../../operations/control-access/rbac#namespaces
 [3]: #metadata-attributes
@@ -367,4 +440,6 @@ name: '*:mysql_status'
 [7]: ../../../sensuctl/filter-responses/
 [8]: ../../observe-filter/filters/
 [9]: ../../../web-ui/filter#filter-with-label-selectors
-[10]: ../../../web-ui/filter
+[10]: ../../../web-ui/filter/
+[11]: #silence-all-checks-on-entities-with-a-specific-subscription
+[12]: #silence-a-specific-check-on-every-entity

--- a/content/sensu-go/6.1/api/silenced.md
+++ b/content/sensu-go/6.1/api/silenced.md
@@ -134,6 +134,31 @@ http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
 HTTP/1.1 201 Created
 {{< /code >}}
 
+Here's another example that shows an HTTP POST request to the `/silenced` API endpoint to create the silencing entry `*:http`, which will create a silence for any event with the check name `http`, regardless of the originating entities’ subscriptions.
+The request returns a successful HTTP `201 Created` response.
+
+{{< code shell >}}
+curl -X POST \
+-H "Authorization: Key $SENSU_API_KEY" \
+-H 'Content-Type: application/json' \
+-d '{
+  "metadata": {
+    "name": "*:http",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "expire": -1,
+  "expire_on_resolve": false,
+  "creator": "admin",
+  "check": "http",
+  "reason": "Testing"
+}' \
+http://127.0.0.1:8080/api/core/v2/namespaces/default/silenced
+
+HTTP/1.1 201 Created
+{{< /code >}}
+
 ### API Specification {#silenced-post-specification}
 
 /silenced (POST) | 

--- a/content/sensu-go/6.1/api/silenced.md
+++ b/content/sensu-go/6.1/api/silenced.md
@@ -30,18 +30,31 @@ HTTP/1.1 200 OK
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}
@@ -60,18 +73,31 @@ output         | {{< code shell >}}
 [
   {
     "metadata": {
-      "name": "linux:check-cpu",
+      "name": "*:http",
       "namespace": "default",
-      "created_by": "admin",
-      "labels": null,
-      "annotations": null
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "check": "http",
+    "reason": "Testing",
+    "begin": 1605024595,
+    "expire_at": 0
+  },
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
     },
     "expire": -1,
     "expire_on_resolve": false,
     "creator": "admin",
     "reason": "reason for silence",
     "subscription": "linux",
-    "begin": 1542671205
+    "begin": 1542671205,
+    "expire_at": 0
   }
 ]
 {{< /code >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/silencing.md
@@ -26,10 +26,10 @@ If there are one or more matching entries, the event is updated with a list of s
 The presence of silences indicates that the event is silenced.
 
 When creating a silencing entry, you can specify a combination of checks and subscriptions, but only one or the other is strictly required.
-For example, if you create a silencing entry specifying only a check, its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
+For example, if you create a silencing entry [specifying only a check][12], its name will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position.
 This indicates that any event with a matching check name will be marked as silenced, regardless of the originating entities’ subscriptions.
 
-Conversely, a silencing entry that specifies only a subscription will have a name with an asterisk in the `$CHECK` position.
+Conversely, a silencing entry that [specifies only a subscription][11] will have a name with an asterisk in the `$CHECK` position.
 This indicates that any event where the originating entities’ subscriptions match the subscription specified in the entry will be marked as silenced, regardless of the check name.
 
 ## Silencing specification
@@ -246,16 +246,34 @@ To continue the previous example, here's how to silence a check named `check_ntp
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: check_ntp
-expire_on_resolve: true
-subscription: entity:i-424242
+type: Silenced
+api_version: core/v2
+metadata:
+  name: entity:i-424242:check_ntp
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: entity:i-424242
+  check: check_ntp
+  expire_on_resolve: true
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "entity:i-424242", 
-  "check": "check_ntp", 
-  "expire_on_resolve": true 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "entity:i-424242:check_ntp",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "entity:i-424242",
+    "check": "check_ntp",
+    "expire_on_resolve": true
+  }
 }
 {{< /code >}}
 
@@ -273,12 +291,30 @@ Just as in the example of silencing all checks on a specific entity, you’ll cr
 {{< language-toggle >}}
 
 {{< code yml >}}
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver" 
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver"
+  }
 }
 {{< /code >}}
 
@@ -291,14 +327,32 @@ To silence a check `mysql_status` that is running on Sensu entities with the sub
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
-subscription: appserver
+type: Silenced
+api_version: core/v2
+metadata:
+  name: appserver:mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  subscription: appserver
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "subscription": "appserver", 
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "appserver:mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "subscription": "appserver",
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -311,12 +365,30 @@ To silence the check `mysql_status` on every entity in your infrastructure, rega
 {{< language-toggle >}}
 
 {{< code yml >}}
-check: mysql_status
+type: Silenced
+api_version: core/v2
+metadata:
+  name: mysql_status
+  namespace: default
+  labels: 
+  annotations: 
+spec:
+  check: mysql_status
 {{< /code >}}
 
 {{< code json >}}
 {
-  "check": "mysql_status"
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "mysql_status",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "check": "mysql_status"
+  }
 }
 {{< /code >}}
 
@@ -326,7 +398,7 @@ check: mysql_status
 
 To delete a silencing entry, you must provide its name.
 
-Subscription-only silencing entry names will be similar to this example:
+Subscription-only silencing entry names will contain an asterisk (or wildcard) in the `$SUBSCRIPTION` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -342,7 +414,7 @@ name: appserver:*
 
 {{< /language-toggle >}}
 
-Check-only silencing entry names will be similar to this example:
+Check-only silencing entry names will contain an asterisk (or wildcard) in the `$CHECK` position, similar to this example:
 
 {{< language-toggle >}}
 
@@ -358,6 +430,7 @@ name: '*:mysql_status'
 
 {{< /language-toggle >}}
 
+
 [1]: ../../observe-events/events/#attributes
 [2]: ../../../operations/control-access/rbac#namespaces
 [3]: #metadata-attributes
@@ -367,4 +440,6 @@ name: '*:mysql_status'
 [7]: ../../../sensuctl/filter-responses/
 [8]: ../../observe-filter/filters/
 [9]: ../../../web-ui/search#search-for-labels
-[10]: ../../../web-ui/search
+[10]: ../../../web-ui/search/
+[11]: #silence-all-checks-on-entities-with-a-specific-subscription
+[12]: #silence-a-specific-check-on-every-entity


### PR DESCRIPTION
## Description
- Adds a check-only example in the GET and POST /silenced API doc
- Completes examples in the silenced reference doc (to fill in the rest of the yml/json needed to make a silence resource)
- Adds links for subscription-only and check-only examples in the intro to the silenced reference doc to make this information easier to find

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2840