### PR TITLE
Remove sensuctl dump from 6.2.2

### DIFF
--- a/content/sensu-go/6.2/release-notes.md
+++ b/content/sensu-go/6.2/release-notes.md
@@ -95,7 +95,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.2.3.
 
 **January 14, 2021** &mdash; The latest release of Sensu Go, version 6.2.2, is now available for download.
 
-This patch fixes bugs that prevented `sensuctl dump` and PostgreSQL round robin scheduing from working properly.
+This patch fixes bugs that prevented PostgreSQL round robin scheduing from working properly.
 
 See the [upgrade guide][1] to upgrade Sensu to version 6.2.2.
 


### PR DESCRIPTION
Updates release notes to list accurate fixes for 6.2.2 in the release summary
