### PR TITLE
Add graphite integrations and correct tsdb descriptions in notes

### DIFF
--- a/content/sensu-go/6.0/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/_index.md
@@ -45,6 +45,7 @@ Although this category focuses on our most popular supported integrations, you c
 
 - [Elasticsearch][13]
 - [InfluxDB][14]
+- [Graphite][15]
 - [OpenTSDB][16]
 - [Prometheus][17]
 - [TimescaleDB][18]
@@ -65,6 +66,7 @@ Although this category focuses on our most popular supported integrations, you c
 [12]: puppet/
 [13]: elasticsearch/
 [14]: influxdb/
+[15]: graphite/
 [16]: opentsdb/
 [17]: prometheus/
 [18]: timescaledb/

--- a/content/sensu-go/6.0/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/elasticsearch.md
@@ -16,7 +16,7 @@ The Sensu Elasticsearch Handler plugin is a Sensu [handler][1] that sends observ
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
 
 {{% notice note %}}
-**NOTE**: The Sensu Elasticsearch Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu Elasticsearch Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/plugins/supported-integrations/graphite.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/graphite.md
@@ -1,0 +1,38 @@
+---
+title: "Graphite integration"
+linkTitle: "Graphite"
+description: "Use the Sensu Graphite Handler plugin to integrate Sensu with your existing Graphite workflows. Read about the features of Sensu's Graphite integration and learn how to get the plugin."
+version: "6.0"
+product: "Sensu Go"
+menu: 
+  sensu-go-6.0:
+    parent: supported-integrations
+---
+
+The Sensu Graphite Handler plugin is a Sensu [handler][1] that sends Sensu metrics to the time-series database Graphite so you can store, instrument, and visualize Sensu metrics data.
+
+{{% notice note %}}
+**NOTE**: The Sensu Graphite Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
+To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
+{{% /notice %}}
+
+## Features
+
+- Transform metrics to Graphite format: extract and transform the metrics you collect from different sources in formats like Influx, Nagios, and OpenTSDB and populate them into Graphite.
+- Specify custom values for Sensu event metric points via [metric tags][4].
+- Keep your Graphite host and port secure with Sensu [environment variables and secrets management][6].
+
+## Get the plugin
+
+For a turnkey experience with the Sensu Graphite Handler plugin, use our curated, configurable [quick-start template][5] to integrate Sensu with your existing workflows and store Sensu metrics in Graphite.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Graphite Handler plugin][2] with a dynamic runtime asset from Bonsai, the Sensu asset hub.
+[Dynamic runtime assets][3] are shareable, reusable packages that make it easier to deploy Sensu plugins.
+
+
+[1]: ../../../observability-pipeline/observe-process/handlers/
+[2]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-graphite-handler
+[3]: ../../assets/
+[4]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
+[5]: https://github.com/sensu-community/monitoring-pipelines/blob/master/metric-storage/graphite.yaml
+[6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/influxdb.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/influxdb.md
@@ -13,7 +13,7 @@ The Sensu InfluxDB Handler plugin is a Sensu [handler][1] that sends Sensu metri
 You can also use the Sensu InfluxDB Handler integration to create metrics from Sensu status check results for long-term storage in InfluxDB.
 
 {{% notice note %}}
-**NOTE**: The Sensu InfluxDB Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu InfluxDB Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/plugins/supported-integrations/opentsdb.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/opentsdb.md
@@ -13,7 +13,7 @@ The Sensu OpenTSDB Handler plugin is a Sensu [handler][1] that sends Sensu metri
 This allows you to extract, tag, and store Sensu metrics data in an OpenTSDB database.
 
 {{% notice note %}}
-**NOTE**: The Sensu OpenTSDB Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu OpenTSDB Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/plugins/supported-integrations/prometheus.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/prometheus.md
@@ -13,7 +13,7 @@ Sensu has two Prometheus plugins: the [Prometheus Collector][3] and the [Prometh
 Both help you get Sensu observability data into Prometheus.
 
 {{% notice note %}}
-**NOTE**: The Sensu Prometheus plugins are examples of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu Prometheus plugins are examples of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/plugins/supported-integrations/timescaledb.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/timescaledb.md
@@ -12,7 +12,7 @@ menu:
 The Sensu TimescaleDB Handler plugin is a Sensu [handler][1] that sends Sensu metrics to the time-series database TimescaleDB so you can store, instrument, and visualize Sensu metrics data.
 
 {{% notice note %}}
-**NOTE**: The Sensu TimescaleDB Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu TimescaleDB Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/plugins/supported-integrations/wavefront.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/wavefront.md
@@ -12,7 +12,7 @@ menu:
 The Sensu Wavefront Handler plugin is a Sensu [handler][1] that sends Sensu metrics to Wavefront via a proxy, which allows you to store, instrument, and visualize Sensu metrics data in an Wavefront database.
 
 {{% notice note %}}
-**NOTE**: The Sensu Wavefront Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu Wavefront Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 
@@ -20,6 +20,7 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 - Transform metrics to Wavefront format: extract and transform the metrics you collect from different sources in formats like Graphite, OpenTSDB, Nagios, and Influx and populate them into Wavefront.
 - Specify additional tags to include when processing metrics either using the Wavefront plugin's `--tags` flag or via [metric tags][7].
+- Keep your Wavefront host and port secure with Sensu [environment variables and secrets management][6].
 
 ## Get the plugin
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/_index.md
@@ -44,6 +44,7 @@ Although this category focuses on our most popular supported integrations, you c
 ## Time-series and long-term event storage
 
 - [Elasticsearch][13]
+- [Graphite][15]
 - [InfluxDB][14]
 - [OpenTSDB][16]
 - [Prometheus][17]
@@ -65,6 +66,7 @@ Although this category focuses on our most popular supported integrations, you c
 [12]: puppet/
 [13]: elasticsearch/
 [14]: influxdb/
+[15]: graphite/
 [16]: opentsdb/
 [17]: prometheus/
 [18]: timescaledb/

--- a/content/sensu-go/6.1/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/elasticsearch.md
@@ -16,7 +16,7 @@ The Sensu Elasticsearch Handler plugin is a Sensu [handler][1] that sends observ
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
 
 {{% notice note %}}
-**NOTE**: The Sensu Elasticsearch Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu Elasticsearch Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/graphite.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/graphite.md
@@ -1,0 +1,38 @@
+---
+title: "Graphite integration"
+linkTitle: "Graphite"
+description: "Use the Sensu Graphite Handler plugin to integrate Sensu with your existing Graphite workflows. Read about the features of Sensu's Graphite integration and learn how to get the plugin."
+version: "6.1"
+product: "Sensu Go"
+menu: 
+  sensu-go-6.1:
+    parent: supported-integrations
+---
+
+The Sensu Graphite Handler plugin is a Sensu [handler][1] that sends Sensu metrics to the time-series database Graphite so you can store, instrument, and visualize Sensu metrics data.
+
+{{% notice note %}}
+**NOTE**: The Sensu Graphite Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
+To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
+{{% /notice %}}
+
+## Features
+
+- Transform metrics to Graphite format: extract and transform the metrics you collect from different sources in formats like Influx, Nagios, and OpenTSDB and populate them into Graphite.
+- Specify custom values for Sensu event metric points via [metric tags][4].
+- Keep your Graphite host and port secure with Sensu [environment variables and secrets management][6].
+
+## Get the plugin
+
+For a turnkey experience with the Sensu Graphite Handler plugin, use our curated, configurable [quick-start template][5] to integrate Sensu with your existing workflows and store Sensu metrics in Graphite.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Graphite Handler plugin][2] with a dynamic runtime asset from Bonsai, the Sensu asset hub.
+[Dynamic runtime assets][3] are shareable, reusable packages that make it easier to deploy Sensu plugins.
+
+
+[1]: ../../../observability-pipeline/observe-process/handlers/
+[2]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-graphite-handler
+[3]: ../../assets/
+[4]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
+[5]: https://github.com/sensu-community/monitoring-pipelines/blob/master/metric-storage/graphite.yaml
+[6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/influxdb.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/influxdb.md
@@ -13,7 +13,7 @@ The Sensu InfluxDB Handler plugin is a Sensu [handler][1] that sends Sensu metri
 You can also use the Sensu InfluxDB Handler integration to create metrics from Sensu status check results for long-term storage in InfluxDB.
 
 {{% notice note %}}
-**NOTE**: The Sensu InfluxDB Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu InfluxDB Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/opentsdb.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/opentsdb.md
@@ -13,7 +13,7 @@ The Sensu OpenTSDB Handler plugin is a Sensu [handler][1] that sends Sensu metri
 This allows you to extract, tag, and store Sensu metrics data in an OpenTSDB database.
 
 {{% notice note %}}
-**NOTE**: The Sensu OpenTSDB Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu OpenTSDB Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/prometheus.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/prometheus.md
@@ -13,7 +13,7 @@ Sensu has two Prometheus plugins: the [Prometheus Collector][3] and the [Prometh
 Both help you get Sensu observability data into Prometheus.
 
 {{% notice note %}}
-**NOTE**: The Sensu Prometheus plugins are examples of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu Prometheus plugins are examples of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/timescaledb.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/timescaledb.md
@@ -12,7 +12,7 @@ menu:
 The Sensu TimescaleDB Handler plugin is a Sensu [handler][1] that sends Sensu metrics to the time-series database TimescaleDB so you can store, instrument, and visualize Sensu metrics data.
 
 {{% notice note %}}
-**NOTE**: The Sensu TimescaleDB Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu TimescaleDB Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/wavefront.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/wavefront.md
@@ -12,7 +12,7 @@ menu:
 The Sensu Wavefront Handler plugin is a Sensu [handler][1] that sends Sensu metrics to Wavefront via a proxy, which allows you to store, instrument, and visualize Sensu metrics data in an Wavefront database.
 
 {{% notice note %}}
-**NOTE**: The Sensu Wavefront Handler plugin is an example of Sensu's status and metrics processing and storage integrations.
+**NOTE**: The Sensu Wavefront Handler plugin is an example of Sensu's time-series and long-term event storage integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 
@@ -20,6 +20,7 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 - Transform metrics to Wavefront format: extract and transform the metrics you collect from different sources in formats like Graphite, OpenTSDB, Nagios, and Influx and populate them into Wavefront.
 - Specify additional tags to include when processing metrics either using the Wavefront plugin's `--tags` flag or via [metric tags][7].
+- Keep your Graphite host and port secure with Sensu [environment variables and secrets management][6].
 
 ## Get the plugin
 


### PR DESCRIPTION
## Description
- Adds pages for the Graphite integration in the supported integrations category
- Adds Graphite to list on supported integrations index page
- Corrects description note suggesting Bonsai search for all TSDB integrations

## Motivation and Context
Suggestion from https://discourse.sensu.io/t/docs-changes-plugins-docs-moved-plus-a-new-supported-integrations-sub-category/2316/2