### PR TITLE
6.2.3: Update version and build numbers

### DIFF
--- a/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
@@ -279,18 +279,18 @@ sudo yum install sensu-go-cli
 
 {{< code powershell "Windows" >}}
 # Download sensuctl for Windows amd64
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_amd64.zip  -OutFile C:\Users\Administrator\sensu-go_6.2.2_windows_amd64.zip
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_amd64.zip  -OutFile C:\Users\Administrator\sensu-go_6.2.3_windows_amd64.zip
 
 # Or for 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_386.zip  -OutFile C:\Users\Administrator\sensu-go_6.2.2_windows_386.zip
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_386.zip  -OutFile C:\Users\Administrator\sensu-go_6.2.3_windows_386.zip
 {{< /code >}}
 
 {{< code shell "macOS" >}}
 # Download the latest release
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_darwin_amd64.tar.gz
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_darwin_amd64.tar.gz
 
 # Extract the archive
-tar -xvf sensu-go_6.2.2_darwin_amd64.tar.gz
+tar -xvf sensu-go_6.2.3_darwin_amd64.tar.gz
 
 # Copy the executable into your PATH
 sudo cp sensuctl /usr/local/bin/
@@ -360,13 +360,13 @@ sudo yum install sensu-go-agent
 
 {{< code powershell "Windows" >}}
 # Download the Sensu agent for Windows amd64
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go-agent_6.2.2.3967_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.2.3967_en-US.x64.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go-agent_6.2.3.3984_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.3.3984_en-US.x64.msi"
 
 # Or for Windows 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go-agent_6.2.2.3967_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.2.3967_en-US.x86.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go-agent_6.2.3.3984_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.3.3984_en-US.x86.msi"
 
 # Install the Sensu agent
-msiexec.exe /i $env:userprofile\sensu-go-agent_6.2.2.3967_en-US.x64.msi /qn
+msiexec.exe /i $env:userprofile\sensu-go-agent_6.2.3.3984_en-US.x64.msi /qn
 
 # Or via Chocolatey
 choco install sensu-agent

--- a/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
@@ -360,13 +360,13 @@ sudo yum install sensu-go-agent
 
 {{< code powershell "Windows" >}}
 # Download the Sensu agent for Windows amd64
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go-agent_6.2.3.3984_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.3.3984_en-US.x64.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go-agent_6.2.3.3986_en-US.x64.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.3.3986_en-US.x64.msi"
 
 # Or for Windows 386
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go-agent_6.2.3.3984_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.3.3984_en-US.x86.msi"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go-agent_6.2.3.3986_en-US.x86.msi  -OutFile "$env:userprofile\sensu-go-agent_6.2.3.3986_en-US.x86.msi"
 
 # Install the Sensu agent
-msiexec.exe /i $env:userprofile\sensu-go-agent_6.2.3.3984_en-US.x64.msi /qn
+msiexec.exe /i $env:userprofile\sensu-go-agent_6.2.3.3986_en-US.x64.msi /qn
 
 # Or via Chocolatey
 choco install sensu-agent

--- a/content/sensu-go/6.2/platforms.md
+++ b/content/sensu-go/6.2/platforms.md
@@ -97,49 +97,49 @@ Binaries for all other Linux architectures include only the Sensu agent and sens
 <tbody>
 <tr>
 <td><code>386</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_386.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_386.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_386.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_386.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>MIPS LE hard float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mipsle-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mipsle-hardfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mipsle-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mipsle-hardfloat.zip"><code>.zip</code></a></td>
 </tr>
 <tr>
 <td><code>amd64</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_amd64.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_amd64.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_amd64.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_amd64.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>MIPS LE soft float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mipsle-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mipsle-softfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mipsle-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mipsle-softfloat.zip"><code>.zip</code></a></td>
 </tr>
 <tr>
 <td><code>arm64</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_arm64.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_arm64.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_arm64.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_arm64.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>MIPS 64 hard float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64-hardfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64-hardfloat.zip"><code>.zip</code></a></td>
 </tr>
 <tr>
 <td><code>armv5</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv5.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv5.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv5.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv5.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>MIPS 64 soft float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64-softfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64-softfloat.zip"><code>.zip</code></a></td>
 </tr>
 <tr>
 <td><code>armv6</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv6.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv6.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv6.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv6.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>MIPS 64 LE hard float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64le-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64le-hardfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64le-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64le-hardfloat.zip"><code>.zip</code></a></td>
 </tr>
 <tr>
 <td><code>armv7</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv7.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv7.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv7.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv7.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>MIPS 64 LE soft float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64le-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips64le-softfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64le-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips64le-softfloat.zip"><code>.zip</code></a></td>
 </tr>
 <td><code>MIPS hard float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips-hardfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips-hardfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips-hardfloat.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>s390x</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_s390x.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_s390x.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_s390x.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_s390x.zip"><code>.zip</code></a></td>
 </tr>
 <td><code>MIPS soft float</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_mips-softfloat.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips-softfloat.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_mips-softfloat.zip"><code>.zip</code></a></td>
 <td class="vertline"><code>ppc64le</code></td>
-<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_ppc64le.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_ppc64le.zip"><code>.zip</code></a></td>
+<td><a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_ppc64le.tar.gz"><code>.tar.gz</code></a> | <a href="https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_ppc64le.zip"><code>.zip</code></a></td>
 </tr>
 </tbody>
 </table>
@@ -147,19 +147,19 @@ Binaries for all other Linux architectures include only the Sensu agent and sens
 For example, to download Sensu for Linux `amd64` in `tar.gz` format:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_amd64.tar.gz
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_amd64.tar.gz
 {{< /code >}}
 
 Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< code shell >}}
-sha256sum sensu-go_6.2.2_linux_amd64.tar.gz
+sha256sum sensu-go_6.2.3_linux_amd64.tar.gz
 {{< /code >}}
 
 The result should match the checksum for your platform:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_checksums.txt && cat sensu-go_6.2.2_checksums.txt
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_checksums.txt && cat sensu-go_6.2.3_checksums.txt
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -184,21 +184,21 @@ We support Windows 7 and later and Windows Server 2008R2 and later for binary di
 For example, to download Sensu for Windows `amd64` in `zip` format:
 
 {{< code text >}}
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_amd64.zip  -OutFile "$env:userprofile\sensu-go_6.2.2_windows_amd64.zip"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_amd64.zip  -OutFile "$env:userprofile\sensu-go_6.2.3_windows_amd64.zip"
 {{< /code >}}
 
 Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< code text >}}
-Get-FileHash "$env:userprofile\sensu-go_6.2.2_windows_amd64.zip" -Algorithm SHA256 | Format-List
+Get-FileHash "$env:userprofile\sensu-go_6.2.3_windows_amd64.zip" -Algorithm SHA256 | Format-List
 {{< /code >}}
 
 The result should match (with the exception of capitalization) the checksum for your platform:
 
 {{< code text >}}
-Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_checksums.txt -OutFile "$env:userprofile\sensu-go_6.2.2_checksums.txt"
+Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_checksums.txt -OutFile "$env:userprofile\sensu-go_6.2.3_checksums.txt"
 
-Get-Content "$env:userprofile\sensu-go_6.2.2_checksums.txt" | Select-String -Pattern windows_amd64
+Get-Content "$env:userprofile\sensu-go_6.2.3_checksums.txt" | Select-String -Pattern windows_amd64
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -223,25 +223,25 @@ We support macOS 10.11 and later for binary distributions.
 For example, to download Sensu for macOS `amd64` in `tar.gz` format:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_darwin_amd64.tar.gz
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_darwin_amd64.tar.gz
 {{< /code >}}
 
 Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< code shell >}}
-shasum -a 256 sensu-go_6.2.2_darwin_amd64.tar.gz
+shasum -a 256 sensu-go_6.2.3_darwin_amd64.tar.gz
 {{< /code >}}
 
 The result should match the checksum for your platform:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_checksums.txt && cat sensu-go_6.2.2_checksums.txt
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_checksums.txt && cat sensu-go_6.2.3_checksums.txt
 {{< /code >}}
 
 Extract the archive:
 
 {{< code shell >}}
-tar -xvf sensu-go_6.2.2_darwin_amd64.tar.gz
+tar -xvf sensu-go_6.2.3_darwin_amd64.tar.gz
 {{< /code >}}
 
 Copy the executable into your PATH:
@@ -275,19 +275,19 @@ We support FreeBSD 11.2 and later for binary distributions.
 For example, to download Sensu for FreeBSD `amd64` in `tar.gz` format:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_amd64.tar.gz
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_amd64.tar.gz
 {{< /code >}}
 
 Generate a SHA-256 checksum for the downloaded artifact:
 
 {{< code shell >}}
-sha256sum sensu-go_6.2.2_freebsd_amd64.tar.gz
+sha256sum sensu-go_6.2.3_freebsd_amd64.tar.gz
 {{< /code >}}
 
 The result should match the checksum for your platform:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_checksums.txt && cat sensu-go_6.2.2_checksums.txt
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_checksums.txt && cat sensu-go_6.2.3_checksums.txt
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -311,19 +311,19 @@ We support Solaris 11 and later (not SPARC) for binary distributions.
 For example, to download Sensu for Solaris `amd64` in `tar.gz` format:
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_solaris_amd64.tar.gz
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_solaris_amd64.tar.gz
 {{< /code >}}
 
 Generate a SHA-256 checksum for the downloaded artifact.
 
 {{< code shell >}}
-sha256sum sensu-go_6.2.2_solaris_amd64.tar.gz
+sha256sum sensu-go_6.2.3_solaris_amd64.tar.gz
 {{< /code >}}
 
 The result should match the checksum for your platform.
 
 {{< code shell >}}
-curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_checksums.txt && cat sensu-go_6.2.2_checksums.txt
+curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_checksums.txt && cat sensu-go_6.2.3_checksums.txt
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -359,41 +359,41 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [15]: https://sensu.io/enterprise/
 [16]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
 [17]: https://github.com/jaredledvina/sensu-go-ansible/
-[18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv7.tar.gz
-[20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_amd64.zip
-[21]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_arm64.zip
-[22]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv5.zip
-[23]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv6.zip
-[24]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv7.zip
+[18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv7.tar.gz
+[20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_amd64.zip
+[21]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_arm64.zip
+[22]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv5.zip
+[23]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv6.zip
+[24]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv7.zip
 [25]: https://github.com/sensu/sensu-push
-[26]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_amd64.tar.gz
-[27]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_386.tar.gz
-[28]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_amd64.zip
-[29]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_windows_386.zip
-[30]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_darwin_amd64.tar.gz
-[31]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_darwin_amd64.zip
-[32]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_amd64.tar.gz
-[33]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_amd64.zip
-[34]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_386.tar.gz
-[35]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_386.zip
-[36]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_solaris_amd64.tar.gz
-[37]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_solaris_amd64.zip
-[38]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_armv5.tar.gz
-[39]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_armv5.zip
-[40]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_armv6.tar.gz
-[41]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_armv6.zip
-[42]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_armv7.tar.gz
-[43]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_freebsd_armv7.zip
+[26]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_amd64.tar.gz
+[27]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_386.tar.gz
+[28]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_amd64.zip
+[29]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_windows_386.zip
+[30]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_darwin_amd64.tar.gz
+[31]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_darwin_amd64.zip
+[32]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_amd64.tar.gz
+[33]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_amd64.zip
+[34]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_386.tar.gz
+[35]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_386.zip
+[36]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_solaris_amd64.tar.gz
+[37]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_solaris_amd64.zip
+[38]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_armv5.tar.gz
+[39]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_armv5.zip
+[40]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_armv6.tar.gz
+[41]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_armv6.zip
+[42]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_armv7.tar.gz
+[43]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_freebsd_armv7.zip
 [44]: #linux
 [45]: #windows
 [46]: #macos
 [47]: #freebsd
 [48]: #solaris
 [49]: ../api
-[54]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_amd64.tar.gz
-[55]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_arm64.tar.gz
-[56]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv5.tar.gz
-[57]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/sensu-go_6.2.2_linux_armv6.tar.gz
-[58]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/cgo/sensu-go-cgo_6.2.2_darwin_amd64.tar.gz
-[59]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.2/cgo/sensu-go-cgo_6.2.2_darwin_amd64.zip
+[54]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_amd64.tar.gz
+[55]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_arm64.tar.gz
+[56]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv5.tar.gz
+[57]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/sensu-go_6.2.3_linux_armv6.tar.gz
+[58]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/cgo/sensu-go-cgo_6.2.3_darwin_amd64.tar.gz
+[59]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.3/cgo/sensu-go-cgo_6.2.3_darwin_amd64.zip
 [60]: https://github.com/sensu/web


### PR DESCRIPTION
**double-check build number on release spreadsheet key page before merging**

## Description
Updates version and build numbers in http://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/ and https://docs.sensu.io/sensu-go/latest/platforms/

## Motivation and Context
Support 6.2.3 patch release
