### PR TITLE
Update agent cert names to match Generate Certificates

### DIFF
--- a/content/sensu-go/5.20/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.20/operations/deploy-sensu/secure-sensu.md
@@ -191,8 +191,8 @@ agent-auth-trusted-ca-file: "/path/to/ca.pem"
 ##
 # agent configuration
 ##
-cert-file: "/path/to/agent-1.pem"
-key-file: "/path/to/agent-1-key.pem"
+cert-file: "/path/to/agent.pem"
+key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/5.20/reference/agent.md
+++ b/content/sensu-go/5.20/reference/agent.md
@@ -1312,10 +1312,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent-1.pem
+sensu-agent start --cert-file /path/to/agent.pem
 
 # /etc/sensu/agent.yml example
-cert-file: "/path/to/agent-1.pem"{{< /code >}}
+cert-file: "/path/to/agent.pem"{{< /code >}}
 
 
 | trusted-ca-file |      |
@@ -1338,10 +1338,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-1-key.pem
+sensu-agent start --key-file /path/to/agent-key.pem
 
 # /etc/sensu/agent.yml example
-key-file: "/path/to/agent-1-key.pem"{{< /code >}}
+key-file: "/path/to/agent-key.pem"{{< /code >}}
 
 
 

--- a/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
@@ -191,8 +191,8 @@ agent-auth-trusted-ca-file: "/path/to/ca.pem"
 ##
 # agent configuration
 ##
-cert-file: "/path/to/agent-1.pem"
-key-file: "/path/to/agent-1-key.pem"
+cert-file: "/path/to/agent.pem"
+key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -1316,10 +1316,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent-1.pem
+sensu-agent start --cert-file /path/to/agent.pem
 
 # /etc/sensu/agent.yml example
-cert-file: "/path/to/agent-1.pem"{{< /code >}}
+cert-file: "/path/to/agent.pem"{{< /code >}}
 
 
 | trusted-ca-file |      |
@@ -1342,10 +1342,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-1-key.pem
+sensu-agent start --key-file /path/to/agent-key.pem
 
 # /etc/sensu/agent.yml example
-key-file: "/path/to/agent-1-key.pem"{{< /code >}}
+key-file: "/path/to/agent-key.pem"{{< /code >}}
 
 
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -1315,10 +1315,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent-1.pem
+sensu-agent start --cert-file /path/to/agent.pem
 
 # /etc/sensu/agent.yml example
-cert-file: "/path/to/agent-1.pem"{{< /code >}}
+cert-file: "/path/to/agent.pem"{{< /code >}}
 
 
 | trusted-ca-file |      |
@@ -1341,10 +1341,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-1-key.pem
+sensu-agent start --key-file /path/to/agent-key.pem
 
 # /etc/sensu/agent.yml example
-key-file: "/path/to/agent-1-key.pem"{{< /code >}}
+key-file: "/path/to/agent-key.pem"{{< /code >}}
 
 
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -193,8 +193,8 @@ agent-auth-trusted-ca-file: "/path/to/ca.pem"
 ##
 # agent configuration
 ##
-cert-file: "/path/to/agent-1.pem"
-key-file: "/path/to/agent-1-key.pem"
+cert-file: "/path/to/agent.pem"
+key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -1314,10 +1314,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent-1.pem
+sensu-agent start --cert-file /path/to/agent.pem
 
 # /etc/sensu/agent.yml example
-cert-file: "/path/to/agent-1.pem"{{< /code >}}
+cert-file: "/path/to/agent.pem"{{< /code >}}
 
 
 | trusted-ca-file |      |
@@ -1340,10 +1340,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-1-key.pem
+sensu-agent start --key-file /path/to/agent-key.pem
 
 # /etc/sensu/agent.yml example
-key-file: "/path/to/agent-1-key.pem"{{< /code >}}
+key-file: "/path/to/agent-key.pem"{{< /code >}}
 
 
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -193,8 +193,8 @@ agent-auth-trusted-ca-file: "/path/to/ca.pem"
 ##
 # agent configuration
 ##
-cert-file: "/path/to/agent-1.pem"
-key-file: "/path/to/agent-1-key.pem"
+cert-file: "/path/to/agent.pem"
+key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -1314,10 +1314,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent-1.pem
+sensu-agent start --cert-file /path/to/agent.pem
 
 # /etc/sensu/agent.yml example
-cert-file: "/path/to/agent-1.pem"{{< /code >}}
+cert-file: "/path/to/agent.pem"{{< /code >}}
 
 
 | trusted-ca-file |      |
@@ -1340,10 +1340,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
 example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-1-key.pem
+sensu-agent start --key-file /path/to/agent-key.pem
 
 # /etc/sensu/agent.yml example
-key-file: "/path/to/agent-1-key.pem"{{< /code >}}
+key-file: "/path/to/agent-key.pem"{{< /code >}}
 
 
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -193,8 +193,8 @@ agent-auth-trusted-ca-file: "/path/to/ca.pem"
 ##
 # agent configuration
 ##
-cert-file: "/path/to/agent-1.pem"
-key-file: "/path/to/agent-1-key.pem"
+cert-file: "/path/to/agent.pem"
+key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 


### PR DESCRIPTION
## Description
In Agent reference and Secure Sensu, updates names for agent certs to use `agent` with no number to match the names used in Generate Certificates.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2272