### PR TITLE
Change Bonsai description to use hub instead of index

### DIFF
--- a/content/sensu-go/5.20/_index.md
+++ b/content/sensu-go/5.20/_index.md
@@ -51,7 +51,7 @@ Sensu agents automatically register and de-register themselves with the Sensu ba
 Get meaningful alerts when and where you need them.
 Use [event filters][8] to reduce noise and [check hooks][9] to add context and speed up incident response.
 Sensu integrates with the tools and services your organization already uses like [PagerDuty][21], [Slack][19], and more.
-Check out [Bonsai, the Sensu asset index][20], or write your own [Sensu plugins][3] in any language.
+Check out [Bonsai, the Sensu asset hub][20], or write your own [Sensu plugins][3] in any language.
 
 ### Collect and store metrics with built-in support for industry-standard tools
 

--- a/content/sensu-go/5.20/faq.md
+++ b/content/sensu-go/5.20/faq.md
@@ -48,7 +48,7 @@ Get in touch with us using [this form][6].
 Sensu supports a wide range of plugins for monitoring everything from the server closet to the cloud.
 [Install the Sensu agent][8] on the hosts you want to monitor, integrate with the [Sensu API][9], or take advantage of [proxy entities][10] to monitor anything on your network.
 
-Sensuctl integrates with [Bonsai, the Sensu asset index][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
+Sensuctl integrates with [Bonsai, the Sensu asset hub][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
 If you want to add your own asset, read the [guide for sharing an asset on Bonsai][33].
 
 You can also check out the 200+ plugins shared in the [Sensu plugins community][11], including monitoring checks for [AWS][13], [Jenkins][14], [Puppet][15], [InfluxDB][16], and [SNMP][17], or write your own Sensu plugins in any language using the [Sensu plugin specification][12].

--- a/content/sensu-go/5.20/get-started.md
+++ b/content/sensu-go/5.20/get-started.md
@@ -29,7 +29,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 - [**Install Sensu Go**][2] and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100
-- Discover Sensu assets on [Bonsai, the Sensu asset index][6]
+- Discover Sensu assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
 

--- a/content/sensu-go/5.20/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.20/guides/reduce-alert-fatigue.md
@@ -68,7 +68,7 @@ sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `fatigue-filter`.
 
-You can also download the asset directly from [Bonsai, the Sensu asset index][9].
+You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/5.20/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-plugins.md
@@ -24,9 +24,9 @@ To start using and deploying assets, read [Install plugins with assets][7] to be
 You can install Sensu plugins using the [sensu-install](#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
 {{% /notice %}}
 
-## Use Bonsai, the Sensu asset index
+## Use Bonsai, the Sensu asset hub
 
-[Bonsai, the Sensu asset index][8], is a centralized place for downloading and sharing plugin assets.
+[Bonsai, the Sensu asset hub][8], is a centralized place for downloading and sharing plugin assets.
 Make Bonsai your first stop when you need to find an asset.
 Bonsai includes plugins, libraries, and runtimes you need to automate your monitoring workflows.
 You can also [share your asset on Bonsai][9].

--- a/content/sensu-go/5.20/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.20/operations/maintain-sensu/migrate.md
@@ -409,7 +409,7 @@ You can still install [Sensu Community plugins][21] in Ruby via `sensu-install` 
 See the [installing plugins guide][51] for more information.
 
 Sensu supports runtime assets for checks, filters, mutators, and handlers.
-Discover, download, and share assets with [Bonsai][68], the Sensu asset index.
+Discover, download, and share assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own assets, see the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
 To contribute to converting a Sensu plugin to an asset, see [the Discourse post][70].

--- a/content/sensu-go/5.20/reference/assets.md
+++ b/content/sensu-go/5.20/reference/assets.md
@@ -13,7 +13,7 @@ menu:
     parent: reference
 ---
 
-You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
+You can discover, download, and share assets using [Bonsai, the Sensu asset hub][16].
 Read [Install plugins with assets][23] to get started.
 
 Assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].

--- a/content/sensu-go/5.20/reference/checks.md
+++ b/content/sensu-go/5.20/reference/checks.md
@@ -15,7 +15,7 @@ menu:
 Checks work with Sensu agents to produce monitoring events automatically.
 You can use checks to monitor server resources, services, and application health as well as collect and analyze metrics.
 Read [Monitor server resources][12] to get started.
-Use [Bonsai][29], the Sensu asset index, to discover, download, and share Sensu check assets.
+Use [Bonsai][29], the Sensu asset hub, to discover, download, and share Sensu check assets.
 
 ## Check commands
 

--- a/content/sensu-go/5.20/reference/handlers.md
+++ b/content/sensu-go/5.20/reference/handlers.md
@@ -20,7 +20,7 @@ The most common are `pipe` handlers, which work similarly to [checks][1] and ena
 - **TCP/UDP handlers** send event data to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
-Discover, download, and share Sensu handlers assets using [Bonsai][16], the Sensu asset index.
+Discover, download, and share Sensu handlers assets using [Bonsai][16], the Sensu asset hub.
 Read [Install plugins with assets][23] to get started.
 
 ## Pipe handlers

--- a/content/sensu-go/5.20/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/5.20/sensuctl/sensuctl-bonsai.md
@@ -1,7 +1,7 @@
 ---
 title: "Use sensuctl with Bonsai"
 linkTitle: "Use sensuctl with Bonsai"
-description: "Sensuctl supports installing asset definitions directly from Bonsai, the Sensu asset index, and checking for outdated assets. Read this page to learn about using sensuctl with Bonsai."
+description: "Sensuctl supports installing asset definitions directly from Bonsai, the Sensu asset hub, and checking for outdated assets. Read this page to learn about using sensuctl with Bonsai."
 weight: 50
 version: "5.20"
 product: "Sensu Go"
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-Sensuctl supports installing asset definitions directly from [Bonsai, the Sensu asset index][1], and checking your Sensu backend for outdated assets.
+Sensuctl supports installing asset definitions directly from [Bonsai, the Sensu asset hub][1], and checking your Sensu backend for outdated assets.
 You can also use `sensuctl command` to install, execute, list, and delete commands from Bonsai or a URL.
 
 ## Install asset definitions

--- a/content/sensu-go/5.21/_index.md
+++ b/content/sensu-go/5.21/_index.md
@@ -51,7 +51,7 @@ Sensu agents automatically register and de-register themselves with the Sensu ba
 Get meaningful alerts when and where you need them.
 Use [event filters][8] to reduce noise and [check hooks][9] to add context and speed up incident response.
 Sensu integrates with the tools and services your organization already uses like [PagerDuty][21], [Slack][19], and more.
-Check out [Bonsai, the Sensu asset index][20], or write your own [Sensu plugins][3] in any language.
+Check out [Bonsai, the Sensu asset hub][20], or write your own [Sensu plugins][3] in any language.
 
 ### Collect and store metrics with built-in support for industry-standard tools
 

--- a/content/sensu-go/5.21/faq.md
+++ b/content/sensu-go/5.21/faq.md
@@ -48,7 +48,7 @@ Get in touch with us using [this form][6].
 Sensu supports a wide range of plugins for monitoring everything from the server closet to the cloud.
 [Install the Sensu agent][8] on the hosts you want to monitor, integrate with the [Sensu API][9], or take advantage of [proxy entities][10] to monitor anything on your network.
 
-Sensuctl integrates with [Bonsai, the Sensu asset index][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
+Sensuctl integrates with [Bonsai, the Sensu asset hub][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
 If you want to add your own asset, read the [guide for sharing an asset on Bonsai][33].
 
 You can also check out the 200+ plugins shared in the [Sensu plugins community][11], including monitoring checks for [AWS][13], [Jenkins][14], [Puppet][15], [InfluxDB][16], and [SNMP][17], or write your own Sensu plugins in any language using the [Sensu plugin specification][12].

--- a/content/sensu-go/5.21/get-started.md
+++ b/content/sensu-go/5.21/get-started.md
@@ -29,7 +29,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 - [**Install Sensu Go**][2] and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100
-- Discover Sensu assets on [Bonsai, the Sensu asset index][6]
+- Discover Sensu assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
 

--- a/content/sensu-go/5.21/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.21/guides/reduce-alert-fatigue.md
@@ -68,7 +68,7 @@ sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `fatigue-filter`.
 
-You can also download the asset directly from [Bonsai, the Sensu asset index][9].
+You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-plugins.md
@@ -24,9 +24,9 @@ To start using and deploying assets, read [Install plugins with assets][7] to be
 You can install Sensu plugins using the [sensu-install](../install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
 {{% /notice %}}
 
-## Use Bonsai, the Sensu asset index
+## Use Bonsai, the Sensu asset hub
 
-[Bonsai, the Sensu asset index][8], is a centralized place for downloading and sharing plugin assets.
+[Bonsai, the Sensu asset hub][8], is a centralized place for downloading and sharing plugin assets.
 Make Bonsai your first stop when you need to find an asset.
 Bonsai includes plugins, libraries, and runtimes you need to automate your monitoring workflows.
 You can also [share your asset on Bonsai][9].

--- a/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
@@ -409,7 +409,7 @@ You can still install [Sensu Community plugins][21] in Ruby via `sensu-install` 
 See the [installing plugins guide][51] for more information.
 
 Sensu supports runtime assets for checks, filters, mutators, and handlers.
-Discover, download, and share assets with [Bonsai][68], the Sensu asset index.
+Discover, download, and share assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own assets, see the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
 To contribute to converting a Sensu plugin to an asset, see [the Discourse post][70].

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -13,7 +13,7 @@ menu:
     parent: reference
 ---
 
-You can discover, download, and share assets using [Bonsai, the Sensu asset index][16].
+You can discover, download, and share assets using [Bonsai, the Sensu asset hub][16].
 Read [Install plugins with assets][23] to get started.
 
 Assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -15,7 +15,7 @@ menu:
 Checks work with Sensu agents to produce monitoring events automatically.
 You can use checks to monitor server resources, services, and application health as well as collect and analyze metrics.
 Read [Monitor server resources][12] to get started.
-Use [Bonsai][29], the Sensu asset index, to discover, download, and share Sensu check assets.
+Use [Bonsai][29], the Sensu asset hub, to discover, download, and share Sensu check assets.
 
 ## Check commands
 

--- a/content/sensu-go/5.21/reference/handlers.md
+++ b/content/sensu-go/5.21/reference/handlers.md
@@ -20,7 +20,7 @@ The most common are `pipe` handlers, which work similarly to [checks][1] and ena
 - **TCP/UDP handlers** send event data to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
-Discover, download, and share Sensu handlers assets using [Bonsai][16], the Sensu asset index.
+Discover, download, and share Sensu handlers assets using [Bonsai][16], the Sensu asset hub.
 Read [Install plugins with assets][23] to get started.
 
 ## Pipe handlers

--- a/content/sensu-go/5.21/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/5.21/sensuctl/sensuctl-bonsai.md
@@ -1,7 +1,7 @@
 ---
 title: "Use sensuctl with Bonsai"
 linkTitle: "Use sensuctl with Bonsai"
-description: "Sensuctl supports installing asset definitions directly from Bonsai, the Sensu asset index, and checking for outdated assets. Read this page to learn about using sensuctl with Bonsai."
+description: "Sensuctl supports installing asset definitions directly from Bonsai, the Sensu asset hub, and checking for outdated assets. Read this page to learn about using sensuctl with Bonsai."
 weight: 50
 version: "5.21"
 product: "Sensu Go"
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-Sensuctl supports installing asset definitions directly from [Bonsai, the Sensu asset index][1], and checking your Sensu backend for outdated assets.
+Sensuctl supports installing asset definitions directly from [Bonsai, the Sensu asset hub][1], and checking your Sensu backend for outdated assets.
 You can also use `sensuctl command` to install, execute, list, and delete commands from Bonsai or a URL.
 
 ## Install asset definitions

--- a/content/sensu-go/6.0/_index.md
+++ b/content/sensu-go/6.0/_index.md
@@ -32,7 +32,7 @@ Get meaningful alerts when and where you need them so you can [reduce alert fati
 Sensu gives you full control over your alerts with flexible [event filters][8], [check hooks][9] for context-rich notifications, reporting, [observation data handling][24], and auto-remediation.
 
 Sensu's open architecture integrates with the tools and services you already use, like [Ansible, Chef, and Puppet][23]; [PagerDuty][19]; [Slack][17]; and more.
-Check out [Bonsai, the Sensu asset index][18], or write your own [Sensu plugins][3] in any language.
+Check out [Bonsai, the Sensu asset hub][18], or write your own [Sensu plugins][3] in any language.
 
 ## Automate with agent registration-deregistration and check subscriptions
 

--- a/content/sensu-go/6.0/faq.md
+++ b/content/sensu-go/6.0/faq.md
@@ -48,7 +48,7 @@ Get in touch with us using [this form][6].
 Sensu supports a wide range of plugins for monitoring everything from the server closet to the cloud.
 [Install the Sensu agent][8] on the hosts you want to monitor, integrate with the [Sensu API][9], or take advantage of [proxy entities][10] to monitor anything on your network.
 
-Sensuctl integrates with [Bonsai, the Sensu asset index][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
+Sensuctl integrates with [Bonsai, the Sensu asset hub][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
 If you want to add your own dynamic runtime assets, read the [guide for sharing an asset on Bonsai][33].
 
 You can also check out the 200+ plugins shared in the [Sensu plugins community][11], including monitoring checks for [AWS][13], [Jenkins][14], [Puppet][15], [InfluxDB][16], and [SNMP][17], or write your own Sensu plugins in any language using the [Sensu plugin specification][12].

--- a/content/sensu-go/6.0/get-started.md
+++ b/content/sensu-go/6.0/get-started.md
@@ -29,7 +29,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 - [**Install Sensu Go**][2] and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100
-- Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset index][6]
+- Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/_index.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/_index.md
@@ -34,7 +34,7 @@ Sensu applies event filters in the order that they are listed in your handler de
 As soon as an event filter removes an event from your pipeline because it does not meet the conditions, triggers, or thresholds you specified, the Sensu observability pipeline ceases analysis for the event.
 Sensu will not [transform][5] or [process][3] events that your event filter removes from your pipeline.
 
-Use [Bonsai][8], the Sensu asset index, to discover, download, and share Sensu event filter dynamic runtime assets.
+Use [Bonsai][8], the Sensu asset hub, to discover, download, and share Sensu event filter dynamic runtime assets.
 Read [Use assets to install plugins][9] to get started.
 
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -76,7 +76,7 @@ resource, populate the "runtime_assets" field with ["fatigue-filter"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `fatigue-filter`.
 
-You can also download the asset directly from [Bonsai, the Sensu asset index][9].
+You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handlers.md
@@ -23,7 +23,7 @@ The most common are `pipe` handlers, which work similarly to [checks][1] and ena
 - **TCP/UDP handlers** send observation data (events) to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
-Discover, download, and share Sensu handler dynamic runtime assets using [Bonsai][16], the Sensu asset index.
+Discover, download, and share Sensu handler dynamic runtime assets using [Bonsai][16], the Sensu asset hub.
 Read [Use assets to install plugins][23] to get started.
 
 ## Pipe handlers

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
@@ -16,7 +16,7 @@ menu:
 Checks work with Sensu agents to produce observability events automatically.
 You can use checks to monitor server resources, services, and application health as well as collect and analyze metrics.
 Read [Monitor server resources][12] to get started.
-Use [Bonsai][29], the Sensu asset index, to discover, download, and share Sensu check dynamic runtime assets.
+Use [Bonsai][29], the Sensu asset hub, to discover, download, and share Sensu check dynamic runtime assets.
 
 ## Check commands
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-transform/_index.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-transform/_index.md
@@ -30,7 +30,7 @@ If the handler includes a mutator, the Sensu backend executes the mutator.
 * If the mutator executes successfully (i.e. returns an exit status code of `0`), Sensu applies the mutator to transform the event data, returns the transformed event data to the handler, and executes the handler.
 * If the mutator fails to execute (i.e. returns a non-zero exit status code or fails to complete within its configured timeout), Sensu logs an error and does not execute the handler.
 
-Use [Bonsai][5], the Sensu asset index, to discover, download, and share Sensu mutator dynamic runtime assets.
+Use [Bonsai][5], the Sensu asset hub, to discover, download, and share Sensu mutator dynamic runtime assets.
 Read [Use assets to install plugins][6] to get started.
 
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/assets.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/assets.md
@@ -13,7 +13,7 @@ menu:
     parent: deploy-sensu
 ---
 
-You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset index][16].
+You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
 Read [Use assets to install plugins][23] to get started.
 
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-plugins.md
@@ -24,9 +24,9 @@ To start using and deploying assets, read [Use dynamic runtime assets to install
 You can install Sensu plugins using the [sensu-install](#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
 {{% /notice %}}
 
-## Use Bonsai, the Sensu asset index
+## Use Bonsai, the Sensu asset hub
 
-[Bonsai, the Sensu asset index][8], is a centralized place for downloading and sharing dynamic runtime assets.
+[Bonsai, the Sensu asset hub][8], is a centralized place for downloading and sharing dynamic runtime assets.
 Make Bonsai your first stop when you need to find an asset.
 Bonsai includes plugins, libraries, and runtimes you need to automate your monitoring workflows.
 You can also [share your asset on Bonsai][9].

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -409,7 +409,7 @@ You can still install [Sensu Community plugins][21] in Ruby via `sensu-install` 
 See the [installing plugins guide][51] for more information.
 
 Sensu supports dynamic runtime assets for checks, filters, mutators, and handlers.
-Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset index.
+Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own dynamic runtime assets, see the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
 To contribute to converting a Sensu plugin to a dynamic runtime asset, see [the Discourse post][70].

--- a/content/sensu-go/6.0/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.0/sensuctl/sensuctl-bonsai.md
@@ -1,7 +1,7 @@
 ---
 title: "Use sensuctl with Bonsai"
 linkTitle: "Use sensuctl with Bonsai"
-description: "Sensuctl supports installing dynamic runtime asset definitions directly from Bonsai, the Sensu asset index, and checking for outdated dynamic runtime assets. Read this page to learn about using sensuctl with Bonsai."
+description: "Sensuctl supports installing dynamic runtime asset definitions directly from Bonsai, the Sensu asset hub, and checking for outdated dynamic runtime assets. Read this page to learn about using sensuctl with Bonsai."
 weight: 50
 version: "6.0"
 product: "Sensu Go"
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-Sensuctl supports installing dynamic runtime asset definitions directly from [Bonsai, the Sensu asset index][1], and checking your Sensu backend for outdated dynamic runtime assets.
+Sensuctl supports installing dynamic runtime asset definitions directly from [Bonsai, the Sensu asset hub][1], and checking your Sensu backend for outdated dynamic runtime assets.
 You can also use `sensuctl command` to install, execute, list, and delete commands from Bonsai or a URL.
 
 ## Install dynamic runtime asset definitions

--- a/content/sensu-go/6.1/_index.md
+++ b/content/sensu-go/6.1/_index.md
@@ -32,7 +32,7 @@ Get meaningful alerts when and where you need them so you can [reduce alert fati
 Sensu gives you full control over your alerts with flexible [event filters][8], [check hooks][9] for context-rich notifications, reporting, [observation data handling][24], and auto-remediation.
 
 Sensu's open architecture integrates with the tools and services you already use, like [Ansible, Chef, and Puppet][23]; [PagerDuty][19]; [Slack][17]; and more.
-Check out [Bonsai, the Sensu asset index][18], or write your own [Sensu plugins][3] in any language.
+Check out [Bonsai, the Sensu asset hub][18], or write your own [Sensu plugins][3] in any language.
 
 ## Automate with agent registration-deregistration and check subscriptions
 

--- a/content/sensu-go/6.1/faq.md
+++ b/content/sensu-go/6.1/faq.md
@@ -48,7 +48,7 @@ Get in touch with us using [this form][6].
 Sensu supports a wide range of plugins for monitoring everything from the server closet to the cloud.
 [Install the Sensu agent][8] on the hosts you want to monitor, integrate with the [Sensu API][9], or take advantage of [proxy entities][10] to monitor anything on your network.
 
-Sensuctl integrates with [Bonsai, the Sensu asset index][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
+Sensuctl integrates with [Bonsai, the Sensu asset hub][32], where you’ll find plugins, libraries, and runtimes you need to automate your monitoring workflows.
 If you want to add your own dynamic runtime assets, read the [guide for sharing an asset on Bonsai][33].
 
 You can also check out the 200+ plugins shared in the [Sensu plugins community][11], including monitoring checks for [AWS][13], [Jenkins][14], [Puppet][15], [InfluxDB][16], and [SNMP][17], or write your own Sensu plugins in any language using the [Sensu plugin specification][12].

--- a/content/sensu-go/6.1/get-started.md
+++ b/content/sensu-go/6.1/get-started.md
@@ -29,7 +29,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 - [**Install Sensu Go**][2] and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100
-- Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset index][6]
+- Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/_index.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/_index.md
@@ -34,7 +34,7 @@ Sensu applies event filters in the order that they are listed in your handler de
 As soon as an event filter removes an event from your pipeline because it does not meet the conditions, triggers, or thresholds you specified, the Sensu observability pipeline ceases analysis for the event.
 Sensu will not [transform][5] or [process][3] events that your event filter removes from your pipeline.
 
-Use [Bonsai][8], the Sensu asset index, to discover, download, and share Sensu event filter dynamic runtime assets.
+Use [Bonsai][8], the Sensu asset hub, to discover, download, and share Sensu event filter dynamic runtime assets.
 Read [Use assets to install plugins][9] to get started.
 
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -76,7 +76,7 @@ resource, populate the "runtime_assets" field with ["fatigue-filter"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `fatigue-filter`.
 
-You can also download the asset directly from [Bonsai, the Sensu asset index][9].
+You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
@@ -23,7 +23,7 @@ The most common are `pipe` handlers, which work similarly to [checks][1] and ena
 - **TCP/UDP handlers** send observation data (events) to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
-Discover, download, and share Sensu handler dynamic runtime assets using [Bonsai][16], the Sensu asset index.
+Discover, download, and share Sensu handler dynamic runtime assets using [Bonsai][16], the Sensu asset hub.
 Read [Use assets to install plugins][23] to get started.
 
 ## Pipe handlers

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
@@ -16,7 +16,7 @@ menu:
 Checks work with Sensu agents to produce observability events automatically.
 You can use checks to monitor server resources, services, and application health as well as collect and analyze metrics.
 Read [Monitor server resources][12] to get started.
-Use [Bonsai][29], the Sensu asset index, to discover, download, and share Sensu check dynamic runtime assets.
+Use [Bonsai][29], the Sensu asset hub, to discover, download, and share Sensu check dynamic runtime assets.
 
 ## Check commands
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-transform/_index.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-transform/_index.md
@@ -30,7 +30,7 @@ If the handler includes a mutator, the Sensu backend executes the mutator.
 * If the mutator executes successfully (i.e. returns an exit status code of `0`), Sensu applies the mutator to transform the event data, returns the transformed event data to the handler, and executes the handler.
 * If the mutator fails to execute (i.e. returns a non-zero exit status code or fails to complete within its configured timeout), Sensu logs an error and does not execute the handler.
 
-Use [Bonsai][5], the Sensu asset index, to discover, download, and share Sensu mutator dynamic runtime assets.
+Use [Bonsai][5], the Sensu asset hub, to discover, download, and share Sensu mutator dynamic runtime assets.
 Read [Use assets to install plugins][6] to get started.
 
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/assets.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/assets.md
@@ -13,7 +13,7 @@ menu:
     parent: deploy-sensu
 ---
 
-You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset index][16].
+You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
 Read [Use assets to install plugins][23] to get started.
 
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-plugins.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-plugins.md
@@ -24,9 +24,9 @@ To start using and deploying assets, read [Use dynamic runtime assets to install
 You can install Sensu plugins using the [sensu-install](#install-plugins/#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../configuration-management/) solution.
 {{% /notice %}}
 
-## Use Bonsai, the Sensu asset index
+## Use Bonsai, the Sensu asset hub
 
-[Bonsai, the Sensu asset index][8], is a centralized place for downloading and sharing dynamic runtime assets.
+[Bonsai, the Sensu asset hub][8], is a centralized place for downloading and sharing dynamic runtime assets.
 Make Bonsai your first stop when you need to find an asset.
 Bonsai includes plugins, libraries, and runtimes you need to automate your monitoring workflows.
 You can also [share your asset on Bonsai][9].

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -409,7 +409,7 @@ You can still install [Sensu Community plugins][21] in Ruby via `sensu-install` 
 See the [installing plugins guide][51] for more information.
 
 Sensu supports dynamic runtime assets for checks, filters, mutators, and handlers.
-Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset index.
+Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own dynamic runtime assets, see the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
 To contribute to converting a Sensu plugin to a dynamic runtime asset, see [the Discourse post][70].

--- a/content/sensu-go/6.1/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.1/sensuctl/sensuctl-bonsai.md
@@ -1,7 +1,7 @@
 ---
 title: "Use sensuctl with Bonsai"
 linkTitle: "Use sensuctl with Bonsai"
-description: "Sensuctl supports installing dynamic runtime asset definitions directly from Bonsai, the Sensu asset index, and checking for outdated dynamic runtime assets. Read this page to learn about using sensuctl with Bonsai."
+description: "Sensuctl supports installing dynamic runtime asset definitions directly from Bonsai, the Sensu asset hub, and checking for outdated dynamic runtime assets. Read this page to learn about using sensuctl with Bonsai."
 weight: 50
 version: "6.1"
 product: "Sensu Go"
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-Sensuctl supports installing dynamic runtime asset definitions directly from [Bonsai, the Sensu asset index][1], and checking your Sensu backend for outdated dynamic runtime assets.
+Sensuctl supports installing dynamic runtime asset definitions directly from [Bonsai, the Sensu asset hub][1], and checking your Sensu backend for outdated dynamic runtime assets.
 You can also use `sensuctl command` to install, execute, list, and delete commands from Bonsai or a URL.
 
 ## Install dynamic runtime asset definitions


### PR DESCRIPTION
## Description
Changes "Sensu asset index" to "Sensu asset hub" throughout Sensu Go documentation.

## Motivation and Context
Align with description at https://bonsai.sensu.io/