### PR TITLE
Move EC2 to dereg

### DIFF
--- a/content/sensu-go/6.0/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/_index.md
@@ -38,11 +38,11 @@ Although this category focuses on our most popular supported integrations, you c
 ## Deregistration
 
 - [Chef][11]
+- [EC2][2]
 - [Puppet][12]
 
 ## Time-series and long-term event storage
 
-- [EC2][2]
 - [Elasticsearch][13]
 - [InfluxDB][14]
 - [OpenTSDB][16]

--- a/content/sensu-go/6.1/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/_index.md
@@ -38,11 +38,11 @@ Although this category focuses on our most popular supported integrations, you c
 ## Deregistration
 
 - [Chef][11]
+- [EC2][2]
 - [Puppet][12]
 
 ## Time-series and long-term event storage
 
-- [EC2][2]
 - [Elasticsearch][13]
 - [InfluxDB][14]
 - [OpenTSDB][16]


### PR DESCRIPTION
## Description
Moves EC2 from TSDB to deregistration section on Supported Integrations index page.

## Motivation and Context
Mistake I merged in https://github.com/sensu/sensu-docs/pull/2833