### PR TITLE
Document #sensu.io.graphic appendix for displaying inline images in web UI

### DIFF
--- a/content/sensu-go/6.1/api/webconfig.md
+++ b/content/sensu-go/6.1/api/webconfig.md
@@ -53,7 +53,8 @@ HTTP/1.1 200 OK
           "steamapp://34234234",
           "//google.com",
           "//*.google.com",
-          "//bob.local"
+          "//bob.local",
+          "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
         ]
       }
     }
@@ -91,7 +92,8 @@ output         | {{< code shell >}}
           "steamapp://34234234",
           "//google.com",
           "//*.google.com",
-          "//bob.local"
+          "//bob.local",
+          "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
         ]
       }
     }
@@ -133,7 +135,8 @@ HTTP/1.1 200 OK
         "steamapp://34234234",
         "//google.com",
         "//*.google.com",
-        "//bob.local"
+        "//bob.local",
+        "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
       ]
     }
   }
@@ -169,7 +172,8 @@ output               | {{< code json >}}
         "steamapp://34234234",
         "//google.com",
         "//*.google.com",
-        "//bob.local"
+        "//bob.local",
+        "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
       ]
     }
   }
@@ -208,7 +212,8 @@ curl -X PUT \
         "steamapp://34234234",
         "//google.com",
         "//*.google.com",
-        "//bob.local"
+        "//bob.local",
+        "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
       ]
     }
   }
@@ -245,7 +250,8 @@ payload         | {{< code shell >}}
         "steamapp://34234234",
         "//google.com",
         "//*.google.com",
-        "//bob.local"
+        "//bob.local",
+        "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
       ]
     }
   }

--- a/content/sensu-go/6.1/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.1/web-ui/webconfig-reference.md
@@ -71,7 +71,8 @@ example      | {{< code shell >}}
       "steamapp://34234234",
       "//google.com",
       "//*.google.com",
-      "//bob.local"
+      "//bob.local",
+      "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
     ]
   }
 }
@@ -127,7 +128,8 @@ example      | {{< code shell >}}"link_policy": {
     "steamapp://34234234",
     "//google.com",
     "//*.google.com",
-    "//bob.local"
+    "//bob.local",
+    "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
   ]
 }{{< /code >}}
 
@@ -165,7 +167,8 @@ example      | {{< code shell >}}"allow_list": true{{< /code >}}
 
 urls | 
 -------------|------ 
-description  | The list of URLs to use as an allow or deny list.
+description  | The list of URLs to use as an allow or deny list.<br>{{% notice note %}}**NOTE**: For images from services that may not have an easily distinguishable file extension, append the anchor `#sensu.io.graphic` to the image URLs.
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< code shell >}}"urls": [
@@ -173,7 +176,8 @@ example      | {{< code shell >}}"urls": [
   "steamapp://34234234",
   "//google.com",
   "//*.google.com",
-  "//bob.local"
+  "//bob.local",
+  "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
 ]{{< /code >}}
 
 ## Web UI configuration examples
@@ -205,6 +209,7 @@ spec:
     - //google.com
     - //*.google.com
     - //bob.local
+    - https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic
 {{< /code >}}
 
 {{< code json >}}
@@ -228,7 +233,8 @@ spec:
         "steamapp://34234234",
         "//google.com",
         "//*.google.com",
-        "//bob.local"
+        "//bob.local",
+        "https://grafana-host/render/metrics?width=500&height=250#sensu.io.graphic"
       ]
     }
   }


### PR DESCRIPTION
## Description
- Adds note to explain when and how to use the `#sensu.io.graphic` anchor link to ensure linked images from services like Grafana will appear in the web UI in the web UI config reference doc.
- Adds link that uses `#sensu.io.graphic` to all examples in the web UI config reference and API doc.

## Motivation and Context
Appendix added in https://github.com/sensu/sensu-enterprise-go/blob/main/dashboard/src/app/util/url.ts#L22
