### PR TITLE
Fix links to interactive training and plugins on landing page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,13 +34,13 @@
           Ask questions, search answers, and help other Sensu users in Sensu's community forum
         </div>
       </a>
-      <a class="product-grid--product product-grid--product-sensu-enterprise-dashboard" href="./sensu-go/6.1/learn/learn-sensu-go/">
+      <a class="product-grid--product product-grid--product-sensu-enterprise-dashboard" href="./sensu-go/6.2/learn/interactive-tutorials/">
         <div class="product-grid--product--title">Interactive Training</div>
         <div class="product-grid--product--description">
           Learn Sensu Go with interactive training tutorials
         </div>
       </a>
-      <a class="product-grid--product product-grid--product-uchiwa" href="sensu-go/6.1/plugins/">
+      <a class="product-grid--product product-grid--product-uchiwa" href="sensu-go/6.2/plugins/">
         <div class="product-grid--product--title">Plugins</div>
         <div class="product-grid--product--description">
           Find checks, handlers, and other plugins to power your Sensu deployment


### PR DESCRIPTION
Link to interactive tutorials was broken and plugins still went to 6.1