### PR TITLE
Correct the note in the EC2 handler integration doc

### DIFF
--- a/content/sensu-go/6.0/plugins/supported-integrations/aws-ec2.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/aws-ec2.md
@@ -12,7 +12,7 @@ menu:
 The Sensu EC2 Handler plugin is a Sensu [handler][1] that checks an AWS EC2 instance and removes it from Sensu if it is not in one of the specified states.
 
 {{% notice note %}}
-**NOTE**: The Sensu EC2 Handler plugin is an example of Sensu's alerting and incident management integrations.
+**NOTE**: The Sensu EC2 Handler plugin is an example of Sensu's deregistration integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/aws-ec2.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/aws-ec2.md
@@ -12,7 +12,7 @@ menu:
 The Sensu EC2 Handler plugin is a Sensu [handler][1] that checks an AWS EC2 instance and removes it from Sensu if it is not in one of the specified states.
 
 {{% notice note %}}
-**NOTE**: The Sensu EC2 Handler plugin is an example of Sensu's alerting and incident management integrations.
+**NOTE**: The Sensu EC2 Handler plugin is an example of Sensu's deregistration integrations.
 To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
 {{% /notice %}}
 


### PR DESCRIPTION
## Description
Correct the note in the EC2 integration doc to state that EC2 is a deregistration integration.

## Motivation and Context
Current note is incorrect -- says EC2 is an alert and incident mgmt integration
