### PR TITLE
Reverse order of first two paragraphs in asset reference

### DIFF
--- a/content/sensu-go/6.0/plugins/assets.md
+++ b/content/sensu-go/6.0/plugins/assets.md
@@ -13,12 +13,12 @@ menu:
     parent: plugins
 ---
 
-You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
-Read [Use assets to install plugins][23] to get started.
-
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].
 You can use dynamic runtime assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
 Sensu supports dynamic runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
+
+You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
+Read [Use assets to install plugins][23] to get started.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime assets are not required to use Sensu Go.

--- a/content/sensu-go/6.1/plugins/assets.md
+++ b/content/sensu-go/6.1/plugins/assets.md
@@ -13,12 +13,12 @@ menu:
     parent: plugins
 ---
 
-You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
-Read [Use assets to install plugins][23] to get started.
-
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].
 You can use dynamic runtime assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
 Sensu supports dynamic runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
+
+You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
+Read [Use assets to install plugins][23] to get started.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime assets are not required to use Sensu Go.

--- a/content/sensu-go/6.2/plugins/assets.md
+++ b/content/sensu-go/6.2/plugins/assets.md
@@ -13,12 +13,12 @@ menu:
     parent: plugins
 ---
 
-You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
-Read [Use assets to install plugins][23] to get started.
-
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu [plugins][29].
 You can use dynamic runtime assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
 Sensu supports dynamic runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
+
+You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
+Read [Use assets to install plugins][23] to get started.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime assets are not required to use Sensu Go.


### PR DESCRIPTION
## Description
Reverses the order of the first two paragraphs in the asset reference

## Motivation and Context
I think we should define assets before we tell people where to find more of them
