### PR TITLE
6.2.0: Add config-file environment variables

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -977,7 +977,7 @@ cache-dir: "/cache/sensu-agent"{{< /code >}}
 description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
-environment variable | The config file path cannot be set by an environment variable.
+environment variable | `SENSU_CONFIG_FILE`
 example       | {{< code shell >}}# Command line example
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -450,7 +450,7 @@ cache-dir: "/cache/sensu-backend"{{< /code >}}
 description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
-environment variable | The config file path cannot be set by an environment variable.
+environment variable | `SENSU_BACKEND_CONFIG_FILE`
 example       | {{< code shell >}}# Command line example
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml


### PR DESCRIPTION
## Description
Adds environment variables to the description tables for the config-file flags in the agent and backend references. The env vars will be added in 6.2.0.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2885