### PR TITLE
Add Intro to Sensu Go 6 video on get started page

### DIFF
--- a/content/sensu-go/6.0/get-started.md
+++ b/content/sensu-go/6.0/get-started.md
@@ -11,17 +11,7 @@ menu: "sensu-go-6.0"
 [Sensu Go][2] is the flexible observability pipeline designed for container-based and multi-cloud infrastructures.
 
 Sensu is available as packages, Docker images, and binary-only distributions.
-You can [install the commercial distribution of Sensu Go][15] or [build Sensu from source][16].
-
-## Learn Sensu
-
-We recommend these resources for learning more about Sensu:
-
-- Learn how the Sensu pipeline works in your browser with an [interactive tutorial][12]
-- [Download the sandbox][7] and create an [observability pipeline][22] in your local environment
-- See a [live demo of the Sensu web UI][1]
-- Sign up for our step-by-step [Learn Sensu email course][21]
-- Join the [Sensu Community Forum on Discourse][8]
+You can [install the commercial distribution][15] or [build Sensu from source][16].
 
 ## Install the commercial distribution of Sensu Go
 
@@ -32,6 +22,20 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 - Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
+
+## Learn Sensu
+
+Watch this video for an 8-minute Sensu Go overview and demo:
+
+{{< youtube eUZTMdYtCmg >}}
+
+We recommend these resources for learning more about Sensu:
+
+- Learn how the Sensu pipeline works in your browser with an [interactive tutorial][12]
+- [Download the sandbox][7] and create an [observability pipeline][22] in your local environment
+- See a [live demo of the Sensu web UI][1]
+- Sign up for our step-by-step [Learn Sensu email course][21]
+- Join the [Sensu Community Forum on Discourse][8]
 
 ## Explore monitoring at scale with Sensu Go
 

--- a/content/sensu-go/6.1/get-started.md
+++ b/content/sensu-go/6.1/get-started.md
@@ -11,17 +11,7 @@ menu: "sensu-go-6.1"
 [Sensu Go][2] is the flexible observability pipeline designed for container-based and multi-cloud infrastructures.
 
 Sensu is available as packages, Docker images, and binary-only distributions.
-You can [install the commercial distribution of Sensu Go][15] or [build Sensu from source][16].
-
-## Learn Sensu
-
-We recommend these resources for learning more about Sensu:
-
-- Learn how the Sensu pipeline works in your browser with an [interactive tutorial][12]
-- [Download the sandbox][7] and create an [observability pipeline][22] in your local environment
-- See a [live demo of the Sensu web UI][1]
-- Sign up for our step-by-step [Learn Sensu email course][21]
-- Join the [Sensu Community Forum on Discourse][8]
+You can [install the commercial distribution][15] or [build Sensu from source][16].
 
 ## Install the commercial distribution of Sensu Go
 
@@ -32,6 +22,20 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 - Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
+
+## Learn Sensu
+
+Watch this video for an 8-minute Sensu Go overview and demo:
+
+{{< youtube eUZTMdYtCmg >}}
+
+We recommend these resources for learning more about Sensu:
+
+- Learn how the Sensu pipeline works in your browser with an [interactive tutorial][12]
+- [Download the sandbox][7] and create an [observability pipeline][22] in your local environment
+- See a [live demo of the Sensu web UI][1]
+- Sign up for our step-by-step [Learn Sensu email course][21]
+- Join the [Sensu Community Forum on Discourse][8]
 
 ## Explore monitoring at scale with Sensu Go
 

--- a/content/sensu-go/6.2/get-started.md
+++ b/content/sensu-go/6.2/get-started.md
@@ -11,17 +11,7 @@ menu: "sensu-go-6.2"
 [Sensu Go][2] is the flexible observability pipeline designed for container-based and multi-cloud infrastructures.
 
 Sensu is available as packages, Docker images, and binary-only distributions.
-You can [install the commercial distribution of Sensu Go][15] or [build Sensu from source][16].
-
-## Learn Sensu
-
-We recommend these resources for learning more about Sensu:
-
-- Learn how the Sensu pipeline works in your browser with an [interactive tutorial][12]
-- [Download the sandbox][7] and create an [observability pipeline][22] in your local environment
-- See a [live demo of the Sensu web UI][1]
-- Sign up for our step-by-step [Learn Sensu email course][21]
-- Join the [Sensu Community Forum on Discourse][8]
+You can [install the commercial distribution][15] or [build Sensu from source][16].
 
 ## Install the commercial distribution of Sensu Go
 
@@ -32,6 +22,20 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 - Discover Sensu dynamic runtime assets on [Bonsai, the Sensu asset hub][6]
 - Find the [Sensu architecture][18] that best meets your needs
 - [Migrate from Sensu Core to Sensu Go][13]
+
+## Learn Sensu
+
+Watch this video for an 8-minute Sensu Go overview and demo:
+
+{{< youtube eUZTMdYtCmg >}}
+
+We recommend these resources for learning more about Sensu:
+
+- Learn how the Sensu pipeline works in your browser with an [interactive tutorial][12]
+- [Download the sandbox][7] and create an [observability pipeline][22] in your local environment
+- See a [live demo of the Sensu web UI][1]
+- Sign up for our step-by-step [Learn Sensu email course][21]
+- Join the [Sensu Community Forum on Discourse][8]
 
 ## Explore monitoring at scale with Sensu Go
 


### PR DESCRIPTION
## Description
- Embeds [Intro to Sensu Go 6](https://www.youtube.com/watch?v=eUZTMdYtCmg) video to Get Started page in the docs
- Switches positions of Install... and Learn... sections on the page (the Install Sensu Go link is the most-clicked item on the entire page, so I wanted to preserver it above the fold)

## Motivation and Context
Help readers who are new to Sensu find the intro/demo video