### PR TITLE
Add port 6060 to list of backend port requirements

### DIFF
--- a/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
@@ -61,7 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
-6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
+6060 | HTTP/HTTPS | Required for all Sensu backends when performance profiling is enabled via [debug][43] setting |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 

--- a/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
@@ -61,6 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
+6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -565,3 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../reference/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
+[43]: ../../maintain-sensu/troubleshoot/#log-levels

--- a/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
@@ -566,4 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../reference/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
-[43]: ../../maintain-sensu/troubleshoot/#log-levels
+[43]: ../../../reference/backend/#debug-attribute

--- a/content/sensu-go/5.20/reference/backend.md
+++ b/content/sensu-go/5.20/reference/backend.md
@@ -435,10 +435,11 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
+<a name="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
-description | If `true`, enable debugging and profiling features. Otherwise, `false`.
+description | If `true`, enable debugging and profiling features for use with the [Go pprof package][27]. Otherwise, `false`.
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
@@ -1411,4 +1412,5 @@ The _SIGHUP_ signal causes the `backend` component to reload instead of restarti
 [24]: ../../operations/deploy-sensu/install-sensu#2-configure-and-start
 [25]: ../../operations/deploy-sensu/install-sensu#3-initialize
 [26]: ../../sensuctl/#change-admin-users-password
+[27]: https://golang.org/pkg/net/http/pprof/
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
@@ -61,6 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
+6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -565,3 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../reference/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
+[43]: ../../maintain-sensu/troubleshoot/#log-levels

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
@@ -61,7 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
-6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
+6060 | HTTP/HTTPS | Required for all Sensu backends when performance profiling is enabled via [debug][43] setting |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -566,4 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../reference/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
-[43]: ../../maintain-sensu/troubleshoot/#log-levels
+[43]: ../../../reference/backend/#debug-attribute

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -437,10 +437,11 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
+<a name="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
-description | If `true`, enable debugging and profiling features. Otherwise, `false`.
+description | If `true`, enable debugging and profiling features for use with the [Go pprof package][27]. Otherwise, `false`.
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
@@ -1444,4 +1445,5 @@ The _SIGHUP_ signal causes the `backend` component to reload instead of restarti
 [24]: ../../operations/deploy-sensu/install-sensu#2-configure-and-start
 [25]: ../../operations/deploy-sensu/install-sensu#3-initialize
 [26]: ../../sensuctl/#change-admin-users-password
+[27]: https://golang.org/pkg/net/http/pprof/
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -441,10 +441,11 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
+<a name="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
-description | If `true`, enable debugging and profiling features. Otherwise, `false`.
+description | If `true`, enable debugging and profiling features for use with the [Go pprof package][27]. Otherwise, `false`.
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
@@ -1452,5 +1453,6 @@ The _SIGHUP_ signal causes the `backend` component to reload instead of restarti
 [24]: ../../../operations/deploy-sensu/install-sensu#2-configure-and-start
 [25]: ../../../operations/deploy-sensu/install-sensu#3-initialize
 [26]: ../../../sensuctl/#change-admin-users-password
+[27]: https://golang.org/pkg/net/http/pprof/
 [28]: ../checks/#subscriptions
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -61,6 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
+6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -565,3 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
+[43]: ../../maintain-sensu/troubleshoot/#log-levels

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -61,7 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
-6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
+6060 | HTTP/HTTPS | Required for all Sensu backends when performance profiling is enabled via [debug][43] setting |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -566,4 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
-[43]: ../../maintain-sensu/troubleshoot/#log-levels
+[43]: ../../../observability-pipeline/observe-schedule/backend/#debug-attribute

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -456,10 +456,11 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
+<a name="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
-description | If `true`, enable debugging and profiling features. Otherwise, `false`.
+description | If `true`, enable debugging and profiling features for use with the [Go pprof package][27]. Otherwise, `false`.
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
@@ -1467,5 +1468,6 @@ The _SIGHUP_ signal causes the `backend` component to reload instead of restarti
 [24]: ../../../operations/deploy-sensu/install-sensu#2-configure-and-start
 [25]: ../../../operations/deploy-sensu/install-sensu#3-initialize
 [26]: ../../../sensuctl/#change-admin-users-password
+[27]: https://golang.org/pkg/net/http/pprof/
 [28]: ../checks/#subscriptions
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -61,6 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
+6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -565,3 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
+[43]: ../../maintain-sensu/troubleshoot/#log-levels

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -61,7 +61,7 @@ Port | Protocol | Description |
 2379 | gRPC | Sensu storage client: Required for Sensu backends using an external etcd instance |
 2380 | gRPC | Sensu storage peer: Required for other Sensu backends in a [cluster][22] |
 3000 | HTTP/HTTPS | [Sensu web UI][3]: Required for all Sensu backends using a Sensu web UI |
-6060 | HTTP/HTTPS | Required for all Sensu backends when [debug log level][43] is enabled |
+6060 | HTTP/HTTPS | Required for all Sensu backends when performance profiling is enabled via [debug][43] setting |
 8080 | HTTP/HTTPS | [Sensu API][26]: Required for all users accessing the Sensu API |
 8081 | WS/WSS | Agent API: Required for all Sensu agents connecting to a Sensu backend |
 
@@ -566,4 +566,4 @@ sensuctl license info
 [40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
-[43]: ../../maintain-sensu/troubleshoot/#log-levels
+[43]: ../../../observability-pipeline/observe-schedule/backend/#debug-attribute


### PR DESCRIPTION
## Description
Add port 6060 to the list of ports the Sensu backend requires in https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/#ports

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2862