### PR TITLE
Update links to Sensu blog posts

### DIFF
--- a/content/sensu-go/5.20/commercial.md
+++ b/content/sensu-go/5.20/commercial.md
@@ -82,7 +82,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [4]: ../api#response-filtering
 [5]: ../sensuctl/filter-responses/
 [6]: ../web-ui/filter/
-[7]: https://blog.sensu.io/one-year-of-sensu-go/
+[7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
 [9]: ../operations/control-access/
 [10]: ../reference/backend#event-logging

--- a/content/sensu-go/5.20/faq.md
+++ b/content/sensu-go/5.20/faq.md
@@ -104,7 +104,7 @@ Sensu Go does have a [built-in web UI][24] that you can use to visually interact
 
 [1]: ../platforms/
 [2]: ../operations/deploy-sensu/install-sensu/
-[3]: https://blog.sensu.io/sensu-go-is-here/
+[3]: https://sensu.io/blog/sensu-go-is-here/
 [4]: ../operations/maintain-sensu/upgrade/
 [5]: ../operations/deploy-sensu/hardware-requirements/
 [6]: https://sensu.io/sales/
@@ -131,9 +131,9 @@ Sensu Go does have a [built-in web UI][24] that you can use to visually interact
 [27]: ../operations/deploy-sensu/cluster-sensu/
 [28]: ../commercial/
 [30]: https://sensu.io/enterprise/
-[31]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[31]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [32]: https://bonsai.sensu.io/
 [33]: ../reference/assets/#share-an-asset-on-bonsai
-[34]: https://blog.sensu.io/one-year-of-sensu-go/
+[34]: https://sensu.io/blog/one-year-of-sensu-go/
 [36]: https://sensu.io/contact/
 [37]: #go-ports

--- a/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/install-sensu.md
@@ -552,7 +552,7 @@ sensuctl license info
 [26]: ../../../api/
 [27]: ../../../reference/agent#create-monitoring-events-using-the-agent-api
 [28]: ../../../reference/agent#create-monitoring-events-using-the-statsd-listener
-[29]: https://blog.sensu.io/one-year-of-sensu-go/
+[29]: https://sensu.io/blog/one-year-of-sensu-go/
 [30]: ../../../reference/backend#initialization
 [31]: ../deployment-architecture/
 [32]: http://localhost:3000/

--- a/content/sensu-go/5.20/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.20/operations/maintain-sensu/migrate.md
@@ -449,8 +449,8 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [24]: ../../../reference/entities#metadata-attributes
-[25]: https://blog.sensu.io/check-configuration-upgrades-with-the-sensu-go-sandbox/
-[26]: https://blog.sensu.io/self-service-monitoring-checks-in-sensu-go/
+[25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
+[26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../reference/backend#operation
@@ -482,7 +482,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [59]: https://bonsai.sensu.io/assets?q=eventfilter
 [60]: ../../../guides/reduce-alert-fatigue/
 [61]: ../../../reference/filters/#build-event-filter-expressions
-[62]: https://blog.sensu.io/filters-valves-for-the-sensu-monitoring-event-pipeline
+[62]: https://sensu.io/blog/filters-valves-for-the-sensu-monitoring-event-pipeline
 [63]: ../../../reference/filters/#built-in-filter-is_incident
 [64]: ../../../reference/filters/#built-in-filter-not_silenced
 [65]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-fatigue-check-filter

--- a/content/sensu-go/5.20/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/5.20/operations/maintain-sensu/upgrade.md
@@ -87,5 +87,5 @@ Then restart the backend.
 [2]: ../../../reference/backend#operation
 [3]: /images/web-ui-entity-warning.png
 [4]: https://sensu.io/contact?subject=contact-sales/
-[5]: https://blog.sensu.io/one-year-of-sensu-go
+[5]: https://sensu.io/blog/one-year-of-sensu-go
 [6]: ../../../commercial/

--- a/content/sensu-go/5.20/reference/entities.md
+++ b/content/sensu-go/5.20/reference/entities.md
@@ -1129,7 +1129,7 @@ spec:
 [8]: #metadata-attributes
 [9]: ../../commercial/
 [10]: https://sensu.io/contact
-[11]: https://blog.sensu.io/one-year-of-sensu-go
+[11]: https://sensu.io/blog/one-year-of-sensu-go
 [12]: ../../sensuctl/create-manage-resources/#create-resources
 [13]: #spec-attributes
 [14]: ../../api#response-filtering

--- a/content/sensu-go/5.20/reference/tessen.md
+++ b/content/sensu-go/5.20/reference/tessen.md
@@ -210,7 +210,7 @@ journalctl _COMM=sensu-backend.service
 
 To view the events on-disk, see [Log Sensu services with systemd][9].
 
-[1]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service
+[1]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service
 [2]: ../../api/tessen/
 [3]: ../../sensuctl/
 [4]: ../license/

--- a/content/sensu-go/5.20/release-notes.md
+++ b/content/sensu-go/5.20/release-notes.md
@@ -1191,7 +1191,7 @@ To get started with Sensu Go:
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
 [5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
-[6]: https://blog.sensu.io/sensu-go-is-here/
+[6]: https://sensu.io/blog/sensu-go-is-here/
 [7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
@@ -1199,7 +1199,7 @@ To get started with Sensu Go:
 [11]: /sensu-go/5.1/api/auth/
 [12]: /sensu-go/5.1/installation/install-sensu/
 [13]: https://nvd.nist.gov/vuln/detail/CVE-2019-6486/
-[14]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[14]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [15]: https://docs.sensu.io/sensu-go/5.2/reference/checks/#check-output-truncation-attributes
 [16]: /sensu-go/5.2/installation/install-sensu/
 [17]: /sensu-go/5.2/sensuctl/reference/#global-flags
@@ -1213,7 +1213,7 @@ To get started with Sensu Go:
 [25]: /sensu-go/5.4/guides/securing-sensu/
 [26]: /sensu-go/5.4/reference/agent#events-post
 [27]: /sensu-go/5.5/reference/tessen/
-[28]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service/
+[28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
 [29]: /sensu-go/5.5/reference/agent#general-configuration-flags
 [30]: /sensu-go/5.5/reference/agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/metrics/
@@ -1276,7 +1276,7 @@ To get started with Sensu Go:
 [88]: /sensu-go/5.15/api/overview/#authenticate-with-the-api-key-feature
 [89]: /sensu-go/5.15/sensuctl/reference/
 [90]: https://sensu.io/contact/
-[91]: https://blog.sensu.io/one-year-of-sensu-go/
+[91]: https://sensu.io/blog/one-year-of-sensu-go/
 [92]: /sensu-go/5.15/api/license/
 [93]: /sensu-go/5.15/sensuctl/sensuctl-bonsai#extend-sensuctl-with-commands
 [94]: /sensu-go/5.15/reference/checks/#cron-scheduling

--- a/content/sensu-go/5.21/commercial.md
+++ b/content/sensu-go/5.21/commercial.md
@@ -82,7 +82,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [4]: ../api#response-filtering
 [5]: ../sensuctl/filter-responses/
 [6]: ../web-ui/filter/
-[7]: https://blog.sensu.io/one-year-of-sensu-go/
+[7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
 [9]: ../operations/control-access/
 [10]: ../reference/backend#event-logging

--- a/content/sensu-go/5.21/faq.md
+++ b/content/sensu-go/5.21/faq.md
@@ -104,7 +104,7 @@ Sensu Go does have a [built-in web UI][24] that you can use to visually interact
 
 [1]: ../platforms/
 [2]: ../operations/deploy-sensu/install-sensu/
-[3]: https://blog.sensu.io/sensu-go-is-here/
+[3]: https://sensu.io/blog/sensu-go-is-here/
 [4]: ../operations/maintain-sensu/upgrade/
 [5]: ../operations/deploy-sensu/hardware-requirements/
 [6]: https://sensu.io/sales/
@@ -131,9 +131,9 @@ Sensu Go does have a [built-in web UI][24] that you can use to visually interact
 [27]: ../operations/deploy-sensu/cluster-sensu/
 [28]: ../commercial/
 [30]: https://sensu.io/enterprise/
-[31]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[31]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [32]: https://bonsai.sensu.io/
 [33]: ../reference/assets/#share-an-asset-on-bonsai
-[34]: https://blog.sensu.io/one-year-of-sensu-go/
+[34]: https://sensu.io/blog/one-year-of-sensu-go/
 [36]: https://sensu.io/contact/
 [37]: #go-ports

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
@@ -552,7 +552,7 @@ sensuctl license info
 [26]: ../../../api/
 [27]: ../../../reference/agent#create-monitoring-events-using-the-agent-api
 [28]: ../../../reference/agent#create-monitoring-events-using-the-statsd-listener
-[29]: https://blog.sensu.io/one-year-of-sensu-go/
+[29]: https://sensu.io/blog/one-year-of-sensu-go/
 [30]: ../../../reference/backend#initialization
 [31]: ../deployment-architecture/
 [32]: http://localhost:3000/

--- a/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
@@ -449,8 +449,8 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [24]: ../../../reference/entities#metadata-attributes
-[25]: https://blog.sensu.io/check-configuration-upgrades-with-the-sensu-go-sandbox/
-[26]: https://blog.sensu.io/self-service-monitoring-checks-in-sensu-go/
+[25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
+[26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../reference/backend#operation
@@ -482,7 +482,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [59]: https://bonsai.sensu.io/assets?q=eventfilter
 [60]: ../../../guides/reduce-alert-fatigue/
 [61]: ../../../reference/filters/#build-event-filter-expressions
-[62]: https://blog.sensu.io/filters-valves-for-the-sensu-monitoring-event-pipeline
+[62]: https://sensu.io/blog/filters-valves-for-the-sensu-monitoring-event-pipeline
 [63]: ../../../reference/filters/#built-in-filter-is_incident
 [64]: ../../../reference/filters/#built-in-filter-not_silenced
 [65]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-fatigue-check-filter

--- a/content/sensu-go/5.21/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/upgrade.md
@@ -87,5 +87,5 @@ Then restart the backend.
 [2]: ../../../reference/backend#operation
 [3]: /images/web-ui-entity-warning.png
 [4]: https://sensu.io/contact?subject=contact-sales/
-[5]: https://blog.sensu.io/one-year-of-sensu-go
+[5]: https://sensu.io/blog/one-year-of-sensu-go
 [6]: ../../../commercial/

--- a/content/sensu-go/5.21/reference/entities.md
+++ b/content/sensu-go/5.21/reference/entities.md
@@ -1129,7 +1129,7 @@ spec:
 [8]: #metadata-attributes
 [9]: ../../commercial/
 [10]: https://sensu.io/contact
-[11]: https://blog.sensu.io/one-year-of-sensu-go
+[11]: https://sensu.io/blog/one-year-of-sensu-go
 [12]: ../../sensuctl/create-manage-resources/#create-resources
 [13]: #spec-attributes
 [14]: ../../api#response-filtering

--- a/content/sensu-go/5.21/reference/tessen.md
+++ b/content/sensu-go/5.21/reference/tessen.md
@@ -210,7 +210,7 @@ journalctl _COMM=sensu-backend.service
 
 To view the events on-disk, see [Log Sensu services with systemd][9].
 
-[1]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service
+[1]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service
 [2]: ../../api/tessen/
 [3]: ../../sensuctl/
 [4]: ../license/

--- a/content/sensu-go/5.21/release-notes.md
+++ b/content/sensu-go/5.21/release-notes.md
@@ -1266,7 +1266,7 @@ To get started with Sensu Go:
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
 [5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
-[6]: https://blog.sensu.io/sensu-go-is-here/
+[6]: https://sensu.io/blog/sensu-go-is-here/
 [7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
@@ -1274,7 +1274,7 @@ To get started with Sensu Go:
 [11]: /sensu-go/5.1/api/auth/
 [12]: /sensu-go/5.1/installation/install-sensu/
 [13]: https://nvd.nist.gov/vuln/detail/CVE-2019-6486/
-[14]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[14]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [15]: https://docs.sensu.io/sensu-go/5.2/reference/checks/#check-output-truncation-attributes
 [16]: /sensu-go/5.2/installation/install-sensu/
 [17]: /sensu-go/5.2/sensuctl/reference/#global-flags
@@ -1288,7 +1288,7 @@ To get started with Sensu Go:
 [25]: /sensu-go/5.4/guides/securing-sensu/
 [26]: /sensu-go/5.4/reference/agent#events-post
 [27]: /sensu-go/5.5/reference/tessen/
-[28]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service/
+[28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
 [29]: /sensu-go/5.5/reference/agent#general-configuration-flags
 [30]: /sensu-go/5.5/reference/agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/metrics/
@@ -1351,7 +1351,7 @@ To get started with Sensu Go:
 [88]: /sensu-go/5.15/api/overview/#authenticate-with-the-api-key-feature
 [89]: /sensu-go/5.15/sensuctl/reference/
 [90]: https://sensu.io/contact/
-[91]: https://blog.sensu.io/one-year-of-sensu-go/
+[91]: https://sensu.io/blog/one-year-of-sensu-go/
 [92]: /sensu-go/5.15/api/license/
 [93]: /sensu-go/5.15/sensuctl/sensuctl-bonsai#extend-sensuctl-with-commands
 [94]: /sensu-go/5.15/reference/checks/#cron-scheduling

--- a/content/sensu-go/6.0/commercial.md
+++ b/content/sensu-go/6.0/commercial.md
@@ -82,7 +82,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [4]: ../api#response-filtering
 [5]: ../sensuctl/filter-responses/
 [6]: ../web-ui/filter/
-[7]: https://blog.sensu.io/one-year-of-sensu-go/
+[7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
 [9]: ../operations/control-access/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging

--- a/content/sensu-go/6.0/faq.md
+++ b/content/sensu-go/6.0/faq.md
@@ -104,7 +104,7 @@ Sensu Go does have a [built-in web UI][29] that you can use to visually interact
 
 [1]: ../platforms/
 [2]: ../installation/install-sensu/
-[3]: https://blog.sensu.io/sensu-go-is-here/
+[3]: https://sensu.io/blog/sensu-go-is-here/
 [4]: ../installation/upgrade/
 [5]: ../installation/recommended-hardware/
 [6]: https://sensu.io/sales/
@@ -132,9 +132,9 @@ Sensu Go does have a [built-in web UI][29] that you can use to visually interact
 [28]: ../commercial/
 [29]: web-ui/
 [30]: https://sensu.io/enterprise/
-[31]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[31]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [32]: https://bonsai.sensu.io/
 [33]: ../plugins/assets#share-an-asset-on-bonsai
-[34]: https://blog.sensu.io/one-year-of-sensu-go/
+[34]: https://sensu.io/blog/one-year-of-sensu-go/
 [36]: https://sensu.io/contact/
 [37]: #go-ports

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/_index.md
@@ -68,7 +68,7 @@ Use sensuctl or the license API to [view your overall entity count and limit][5]
 [1]: monitor-external-resources/
 [2]: ../../commercial/
 [3]: https://sensu.io/contact
-[4]: https://blog.sensu.io/one-year-of-sensu-go
+[4]: https://sensu.io/blog/one-year-of-sensu-go
 [5]: ../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [6]: entities/
 [7]: ../observe-schedule/checks/#proxy-entity-name-attribute

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -1129,7 +1129,7 @@ spec:
 [8]: #metadata-attributes
 [9]: ../../../commercial/
 [10]: https://sensu.io/contact
-[11]: https://blog.sensu.io/one-year-of-sensu-go
+[11]: https://sensu.io/blog/one-year-of-sensu-go
 [12]: ../../../sensuctl/create-manage-resources/#create-resources
 [13]: #spec-attributes
 [14]: ../../../api#response-filtering

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -552,7 +552,7 @@ sensuctl license info
 [26]: ../../../api/
 [27]: ../../../observability-pipeline/observe-schedule/agent#create-observability-events-using-the-agent-api
 [28]: ../../../observability-pipeline/observe-schedule/agent#create-observability-events-using-the-statsd-listener
-[29]: https://blog.sensu.io/one-year-of-sensu-go/
+[29]: https://sensu.io/blog/one-year-of-sensu-go/
 [30]: ../../../observability-pipeline/observe-schedule/backend#initialization
 [31]: ../deployment-architecture/
 [32]: http://localhost:3000/

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -449,8 +449,8 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
-[25]: https://blog.sensu.io/check-configuration-upgrades-with-the-sensu-go-sandbox/
-[26]: https://blog.sensu.io/self-service-monitoring-checks-in-sensu-go/
+[25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
+[26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../observability-pipeline/observe-schedule/backend#operation
@@ -482,7 +482,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [59]: https://bonsai.sensu.io/assets?q=eventfilter
 [60]: ../../../observability-pipeline/observe-filter/reduce-alert-fatigue/
 [61]: ../../../observability-pipeline/observe-filter/filters/#build-event-filter-expressions-with-sensu-query-expressions
-[62]: https://blog.sensu.io/filters-valves-for-the-sensu-monitoring-event-pipeline
+[62]: https://sensu.io/blog/filters-valves-for-the-sensu-monitoring-event-pipeline
 [63]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [64]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-not_silenced
 [65]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-fatigue-check-filter

--- a/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
@@ -136,5 +136,5 @@ Then restart the backend.
 [2]: ../../../observability-pipeline/observe-schedule/backend#operation
 [3]: /images/web-ui-entity-warning.png
 [4]: https://sensu.io/contact?subject=contact-sales/
-[5]: https://blog.sensu.io/one-year-of-sensu-go
+[5]: https://sensu.io/blog/one-year-of-sensu-go
 [6]: ../../../commercial/

--- a/content/sensu-go/6.0/operations/monitor-sensu/tessen.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/tessen.md
@@ -211,7 +211,7 @@ journalctl _COMM=sensu-backend.service
 
 To view the events on-disk, see [Log Sensu services with systemd][9].
 
-[1]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service
+[1]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service
 [2]: ../../../api/tessen/
 [3]: ../../../sensuctl/
 [4]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.0/release-notes.md
+++ b/content/sensu-go/6.0/release-notes.md
@@ -1326,7 +1326,7 @@ To get started with Sensu Go:
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
 [5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
-[6]: https://blog.sensu.io/sensu-go-is-here/
+[6]: https://sensu.io/blog/sensu-go-is-here/
 [7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
@@ -1334,7 +1334,7 @@ To get started with Sensu Go:
 [11]: /sensu-go/5.1/api/auth/
 [12]: /sensu-go/5.1/installation/install-sensu/
 [13]: https://nvd.nist.gov/vuln/detail/CVE-2019-6486/
-[14]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[14]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [15]: https://docs.sensu.io/sensu-go/5.2/reference/checks/#check-output-truncation-attributes
 [16]: /sensu-go/5.2/installation/install-sensu/
 [17]: /sensu-go/5.2/sensuctl/reference/#global-flags
@@ -1348,7 +1348,7 @@ To get started with Sensu Go:
 [25]: /sensu-go/5.4/guides/securing-sensu/
 [26]: /sensu-go/5.4/reference/agent#events-post
 [27]: /sensu-go/5.5/reference/tessen/
-[28]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service/
+[28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
 [29]: /sensu-go/5.5/reference/agent#general-configuration-flags
 [30]: /sensu-go/5.5/reference/agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/metrics/
@@ -1411,7 +1411,7 @@ To get started with Sensu Go:
 [88]: /sensu-go/5.15/api/overview/#authenticate-with-the-api-key-feature
 [89]: /sensu-go/5.15/sensuctl/reference/
 [90]: https://sensu.io/contact/
-[91]: https://blog.sensu.io/one-year-of-sensu-go/
+[91]: https://sensu.io/blog/one-year-of-sensu-go/
 [92]: /sensu-go/5.15/api/license/
 [93]: /sensu-go/5.15/sensuctl/sensuctl-bonsai#extend-sensuctl-with-commands
 [94]: /sensu-go/5.15/reference/checks/#cron-scheduling

--- a/content/sensu-go/6.1/commercial.md
+++ b/content/sensu-go/6.1/commercial.md
@@ -82,7 +82,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [4]: ../api#response-filtering
 [5]: ../sensuctl/filter-responses/
 [6]: ../web-ui/search/
-[7]: https://blog.sensu.io/one-year-of-sensu-go/
+[7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
 [9]: ../operations/control-access/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging

--- a/content/sensu-go/6.1/faq.md
+++ b/content/sensu-go/6.1/faq.md
@@ -104,7 +104,7 @@ Sensu Go does have a [built-in web UI][29] that you can use to visually interact
 
 [1]: ../platforms/
 [2]: ../installation/install-sensu/
-[3]: https://blog.sensu.io/sensu-go-is-here/
+[3]: https://sensu.io/blog/sensu-go-is-here/
 [4]: ../installation/upgrade/
 [5]: ../installation/recommended-hardware/
 [6]: https://sensu.io/sales/
@@ -132,9 +132,9 @@ Sensu Go does have a [built-in web UI][29] that you can use to visually interact
 [28]: ../commercial/
 [29]: web-ui/
 [30]: https://sensu.io/enterprise/
-[31]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[31]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [32]: https://bonsai.sensu.io/
 [33]: ../plugins/assets#share-an-asset-on-bonsai
-[34]: https://blog.sensu.io/one-year-of-sensu-go/
+[34]: https://sensu.io/blog/one-year-of-sensu-go/
 [36]: https://sensu.io/contact/
 [37]: #go-ports

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/_index.md
@@ -68,7 +68,7 @@ Use sensuctl or the license API to [view your overall entity count and limit][5]
 [1]: monitor-external-resources/
 [2]: ../../commercial/
 [3]: https://sensu.io/contact
-[4]: https://blog.sensu.io/one-year-of-sensu-go
+[4]: https://sensu.io/blog/one-year-of-sensu-go
 [5]: ../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [6]: entities/
 [7]: ../observe-schedule/checks/#proxy-entity-name-attribute

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -1129,7 +1129,7 @@ spec:
 [8]: #metadata-attributes
 [9]: ../../../commercial/
 [10]: https://sensu.io/contact
-[11]: https://blog.sensu.io/one-year-of-sensu-go
+[11]: https://sensu.io/blog/one-year-of-sensu-go
 [12]: ../../../sensuctl/create-manage-resources/#create-resources
 [13]: #spec-attributes
 [14]: ../../../api#response-filtering

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -552,7 +552,7 @@ sensuctl license info
 [26]: ../../../api/
 [27]: ../../../observability-pipeline/observe-schedule/agent#create-observability-events-using-the-agent-api
 [28]: ../../../observability-pipeline/observe-schedule/agent#create-observability-events-using-the-statsd-listener
-[29]: https://blog.sensu.io/one-year-of-sensu-go/
+[29]: https://sensu.io/blog/one-year-of-sensu-go/
 [30]: ../../../observability-pipeline/observe-schedule/backend#initialization
 [31]: ../deployment-architecture/
 [32]: http://localhost:3000/

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -449,8 +449,8 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
-[25]: https://blog.sensu.io/check-configuration-upgrades-with-the-sensu-go-sandbox/
-[26]: https://blog.sensu.io/self-service-monitoring-checks-in-sensu-go/
+[25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
+[26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../observability-pipeline/observe-schedule/backend#operation
@@ -482,7 +482,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [59]: https://bonsai.sensu.io/assets?q=eventfilter
 [60]: ../../../observability-pipeline/observe-filter/reduce-alert-fatigue/
 [61]: ../../../observability-pipeline/observe-filter/filters/#build-event-filter-expressions-with-sensu-query-expressions
-[62]: https://blog.sensu.io/filters-valves-for-the-sensu-monitoring-event-pipeline
+[62]: https://sensu.io/blog/filters-valves-for-the-sensu-monitoring-event-pipeline
 [63]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [64]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-not_silenced
 [65]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-fatigue-check-filter

--- a/content/sensu-go/6.1/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/upgrade.md
@@ -160,5 +160,5 @@ Then restart the backend.
 [2]: ../../../observability-pipeline/observe-schedule/backend#operation
 [3]: /images/web-ui-entity-warning.png
 [4]: https://sensu.io/contact?subject=contact-sales/
-[5]: https://blog.sensu.io/one-year-of-sensu-go
+[5]: https://sensu.io/blog/one-year-of-sensu-go
 [6]: ../../../commercial/

--- a/content/sensu-go/6.1/operations/monitor-sensu/tessen.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/tessen.md
@@ -211,7 +211,7 @@ journalctl _COMM=sensu-backend.service
 
 To view the events on-disk, see [Log Sensu services with systemd][9].
 
-[1]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service
+[1]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service
 [2]: ../../../api/tessen/
 [3]: ../../../sensuctl/
 [4]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -1429,7 +1429,7 @@ To get started with Sensu Go:
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
 [5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
-[6]: https://blog.sensu.io/sensu-go-is-here/
+[6]: https://sensu.io/blog/sensu-go-is-here/
 [7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
@@ -1437,7 +1437,7 @@ To get started with Sensu Go:
 [11]: /sensu-go/5.1/api/auth/
 [12]: /sensu-go/5.1/installation/install-sensu/
 [13]: https://nvd.nist.gov/vuln/detail/CVE-2019-6486/
-[14]: https://blog.sensu.io/enterprise-features-in-sensu-go/
+[14]: https://sensu.io/blog/enterprise-features-in-sensu-go/
 [15]: https://docs.sensu.io/sensu-go/5.2/reference/checks/#check-output-truncation-attributes
 [16]: /sensu-go/5.2/installation/install-sensu/
 [17]: /sensu-go/5.2/sensuctl/reference/#global-flags
@@ -1451,7 +1451,7 @@ To get started with Sensu Go:
 [25]: /sensu-go/5.4/guides/securing-sensu/
 [26]: /sensu-go/5.4/reference/agent#events-post
 [27]: /sensu-go/5.5/reference/tessen/
-[28]: https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service/
+[28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
 [29]: /sensu-go/5.5/reference/agent#general-configuration-flags
 [30]: /sensu-go/5.5/reference/agent#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/metrics/
@@ -1514,7 +1514,7 @@ To get started with Sensu Go:
 [88]: /sensu-go/5.15/api/overview/#authenticate-with-the-api-key-feature
 [89]: /sensu-go/5.15/sensuctl/reference/
 [90]: https://sensu.io/contact/
-[91]: https://blog.sensu.io/one-year-of-sensu-go/
+[91]: https://sensu.io/blog/one-year-of-sensu-go/
 [92]: /sensu-go/5.15/api/license/
 [93]: /sensu-go/5.15/sensuctl/sensuctl-bonsai#extend-sensuctl-with-commands
 [94]: /sensu-go/5.15/reference/checks/#cron-scheduling


### PR DESCRIPTION
## Description
Update links to sensu.io blog posts throughout our docs to use the new URLs: change `blog.sensu.io` to `sensu.io/blog`

## Motivation and Context
Anna notified me about the URL change in our 1:1 last week.
