### PR TITLE
Fix namespace API sample URLs

### DIFF
--- a/content/sensu-go/5.20/api/namespaces.md
+++ b/content/sensu-go/5.20/api/namespaces.md
@@ -74,7 +74,7 @@ curl -X POST \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces
+http://127.0.0.1:8080/api/core/v2/namespaces
 
 HTTP/1.1 201 Created
 {{< /code >}}
@@ -108,7 +108,7 @@ curl -X PUT \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces/development
+http://127.0.0.1:8080/api/core/v2/namespaces/development
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/5.21/api/namespaces.md
+++ b/content/sensu-go/5.21/api/namespaces.md
@@ -74,7 +74,7 @@ curl -X POST \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces
+http://127.0.0.1:8080/api/core/v2/namespaces
 
 HTTP/1.1 201 Created
 {{< /code >}}
@@ -108,7 +108,7 @@ curl -X PUT \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces/development
+http://127.0.0.1:8080/api/core/v2/namespaces/development
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/6.0/api/namespaces.md
+++ b/content/sensu-go/6.0/api/namespaces.md
@@ -74,7 +74,7 @@ curl -X POST \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces
+http://127.0.0.1:8080/api/core/v2/namespaces
 
 HTTP/1.1 201 Created
 {{< /code >}}
@@ -108,7 +108,7 @@ curl -X PUT \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces/development
+http://127.0.0.1:8080/api/core/v2/namespaces/development
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/6.1/api/namespaces.md
+++ b/content/sensu-go/6.1/api/namespaces.md
@@ -74,7 +74,7 @@ curl -X POST \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces
+http://127.0.0.1:8080/api/core/v2/namespaces
 
 HTTP/1.1 201 Created
 {{< /code >}}
@@ -108,7 +108,7 @@ curl -X PUT \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces/development
+http://127.0.0.1:8080/api/core/v2/namespaces/development
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/6.2/api/namespaces.md
+++ b/content/sensu-go/6.2/api/namespaces.md
@@ -74,7 +74,7 @@ curl -X POST \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces
+http://127.0.0.1:8080/api/core/v2/namespaces
 
 HTTP/1.1 201 Created
 {{< /code >}}
@@ -108,7 +108,7 @@ curl -X PUT \
 -d '{
   "name": "development"
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/namespaces/development
+http://127.0.0.1:8080/api/core/v2/namespaces/development
 
 HTTP/1.1 201 Created
 {{< /code >}}


### PR DESCRIPTION
Namespaces are cluster-wide resources, but some of the sample URLs used in the API documentation used paths for namespaced resources. Well, not anymore ;)