### PR TITLE
Update federation API doc to replace one :etcd-replicator with :cluster

### DIFF
--- a/content/sensu-go/5.21/api/federation.md
+++ b/content/sensu-go/5.21/api/federation.md
@@ -369,7 +369,7 @@ The `/clusters/:cluster` API endpoint provides HTTP GET access to data for a spe
 
 ### Example {#clusterscluster-get-example}
 
-In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:etcd-replicator`.
+In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:cluster`.
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.0/api/federation.md
+++ b/content/sensu-go/6.0/api/federation.md
@@ -369,7 +369,7 @@ The `/clusters/:cluster` API endpoint provides HTTP GET access to data for a spe
 
 ### Example {#clusterscluster-get-example}
 
-In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:etcd-replicator`.
+In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:cluster`.
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.1/api/federation.md
+++ b/content/sensu-go/6.1/api/federation.md
@@ -369,7 +369,7 @@ The `/clusters/:cluster` API endpoint provides HTTP GET access to data for a spe
 
 ### Example {#clusterscluster-get-example}
 
-In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:etcd-replicator`.
+In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:cluster`.
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.2/api/federation.md
+++ b/content/sensu-go/6.2/api/federation.md
@@ -369,7 +369,7 @@ The `/clusters/:cluster` API endpoint provides HTTP GET access to data for a spe
 
 ### Example {#clusterscluster-get-example}
 
-In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:etcd-replicator`.
+In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:cluster`.
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.3/api/federation.md
+++ b/content/sensu-go/6.3/api/federation.md
@@ -369,7 +369,7 @@ The `/clusters/:cluster` API endpoint provides HTTP GET access to data for a spe
 
 ### Example {#clusterscluster-get-example}
 
-In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:etcd-replicator`.
+In the following example, querying the `/clusters/:cluster` API endpoint returns a JSON map that contains the requested `:cluster`.
 
 {{< code shell >}}
 curl -X GET \


### PR DESCRIPTION
## Description
In the federation API doc, one of the descriptions in the "Get a specific cluster" endpoint listed :etcd-replicator instead of :cluster

## Motivation and Context
Found error while working on another doc