### PR TITLE
Add note re: agent-managed-entity flag for 6.2.1 and 6.2.2

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -45,6 +45,11 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 If you prefer, you can manage agent entities via the agent rather than the backend.
 To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
+{{% notice important%}}
+**IMPORTANT**: In Sensu Go 6.2.1 or 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
+Include a [label](../../observe-schedule/agent/#labels) to mitigate this issue: `sensu-agent start --agent-managed-entity --labels workaround=agent_managed-entity_flag`.
+{{% /notice %}}
+
 When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in agent.yml, the agent becomes responsible for managing its entity configuration.
 An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
 You cannot update these agent-managed entities via the Sensu backend REST API.

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -46,7 +46,7 @@ If you prefer, you can manage agent entities via the agent rather than the backe
 To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
 {{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 or 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
+**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
 Include a [label](../../observe-schedule/agent/#labels) to mitigate this issue: `sensu-agent start --agent-managed-entity --labels workaround=agent_managed-entity_flag`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -847,7 +847,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 | agent-managed-entity |      |
 -------------|------
 description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.<br>{{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 or 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
+**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
 Include a [label](#labels) to mitigate this issue: `sensu-agent start --agent-managed-entity --labels workaround=agent_managed-entity_flag`.
 {{% /notice %}}
 required     | false

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -846,7 +846,10 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 | agent-managed-entity |      |
 -------------|------
-description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.
+description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.<br>{{% notice important%}}
+**IMPORTANT**: In Sensu Go 6.2.1 or 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
+Include a [label](#labels) to mitigate this issue: `sensu-agent start --agent-managed-entity --labels workaround=agent_managed-entity_flag`.
+{{% /notice %}}
 required     | false
 type         | Boolean
 default      | false
@@ -1037,6 +1040,8 @@ sensu-agent start --discover-processes
 
 # /etc/sensu/agent.yml example
 discover-processes: true{{< /code >}}
+
+<a name="labels"></a>
 
 | labels     |      |
 -------------|------


### PR DESCRIPTION
## Description
Adds a note in entity and agent reference docs to describe workaround for using labels flag with agent-managed-entities flag. https://github.com/sensu/sensu-go/issues/4171 for context.

## Motivation and Context
Issue discovered in 6.2.2 patch release testing
