### PR TITLE
6.2.3: Update note about agent-managed-entity flag

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -46,8 +46,8 @@ If you prefer, you can manage agent entities via the agent rather than the backe
 To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
 {{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
-Include a [label](../../observe-schedule/agent/#labels) to mitigate this issue: `sensu-agent start --agent-managed-entity --labels workaround=agent_managed-entity_flag`.
+**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
+Upgrade to [Sensu Go 6.2.3](../../../release-notes/#623-release-notes) to use the agent-managed-entity configuration flag.
 {{% /notice %}}
 
 When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in agent.yml, the agent becomes responsible for managing its entity configuration.

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -847,8 +847,8 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 | agent-managed-entity |      |
 -------------|------
 description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.<br>{{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity flag can prevent the agent from starting.
-Include a [label](#labels) to mitigate this issue: `sensu-agent start --agent-managed-entity --labels workaround=agent_managed-entity_flag`.
+**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
+Upgrade to [Sensu Go 6.2.3](../../../release-notes/#623-release-notes) to use the agent-managed-entity configuration flag.
 {{% /notice %}}
 required     | false
 type         | Boolean


### PR DESCRIPTION
## Description
Updates the notes about using labels to work around the agent-managed-entity flag issue to recommend upgrading to Sensu Go 6.2.3 instead.

Affected docs are https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent and https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#general-configuration-flags.

## Motivation and Context
Support 6.2.3 patch release
