### PR TITLE
Correct links to fatigue check filter in Bonsai

### DIFF
--- a/content/sensu-go/5.20/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.20/guides/reduce-alert-fatigue.md
@@ -60,7 +60,7 @@ This will help you understand what assets are and how they are used in Sensu.
 
 In this approach, the first step is to obtain an event filter asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use [`sensuctl asset add`][5] to register the [fatigue check filter][9] asset:
+Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] asset:
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter

--- a/content/sensu-go/5.21/guides/reduce-alert-fatigue.md
+++ b/content/sensu-go/5.21/guides/reduce-alert-fatigue.md
@@ -60,7 +60,7 @@ This will help you understand what assets are and how they are used in Sensu.
 
 In this approach, the first step is to obtain an event filter asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use [`sensuctl asset add`][5] to register the [fatigue check filter][9] asset:
+Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] asset:
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -62,7 +62,7 @@ This will help you understand what dynamic runtime assets are and how they are u
 
 In this approach, the first step is to obtain an event filter dynamic runtime asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use [`sensuctl asset add`][5] to register the [fatigue check filter][9] dynamic runtime asset:
+Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -62,7 +62,7 @@ This will help you understand what dynamic runtime assets are and how they are u
 
 In this approach, the first step is to obtain an event filter dynamic runtime asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use [`sensuctl asset add`][5] to register the [fatigue check filter][9] dynamic runtime asset:
+Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter


### PR DESCRIPTION
## Description
Fixed incorrect link references for the fatigue check filter asset in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/reduce-alert-fatigue/#approach-2-use-an-event-filter-dynamic-runtime-asset.

## Motivation and Context
Found incorrect link (pointed to `[9]` instead of `[8]`)
