### PR TITLE
Document agent-managed-entity setting

### DIFF
--- a/content/sensu-go/6.2/api/entities.md
+++ b/content/sensu-go/6.2/api/entities.md
@@ -501,6 +501,11 @@ output               | {{< code json >}}
 
 ## Create or update an entity {#entitiesentity-put}
 
+{{% notice note %}}
+**NOTE**: This endpoint will not update [agent-managed entities](../../observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent).
+Requests to update agent-managed entities via the Sensu backend REST API will fail and return `HTTP 409 Conflict`.
+{{% /notice %}}
+
 The `/entities/:entity` API endpoint provides HTTP PUT access to create or update the specified Sensu entity.
 
 ### Example {#entitiesentity-put-example}
@@ -562,6 +567,11 @@ payload         | {{< code shell >}}
 response codes  | <ul><li>**Success**: 200 (OK)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 ## Update an entity with PATCH
+
+{{% notice note %}}
+**NOTE**: This endpoint will not update [agent-managed entities](../../observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent).
+Requests to update agent-managed entities via the Sensu backend REST API will fail and return `HTTP 409 Conflict`.
+{{% /notice %}}
 
 The `/entities/:entity` API endpoint provides HTTP PATCH access to update **entity configuration attributes** in `:entity` definitions, specified by entity name:
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -26,22 +26,33 @@ See [the announcement on our blog][11] for more information about our usage poli
 When an agent connects to a backend, the agent entity definition is created from the information in the `agent.yml` configuration file.
 The default `agent.yml` file location [depends on your operating system][35].
 
+### Manage agent entities via the backend
+
 You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
 This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
+This is the default configuration for agent entities.
 
 {{% notice note %}}
-**NOTE**: You cannot modify an agent entity with the `agent.yml` configuration file unless you delete the entity.
-The entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
+**NOTE**: If you manage an agent entity via the backend, you cannot modify the agent entity with the `agent.yml` configuration file unless you delete the entity.
+In this case, the entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
 
 If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
 
-To maintain agent entities based on `agent.yml`, create ephemeral agent entities with the [deregister attribute][34] set to `true`.
+### Manage agent entities via the agent
+
+If you prefer, you can manage agent entities via the agent rather than the backend.
+To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
+
+When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in `agent.yml`, the agent becomes responsible for managing its entity configuration.
+In this case, you cannot edit the entity via the backend API (which will return HTTP 409 Conflict).
+To change an agent's configuration, restart the agent.
+
+You can also maintain agent entities based on `agent.yml` by creating ephemeral agent entities with the [deregister attribute][34] set to `true`.
 With this setting, the agent entity will deregister every time the agent process stops and its keepalive expires.
 When it restarts, it will revert to the original configuration from `agent.yml`
 You must set `deregister: true` in `agent.yml` before the agent entity is created.
-
-If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
 
 ## Create and manage proxy entities
 
@@ -1134,6 +1145,7 @@ spec:
 [13]: #spec-attributes
 [14]: ../../../api#response-filtering
 [15]: ../../../sensuctl/filter-responses/
+[16]: ../../observe-schedule/agent/#agent-managed-entity
 [17]: ../../observe-entities/monitor-external-resources/
 [18]: ../../observe-schedule/checks/#round-robin-checks
 [19]: #proxy-entities-managed

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -45,8 +45,9 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 If you prefer, you can manage agent entities via the agent rather than the backend.
 To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in `agent.yml`, the agent becomes responsible for managing its entity configuration.
-In this case, you cannot edit the entity via the backend API (which will return HTTP 409 Conflict).
+When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in agent.yml, the agent becomes responsible for managing its entity configuration.
+An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
+You cannot update these agent-managed entities via the Sensu backend REST API.
 To change an agent's configuration, restart the agent.
 
 You can also maintain agent entities based on `agent.yml` by creating ephemeral agent entities with the [deregister attribute][34] set to `true`.

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -842,7 +842,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 | agent-managed-entity |      |
 -------------|------
-description  | Indicates whether the agent's entity is solely managed by the agent rather than the backend API.
+description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.
 required     | false
 type         | Boolean
 default      | false

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -771,6 +771,7 @@ Usage:
   sensu-agent start [flags]
 
 Flags:
+      --agent-managed-entity                  manage this entity via the agent
       --allow-list string                     path to agent execution allow list configuration file
       --annotations stringToString            entity annotations map (default [])
       --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
@@ -836,6 +837,22 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 {{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
+
+<a name="agent-managed-entity"></a>
+
+| agent-managed-entity |      |
+-------------|------
+description  | Indicates whether the agent's entity is solely managed by the agent rather than the backend API.
+required     | false
+type         | Boolean
+default      | false
+environment variable | `SENSU_AGENT_MANAGED_ENTITY`
+example       | {{< code shell >}}# Command line example
+sensu-agent start --agent-managed-entity
+
+# /etc/sensu/agent.yml example
+agent-managed-entity: true{{< /code >}}
+
 
 <a name="allow-list"></a>
 

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -22,6 +22,11 @@ Both JSON and YAML resource definitions wrap the contents of the resource in `sp
 See the [`wrapped-json`example][9] and [this table][3] for a list of supported types.
 See the [reference docs][6] for information about creating resource definitions.
 
+{{% notice note %}}
+**NOTE**: You cannot use sensuctl to update [agent-managed entities](../../observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent).
+Requests to update agent-managed entities via sensuctl will fail and return an error.
+{{% /notice %}}
+
 ### `wrapped-json` format
 
 In this example, the file `my-resources.json` specifies two resources: a `marketing-site` check and a `slack` handler, separated _without_ a comma:
@@ -228,6 +233,11 @@ For example, to edit a handler named `slack` with `sensuctl edit`:
 {{< code shell >}}
 sensuctl edit handler slack
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: You cannot use sensuctl to update [agent-managed entities](../../observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent).
+Requests to update agent-managed entities via sensuctl will fail and return an error.
+{{% /notice %}}
 
 ### sensuctl edit resource types
 


### PR DESCRIPTION
## Description
- Adds agent-managed-entity flag and description table to agent reference
- Adds information about using agent management for agent entities in the entities reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2905