### PR TITLE
Explain purpose of sensu-ruby-runtime asset

### DIFF
--- a/content/sensu-go/5.20/guides/contact-routing.md
+++ b/content/sensu-go/5.20/guides/contact-routing.md
@@ -283,7 +283,7 @@ To assign an alert to a contact, add a `contacts` label to the check or entity.
 ### Checks
 
 This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To set up the `check_cpu` check, see [Monitor server resources][9].
+To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
 
 {{< code yml >}}
 ---

--- a/content/sensu-go/5.20/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.20/guides/monitor-external-resources.md
@@ -25,9 +25,13 @@ In this section, you'll monitor the status of [sensu.io](https://sensu.io) by co
 
 ### Register assets
 
-To power the check, use the [Sensu Plugins HTTP][16] asset and the [Sensu Ruby Runtime][17] asset.
+To power the check, you'll use the [Sensu Plugins HTTP][16] asset.
+The Sensu Plugins HTTP asset includes `check-http.rb`, which [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the `sensu-plugins-http` asset:
+The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] asset.
+Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` plugin.
+
+Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP asset, `sensu-plugins/sensu-plugins-http:5.1.1`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
@@ -37,7 +41,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset definition for Debian or Alpine from [Bonsai][16] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -370,6 +374,7 @@ Now that you know how to run a proxy check to verify the status of a website and
 [12]: ../../reference/tokens/
 [13]: #register-assets
 [14]: #add-the-subscription
+[15]: #create-the-check
 [16]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-http
 [17]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [18]: ../../reference/checks#round-robin-checks

--- a/content/sensu-go/5.20/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.20/guides/monitor-server-resources.md
@@ -21,9 +21,13 @@ To use this guide, you'll need to install a Sensu backend and have at least one 
 
 ## Register assets
 
-To power the check, you'll use the [Sensu CPU Checks][1] asset and the [Sensu Ruby Runtime][7] asset.
+To power the check, you'll use the [Sensu CPU Checks][1] asset.
+The Sensu CPU Checks asset includes the `check-cpu.rb` plugin, which [your check][10] will rely on.
 
-Use [`sensuctl asset add`][9] to register the `sensu-plugins-cpu-checks` asset:
+The Sensu assets packaged from Sensu CPU Checks are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] asset.
+The Sensu Ruby Runtime asset delivers the Ruby runtime asset the check will need to run the `check-cpu.rb` plugin.
+
+Use [`sensuctl asset add`][9] to register the Sensu CPU Checks asset, `sensu-plugins/sensu-plugins-cpu-checks:4.1.0`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
@@ -33,7 +37,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset definition for Debian or Alpine from [Bonsai][1] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -115,3 +119,4 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [7]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [8]: ../../reference/agent/#restart-the-service
 [9]: ../../sensuctl/sensuctl-bonsai/#install-asset-definitions
+[10]: #create-a-check

--- a/content/sensu-go/5.20/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.20/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -40,7 +40,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http` plugin from the [Monitoring plugins asset][3] to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/5.20/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.20/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -40,7 +40,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check-http.rb` plugin from the [Sensu Plugins HTTP][3] asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/5.21/guides/contact-routing.md
+++ b/content/sensu-go/5.21/guides/contact-routing.md
@@ -283,7 +283,7 @@ To assign an alert to a contact, add a `contacts` label to the check or entity.
 ### Checks
 
 This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To set up the `check_cpu` check, see [Monitor server resources][9].
+To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
 
 {{< code yml >}}
 ---

--- a/content/sensu-go/5.21/guides/monitor-external-resources.md
+++ b/content/sensu-go/5.21/guides/monitor-external-resources.md
@@ -25,9 +25,13 @@ In this section, you'll monitor the status of [sensu.io](https://sensu.io) by co
 
 ### Register assets
 
-To power the check, use the [Sensu Plugins HTTP][16] asset and the [Sensu Ruby Runtime][17] asset.
+To power the check, you'll use the [Sensu Plugins HTTP][16] asset.
+The Sensu Plugins HTTP asset includes `check-http.rb`, which [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the `sensu-plugins-http` asset:
+The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] asset.
+Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` plugin.
+
+Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP asset, `sensu-plugins/sensu-plugins-http:5.1.1`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
@@ -37,7 +41,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset definition for Debian or Alpine from [Bonsai][16] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -370,6 +374,7 @@ Now that you know how to run a proxy check to verify the status of a website and
 [12]: ../../reference/tokens/
 [13]: #register-assets
 [14]: #add-the-subscription
+[15]: #create-the-check
 [16]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-http
 [17]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [18]: ../../reference/checks#round-robin-checks

--- a/content/sensu-go/5.21/guides/monitor-server-resources.md
+++ b/content/sensu-go/5.21/guides/monitor-server-resources.md
@@ -21,9 +21,13 @@ To use this guide, you'll need to install a Sensu backend and have at least one 
 
 ## Register assets
 
-To power the check, you'll use the [Sensu CPU Checks][1] asset and the [Sensu Ruby Runtime][7] asset.
+To power the check, you'll use the [Sensu CPU Checks][1] asset.
+The Sensu CPU Checks asset includes the `check-cpu.rb` plugin, which [your check][10] will rely on.
 
-Use [`sensuctl asset add`][9] to register the `sensu-plugins-cpu-checks` asset:
+The Sensu assets packaged from Sensu CPU Checks are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] asset.
+The Sensu Ruby Runtime asset delivers the Ruby runtime asset the check will need to run the `check-cpu.rb` plugin.
+
+Use [`sensuctl asset add`][9] to register the Sensu CPU Checks asset, `sensu-plugins/sensu-plugins-cpu-checks:4.1.0`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
@@ -33,7 +37,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 You can also download the asset definition for Debian or Alpine from [Bonsai][1] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -115,3 +119,4 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [7]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [8]: ../../reference/agent/#restart-the-service
 [9]: ../../sensuctl/sensuctl-bonsai/#install-asset-definitions
+[10]: #create-a-check

--- a/content/sensu-go/5.21/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.21/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -40,7 +40,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http` plugin from the [Monitoring plugins asset][3] to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/5.21/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/5.21/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -40,7 +40,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check-http.rb` plugin from the [Sensu Plugins HTTP][3] asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -27,9 +27,13 @@ In this section, you'll monitor the status of [sensu.io](https://sensu.io) by co
 
 ### Register dynamic runtime assets
 
-To power the check, use the [Sensu Plugins HTTP][16] and [Sensu Ruby Runtime][17] dynamic runtime assets.
+To power the check, you'll use the [Sensu Plugins HTTP][16] dynamic runtime asset.
+The Sensu Plugins HTTP asset includes `check-http.rb`, which [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the `sensu-plugins-http` dynamic runtime asset:
+The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] dynamic runtime asset.
+Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` plugin.
+
+Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP dynamic runtime asset, `sensu-plugins/sensu-plugins-http:5.1.1`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
@@ -45,7 +49,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][16] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` dynamic runtime asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime dynamic runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -384,6 +388,7 @@ Now that you know how to run a proxy check to verify the status of a website and
 [12]: ../../observe-schedule/tokens/
 [13]: #register-assets
 [14]: #add-the-subscription
+[15]: #create-the-check
 [16]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-http
 [17]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [18]: ../../observe-schedule/checks#round-robin-checks

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
@@ -297,7 +297,7 @@ To assign an alert to a contact, add a `contacts` label to the check or entity.
 ### Checks
 
 This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To set up the `check_cpu` check, see [Monitor server resources][9].
+To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
 
 {{< code yml >}}
 ---

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -23,9 +23,13 @@ To use this guide, you'll need to install a Sensu backend and have at least one 
 
 ## Register dynamic runtime assets
 
-To power the check, you'll use the [Sensu CPU Checks][1] and [Sensu Ruby Runtime][7] dynamic runtime assets.
+To power the check, you'll use the [Sensu CPU Checks][1] dynamic runtime asset.
+The Sensu CPU Checks asset includes the `check-cpu.rb` plugin, which [your check][10] will rely on.
 
-Use [`sensuctl asset add`][9] to register the `sensu-plugins-cpu-checks` dynamic runtime asset:
+The Sensu assets packaged from Sensu CPU Checks are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] dynamic runtime asset.
+The Sensu Ruby Runtime asset delivers the Ruby runtime asset the check will need to run the `check-cpu.rb` plugin.
+
+Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime asset, `sensu-plugins/sensu-plugins-cpu-checks:4.1.0`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
@@ -41,7 +45,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][1] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` dynamic runtime asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime dynamic runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -129,3 +133,4 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [7]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [8]: ../agent/#restart-the-service
 [9]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[10]: #create-a-check

--- a/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -42,7 +42,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] dynamic runtime asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check-http.rb` plugin from the [Sensu Plugins HTTP][3] dynamic runtime asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -42,7 +42,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http` plugin from the [Monitoring plugins dynamic runtime asset][3] to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] dynamic runtime asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -29,8 +29,8 @@ In this section, you'll monitor the status of [sensu.io](https://sensu.io) by co
 
 To power the check, use the [Sensu Plugins HTTP][16] (`sensu-plugins-http`) and [Sensu Ruby Runtime][17] (`sensu-ruby-runtime`) dynamic runtime assets.
 
-{{% notice protip %}}
-**PRO TIP**: You need the Sensu Plugins HTTP asset because it includes `check-http.rb`, which [your check](#create-the-check) will rely on.
+{{% notice note %}}
+**NOTE**: You need the Sensu Plugins HTTP asset because it includes `check-http.rb`, which [your check](#create-the-check) will rely on.
 The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
 Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` command.
 {{% /notice %}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -27,15 +27,13 @@ In this section, you'll monitor the status of [sensu.io](https://sensu.io) by co
 
 ### Register dynamic runtime assets
 
-To power the check, use the [Sensu Plugins HTTP][16] (`sensu-plugins-http`) and [Sensu Ruby Runtime][17] (`sensu-ruby-runtime`) dynamic runtime assets.
+To power the check, you'll use the [Sensu Plugins HTTP][16] dynamic runtime asset.
+The Sensu Plugins HTTP asset includes `check-http.rb`, which [your check][15] will rely on.
 
-{{% notice note %}}
-**NOTE**: You need the Sensu Plugins HTTP asset because it includes `check-http.rb`, which [your check](#create-the-check) will rely on.
-The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
-Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` command.
-{{% /notice %}}
+The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] dynamic runtime asset.
+Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` plugin.
 
-Use [`sensuctl asset add`][21] to register the `sensu-plugins-http` dynamic runtime asset:
+Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP dynamic runtime asset, `sensu-plugins/sensu-plugins-http:5.1.1`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
@@ -51,7 +49,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][16] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` dynamic runtime asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime dynamic runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -390,6 +388,7 @@ Now that you know how to run a proxy check to verify the status of a website and
 [12]: ../../observe-schedule/tokens/
 [13]: #register-assets
 [14]: #add-the-subscription
+[15]: #create-the-check
 [16]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-http
 [17]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [18]: ../../observe-schedule/checks#round-robin-checks

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -27,7 +27,13 @@ In this section, you'll monitor the status of [sensu.io](https://sensu.io) by co
 
 ### Register dynamic runtime assets
 
-To power the check, use the [Sensu Plugins HTTP][16] and [Sensu Ruby Runtime][17] dynamic runtime assets.
+To power the check, use the [Sensu Plugins HTTP][16] (`sensu-plugins-http`) and [Sensu Ruby Runtime][17] (`sensu-ruby-runtime`) dynamic runtime assets.
+
+{{% notice protip %}}
+**PRO TIP**: You need the Sensu Plugins HTTP asset because it includes `check-http.rb`, which [your check](#create-the-check) will rely on.
+The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
+Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` command.
+{{% /notice %}}
 
 Use [`sensuctl asset add`][21] to register the `sensu-plugins-http` dynamic runtime asset:
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
@@ -297,7 +297,7 @@ To assign an alert to a contact, add a `contacts` label to the check or entity.
 ### Checks
 
 This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To set up the `check_cpu` check, see [Monitor server resources][9].
+To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
 
 {{< code yml >}}
 ---

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -25,9 +25,9 @@ To use this guide, you'll need to install a Sensu backend and have at least one 
 
 To power the check, you'll use the [Sensu CPU Checks][1] (`sensu-plugins-cpu-checks`) and [Sensu Ruby Runtime][7] (`sensu-ruby-runtime`) dynamic runtime assets.
 
-{{% notice protip %}}
-**PRO TIP**: You need the Sensu CPU Checks asset because it includes `check-cpu.rb`, which [your check](#create-a-check) will rely on.
-The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
+{{% notice note %}}
+**NOTE**: You need the Sensu CPU Checks asset because it includes `check-cpu.rb`, which [your check](#create-a-check) will rely on.
+The Sensu assets packaged from Sensu CPU Checks are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
 Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` command.
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -23,7 +23,13 @@ To use this guide, you'll need to install a Sensu backend and have at least one 
 
 ## Register dynamic runtime assets
 
-To power the check, you'll use the [Sensu CPU Checks][1] and [Sensu Ruby Runtime][7] dynamic runtime assets.
+To power the check, you'll use the [Sensu CPU Checks][1] (`sensu-plugins-cpu-checks`) and [Sensu Ruby Runtime][7] (`sensu-ruby-runtime`) dynamic runtime assets.
+
+{{% notice protip %}}
+**PRO TIP**: You need the Sensu CPU Checks asset because it includes `check-cpu.rb`, which [your check](#create-a-check) will rely on.
+The Sensu assets packaged from Sensu Plugins HTTP are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
+Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` command.
+{{% /notice %}}
 
 Use [`sensuctl asset add`][9] to register the `sensu-plugins-cpu-checks` dynamic runtime asset:
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -23,15 +23,13 @@ To use this guide, you'll need to install a Sensu backend and have at least one 
 
 ## Register dynamic runtime assets
 
-To power the check, you'll use the [Sensu CPU Checks][1] (`sensu-plugins-cpu-checks`) and [Sensu Ruby Runtime][7] (`sensu-ruby-runtime`) dynamic runtime assets.
+To power the check, you'll use the [Sensu CPU Checks][1] dynamic runtime asset.
+The Sensu CPU Checks asset includes the `check-cpu.rb` plugin, which [your check][10] will rely on.
 
-{{% notice note %}}
-**NOTE**: You need the Sensu CPU Checks asset because it includes `check-cpu.rb`, which [your check](#create-a-check) will rely on.
-The Sensu assets packaged from Sensu CPU Checks are built against the Sensu Ruby runtime environment, so you also need the Sensu Ruby Runtime asset.
-Sensu Ruby Runtime delivers the Ruby runtime asset the check will need to run the `check-http.rb` command.
-{{% /notice %}}
+The Sensu assets packaged from Sensu CPU Checks are built against the Sensu Ruby runtime environment, so you also need to add the [Sensu Ruby Runtime][7] dynamic runtime asset.
+The Sensu Ruby Runtime asset delivers the Ruby runtime asset the check will need to run the `check-cpu.rb` plugin.
 
-Use [`sensuctl asset add`][9] to register the `sensu-plugins-cpu-checks` dynamic runtime asset:
+Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime asset, `sensu-plugins/sensu-plugins-cpu-checks:4.1.0`:
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
@@ -47,7 +45,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][1] and register the asset with `sensuctl create --file filename.yml`.
 
-Then, use the following sensuctl example to register the `sensu-ruby-runtime` dynamic runtime asset:
+Then, use the following sensuctl example to register the Sensu Ruby Runtime dynamic runtime asset, `sensu/sensu-ruby-runtime:0.0.10`:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
@@ -135,3 +133,4 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [7]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [8]: ../agent/#restart-the-service
 [9]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[10]: #create-a-check

--- a/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -42,7 +42,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] dynamic runtime asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check-http.rb` plugin from the [Sensu Plugins HTTP][3] dynamic runtime asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -84,6 +84,11 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: This example uses the [Sensu Plugins HTTP](https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-http) and [Sensu Ruby Runtime](https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime) dynamic runtime assets.
+Read [Monitor server resources with checks](../../../observability-pipeline/observe-schedule/monitor-server-resources/#register-dynamic-runtime-assets) to learn how to add these assets.
+{{% /notice %}}
+
 ## Monitor external etcd
 
 If your Sensu Go deployment uses an external etcd cluster, you'll need to check the health of the respective etcd instances.
@@ -250,6 +255,11 @@ spec:
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: This example uses the [Sensu Plugins HTTP](https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-http) and [Sensu Ruby Runtime](https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime) dynamic runtime assets.
+Read [Monitor server resources with checks](../../../observability-pipeline/observe-schedule/monitor-server-resources/#register-dynamic-runtime-assets) to learn how to add these assets.
+{{% /notice %}}
 
 A successful check result will look like this:
 

--- a/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -42,7 +42,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, use the `check_http` plugin from the [Monitoring plugins dynamic runtime asset][3] to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
+To do this, use the `check_http.rb` plugin from the [Sensu Plugins HTTP][3] dynamic runtime asset to query Sensu's [health API endpoint][2] with a check definition for your primary (Backend Alpha) and secondary (Backend Beta) backends:
 
 {{< language-toggle >}}
 


### PR DESCRIPTION
## Description
Explains why the examples add the sensu-ruby-runtime asset in:
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-entities/monitor-external-resources/#register-dynamic-runtime-assets
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/monitor-server-resources/#register-dynamic-runtime-assets

Adds "To add the runtime assets..." to the note about reading Monitor server resources to set up the required check in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/route-alerts/#checks

Adds note about reading Monitor server resources with checks to learn how to add the required assets in https://docs.sensu.io/sensu-go/latest/operations/monitor-sensu/monitor-sensu-with-sensu/#monitor-your-sensu-backend-instances and https://docs.sensu.io/sensu-go/latest/operations/monitor-sensu/monitor-sensu-with-sensu/#monitor-postgres

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2846