### PR TITLE
EOL repos removal: Updates throughout all product docs

### DIFF
--- a/content/sensu-core/1.9/_index.md
+++ b/content/sensu-core/1.9/_index.md
@@ -11,7 +11,7 @@ layout: "single"
 
 <iframe src="https://ghbtns.com/github-btn.html?user=sensu&repo=sensu&type=star&count=true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe> | <a href="https://docs.sensu.io/sensu-go/latest/">Learn about Sensu Go</a>
 
-_**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project. Learn more about [Core and Enterprise EOL][31]._
+_**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][21], more than 8 years after its inception as an open source software project, and we [permanently removed][32] the Sensu EOL repository on February 1, 2021.<br><br>To migrate to Sensu Go, read the [Sensu Core migration guide][33]._
 
 **These resources can help you migrate to [Sensu Go][24]**, the latest version of Sensu:
 
@@ -104,4 +104,5 @@ training, and other benefits, check out [Sensu Enterprise][14].
 [28]: https://docs.sensu.io/sensu-go/latest/getting-started/sandbox/
 [29]: https://sensu.io/support/
 [30]: https://sensu.io/contact/
-[31]: https://blog.sensu.io/announcing-the-sensu-archives
+[32]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[33]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/faq.md
+++ b/content/sensu-core/1.9/faq.md
@@ -144,7 +144,8 @@ including RHEL, CentOS, Debian and Ubuntu.
 
 > Is Sensu available for Microsoft Windows?
 
-_IMPORTANT: We [permanently removed][1] the Sensu end-of-life (EOL) repository on February 1, 2021. [Start your migration to Sensu Go][6]._
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][7], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021. This means the Sensu Core packages are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][6]._
+
 
 **Yes.** An MSI installer package is available.
 Please visit the Sensu documentation for
@@ -215,3 +216,4 @@ _NOTE: For `config.json`, it is not necessary to have this file present on eithe
 [4]: ../installation/upgrading/#tls-ssl-changes
 [5]: https://github.com/sensu/sensu-omnibus/blob/master/platform-docs/MAC_OS_X.md
 [6]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
+[7]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise

--- a/content/sensu-core/1.9/faq.md
+++ b/content/sensu-core/1.9/faq.md
@@ -146,7 +146,6 @@ including RHEL, CentOS, Debian and Ubuntu.
 
 _IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][7], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021. This means the Sensu Core packages are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][6]._
 
-
 **Yes.** An MSI installer package is available.
 Please visit the Sensu documentation for
 more information on [configuring Sensu on

--- a/content/sensu-core/1.9/faq.md
+++ b/content/sensu-core/1.9/faq.md
@@ -144,7 +144,9 @@ including RHEL, CentOS, Debian and Ubuntu.
 
 > Is Sensu available for Microsoft Windows?
 
-**Yes.** An [MSI installer package][1] is available.
+_IMPORTANT: We [permanently removed][1] the Sensu end-of-life (EOL) repository on February 1, 2021. [Start your migration to Sensu Go][6]._
+
+**Yes.** An MSI installer package is available.
 Please visit the Sensu documentation for
 more information on [configuring Sensu on
 Windows](../platforms/sensu-on-microsoft-windows/).
@@ -207,8 +209,9 @@ See the table below for the location of the respective files needed:
 
 _NOTE: For `config.json`, it is not necessary to have this file present on either a Sensu client or server, provided that you have the rest of the configuration files present._
 
-[1]: https://eol-repositories.sensuapp.org/msi/
+[1]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
 [2]: https://www.amqp.org/
 [3]: https://www.rabbitmq.com/which-erlang.html
 [4]: ../installation/upgrading/#tls-ssl-changes
 [5]: https://github.com/sensu/sensu-omnibus/blob/master/platform-docs/MAC_OS_X.md
+[6]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/guides/pre-compile-plugins.md
+++ b/content/sensu-core/1.9/guides/pre-compile-plugins.md
@@ -31,6 +31,8 @@ _NOTE: Compiled gems are tied to CPU architecture for which they are compiled on
 
 First we'll add the Sensu yum repository definition and install Sensu.
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][1], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021. This means the baseurl specified in the code example below is no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][3]._
+
 {{< code shell >}}
 printf '[sensu]
 name=sensu
@@ -139,3 +141,7 @@ There is no ACTIVE Load Balancer named 'foo'{{< /code >}}
 ## Recap
 
 In this guide we covered the components involved in building out Sensu pre-compiled plugins. This allows system builders a method to pre-compile gems for systems that you may not want all the build tools required installed on them or for an easy to ship package for deploying gems on systems that may not have access to the internet.
+
+[1]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[2]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[3]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/installation/install-sensu-server-api.md
+++ b/content/sensu-core/1.9/installation/install-sensu-server-api.md
@@ -22,15 +22,17 @@ and jump directly to [installing Sensu Enterprise][9]._
 
 ## Sensu Core (OSS) {#sensu-core}
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][1], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021. To migrate to Sensu Go, read the [Sensu Core migration guide][3]._
+
 Sensu Core is installed via native system installer package formats (e.g. .deb, .rpm, .msi, .pkg, etc), which are available for download using the links listed below and from package manager repositories for APT (for Ubuntu/Debian systems) and YUM (for RHEL/CentOS).
 
-- [FreeBSD][1]
-- [IBM AIX][2]
-- [Mac OS X][3]
-- [Microsoft Windows][4]
-- [Solaris 10][5] or [Solaris 11][6]
-- [RHEL/CentOS][7]
-- [Ubuntu/Debian][8]
+- FreeBSD
+- IBM AIX
+- Mac OS X
+- Microsoft Windows
+- Solaris 10 or Solaris 11
+- RHEL/CentOS
+- Ubuntu/Debian
 
 The Sensu Core packages installs several processes, including `sensu-server`, `sensu-api`, and `sensu-client`.
 
@@ -57,12 +59,7 @@ functionality of Sensu server and API in a single process.
 - [Install Sensu Enterprise on Ubuntu/Debian](../../platforms/sensu-on-ubuntu-debian/#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../../platforms/sensu-on-rhel-centos/#sensu-enterprise)
 
-[1]: https://eol-repositories.sensuapp.org/freebsd/
-[2]: https://eol-repositories.sensuapp.org/aix/
-[3]: https://eol-repositories.sensuapp.org/osx/
-[4]: https://eol-repositories.sensuapp.org/msi/
-[5]: https://eol-repositories.sensuapp.org/solaris/pkg/
-[6]: https://eol-repositories.sensuapp.org/solaris/ips/
-[7]: https://eol-repositories.sensuapp.org/yum/
-[8]: https://eol-repositories.sensuapp.org/apt/pool/
+[1]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[2]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[3]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
 [9]: #sensu-enterprise

--- a/content/sensu-core/1.9/installation/testing-prereleases.md
+++ b/content/sensu-core/1.9/installation/testing-prereleases.md
@@ -30,6 +30,8 @@ these changes in order to return to using stable releases._
 
 ### Ubuntu/Debian
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][1], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021.<br><br>This means the https://eol-repositories.sensuapp.org URLs specified in the code examples below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][3]._
+
 1. Install the GPG public key:
    {{< code shell >}}
 wget -q https://eol-repositories.sensuapp.org/apt/pubkey.gpg -O- | sudo apt-key add -{{< /code >}}
@@ -51,6 +53,8 @@ sudo apt-get update{{< /code >}}
 
 ### RHEL/CentOS
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][1], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021.<br><br>This means the https://eol-repositories.sensuapp.org URL specified in the code example below is no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][3]._
+
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
    {{< code shell >}}
@@ -63,7 +67,10 @@ enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo{{< /code >}}
 ## Reporting issues
 
 If you encounter an issue while installing or using a Sensu
-prerelease, please create a [Sensu Core GitHub issue][1] if one does
+prerelease, please create a [Sensu Core GitHub issue][4] if one does
 not already exist for it.
 
-[1]:  https://github.com/sensu/sensu/issues
+[1]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[2]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[3]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
+[4]: https://github.com/sensu/sensu/issues

--- a/content/sensu-core/1.9/migration.md
+++ b/content/sensu-core/1.9/migration.md
@@ -8,7 +8,7 @@ menu: "sensu-core-1.9"
 product: "Sensu Core"
 ---
 
-_**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][73]. This guide describes how to migrate your Sensu instance from Sensu Core to Sensu Go. To migrate from Sensu Enterprise, see the [Sensu Enterprise migration guide][30]. Learn more about [Core and Enterprise EOL][85]._
+_**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][73], and we [permanently removed][86] the Sensu EOL repository on February 1, 2021.<br><br>This guide describes how to migrate your Sensu instance from Sensu Core to Sensu Go. To migrate from Sensu Enterprise, see the [Sensu Enterprise migration guide][30]._
 
 Here's a quick overview of Sensu Go's advantages:
 
@@ -388,7 +388,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [25]: https://blog.sensu.io/check-configuration-upgrades-with-the-sensu-go-sandbox
 [26]: https://blog.sensu.io/self-service-monitoring-checks-in-sensu-go
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check
-[30]: /sensu-enterprise/3.6/migration
+[30]: https://docs.sensu.io/sensu-enterprise/3.8/migration
 [31]: https://blog.sensu.io/enterprise-features-in-sensu-go
 [32]: https://docs.sensu.io/sensu-go/latest/getting-started/learn-sensu
 [33]: ../installation/upgrading/
@@ -446,3 +446,4 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [83]: https://docs.sensu.io/sensu-go/latest/reference/agent/
 [84]: https://docs.sensu.io/sensu-go/latest/reference/backend/
 [85]: https://blog.sensu.io/announcing-the-sensu-archives
+[86]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396

--- a/content/sensu-core/1.9/platforms/_index.md
+++ b/content/sensu-core/1.9/platforms/_index.md
@@ -10,4 +10,10 @@ menu:
     identifier: platforms
 ---
 
+_**IMPORTANT**: [Sensu Core reached end-of-life (EOL) on December 31, 2019][1], and we [permanently removed][2] the Sensu EOL repository on February 1, 2021. To migrate to Sensu Go, read the [Sensu Core migration guide][3]._
+
 {{< directoryListing >}}
+
+[1]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[2]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[3]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/platforms/sensu-on-freebsd.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-freebsd.md
@@ -23,8 +23,10 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages specified in the instructions below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
 Sensu Core is installed on FreeBSD systems via a native system installer package
-(i.e. a .txz file), which is available for [download][1] and from [this repository (64-bit FreeBSD 10+ only)][2].
+(i.e. a .txz file).
 
 _WARNING: FreeBSD packages are currently as a "beta" release. Support for
 running Sensu on FreeBSD will be provided on a best-effort basis until further
@@ -37,7 +39,7 @@ To install or upgrade to the latest version of Sensu, please ensure
 you have updated existing configurations to follow the repository URL
 format specified below._
 
-1. Download the Sensu [FreeBSD package][1].
+1. Download the Sensu FreeBSD package.
    _NOTE: FreeBSD packages are available for FreeBSD 10 and 11._
 
 2. Install the `sensu-1.4.1_1.txz` package using the `pkg` utility:
@@ -115,9 +117,6 @@ connect to the configured [Sensu Transport][6].
 Please see [Redis][7] or [RabbitMQ][8] reference documentation for examples.
 
 
-[1]:  https://eol-repositories.sensuapp.org/freebsd/
-[2]:  https://eol-repositories.sensuapp.org/freebsd/
-[3]:  https://eol-repositories.sensuapp.org/freebsd/FreeBSD:10:amd64/sensu/sensu-1.4.1_1.txz
 [4]:  https://sensuapp.org/mit-license
 [5]:  ../../reference/configuration/
 [6]:  ../../reference/transport/
@@ -126,3 +125,6 @@ Please see [Redis][7] or [RabbitMQ][8] reference documentation for examples.
 [9]:  #configure-sensu
 [10]: #example-transport-configuration
 [11]: #example-client-configuration
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/platforms/sensu-on-ibm-aix.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-ibm-aix.md
@@ -27,8 +27,10 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages specified in the instructions below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
 Sensu Core is installed on IBM AIX systems via a native system installer package
-(i.e. a .bff file), which is available for [download][1] and from [this repository][2].
+(i.e. a .bff file).
 
 ### Download and install Sensu using the Sensu .bff package {#download-and-install-sensu-core}
 
@@ -37,7 +39,7 @@ install or upgrade to the latest version of Sensu, please ensure you
 have updated existing configurations to follow the repository URL
 format specified below._
 
-1. Download the Sensu [AIX package][1].
+1. Download the Sensu AIX package.
 
 2. The Sensu installer package for IBM AIX systems is provided in **backup file
    format** (.bff). In order to install the content, you will need to know the
@@ -159,9 +161,6 @@ not working at this time, so any Ruby-based Sensu plugins that require FFI will
 not work (however all other plugins should work). It is possible that FFI
 support will be enabled in a future release.
 
-[1]:  https://eol-repositories.sensuapp.org/aix/
-[2]:  https://eol-repositories.sensuapp.org/aix/
-[3]:  https://eol-repositories.sensuapp.org/aix/6.1/sensu-1.4.1-1.powerpc.bff
 [4]:  https://sensuapp.org/mit-license
 [5]:  ../../reference/configuration/
 [6]:  ../../reference/transport/
@@ -172,6 +171,9 @@ support will be enabled in a future release.
 [11]: #example-transport-configuration
 [12]: #example-client-configuration
 [13]: ../../reference/transport/#transport-definition-specification
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
 
 <!-- Supplemental links -->
 [aix-logrotate]: https://www.ibm.com/developerworks/aix/library/aix-toolbox/alpha.html#L

--- a/content/sensu-core/1.9/platforms/sensu-on-mac-os-x.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-mac-os-x.md
@@ -26,7 +26,9 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
-Sensu Core is installed on Mac OS X systems via a native system installer package (i.e. a .pkg file), which is available for [download][1].
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages specified in the instructions below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
+Sensu Core is installed on Mac OS X systems via a native system installer package (i.e. a .pkg file).
 
 _WARNING: Mac OS X packages are currently as a "beta" release. Support for
 running Sensu on Mac OS X will be provided on a best-effort basis until further
@@ -34,9 +36,9 @@ notice._
 
 ### Download and install Sensu using the Sensu Universal .pkg file {#download-and-install-sensu-core}
 
-1. Download the Sensu [Mac OS X package][1].
+1. Download the Sensu Mac OS X package.
    _NOTE: the Universal .pkg file supports OS X "Mavericks" (10.9) and newer.
-   Mountain Lion users: please use [this installer][3]._
+   Mountain Lion users: please use this installer._
 
 2. Install the package using the `installer` utility
    {{< code shell >}}
@@ -182,16 +184,17 @@ $ sudo -u _sensu /opt/sensu/bin/sensu-client -V
 1.4.1{{< /code >}}
 
 
-[1]:  https://eol-repositories.sensuapp.org/osx/
-[3]:  https://eol-repositories.sensuapp.org/osx/sensu-0.26.3-1.mountainlion.pkg
 [4]:  #configure-the-sensu-client-launchd-daemon
 [5]:  ../../reference/configuration/
 [6]:  ../../reference/transport/
 [7]:  ../../reference/redis/#configure-sensu
 [8]:  ../../reference/rabbitmq/#sensu-rabbitmq-configuration
-[10]: ../../reference/configuration/#sensu-service-cli-arguments
+[10]: ../../reference/configuration/#sensu-command-line-interfaces-and-arguments
 [11]: https://ss64.com/osx/launchctl.html
 [12]: #configure-sensu
 [13]: #example-transport-configuration
 [14]: #example-client-configuration
 [15]: ../../reference/transport/#transport-definition-specification
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/platforms/sensu-on-microsoft-windows.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-microsoft-windows.md
@@ -28,15 +28,17 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][20], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages specified in the instructions below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
 Sensu Core is installed on Microsoft Windows systems via a native system
-installer package (i.e. a .msi file), which is available for [download][1] and from [this repository][2].
+installer package (i.e. a .msi file).
 
 ### Download and install Sensu using the Sensu MSI {#download-and-install-sensu-core}
 
 _NOTE: As of Sensu version 1.0, repository URLs have changed.
 To install or upgrade to the latest version of Sensu, please ensure you have updated existing configurations to follow the repository URL format specified below._
 
-1. Download the Sensu [Microsoft Windows package][1].
+1. Download the Sensu Microsoft Windows package.
 
 2. Double-click the `sensu-1.4.1-1-x64.msi` installer package to launch the
    installer, accept the Sensu Core [MIT License][4] and install Sensu using the
@@ -179,15 +181,12 @@ sc start sensu-client
 sc stop sensu-client{{< /code >}}
 
 
-[1]:  https://eol-repositories.sensuapp.org/msi/
-[2]:  https://eol-repositories.sensuapp.org/msi/
-[3]:  https://eol-repositories.sensuapp.org/msi/2012r2/sensu-1.4.1-1-x64.msi
 [4]:  https://sensuapp.org/mit-license
 [5]:  ../../reference/configuration/
 [6]:  ../../reference/transport/
 [7]:  ../../reference/redis/#configure-sensu
 [8]:  ../../reference/rabbitmq/#sensu-rabbitmq-configuration
-[9]:  ../../reference/configuration/#sensu-service-cli-arguments
+[9]:  ../../reference/configuration/#sensu-command-line-interfaces-and-arguments
 [10]: https://technet.microsoft.com/en-us/library/bb490995.aspx
 [11]: https://technet.microsoft.com/en-us/library/cc755249.aspx
 [12]: #configure-sensu
@@ -196,3 +195,6 @@ sc stop sensu-client{{< /code >}}
 [15]: ../../reference/transport/#transport-definition-specification
 [16]: http://stackoverflow.com/questions/2223882/whats-different-between-utf-8-and-utf-8-without-bom
 [17]: http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
+[20]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise

--- a/content/sensu-core/1.9/platforms/sensu-on-oracle-solaris.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-oracle-solaris.md
@@ -27,8 +27,10 @@ menu:
 
 ## Install Sensu {#sensu-core}
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages specified in the instructions below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
 Sensu Core is installed on Solaris systems via native system installer packages
-(i.e. .pkg or [IPS][13] .p5p files), which are available for download for [Solaris 10][1] and [Solaris 11][14] page and from the repositories for [Solaris 10 (.pkg)][2], and [Solaris 11 (IPS .p5p)][3].
+(i.e. .pkg or [IPS][13] .p5p files).
 
 ### Download and install Sensu on Solaris 10 {#download-and-install-sensu-core-on-solaris-10}
 
@@ -37,7 +39,7 @@ To install or upgrade to the latest version of Sensu, please ensure
 you have updated existing configurations to follow the repository URL
 format specified below._
 
-1. Download the Sensu [Solaris 10 package][1].
+1. Download the Sensu Solaris 10 package.
 
 2. Install the `sensu-1.4.1-1.i386.pkg` package using the `pkgadd` utility:
    {{< code shell >}}
@@ -56,7 +58,7 @@ svccfg import /lib/svc/manifest/site/sensu-client.xml{{< /code >}}
 
 ### Download and install Sensu on Solaris 11 {#download-and-install-sensu-core-on-solaris-11}
 
-1. Download the Sensu [Solaris 11 package][14] or use the `wget` utility:
+1. Download the Sensu Solaris 11 package or use the `wget` utility:
    {{< code shell >}}
 wget https://eol-repositories.sensuapp.org/solaris/ips/5.11/sensu-1.4.1-1.i386.p5p{{< /code >}}
 
@@ -161,9 +163,7 @@ $ svcadm enable sensu-client
 $ svcadm disable sensu-client
 $ svcadm restart sensu-client{{< /code >}}
 
-[1]: https://eol-repositories.sensuapp.org/solaris/pkg/
-[2]: https://eol-repositories.sensuapp.org/solaris/pkg/
-[3]: https://eol-repositories.sensuapp.org/solaris/ips/
+
 [4]: https://sensuapp.org/mit-license
 [5]: ../../reference/configuration/
 [6]: ../../reference/transport/
@@ -175,3 +175,6 @@ $ svcadm restart sensu-client{{< /code >}}
 [12]: ../../files/postinst.sh
 [13]: http://www.oracle.com/technetwork/server-storage/solaris11/technologies/ips-323421.html
 [14]: https://eol-repositories.sensuapp.org/solaris/ips/
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/platforms/sensu-on-rhel-centos.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-rhel-centos.md
@@ -20,7 +20,6 @@ menu:
 - [Installing Sensu Enterprise](#sensu-enterprise)
   - [Install the Sensu Enterprise repository](#install-sensu-enterprise-repository)
   - [Install the Sensu Enterprise Dashboard repository](#install-sensu-enterprise-dashboard-repository)
-  - [Install Sensu Enterprise (server & API)](#install-sensu-enterprise)
 - [Configure Sensu](#configure-sensu)
   - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
@@ -39,7 +38,9 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
-Sensu Core is installed on RHEL and CentOS systems via a native system installer package (i.e. a .rpm file), which is available for [download][1] and from YUM package management repositories.
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages and https://eol-repositories.sensuapp.org URLs specified in the instructions and code examples below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
+Sensu Core is installed on RHEL and CentOS systems via a native system installer package (i.e. a .rpm file), which is available for download and from YUM package management repositories.
 The Sensu Core package installs several processes including `sensu-server`, `sensu-api`, and `sensu-client`.
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
@@ -87,6 +88,8 @@ sudo yum install sensu{{< /code >}}
    below.
 
 ## Install Sensu Enterprise {#sensu-enterprise}
+
+_IMPORTANT: [Sensu Enterprise reached end-of-life (EOL) March 31, 2020][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages and https://eol-repositories.sensuapp.org URLs specified in the instructions and code examples below are no longer available. To migrate to Sensu Go, read the [Sensu Enterprise migration guide][20]._
 
 [Sensu Enterprise][2] is installed on RHEL and CentOS systems via a native
 system installer package (i.e. a .rpm file). The Sensu Enterprise installer
@@ -439,7 +442,6 @@ sudo service sensu-enterprise-dashboard stop{{< /code >}}
   IP address where the Sensu Enterprise Dashboard is running).
 
 
-[1]:  https://eol-repositories.sensuapp.org/yum/
 [2]:  https://sensu.io/products/enterprise
 [3]:  ../../reference/configuration/
 [4]:  ../../reference/transport/
@@ -456,3 +458,7 @@ sudo service sensu-enterprise-dashboard stop{{< /code >}}
 [15]: https://account.sensu.io
 [16]: #example-sensu-enterprise-dashboard-configurations
 [epel]: https://www.fedoraproject.org/wiki/EPEL
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
+[20]: https://docs.sensu.io/sensu-enterprise/3.8/migration/

--- a/content/sensu-core/1.9/platforms/sensu-on-ubuntu-debian.md
+++ b/content/sensu-core/1.9/platforms/sensu-on-ubuntu-debian.md
@@ -20,7 +20,6 @@ menu:
 - [Installing Sensu Enterprise](#sensu-enterprise)
   - [Install the Sensu Enterprise repository](#install-sensu-enterprise-repository)
   - [Install the Sensu Enterprise Dashboard repository](#install-sensu-enterprise-dashboard-repository)
-  - [Install Sensu Enterprise (server & API)](#install-sensu-enterprise)
 - [Configure Sensu](#configure-sensu)
   - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
@@ -39,7 +38,9 @@ menu:
 
 ## Install Sensu Core {#sensu-core}
 
-Sensu Core is installed on Ubuntu and Debian systems via a native system installer package (i.e. a .deb file), which is available for [download][1] and from APT package management repositories.
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][19], and we [permanently removed][20] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages and https://eol-repositories.sensuapp.org URLs specified in the instructions and examples below are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][21]._
+
+Sensu Core is installed on Ubuntu and Debian systems via a native system installer package (i.e. a .deb file).
 The Sensu Core package installs several processes including `sensu-server`, `sensu-api`, and `sensu-client`.
 
 Sensu packages for Debian target current [`stable` and `oldstable`
@@ -93,6 +94,8 @@ sudo apt-get install sensu{{< /code >}}
    below.
 
 ## Install Sensu Enterprise {#sensu-enterprise}
+
+_IMPORTANT: [Sensu Enterprise reached end-of-life (EOL) March 31, 2020][19], and we [permanently removed][20] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages specified in the instructions below are no longer available. To migrate to Sensu Go, read the [Sensu Enterprise migration guide][22]._
 
 [Sensu Enterprise][2] is installed on Ubuntu and Debian systems via a native
 system installer package (i.e. a .deb file). The Sensu Enterprise installer
@@ -455,7 +458,6 @@ sudo service sensu-enterprise-dashboard stop{{< /code >}}
   IP address where the Sensu Enterprise Dashboard is running).
 
 
-[1]:  https://eol-repositories.sensuapp.org/apt/pool/
 [2]:  https://sensu.io/products/enterprise
 [3]:  ../../reference/configuration
 [4]:  ../../reference/transport
@@ -473,3 +475,7 @@ sudo service sensu-enterprise-dashboard stop{{< /code >}}
 [16]: https://wiki.ubuntu.com/LTS
 [17]: https://account.sensu.io
 [18]: #example-sensu-enterprise-dashboard-configurations
+[19]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[20]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[21]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/
+[22]: https://docs.sensu.io/sensu-enterprise/3.8/migration/

--- a/content/sensu-core/1.9/quick-start/client-installation.md
+++ b/content/sensu-core/1.9/quick-start/client-installation.md
@@ -10,6 +10,8 @@ menu:
     parent: quick-start
 ---
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the packages and https://eol-repositories.sensuapp.org URLs specified in the instructions and code examples on this page are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
 ## Install the Sensu Client
 
 Having successfully installed and configured a Sensu server and API (Sensu Core
@@ -43,11 +45,10 @@ and/or enabling the Sensu client process to start automatically on system boot.
 
 ### Ubuntu/Debian
 
-Sensu Core is installed on Ubuntu and Debian systems via a native system installer package (i.e. a .deb file), which is available for [download][2] and from APT package management repositories.
+Sensu Core is installed on Ubuntu and Debian systems via a native system installer package (i.e. a .deb file).
 The Sensu Core package installs several processes including `sensu-server`, `sensu-api`, and `sensu-client`.
 
-Sensu packages for Debian target current [`stable` and `oldstable`
-releases][15].
+Sensu packages for Debian target current [`stable` and `oldstable` releases][15].
 
 Sensu packages for Ubuntu target current [Long Term Support (LTS) releases][16].
 
@@ -103,8 +104,7 @@ sudo apt-get install sensu{{< /code >}}
 ### RHEL/CentOS
 
 Sensu Core is installed on RHEL and CentOS systems via a native system installer
-package (i.e. a .rpm file), which is available for download from the [Sensu
-Downloads][2] page, and from YUM package management repositories. The Sensu Core
+package (i.e. a .rpm file). The Sensu Core
 package installs several processes including `sensu-server`, `sensu-api`, and
 `sensu-client`.
 
@@ -153,9 +153,11 @@ sudo yum install sensu{{< /code >}}
 {{< platformBlockClose >}}
 
 [1]: ../../quick-start/five-minute-install
-[2]: https://eol-repositories.sensuapp.org/apt/pool/
 [12]: ../../reference/transport/#transport-configuration
 [13]: ../../reference/clients/#client-configuration
 [14]: ../../reference/redis/#configure-sensu
 [15]: https://wiki.debian.org/DebianReleases
 [16]: https://wiki.ubuntu.com/LTS
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-core/1.9/quick-start/five-minute-install.md
+++ b/content/sensu-core/1.9/quick-start/five-minute-install.md
@@ -9,6 +9,8 @@ menu:
     parent: quick-start
 ---
 
+_IMPORTANT: [Sensu Core reached end-of-life (EOL) on December 31, 2019][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the repositories and https://eol-repositories.sensuapp.org URLs specified in the instructions and code examples on this page are no longer available. To migrate to Sensu Go, read the [Sensu Core migration guide][19]._
+
 This installation guide is intended to help you install Sensu Core in
 a development environment for testing purposes. To try out Sensu Enterprise,
 see the [Sensu Enterprise quick install guide][12].
@@ -225,3 +227,6 @@ Now you're ready to start building monitoring event pipelines with Sensu!
 [14]: ../../guides/intro-to-mutators
 [15]: ../../guides/intro-to-checks
 [16]: ../../guides/adding-a-client/#add-a-remote-sensu-client
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/content/sensu-enterprise-dashboard/2.16/_index.md
+++ b/content/sensu-enterprise-dashboard/2.16/_index.md
@@ -10,8 +10,7 @@ layout: "single"
 
 [Learn about Sensu Go's built-in dashboard](/sensu-go/latest/dashboard/overview)
 
-_IMPORTANT: [Sensu Enterprise Dashboard reached end-of-life (EOL) on March 31, 2020](https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise), more than 8 years after Sensu Core's inception as an open source software project.
-Learn more about [Core and Enterprise EOL](https://blog.sensu.io/announcing-the-sensu-archives)._
+_IMPORTANT: [Sensu Enterprise Dashboard reached end-of-life (EOL) on March 31, 2020](https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise), more than 8 years after Sensu Core's inception as an open source software project, and we [permanently removed][20] the Sensu EOL repository on February 1, 2021.<br><br>To migrate to Sensu Go, see the [Sensu Enterprise migration guide][21]._
 
 ## Reference Documentation
 
@@ -86,3 +85,5 @@ installation or cluster).
 [17]: rbac/rbac-for-oidc
 [18]: #oidc-attributes
 [19]: api/overview
+[20]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[21]: https://docs.sensu.io/sensu-enterprise/latest/migration

--- a/content/sensu-enterprise/3.8/_index.md
+++ b/content/sensu-enterprise/3.8/_index.md
@@ -10,8 +10,7 @@ layout: "single"
 
 [Learn about Sensu Go](/sensu-go/latest/)
 
-_IMPORTANT: [Sensu Enterprise reached end-of-life (EOL) on March 31, 2020](https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise), more than 8 years after Sensu Core's inception as an open source software project.
-Learn more about [Core and Enterprise EOL](https://blog.sensu.io/announcing-the-sensu-archives) and [EOL schedule updates](https://discourse.sensu.io/t/updates-to-the-sensu-core-and-enterprise-eol-schedule-in-response-to-covid-19/1686)._
+_IMPORTANT: [Sensu Enterprise reached end-of-life (EOL) on March 31, 2020](https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise), more than 8 years after Sensu Core's inception as an open source software project, and we [permanently removed][27] the Sensu EOL repository on February 1, 2021.<br><br>To migrate to Sensu Go, see the [Sensu Enterprise migration guide][28]._
 
 Sensu Enterprise is the reliable, scalable monitoring event pipeline built to reduce operator burden and make developers and business owners happy.
 Built on [Sensu Core][3], Sensu Enterprise includes built-in integrations and features designed to solve your organization's unique monitoring challenges.
@@ -106,3 +105,5 @@ upgrading from Sensu Core to Sensu Enterprise and Sensu Enterprise Dashboard.
 [24]: #upgrading-to-sensu-enterprise
 [25]: /sensu-enterprise-dashboard/latest/rbac/overview
 [26]: built-in-mutators
+[27]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[28]: migration/

--- a/content/sensu-enterprise/3.8/quick-start/five-minute-install.md
+++ b/content/sensu-enterprise/3.8/quick-start/five-minute-install.md
@@ -9,6 +9,8 @@ menu:
     parent: quick-start
 ---
 
+_IMPORTANT: [Sensu Enterprise reached end-of-life (EOL) March 31, 2020][17], and we [permanently removed][18] the Sensu EOL repository on February 1, 2021.<br><br>This means the repositories specified in the instructions and code examples below are no longer available. To migrate to Sensu Go, read the [Sensu Enterprise migration guide][19]._
+
 This installation guide is intended to help you install Sensu Enterprise in
 a development environment for testing purposes.
 
@@ -262,3 +264,6 @@ Now you're ready to start building monitoring event pipelines with Sensu!
 [14]: ../../built-in-filters
 [15]: ../../integrations/influxdb
 [16]: /sensu-enterprise-dashboard/latest/rbac/overview/
+[17]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[18]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[19]: https://docs.sensu.io/sensu-enterprise/3.8/migration/

--- a/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
@@ -20,7 +20,8 @@ Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -20,7 +20,8 @@ Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -20,7 +20,8 @@ Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -20,7 +20,8 @@ Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -20,7 +20,8 @@ Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least [Sensu Core 1.9.0-2](https://eol-repositories.sensuapp.org/).
+**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core to Sensu Go:

--- a/content/uchiwa/1.0/_index.md
+++ b/content/uchiwa/1.0/_index.md
@@ -9,8 +9,7 @@ layout: "single"
 
 [Learn about Sensu Go's built-in dashboard](/sensu-go/latest/dashboard/overview)
 
-_IMPORTANT: [Uchiwa reached end-of-life (EOL) on December 31, 2019](https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise), more than 8 years after Sensu Core's inception as an open source software project.
-Learn more about [Core and Enterprise EOL](https://blog.sensu.io/announcing-the-sensu-archives)._
+_IMPORTANT: [Uchiwa reached end-of-life (EOL) on December 31, 2019][1], more than 8 years after Sensu Core's inception as an open source software project, and we [permanently removed][2] the Sensu EOL repository on February 1, 2021.<br><br>To migrate to Sensu Go, read the [Sensu Core migration guide][3]._
 
 ## What is Uchiwa?
 
@@ -29,3 +28,8 @@ Uchiwa is:
 * **Light**: No dependencies and a small footprint
 * **Powerful**: Manage ten of thousands of servers, applications and others
 * **Easy to use**: Abstract complex monitoring concepts to your users
+
+
+[1]: https://blog.sensu.io/eol-schedule-for-sensu-core-and-enterprise
+[2]: https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396
+[3]: https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/migrate/

--- a/layouts/partials/eolSection.html
+++ b/layouts/partials/eolSection.html
@@ -3,28 +3,28 @@
   {{ $product := replace .Section "-" "_" }}
   {{ $product_info := (index .Site.Params.products $product) }}
   {{ if and (isset .Params "version") (eq .Params.product "Sensu Core") }}
-    {{ $message := (printf "%s reached end-of-life on December 31, 2019. Click here to start your migration to Sensu Go." .Params.product) }}
+    {{ $message := (printf "%s reached end-of-life (EOL) on December 31, 2019, and we removed the EOL repository on February 1, 2021. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-core/../migration" ".." .Params.version }}
     {{ $params := slice "#b7312e" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 
   {{ if and (isset .Params "version") (eq .Params.product "Uchiwa") }}
-    {{ $message := (printf "%s reached end-of-life on December 31, 2019. Click here to start your migration to Sensu Go." .Params.product) }}
+    {{ $message := (printf "%s reached end-of-life (EOL) on December 31, 2019, and we removed the EOL repository on February 1, 2021. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-core/latest/migration" ".." .Params.version }}
     {{ $params := slice "#b7312e" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 
   {{ if and (isset .Params "version") (eq .Params.product "Sensu Enterprise") }}
-    {{ $message := (printf "%s reached end-of-life on March 31, 2020. Click here to start your migration to Sensu Go." .Params.product) }}
+    {{ $message := (printf "%s reached end-of-life (EOL) on March 31, 2020, and we removed the EOL repository on February 1, 2021. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-enterprise/../migration" ".." .Params.version }}
     {{ $params := slice "#b7312e" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 
   {{ if and (isset .Params "version") (eq .Params.product "Sensu Enterprise Dashboard") }}
-    {{ $message := (printf "%s reached end-of-life on March 31, 2020. Click here to start your migration to Sensu Go." .Params.product) }}
+    {{ $message := (printf "%s reached end-of-life (EOL) on March 31, 2020, and we removed the EOL repository on February 1, 2021. Click here to start your migration to Sensu Go." .Params.product) }}
     {{ $link := replace "https://docs.sensu.io/sensu-enterprise/latest/migration" ".." .Params.version }}
     {{ $params := slice "#b7312e" $message $link }}
     {{ partial "alert" $params }}


### PR DESCRIPTION
## Description
Updates notes, banners, and text throughout the Core, Enterprise, Enterprise Dashboard, Uchiwa, and Go docs to explain that we permanently removed the EOL repositories for Core and Enterprise on February 1, 2021.

- Adds link to [Caleb's latest Discourse post](https://discourse.sensu.io/t/updated-eol-timeline-for-sensu-core-and-sensu-enterprise-repos/2396)
- Removes links to eol-repositories packages
- Adds IMPORTANT notes where instructions or code examples refer to eol-repositories packages or the eol-repositories URLs

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2945