### PR TITLE
Fix link to Prometheus Pushgateway Handler in supported integrations page

### DIFF
--- a/content/sensu-go/6.0/plugins/supported-integrations/prometheus.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/prometheus.md
@@ -30,7 +30,7 @@ The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects m
 
 ## Sensu Prometheus Pushgateway Handler
 
-The [Sensu Prometheus Pushgateway Handler][3] plugin is a Sensu [handler][1] that sends Sensu metrics to a Prometheus Pushgateway, which Prometheus can then scrape.
+The [Sensu Prometheus Pushgateway Handler][7] plugin is a Sensu [handler][1] that sends Sensu metrics to a Prometheus Pushgateway, which Prometheus can then scrape.
 
 ### Features
 

--- a/content/sensu-go/6.1/plugins/supported-integrations/prometheus.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/prometheus.md
@@ -30,7 +30,7 @@ The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects m
 
 ## Sensu Prometheus Pushgateway Handler
 
-The [Sensu Prometheus Pushgateway Handler][3] plugin is a Sensu [handler][1] that sends Sensu metrics to a Prometheus Pushgateway, which Prometheus can then scrape.
+The [Sensu Prometheus Pushgateway Handler][7] plugin is a Sensu [handler][1] that sends Sensu metrics to a Prometheus Pushgateway, which Prometheus can then scrape.
 
 ### Features
 

--- a/content/sensu-go/6.2/plugins/supported-integrations/prometheus.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/prometheus.md
@@ -30,7 +30,7 @@ The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects m
 
 ## Sensu Prometheus Pushgateway Handler
 
-The [Sensu Prometheus Pushgateway Handler][3] plugin is a Sensu [handler][1] that sends Sensu metrics to a Prometheus Pushgateway, which Prometheus can then scrape.
+The [Sensu Prometheus Pushgateway Handler][7] plugin is a Sensu [handler][1] that sends Sensu metrics to a Prometheus Pushgateway, which Prometheus can then scrape.
 
 ### Features
 


### PR DESCRIPTION
## Description
Fixes a Prometheus Pushgateway Handler link that points to the wrong reference number in the Prometheus supported integrations page.

## Motivation and Context
Found incorrect link while working on metrics reference
