### PR TITLE
Add memberOf attribute documentation for LDAP

### DIFF
--- a/content/sensu-go/6.2/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ldap-auth.md
@@ -146,7 +146,7 @@ spec:
 
 **Example LDAP configuration: Use `memberOf` attribute instead of `group_search`**
 
-LDAP automatically returns a `memberOf` attribute in users' accounts.
+If your LDAP server is configured to return a `memberOf` attribute when you perform a query, you can use `memberOf` in your Sensu LDAP implementation instead of `group_search`.
 The `memberOf` attribute contains the user's group membership, which effectively removes the requirement to look up the user's groups.
 
 To use the `memberOf` attribute in your LDAP implementation, remove the `group_search` object from your LDAP config:

--- a/content/sensu-go/6.2/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ldap-auth.md
@@ -144,6 +144,56 @@ spec:
 
 {{< /language-toggle >}}
 
+**Example LDAP configuration: Use `memberOf` attribute instead of `group_search`**
+
+LDAP automatically returns a `memberOf` attribute in users' accounts.
+The `memberOf` attribute contains the user's group membership, which effectively removes the requirement to look up the user's groups.
+
+To use the `memberOf` attribute in your LDAP implementation, remove the `group_search` object from your LDAP config:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: ldap
+api_version: authentication/v2
+metadata:
+  name: openldap
+spec:
+  servers:
+    host: 127.0.0.1
+    user_search:
+      base_dn: dc=acme,dc=org
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ldap",
+  "api_version": "authentication/v2",
+  "spec": {
+    "servers": [
+      {
+        "host": "127.0.0.1",
+        "user_search": {
+          "base_dn": "dc=acme,dc=org"
+        }
+      }
+    ]
+  },
+  "metadata": {
+    "name": "openldap"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+After you configure LDAP to use the `memberOf` attribute, the `debug` log level will include the following log entries:
+
+{{< code shell >}}
+{"component":"authentication/v2","level":"debug","msg":"using the \"memberOf\" attribute to determine the group membership of user \"user1\"","time":"2020-06-25T14:10:58-04:00"}
+{"component":"authentication/v2","level":"debug","msg":"found 1 LDAP group(s): [\"sensu\"]","time":"2020-06-25T14:10:58-04:00"}
+{{< /code >}}
+
 ## LDAP specification
 
 ### Top-level attributes
@@ -336,8 +386,8 @@ example      | {{< code shell >}}
 
 | group_search |    |
 -------------|------
-description  | Search configuration for groups. See the [group search attributes][21] for more information.
-required     | true
+description  | Search configuration for groups. See the [group search attributes][21] for more information. Remove the `group_search` object from your configuration to use the `memberOf` attribute instead.
+required     | false
 type         | Map
 example      | {{< code shell >}}
 "group_search": {


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/operations/control-access/ldap-auth/:
- Adds an example with memberOf attribute
- Adds explanation re: deleting group_search to use memberOf instead

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2889