### PR TITLE
Add list of available APIs to API category page

### DIFF
--- a/content/sensu-go/5.21/api/_index.md
+++ b/content/sensu-go/5.21/api/_index.md
@@ -21,7 +21,8 @@ The cluster protocol will replicate your changes to all cluster members.
 
 ## Available APIs
 
-explain.........
+Access all of the data and functionality of Sensu's first-class API clients, [sensuctl][25] and the [web UI][26], with Sensu's backend REST APIs.
+Use the Sensu APIs to customize your workflows and integrate your favorite Sensu features with other tools and products.
 
 {{< apitypeListing >}}
 

--- a/content/sensu-go/5.21/api/_index.md
+++ b/content/sensu-go/5.21/api/_index.md
@@ -714,3 +714,5 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
 [19]: apikeys/
 [20]: #authenticate-with-the-authentication-api
+[25]: ../sensuctl/
+[26]: ../web-ui/

--- a/content/sensu-go/5.21/api/_index.md
+++ b/content/sensu-go/5.21/api/_index.md
@@ -19,6 +19,12 @@ For information about the Sensu agent API, see the [agent reference][4].
 If you have a healthy [clustered][10] backend, you only need to make Sensu API calls to any one of the cluster members.
 The cluster protocol will replicate your changes to all cluster members.
 
+## Available APIs
+
+explain.........
+
+{{< apitypeListing >}}
+
 ## URL format
 
 Sensu API endpoints use the standard URL format `/api/{group}/{version}/namespaces/{namespace}` where:

--- a/content/sensu-go/5.21/api/apikeys.md
+++ b/content/sensu-go/5.21/api/apikeys.md
@@ -1,6 +1,8 @@
 ---
 title: "APIKeys API"
 description: "The Sensu APIKeys API provides HTTP access to API key data. This reference includes examples for returning lists of API keys, creating API keys, and more."
+api_title: "APIKeys API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/assets.md
+++ b/content/sensu-go/5.21/api/assets.md
@@ -1,6 +1,8 @@
 ---
 title: "Assets API"
 description: "The Sensu assets API provides HTTP access to asset data. This reference includes examples for returning lists of assets, creating assets, and more."
+api_title: "Assets API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/auth.md
+++ b/content/sensu-go/5.21/api/auth.md
@@ -1,6 +1,8 @@
 ---
 title: "Authentication API"
 description: "The Sensu authentication API provides HTTP access to test whether user credentials are valid and use these credentials to obtain access tokens. Read on for the full reference."
+api_title: "Authentication API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/authproviders.md
+++ b/content/sensu-go/5.21/api/authproviders.md
@@ -2,6 +2,8 @@
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
 description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+api_title: "Authentication providers API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/checks.md
+++ b/content/sensu-go/5.21/api/checks.md
@@ -1,6 +1,8 @@
 ---
 title: "Checks API"
 description: "The Sensu checks API provides HTTP access to check data. This reference includes examples for returning the list of checks, creating a Sensu check, and more. Read on for the full reference."
+api_title: "Checks API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/cluster-role-bindings.md
+++ b/content/sensu-go/5.21/api/cluster-role-bindings.md
@@ -2,6 +2,8 @@
 title: "Cluster role bindings API"
 linktitle: "Cluster Role Bindings API"
 description: "The Sensu cluster role bindings API provides HTTP access to cluster role binding data. This reference includes examples for returning lists of cluster role bindings, creating Sensu cluster role bindings, and more. Read on for the full reference."
+api_title: "Cluster role bindings API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/cluster-roles.md
+++ b/content/sensu-go/5.21/api/cluster-roles.md
@@ -2,6 +2,8 @@
 title: "Cluster roles API"
 linkTitle: "Cluster Roles API"
 description: "The Sensu cluster roles API provides HTTP access to cluster role data. This reference includes examples for returning lists of cluster roles, creating Sensu cluster roles, and more. Read on for the full reference."
+api_title: "Cluster roles API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/cluster.md
+++ b/content/sensu-go/5.21/api/cluster.md
@@ -1,6 +1,8 @@
 ---
 title: "Cluster API"
 description: "The Sensu cluster API endpoint provides HTTP access to Sensu cluster data. This reference includes examples for returning the cluster definition, creating a cluster member, and more. Read on for the full reference."
+api_title: "Cluster API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/datastore.md
+++ b/content/sensu-go/5.21/api/datastore.md
@@ -1,6 +1,8 @@
 ---
 title: "Datastore API"
 description: "The datastore API endpoint provides HTTP access to Sensu datastore providers. This reference includes examples for returning the provider definitions, creating a provider, and more."
+api_title: "Datastore API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/entities.md
+++ b/content/sensu-go/5.21/api/entities.md
@@ -1,6 +1,8 @@
 ---
 title: "Entities API"
 description: "The Sensu entities API provides HTTP access to entity data. This reference includes examples for returning lists of entities, creating Sensu entities, and more. Read on for the full reference."
+api_title: "Entities API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/events.md
+++ b/content/sensu-go/5.21/api/events.md
@@ -1,6 +1,8 @@
 ---
 title: "Events API"
 description: "The Sensu events API provides HTTP access to event data. This reference includes examples for returning lists of events, creating Sensu events, and more. Read on for the full reference."
+api_title: "Events API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/federation.md
+++ b/content/sensu-go/5.21/api/federation.md
@@ -1,6 +1,8 @@
 ---
 title: "Federation API"
 description: "The federation API controls federation of Sensu clusters. This reference describes the Sensu federation API, including examples. Read on for the full reference."
+api_title: "Federation API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/filters.md
+++ b/content/sensu-go/5.21/api/filters.md
@@ -1,6 +1,8 @@
 ---
 title: "Filters API"
 description: "The Sensu filters API provides HTTP access to event filter data. This reference includes examples for returning lists of filters, creating Sensu filters, and more. Read on for the full reference."
+api_title: "Filters API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/handlers.md
+++ b/content/sensu-go/5.21/api/handlers.md
@@ -1,6 +1,8 @@
 ---
 title: "Handlers API"
 description: "The Sensu handlers API provides HTTP access to handler data. This reference includes examples for returning lists of handlers, creating a Sensu handler, and more. Read on for the full reference."
+api_title: "Handlers API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/health.md
+++ b/content/sensu-go/5.21/api/health.md
@@ -1,6 +1,8 @@
 ---
 title: "Health API"
 description: "The Sensu health API provides HTTP access to health data for your Sensu instance. This reference includes examples for retrieving health information about your Sensu instance. Read on for the full reference."
+api_title: "Health API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/hooks.md
+++ b/content/sensu-go/5.21/api/hooks.md
@@ -1,6 +1,8 @@
 ---
 title: "Hooks API"
 description: "The Sensu hooks API provides HTTP access to hook data. This reference includes examples for returning lists of hooks, creating a Sensu hook, and more. Read on for the full reference."
+api_title: "Hooks API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/license.md
+++ b/content/sensu-go/5.21/api/license.md
@@ -1,7 +1,9 @@
 ---
-title: "License management API"
+title: "License API"
 linkTitle: "License API"
 description: "The Sensu license API provides HTTP access to the active commercial license configuration. This reference includes examples for returning the active commercial license configuration and activating or updating a commercial license. Read on for the full reference."
+api_title: "License API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/metrics.md
+++ b/content/sensu-go/5.21/api/metrics.md
@@ -1,6 +1,8 @@
 ---
 title: "Metrics API"
 description: "The Sensu metrics API provides HTTP access to internal Sensu metrics, including embedded etcd, memory usage, garbage collection, and gRPC metrics. Read on for the full reference."
+api_title: "Metrics API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/mutators.md
+++ b/content/sensu-go/5.21/api/mutators.md
@@ -1,6 +1,8 @@
 ---
 title: "Mutators API"
 description: "The Sensu mutator API provides HTTP access to mutator data. This reference includes examples for returning lists of mutators, creating a Sensu mutator, and more. Read on for the full reference."
+api_title: "Mutators API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/namespaces.md
+++ b/content/sensu-go/5.21/api/namespaces.md
@@ -1,6 +1,8 @@
 ---
 title: "Namespaces API"
 description: "The Sensu namespace API provides HTTP access to namespace data. This reference includes examples for returning lists of namespaces, creating Sensu namespaces, and more. Read on for the full reference."
+api_title: "Namespaces API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/prune.md
+++ b/content/sensu-go/5.21/api/prune.md
@@ -1,6 +1,8 @@
 ---
 title: "Prune API"
 description: "The Sensu prune API provides HTTP access to create pruning commands to delete resources that do not appear in a given set of Sensu objects from a file, URL, or STDIN. This reference includes an example for creating a prune command for your Sensu instance. Read on for the full reference."
+api_title: "Prune API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/role-bindings.md
+++ b/content/sensu-go/5.21/api/role-bindings.md
@@ -2,6 +2,8 @@
 title: "Role bindings API"
 linkTitle: "Role Bindings API"
 description: "The Sensu role bindings API provides HTTP access to role binding data. This reference includes examples for returning lists of role bindings, creating Sensu role bindings, and more. Read on for the full reference."
+api_title: "Role bindings API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/roles.md
+++ b/content/sensu-go/5.21/api/roles.md
@@ -1,6 +1,8 @@
 ---
 title: "Roles API"
 description: "The Sensu roles API provides HTTP access to user role data. This reference includes examples for returning lists of roles, creating Sensu roles, and more. Read on for the full reference."
+api_title: "Roles API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/searches.md
+++ b/content/sensu-go/5.21/api/searches.md
@@ -1,6 +1,8 @@
 ---
 title: "Searches API"
 description: "The Sensu searches API provides HTTP access to the saved searches feature in the Sensu web UI. This reference includes examples for returning lists of saved searches and creating, updating, and deleting saved searches. Read on for the full API documentation."
+api_title: "Searches API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/secrets.md
+++ b/content/sensu-go/5.21/api/secrets.md
@@ -1,6 +1,8 @@
 ---
 title: "Secrets API"
 description: "The secrets API controls secrets management for Sensu. This reference describes the Sensu secrets API, including examples. Read on for the full reference."
+api_title: "Secrets API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/silenced.md
+++ b/content/sensu-go/5.21/api/silenced.md
@@ -1,6 +1,8 @@
 ---
 title: "Silencing API"
 description: "The Sensu silencing API provides HTTP access to silences. This reference includes examples for creating and removing Sensu silences. Read on for the full reference."
+api_title: "Silencing API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/tessen.md
+++ b/content/sensu-go/5.21/api/tessen.md
@@ -1,6 +1,8 @@
 ---
 title: "Tessen API"
 description: "The Sensu Tessen API provides HTTP access to manage Tessen configuration. Read on for the full reference."
+api_title: "Tessen API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/users.md
+++ b/content/sensu-go/5.21/api/users.md
@@ -1,6 +1,8 @@
 ---
 title: "Users API"
 description: "This reference describes the Sensu users API, including some handy examples for how to create users, access user data by username, and update users. Learn how the users API can help you customize Sensu Go to match your workflows."
+api_title: "Users API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/version.md
+++ b/content/sensu-go/5.21/api/version.md
@@ -1,6 +1,8 @@
 ---
 title: "Version API"
 description: "The Sensu version API provides HTTP access to the Sensu and etcd versions. This reference includes examples for returning version information about your Sensu instance. Read on for the full reference."
+api_title: "Version API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/5.21/api/webconfig.md
+++ b/content/sensu-go/5.21/api/webconfig.md
@@ -2,6 +2,8 @@
 title: "Web UI configuration API"
 linkTitle: "Web UI Configuration API"
 description: "The Sensu web configuration API provides HTTP access to the global web UI configuration. This reference includes examples for returning the global web UI configuration and adding or updating the web UI configuration. Read on for the full reference."
+api_title: "Web UI configuration API"
+type: "api"
 version: "5.21"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/_index.md
+++ b/content/sensu-go/6.0/api/_index.md
@@ -19,6 +19,12 @@ The cluster protocol will replicate your changes to all cluster members.
 
 For information about the Sensu agent API, see the [agent reference][4].
 
+## Available APIs
+
+explain.........
+
+{{< apitypeListing >}}
+
 ## URL format
 
 Sensu API endpoints use the standard URL format `/api/{group}/{version}/namespaces/{namespace}` where:

--- a/content/sensu-go/6.0/api/_index.md
+++ b/content/sensu-go/6.0/api/_index.md
@@ -714,3 +714,5 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
 [19]: apikeys/
 [20]: #authenticate-with-the-authentication-api
+[25]: ../sensuctl/
+[26]: ../web-ui/

--- a/content/sensu-go/6.0/api/_index.md
+++ b/content/sensu-go/6.0/api/_index.md
@@ -21,7 +21,8 @@ For information about the Sensu agent API, see the [agent reference][4].
 
 ## Available APIs
 
-explain.........
+Access all of the data and functionality of Sensu's first-class API clients, [sensuctl][25] and the [web UI][26], with Sensu's backend REST APIs.
+Use the Sensu APIs to customize your workflows and integrate your favorite Sensu features with other tools and products.
 
 {{< apitypeListing >}}
 

--- a/content/sensu-go/6.0/api/apikeys.md
+++ b/content/sensu-go/6.0/api/apikeys.md
@@ -1,6 +1,8 @@
 ---
 title: "APIKeys API"
 description: "The Sensu APIKeys API provides HTTP access to API key data. This reference includes examples for returning lists of API keys, creating API keys, and more."
+api_title: "APIKeys API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/assets.md
+++ b/content/sensu-go/6.0/api/assets.md
@@ -1,6 +1,8 @@
 ---
 title: "Assets API"
 description: "The Sensu assets API provides HTTP access to dynamic runtime asset data. This reference includes examples for returning lists of dynamic runtime assets, creating dynamic runtime assets, and more."
+api_title: "Assets API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/auth.md
+++ b/content/sensu-go/6.0/api/auth.md
@@ -1,6 +1,8 @@
 ---
 title: "Authentication API"
 description: "The Sensu authentication API provides HTTP access to test whether user credentials are valid and use these credentials to obtain access tokens. Read on for the full reference."
+api_title: "Authentication API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/authproviders.md
+++ b/content/sensu-go/6.0/api/authproviders.md
@@ -2,6 +2,8 @@
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
 description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+api_title: "Authentication providers API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/checks.md
+++ b/content/sensu-go/6.0/api/checks.md
@@ -1,6 +1,8 @@
 ---
 title: "Checks API"
 description: "The Sensu checks API provides HTTP access to check data. This reference includes examples for returning the list of checks, creating a Sensu check, and more. Read on for the full reference."
+api_title: "Checks API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/cluster-role-bindings.md
+++ b/content/sensu-go/6.0/api/cluster-role-bindings.md
@@ -2,6 +2,8 @@
 title: "Cluster role bindings API"
 linktitle: "Cluster Role Bindings API"
 description: "The Sensu cluster role bindings API provides HTTP access to cluster role binding data. This reference includes examples for returning lists of cluster role bindings, creating Sensu cluster role bindings, and more. Read on for the full reference."
+api_title: "Cluster role bindings API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/cluster-roles.md
+++ b/content/sensu-go/6.0/api/cluster-roles.md
@@ -2,6 +2,8 @@
 title: "Cluster roles API"
 linkTitle: "Cluster Roles API"
 description: "The Sensu cluster roles API provides HTTP access to cluster role data. This reference includes examples for returning lists of cluster roles, creating Sensu cluster roles, and more. Read on for the full reference."
+api_title: "Cluster roles API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/cluster.md
+++ b/content/sensu-go/6.0/api/cluster.md
@@ -1,6 +1,8 @@
 ---
 title: "Cluster API"
 description: "The Sensu cluster API endpoint provides HTTP access to Sensu cluster data. This reference includes examples for returning the cluster definition, creating a cluster member, and more. Read on for the full reference."
+api_title: "Cluster API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/datastore.md
+++ b/content/sensu-go/6.0/api/datastore.md
@@ -1,6 +1,8 @@
 ---
 title: "Datastore API"
 description: "The datastore API endpoint provides HTTP access to Sensu datastore providers. This reference includes examples for returning the provider definitions, creating a provider, and more."
+api_title: "Datastore API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/entities.md
+++ b/content/sensu-go/6.0/api/entities.md
@@ -1,6 +1,8 @@
 ---
 title: "Entities API"
 description: "The Sensu entities API provides HTTP access to entity data. This reference includes examples for returning lists of entities, creating Sensu entities, and more. Read on for the full reference."
+api_title: "Entities API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/events.md
+++ b/content/sensu-go/6.0/api/events.md
@@ -1,6 +1,8 @@
 ---
 title: "Events API"
 description: "The Sensu events API provides HTTP access to event data. This reference includes examples for returning lists of events, creating Sensu events, and more. Read on for the full reference."
+api_title: "Events API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/federation.md
+++ b/content/sensu-go/6.0/api/federation.md
@@ -1,6 +1,8 @@
 ---
 title: "Federation API"
 description: "The federation API controls federation of Sensu clusters. This reference describes the Sensu federation API, including examples. Read on for the full reference."
+api_title: "Federation API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/filters.md
+++ b/content/sensu-go/6.0/api/filters.md
@@ -1,6 +1,8 @@
 ---
 title: "Filters API"
 description: "The Sensu filters API provides HTTP access to event filter data. This reference includes examples for returning lists of filters, creating Sensu filters, and more. Read on for the full reference."
+api_title: "Filters API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/handlers.md
+++ b/content/sensu-go/6.0/api/handlers.md
@@ -1,6 +1,8 @@
 ---
 title: "Handlers API"
 description: "The Sensu handlers API provides HTTP access to handler data. This reference includes examples for returning lists of handlers, creating a Sensu handler, and more. Read on for the full reference."
+api_title: "Handlers API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/health.md
+++ b/content/sensu-go/6.0/api/health.md
@@ -1,6 +1,8 @@
 ---
 title: "Health API"
 description: "The Sensu health API provides HTTP access to health data for your Sensu instance. This reference includes examples for retrieving health information about your Sensu instance. Read on for the full reference."
+api_title: "Health API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/hooks.md
+++ b/content/sensu-go/6.0/api/hooks.md
@@ -1,6 +1,8 @@
 ---
 title: "Hooks API"
 description: "The Sensu hooks API provides HTTP access to hook data. This reference includes examples for returning lists of hooks, creating a Sensu hook, and more. Read on for the full reference."
+api_title: "Hooks API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/license.md
+++ b/content/sensu-go/6.0/api/license.md
@@ -1,7 +1,9 @@
 ---
-title: "License management API"
+title: "License API"
 linkTitle: "License API"
 description: "The Sensu license API provides HTTP access to the active commercial license configuration. This reference includes examples for returning the active commercial license configuration and activating or updating a commercial license. Read on for the full reference."
+api_title: "License API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/metrics.md
+++ b/content/sensu-go/6.0/api/metrics.md
@@ -1,6 +1,8 @@
 ---
 title: "Metrics API"
 description: "The Sensu metrics API provides HTTP access to internal Sensu metrics, including embedded etcd, memory usage, garbage collection, and gRPC metrics. Read on for the full reference."
+api_title: "Metrics API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/mutators.md
+++ b/content/sensu-go/6.0/api/mutators.md
@@ -1,6 +1,8 @@
 ---
 title: "Mutators API"
 description: "The Sensu mutator API provides HTTP access to mutator data. This reference includes examples for returning lists of mutators, creating a Sensu mutator, and more. Read on for the full reference."
+api_title: "Mutators API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/namespaces.md
+++ b/content/sensu-go/6.0/api/namespaces.md
@@ -1,6 +1,8 @@
 ---
 title: "Namespaces API"
 description: "The Sensu namespace API provides HTTP access to namespace data. This reference includes examples for returning lists of namespaces, creating Sensu namespaces, and more. Read on for the full reference."
+api_title: "Namespaces API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/prune.md
+++ b/content/sensu-go/6.0/api/prune.md
@@ -1,6 +1,8 @@
 ---
 title: "Prune API"
 description: "The Sensu prune API provides HTTP access to create pruning commands to delete resources that do not appear in a given set of Sensu objects from a file, URL, or STDIN. This reference includes an example for creating a prune command for your Sensu instance. Read on for the full reference."
+api_title: "Prune API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/role-bindings.md
+++ b/content/sensu-go/6.0/api/role-bindings.md
@@ -2,6 +2,8 @@
 title: "Role bindings API"
 linkTitle: "Role Bindings API"
 description: "The Sensu role bindings API provides HTTP access to role binding data. This reference includes examples for returning lists of role bindings, creating Sensu role bindings, and more. Read on for the full reference."
+api_title: "Role bindings API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/roles.md
+++ b/content/sensu-go/6.0/api/roles.md
@@ -1,6 +1,8 @@
 ---
 title: "Roles API"
 description: "The Sensu roles API provides HTTP access to user role data. This reference includes examples for returning lists of roles, creating Sensu roles, and more. Read on for the full reference."
+api_title: "Roles API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/searches.md
+++ b/content/sensu-go/6.0/api/searches.md
@@ -1,6 +1,8 @@
 ---
 title: "Searches API"
 description: "The Sensu searches API provides HTTP access to the saved searches feature in the Sensu web UI. This reference includes examples for returning lists of saved searches and creating, updating, and deleting saved searches. Read on for the full API documentation."
+api_title: "Searches API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/secrets.md
+++ b/content/sensu-go/6.0/api/secrets.md
@@ -1,6 +1,8 @@
 ---
 title: "Secrets API"
 description: "The secrets API controls secrets management for Sensu. This reference describes the Sensu secrets API, including examples. Read on for the full reference."
+api_title: "Secrets API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/silenced.md
+++ b/content/sensu-go/6.0/api/silenced.md
@@ -1,6 +1,8 @@
 ---
 title: "Silencing API"
 description: "The Sensu silencing API provides HTTP access to silences. This reference includes examples for creating and removing Sensu silences. Read on for the full reference."
+api_title: "Silencing API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/tessen.md
+++ b/content/sensu-go/6.0/api/tessen.md
@@ -1,6 +1,8 @@
 ---
 title: "Tessen API"
 description: "The Sensu Tessen API provides HTTP access to manage Tessen configuration. Read on for the full reference."
+api_title: "Tessen API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/users.md
+++ b/content/sensu-go/6.0/api/users.md
@@ -1,6 +1,8 @@
 ---
 title: "Users API"
 description: "This reference describes the Sensu users API, including some handy examples for how to create users, access user data by username, and update users. Learn how the users API can help you customize Sensu Go to match your workflows."
+api_title: "Users API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/version.md
+++ b/content/sensu-go/6.0/api/version.md
@@ -1,6 +1,8 @@
 ---
 title: "Version API"
 description: "The Sensu version API provides HTTP access to the Sensu and etcd versions. This reference includes examples for returning version information about your Sensu instance. Read on for the full reference."
+api_title: "Version API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.0/api/webconfig.md
+++ b/content/sensu-go/6.0/api/webconfig.md
@@ -2,6 +2,8 @@
 title: "Web UI configuration API"
 linkTitle: "Web UI Configuration API"
 description: "The Sensu web configuration API provides HTTP access to the global web UI configuration. This reference includes examples for returning the global web UI configuration and adding or updating the web UI configuration. Read on for the full reference."
+api_title: "Web UI configuration API"
+type: "api"
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -764,3 +764,5 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
 [23]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
 [24]: ../operations/deploy-sensu/cluster-sensu/
+[25]: ../sensuctl/
+[26]: ../web-ui/

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -19,6 +19,12 @@ The cluster protocol will replicate your changes to all cluster members.
 
 For information about the Sensu agent API, see the [agent reference][4].
 
+## Available APIs
+
+explain.........
+
+{{< apitypeListing >}}
+
 ## URL format
 
 Sensu API endpoints use the standard URL format `/api/{group}/{version}/namespaces/{namespace}` where:

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -21,7 +21,8 @@ For information about the Sensu agent API, see the [agent reference][4].
 
 ## Available APIs
 
-explain.........
+Access all of the data and functionality of Sensu's first-class API clients, [sensuctl][25] and the [web UI][26], with Sensu's backend REST APIs.
+Use the Sensu APIs to customize your workflows and integrate your favorite Sensu features with other tools and products.
 
 {{< apitypeListing >}}
 

--- a/content/sensu-go/6.1/api/apikeys.md
+++ b/content/sensu-go/6.1/api/apikeys.md
@@ -1,6 +1,8 @@
 ---
 title: "APIKeys API"
 description: "The Sensu APIKeys API provides HTTP access to API key data. This reference includes examples for returning lists of API keys, creating API keys, and more."
+api_title: "APIKeys API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/assets.md
+++ b/content/sensu-go/6.1/api/assets.md
@@ -1,6 +1,8 @@
 ---
 title: "Assets API"
 description: "The Sensu assets API provides HTTP access to dynamic runtime asset data. This reference includes examples for returning lists of dynamic runtime assets, creating dynamic runtime assets, and more."
+api_title: "Assets API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/auth.md
+++ b/content/sensu-go/6.1/api/auth.md
@@ -1,6 +1,8 @@
 ---
 title: "Authentication API"
 description: "The Sensu authentication API provides HTTP access to test whether user credentials are valid and use these credentials to obtain access tokens. Read on for the full reference."
+api_title: "Authentication API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/authproviders.md
+++ b/content/sensu-go/6.1/api/authproviders.md
@@ -2,6 +2,8 @@
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
 description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+api_title: "Authentication providers API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/checks.md
+++ b/content/sensu-go/6.1/api/checks.md
@@ -1,6 +1,8 @@
 ---
 title: "Checks API"
 description: "The Sensu checks API provides HTTP access to check data. This reference includes examples for returning the list of checks, creating a Sensu check, and more. Read on for the full reference."
+api_title: "Checks API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/cluster-role-bindings.md
+++ b/content/sensu-go/6.1/api/cluster-role-bindings.md
@@ -2,6 +2,8 @@
 title: "Cluster role bindings API"
 linktitle: "Cluster Role Bindings API"
 description: "The Sensu cluster role bindings API provides HTTP access to cluster role binding data. This reference includes examples for returning lists of cluster role bindings, creating Sensu cluster role bindings, and more. Read on for the full reference."
+api_title: "Cluster role bindings API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/cluster-roles.md
+++ b/content/sensu-go/6.1/api/cluster-roles.md
@@ -2,6 +2,8 @@
 title: "Cluster roles API"
 linkTitle: "Cluster Roles API"
 description: "The Sensu cluster roles API provides HTTP access to cluster role data. This reference includes examples for returning lists of cluster roles, creating Sensu cluster roles, and more. Read on for the full reference."
+api_title: "Cluster roles API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/cluster.md
+++ b/content/sensu-go/6.1/api/cluster.md
@@ -1,6 +1,8 @@
 ---
 title: "Cluster API"
 description: "The Sensu cluster API endpoint provides HTTP access to Sensu cluster data. This reference includes examples for returning the cluster definition, creating a cluster member, and more. Read on for the full reference."
+api_title: "Cluster API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/datastore.md
+++ b/content/sensu-go/6.1/api/datastore.md
@@ -1,6 +1,8 @@
 ---
 title: "Datastore API"
 description: "The datastore API endpoint provides HTTP access to Sensu datastore providers. This reference includes examples for returning the provider definitions, creating a provider, and more."
+api_title: "Datastore API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/entities.md
+++ b/content/sensu-go/6.1/api/entities.md
@@ -1,6 +1,8 @@
 ---
 title: "Entities API"
 description: "The Sensu entities API provides HTTP access to entity data. This reference includes examples for returning lists of entities, creating Sensu entities, and more. Read on for the full reference."
+api_title: "Entities API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/events.md
+++ b/content/sensu-go/6.1/api/events.md
@@ -1,6 +1,8 @@
 ---
 title: "Events API"
 description: "The Sensu events API provides HTTP access to event data. This reference includes examples for returning lists of events, creating Sensu events, and more. Read on for the full reference."
+api_title: "Events API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/federation.md
+++ b/content/sensu-go/6.1/api/federation.md
@@ -1,6 +1,8 @@
 ---
 title: "Federation API"
 description: "The federation API controls federation of Sensu clusters. This reference describes the Sensu federation API, including examples. Read on for the full reference."
+api_title: "Federation API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/filters.md
+++ b/content/sensu-go/6.1/api/filters.md
@@ -1,6 +1,8 @@
 ---
 title: "Filters API"
 description: "The Sensu filters API provides HTTP access to event filter data. This reference includes examples for returning lists of filters, creating Sensu filters, and more. Read on for the full reference."
+api_title: "Filters API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/handlers.md
+++ b/content/sensu-go/6.1/api/handlers.md
@@ -1,6 +1,8 @@
 ---
 title: "Handlers API"
 description: "The Sensu handlers API provides HTTP access to handler data. This reference includes examples for returning lists of handlers, creating a Sensu handler, and more. Read on for the full reference."
+api_title: "Handlers API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/health.md
+++ b/content/sensu-go/6.1/api/health.md
@@ -1,6 +1,8 @@
 ---
 title: "Health API"
 description: "The Sensu health API provides HTTP access to health data for your Sensu instance. This reference includes examples for retrieving health information about your Sensu instance. Read on for the full reference."
+api_title: "Health API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/hooks.md
+++ b/content/sensu-go/6.1/api/hooks.md
@@ -1,6 +1,8 @@
 ---
 title: "Hooks API"
 description: "The Sensu hooks API provides HTTP access to hook data. This reference includes examples for returning lists of hooks, creating a Sensu hook, and more. Read on for the full reference."
+api_title: "Hooks API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/license.md
+++ b/content/sensu-go/6.1/api/license.md
@@ -1,7 +1,9 @@
 ---
-title: "License management API"
+title: "License API"
 linkTitle: "License API"
 description: "The Sensu license API provides HTTP access to the active commercial license configuration. This reference includes examples for returning the active commercial license configuration and activating or updating a commercial license. Read on for the full reference."
+api_title: "License API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/metrics.md
+++ b/content/sensu-go/6.1/api/metrics.md
@@ -1,6 +1,8 @@
 ---
 title: "Metrics API"
 description: "The Sensu metrics API provides HTTP access to internal Sensu metrics, including embedded etcd, memory usage, garbage collection, and gRPC metrics. Read on for the full reference."
+api_title: "Metrics API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/mutators.md
+++ b/content/sensu-go/6.1/api/mutators.md
@@ -1,6 +1,8 @@
 ---
 title: "Mutators API"
 description: "The Sensu mutator API provides HTTP access to mutator data. This reference includes examples for returning lists of mutators, creating a Sensu mutator, and more. Read on for the full reference."
+api_title: "Mutators API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/namespaces.md
+++ b/content/sensu-go/6.1/api/namespaces.md
@@ -1,6 +1,8 @@
 ---
 title: "Namespaces API"
 description: "The Sensu namespace API provides HTTP access to namespace data. This reference includes examples for returning lists of namespaces, creating Sensu namespaces, and more. Read on for the full reference."
+api_title: "Namespaces API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/prune.md
+++ b/content/sensu-go/6.1/api/prune.md
@@ -1,6 +1,8 @@
 ---
 title: "Prune API"
 description: "The Sensu prune API provides HTTP access to create pruning commands to delete resources that do not appear in a given set of Sensu objects from a file, URL, or STDIN. This reference includes an example for creating a prune command for your Sensu instance. Read on for the full reference."
+api_title: "Prune API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/role-bindings.md
+++ b/content/sensu-go/6.1/api/role-bindings.md
@@ -2,6 +2,8 @@
 title: "Role bindings API"
 linkTitle: "Role Bindings API"
 description: "The Sensu role bindings API provides HTTP access to role binding data. This reference includes examples for returning lists of role bindings, creating Sensu role bindings, and more. Read on for the full reference."
+api_title: "Role bindings API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/roles.md
+++ b/content/sensu-go/6.1/api/roles.md
@@ -1,6 +1,8 @@
 ---
 title: "Roles API"
 description: "The Sensu roles API provides HTTP access to user role data. This reference includes examples for returning lists of roles, creating Sensu roles, and more. Read on for the full reference."
+api_title: "Roles API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/searches.md
+++ b/content/sensu-go/6.1/api/searches.md
@@ -1,6 +1,8 @@
 ---
 title: "Searches API"
 description: "The Sensu searches API provides HTTP access to the saved searches feature in the Sensu web UI. This reference includes examples for returning lists of saved searches and creating, updating, and deleting saved searches. Read on for the full API documentation."
+api_title: "Searches API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/secrets.md
+++ b/content/sensu-go/6.1/api/secrets.md
@@ -1,6 +1,8 @@
 ---
 title: "Secrets API"
 description: "The secrets API controls secrets management for Sensu. This reference describes the Sensu secrets API, including examples. Read on for the full reference."
+api_title: "Secrets API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/silenced.md
+++ b/content/sensu-go/6.1/api/silenced.md
@@ -1,6 +1,8 @@
 ---
 title: "Silencing API"
 description: "The Sensu silencing API provides HTTP access to silences. This reference includes examples for creating and removing Sensu silences. Read on for the full reference."
+api_title: "Silencing API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/tessen.md
+++ b/content/sensu-go/6.1/api/tessen.md
@@ -1,6 +1,8 @@
 ---
 title: "Tessen API"
 description: "The Sensu Tessen API provides HTTP access to manage Tessen configuration. Read on for the full reference."
+api_title: "Tessen API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/users.md
+++ b/content/sensu-go/6.1/api/users.md
@@ -1,6 +1,8 @@
 ---
 title: "Users API"
 description: "This reference describes the Sensu users API, including some handy examples for how to create users, access user data by username, and update users. Learn how the users API can help you customize Sensu Go to match your workflows."
+api_title: "Users API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/version.md
+++ b/content/sensu-go/6.1/api/version.md
@@ -1,6 +1,8 @@
 ---
 title: "Version API"
 description: "The Sensu version API provides HTTP access to the Sensu and etcd versions. This reference includes examples for returning version information about your Sensu instance. Read on for the full reference."
+api_title: "Version API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/api/webconfig.md
+++ b/content/sensu-go/6.1/api/webconfig.md
@@ -2,6 +2,8 @@
 title: "Web UI configuration API"
 linkTitle: "Web UI Configuration API"
 description: "The Sensu web configuration API provides HTTP access to the global web UI configuration. This reference includes examples for returning the global web UI configuration and adding or updating the web UI configuration. Read on for the full reference."
+api_title: "Web UI configuration API"
+type: "api"
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -764,3 +764,5 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
 [23]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
 [24]: ../operations/deploy-sensu/cluster-sensu/
+[25]: ../sensuctl/
+[26]: ../web-ui/

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -19,6 +19,12 @@ The cluster protocol will replicate your changes to all cluster members.
 
 For information about the Sensu agent API, see the [agent reference][4].
 
+## Available APIs
+
+explain.........
+
+{{< apitypeListing >}}
+
 ## URL format
 
 Sensu API endpoints use the standard URL format `/api/{group}/{version}/namespaces/{namespace}` where:

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -21,7 +21,8 @@ For information about the Sensu agent API, see the [agent reference][4].
 
 ## Available APIs
 
-explain.........
+Access all of the data and functionality of Sensu's first-class API clients, [sensuctl][25] and the [web UI][26], with Sensu's backend REST APIs.
+Use the Sensu APIs to customize your workflows and integrate your favorite Sensu features with other tools and products.
 
 {{< apitypeListing >}}
 

--- a/content/sensu-go/6.2/api/apikeys.md
+++ b/content/sensu-go/6.2/api/apikeys.md
@@ -1,6 +1,8 @@
 ---
 title: "APIKeys API"
 description: "The Sensu APIKeys API provides HTTP access to API key data. This reference includes examples for returning lists of API keys, creating API keys, and more."
+api_title: "APIKeys API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/assets.md
+++ b/content/sensu-go/6.2/api/assets.md
@@ -1,6 +1,8 @@
 ---
 title: "Assets API"
 description: "The Sensu assets API provides HTTP access to dynamic runtime asset data. This reference includes examples for returning lists of dynamic runtime assets, creating dynamic runtime assets, and more."
+api_title: "Assets API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/auth.md
+++ b/content/sensu-go/6.2/api/auth.md
@@ -1,6 +1,8 @@
 ---
 title: "Authentication API"
 description: "The Sensu authentication API provides HTTP access to test whether user credentials are valid and use these credentials to obtain access tokens. Read on for the full reference."
+api_title: "Authentication API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/authproviders.md
+++ b/content/sensu-go/6.2/api/authproviders.md
@@ -2,6 +2,8 @@
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
 description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+api_title: "Authentication providers API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/checks.md
+++ b/content/sensu-go/6.2/api/checks.md
@@ -1,6 +1,8 @@
 ---
 title: "Checks API"
 description: "The Sensu checks API provides HTTP access to check data. This reference includes examples for returning the list of checks, creating a Sensu check, and more. Read on for the full reference."
+api_title: "Checks API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/cluster-role-bindings.md
+++ b/content/sensu-go/6.2/api/cluster-role-bindings.md
@@ -2,6 +2,8 @@
 title: "Cluster role bindings API"
 linktitle: "Cluster Role Bindings API"
 description: "The Sensu cluster role bindings API provides HTTP access to cluster role binding data. This reference includes examples for returning lists of cluster role bindings, creating Sensu cluster role bindings, and more. Read on for the full reference."
+api_title: "Cluster role bindings API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/cluster-roles.md
+++ b/content/sensu-go/6.2/api/cluster-roles.md
@@ -2,6 +2,8 @@
 title: "Cluster roles API"
 linkTitle: "Cluster Roles API"
 description: "The Sensu cluster roles API provides HTTP access to cluster role data. This reference includes examples for returning lists of cluster roles, creating Sensu cluster roles, and more. Read on for the full reference."
+api_title: "Cluster roles API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/cluster.md
+++ b/content/sensu-go/6.2/api/cluster.md
@@ -1,6 +1,8 @@
 ---
 title: "Cluster API"
 description: "The Sensu cluster API endpoint provides HTTP access to Sensu cluster data. This reference includes examples for returning the cluster definition, creating a cluster member, and more. Read on for the full reference."
+api_title: "Cluster API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/datastore.md
+++ b/content/sensu-go/6.2/api/datastore.md
@@ -1,6 +1,8 @@
 ---
 title: "Datastore API"
 description: "The datastore API endpoint provides HTTP access to Sensu datastore providers. This reference includes examples for returning the provider definitions, creating a provider, and more."
+api_title: "Datastore API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/entities.md
+++ b/content/sensu-go/6.2/api/entities.md
@@ -1,6 +1,8 @@
 ---
 title: "Entities API"
 description: "The Sensu entities API provides HTTP access to entity data. This reference includes examples for returning lists of entities, creating Sensu entities, and more. Read on for the full reference."
+api_title: "Entities API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/events.md
+++ b/content/sensu-go/6.2/api/events.md
@@ -1,6 +1,8 @@
 ---
 title: "Events API"
 description: "The Sensu events API provides HTTP access to event data. This reference includes examples for returning lists of events, creating Sensu events, and more. Read on for the full reference."
+api_title: "Events API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/federation.md
+++ b/content/sensu-go/6.2/api/federation.md
@@ -1,6 +1,8 @@
 ---
 title: "Federation API"
 description: "The federation API controls federation of Sensu clusters. This reference describes the Sensu federation API, including examples. Read on for the full reference."
+api_title: "Federation API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/filters.md
+++ b/content/sensu-go/6.2/api/filters.md
@@ -1,6 +1,8 @@
 ---
 title: "Filters API"
 description: "The Sensu filters API provides HTTP access to event filter data. This reference includes examples for returning lists of filters, creating Sensu filters, and more. Read on for the full reference."
+api_title: "Filters API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/handlers.md
+++ b/content/sensu-go/6.2/api/handlers.md
@@ -1,6 +1,8 @@
 ---
 title: "Handlers API"
 description: "The Sensu handlers API provides HTTP access to handler data. This reference includes examples for returning lists of handlers, creating a Sensu handler, and more. Read on for the full reference."
+api_title: "Handlers API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/health.md
+++ b/content/sensu-go/6.2/api/health.md
@@ -1,6 +1,8 @@
 ---
 title: "Health API"
 description: "The Sensu health API provides HTTP access to health data for your Sensu instance. This reference includes examples for retrieving health information about your Sensu instance. Read on for the full reference."
+api_title: "Health API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/hooks.md
+++ b/content/sensu-go/6.2/api/hooks.md
@@ -1,6 +1,8 @@
 ---
 title: "Hooks API"
 description: "The Sensu hooks API provides HTTP access to hook data. This reference includes examples for returning lists of hooks, creating a Sensu hook, and more. Read on for the full reference."
+api_title: "Hooks API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/license.md
+++ b/content/sensu-go/6.2/api/license.md
@@ -1,7 +1,9 @@
 ---
-title: "License management API"
+title: "License API"
 linkTitle: "License API"
 description: "The Sensu license API provides HTTP access to the active commercial license configuration. This reference includes examples for returning the active commercial license configuration and activating or updating a commercial license. Read on for the full reference."
+api_title: "License API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/metrics.md
+++ b/content/sensu-go/6.2/api/metrics.md
@@ -1,6 +1,8 @@
 ---
 title: "Metrics API"
 description: "The Sensu metrics API provides HTTP access to internal Sensu metrics, including embedded etcd, memory usage, garbage collection, and gRPC metrics. Read on for the full reference."
+api_title: "Metrics API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/mutators.md
+++ b/content/sensu-go/6.2/api/mutators.md
@@ -1,6 +1,8 @@
 ---
 title: "Mutators API"
 description: "The Sensu mutator API provides HTTP access to mutator data. This reference includes examples for returning lists of mutators, creating a Sensu mutator, and more. Read on for the full reference."
+api_title: "Mutators API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/namespaces.md
+++ b/content/sensu-go/6.2/api/namespaces.md
@@ -1,6 +1,8 @@
 ---
 title: "Namespaces API"
 description: "The Sensu namespace API provides HTTP access to namespace data. This reference includes examples for returning lists of namespaces, creating Sensu namespaces, and more. Read on for the full reference."
+api_title: "Namespaces API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/prune.md
+++ b/content/sensu-go/6.2/api/prune.md
@@ -1,6 +1,8 @@
 ---
 title: "Prune API"
 description: "The Sensu prune API provides HTTP access to create pruning commands to delete resources that do not appear in a given set of Sensu objects from a file, URL, or STDIN. This reference includes an example for creating a prune command for your Sensu instance. Read on for the full reference."
+api_title: "Prune API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/role-bindings.md
+++ b/content/sensu-go/6.2/api/role-bindings.md
@@ -2,6 +2,8 @@
 title: "Role bindings API"
 linkTitle: "Role Bindings API"
 description: "The Sensu role bindings API provides HTTP access to role binding data. This reference includes examples for returning lists of role bindings, creating Sensu role bindings, and more. Read on for the full reference."
+api_title: "Role bindings API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/roles.md
+++ b/content/sensu-go/6.2/api/roles.md
@@ -1,6 +1,8 @@
 ---
 title: "Roles API"
 description: "The Sensu roles API provides HTTP access to user role data. This reference includes examples for returning lists of roles, creating Sensu roles, and more. Read on for the full reference."
+api_title: "Roles API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/searches.md
+++ b/content/sensu-go/6.2/api/searches.md
@@ -1,6 +1,8 @@
 ---
 title: "Searches API"
 description: "The Sensu searches API provides HTTP access to the saved searches feature in the Sensu web UI. This reference includes examples for returning lists of saved searches and creating, updating, and deleting saved searches. Read on for the full API documentation."
+api_title: "Searches API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/secrets.md
+++ b/content/sensu-go/6.2/api/secrets.md
@@ -1,6 +1,8 @@
 ---
 title: "Secrets API"
 description: "The secrets API controls secrets management for Sensu. This reference describes the Sensu secrets API, including examples. Read on for the full reference."
+api_title: "Secrets API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/silenced.md
+++ b/content/sensu-go/6.2/api/silenced.md
@@ -1,6 +1,8 @@
 ---
 title: "Silencing API"
 description: "The Sensu silencing API provides HTTP access to silences. This reference includes examples for creating and removing Sensu silences. Read on for the full reference."
+api_title: "Silencing API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/tessen.md
+++ b/content/sensu-go/6.2/api/tessen.md
@@ -1,6 +1,8 @@
 ---
 title: "Tessen API"
 description: "The Sensu Tessen API provides HTTP access to manage Tessen configuration. Read on for the full reference."
+api_title: "Tessen API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/users.md
+++ b/content/sensu-go/6.2/api/users.md
@@ -1,6 +1,8 @@
 ---
 title: "Users API"
 description: "This reference describes the Sensu users API, including some handy examples for how to create users, access user data by username, and update users. Learn how the users API can help you customize Sensu Go to match your workflows."
+api_title: "Users API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/version.md
+++ b/content/sensu-go/6.2/api/version.md
@@ -1,6 +1,8 @@
 ---
 title: "Version API"
 description: "The Sensu version API provides HTTP access to the Sensu and etcd versions. This reference includes examples for returning version information about your Sensu instance. Read on for the full reference."
+api_title: "Version API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/api/webconfig.md
+++ b/content/sensu-go/6.2/api/webconfig.md
@@ -2,6 +2,8 @@
 title: "Web UI configuration API"
 linkTitle: "Web UI Configuration API"
 description: "The Sensu web configuration API provides HTTP access to the global web UI configuration. This reference includes examples for returning the global web UI configuration and adding or updating the web UI configuration. Read on for the full reference."
+api_title: "Web UI configuration API"
+type: "api"
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -19,6 +19,13 @@ The cluster protocol will replicate your changes to all cluster members.
 
 For information about the Sensu agent API, see the [agent reference][4].
 
+## Available APIs
+
+Access all of the data and functionality of Sensu's first-class API clients, [sensuctl][25] and the [web UI][26], with Sensu's backend REST APIs.
+Use the Sensu APIs to customize your workflows and integrate your favorite Sensu features with other tools and products.
+
+{{< apitypeListing >}}
+
 ## URL format
 
 Sensu API endpoints use the standard URL format `/api/{group}/{version}/namespaces/{namespace}` where:
@@ -757,3 +764,5 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
 [23]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
 [24]: ../operations/deploy-sensu/cluster-sensu/
+[25]: ../sensuctl/
+[26]: ../web-ui/

--- a/content/sensu-go/6.3/api/apikeys.md
+++ b/content/sensu-go/6.3/api/apikeys.md
@@ -1,6 +1,8 @@
 ---
 title: "APIKeys API"
 description: "The Sensu APIKeys API provides HTTP access to API key data. This reference includes examples for returning lists of API keys, creating API keys, and more."
+api_title: "APIKeys API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/assets.md
+++ b/content/sensu-go/6.3/api/assets.md
@@ -1,6 +1,8 @@
 ---
 title: "Assets API"
 description: "The Sensu assets API provides HTTP access to dynamic runtime asset data. This reference includes examples for returning lists of dynamic runtime assets, creating dynamic runtime assets, and more."
+api_title: "Assets API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/auth.md
+++ b/content/sensu-go/6.3/api/auth.md
@@ -1,6 +1,8 @@
 ---
 title: "Authentication API"
 description: "The Sensu authentication API provides HTTP access to test whether user credentials are valid and use these credentials to obtain access tokens. Read on for the full reference."
+api_title: "Authentication API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/authproviders.md
+++ b/content/sensu-go/6.3/api/authproviders.md
@@ -2,6 +2,8 @@
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
 description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+api_title: "Authentication providers API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/checks.md
+++ b/content/sensu-go/6.3/api/checks.md
@@ -1,6 +1,8 @@
 ---
 title: "Checks API"
 description: "The Sensu checks API provides HTTP access to check data. This reference includes examples for returning the list of checks, creating a Sensu check, and more. Read on for the full reference."
+api_title: "Checks API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/cluster-role-bindings.md
+++ b/content/sensu-go/6.3/api/cluster-role-bindings.md
@@ -2,6 +2,8 @@
 title: "Cluster role bindings API"
 linktitle: "Cluster Role Bindings API"
 description: "The Sensu cluster role bindings API provides HTTP access to cluster role binding data. This reference includes examples for returning lists of cluster role bindings, creating Sensu cluster role bindings, and more. Read on for the full reference."
+api_title: "Cluster role bindings API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/cluster-roles.md
+++ b/content/sensu-go/6.3/api/cluster-roles.md
@@ -2,6 +2,8 @@
 title: "Cluster roles API"
 linkTitle: "Cluster Roles API"
 description: "The Sensu cluster roles API provides HTTP access to cluster role data. This reference includes examples for returning lists of cluster roles, creating Sensu cluster roles, and more. Read on for the full reference."
+api_title: "Cluster roles API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/cluster.md
+++ b/content/sensu-go/6.3/api/cluster.md
@@ -1,6 +1,8 @@
 ---
 title: "Cluster API"
 description: "The Sensu cluster API endpoint provides HTTP access to Sensu cluster data. This reference includes examples for returning the cluster definition, creating a cluster member, and more. Read on for the full reference."
+api_title: "Cluster API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/datastore.md
+++ b/content/sensu-go/6.3/api/datastore.md
@@ -1,6 +1,8 @@
 ---
 title: "Datastore API"
 description: "The datastore API endpoint provides HTTP access to Sensu datastore providers. This reference includes examples for returning the provider definitions, creating a provider, and more."
+api_title: "Datastore API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/entities.md
+++ b/content/sensu-go/6.3/api/entities.md
@@ -1,6 +1,8 @@
 ---
 title: "Entities API"
 description: "The Sensu entities API provides HTTP access to entity data. This reference includes examples for returning lists of entities, creating Sensu entities, and more. Read on for the full reference."
+api_title: "Entities API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/events.md
+++ b/content/sensu-go/6.3/api/events.md
@@ -1,6 +1,8 @@
 ---
 title: "Events API"
 description: "The Sensu events API provides HTTP access to event data. This reference includes examples for returning lists of events, creating Sensu events, and more. Read on for the full reference."
+api_title: "Events API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/federation.md
+++ b/content/sensu-go/6.3/api/federation.md
@@ -1,6 +1,8 @@
 ---
 title: "Federation API"
 description: "The federation API controls federation of Sensu clusters. This reference describes the Sensu federation API, including examples. Read on for the full reference."
+api_title: "Federation API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/filters.md
+++ b/content/sensu-go/6.3/api/filters.md
@@ -1,6 +1,8 @@
 ---
 title: "Filters API"
 description: "The Sensu filters API provides HTTP access to event filter data. This reference includes examples for returning lists of filters, creating Sensu filters, and more. Read on for the full reference."
+api_title: "Filters API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/handlers.md
+++ b/content/sensu-go/6.3/api/handlers.md
@@ -1,6 +1,8 @@
 ---
 title: "Handlers API"
 description: "The Sensu handlers API provides HTTP access to handler data. This reference includes examples for returning lists of handlers, creating a Sensu handler, and more. Read on for the full reference."
+api_title: "Handlers API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/health.md
+++ b/content/sensu-go/6.3/api/health.md
@@ -1,6 +1,8 @@
 ---
 title: "Health API"
 description: "The Sensu health API provides HTTP access to health data for your Sensu instance. This reference includes examples for retrieving health information about your Sensu instance. Read on for the full reference."
+api_title: "Health API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/hooks.md
+++ b/content/sensu-go/6.3/api/hooks.md
@@ -1,6 +1,8 @@
 ---
 title: "Hooks API"
 description: "The Sensu hooks API provides HTTP access to hook data. This reference includes examples for returning lists of hooks, creating a Sensu hook, and more. Read on for the full reference."
+api_title: "Hooks API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/license.md
+++ b/content/sensu-go/6.3/api/license.md
@@ -1,7 +1,8 @@
 ---
-title: "License management API"
-linkTitle: "License API"
+title: "License API"
 description: "The Sensu license API provides HTTP access to the active commercial license configuration. This reference includes examples for returning the active commercial license configuration and activating or updating a commercial license. Read on for the full reference."
+api_title: "License API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/metrics.md
+++ b/content/sensu-go/6.3/api/metrics.md
@@ -1,6 +1,8 @@
 ---
 title: "Metrics API"
 description: "The Sensu metrics API provides HTTP access to internal Sensu metrics, including embedded etcd, memory usage, garbage collection, and gRPC metrics. Read on for the full reference."
+api_title: "Metrics API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/mutators.md
+++ b/content/sensu-go/6.3/api/mutators.md
@@ -1,6 +1,8 @@
 ---
 title: "Mutators API"
 description: "The Sensu mutator API provides HTTP access to mutator data. This reference includes examples for returning lists of mutators, creating a Sensu mutator, and more. Read on for the full reference."
+api_title: "Mutators API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/namespaces.md
+++ b/content/sensu-go/6.3/api/namespaces.md
@@ -1,6 +1,8 @@
 ---
 title: "Namespaces API"
 description: "The Sensu namespace API provides HTTP access to namespace data. This reference includes examples for returning lists of namespaces, creating Sensu namespaces, and more. Read on for the full reference."
+api_title: "Namespaces API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/prune.md
+++ b/content/sensu-go/6.3/api/prune.md
@@ -1,6 +1,8 @@
 ---
 title: "Prune API"
 description: "The Sensu prune API provides HTTP access to create pruning commands to delete resources that do not appear in a given set of Sensu objects from a file, URL, or STDIN. This reference includes an example for creating a prune command for your Sensu instance. Read on for the full reference."
+api_title: "Prune API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/role-bindings.md
+++ b/content/sensu-go/6.3/api/role-bindings.md
@@ -2,6 +2,8 @@
 title: "Role bindings API"
 linkTitle: "Role Bindings API"
 description: "The Sensu role bindings API provides HTTP access to role binding data. This reference includes examples for returning lists of role bindings, creating Sensu role bindings, and more. Read on for the full reference."
+api_title: "Role bindings API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/roles.md
+++ b/content/sensu-go/6.3/api/roles.md
@@ -1,6 +1,8 @@
 ---
 title: "Roles API"
 description: "The Sensu roles API provides HTTP access to user role data. This reference includes examples for returning lists of roles, creating Sensu roles, and more. Read on for the full reference."
+api_title: "Roles API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/searches.md
+++ b/content/sensu-go/6.3/api/searches.md
@@ -1,6 +1,8 @@
 ---
 title: "Searches API"
 description: "The Sensu searches API provides HTTP access to the saved searches feature in the Sensu web UI. This reference includes examples for returning lists of saved searches and creating, updating, and deleting saved searches. Read on for the full API documentation."
+api_title: "Searches API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/secrets.md
+++ b/content/sensu-go/6.3/api/secrets.md
@@ -1,6 +1,8 @@
 ---
 title: "Secrets API"
 description: "The secrets API controls secrets management for Sensu. This reference describes the Sensu secrets API, including examples. Read on for the full reference."
+api_title: "Secrets API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/silenced.md
+++ b/content/sensu-go/6.3/api/silenced.md
@@ -1,6 +1,8 @@
 ---
 title: "Silencing API"
 description: "The Sensu silencing API provides HTTP access to silences. This reference includes examples for creating and removing Sensu silences. Read on for the full reference."
+api_title: "Silencing API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/tessen.md
+++ b/content/sensu-go/6.3/api/tessen.md
@@ -1,6 +1,8 @@
 ---
 title: "Tessen API"
 description: "The Sensu Tessen API provides HTTP access to manage Tessen configuration. Read on for the full reference."
+api_title: "Tessen API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/users.md
+++ b/content/sensu-go/6.3/api/users.md
@@ -1,6 +1,8 @@
 ---
 title: "Users API"
 description: "This reference describes the Sensu users API, including some handy examples for how to create users, access user data by username, and update users. Learn how the users API can help you customize Sensu Go to match your workflows."
+api_title: "Users API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/version.md
+++ b/content/sensu-go/6.3/api/version.md
@@ -1,6 +1,8 @@
 ---
 title: "Version API"
 description: "The Sensu version API provides HTTP access to the Sensu and etcd versions. This reference includes examples for returning version information about your Sensu instance. Read on for the full reference."
+api_title: "Version API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/api/webconfig.md
+++ b/content/sensu-go/6.3/api/webconfig.md
@@ -2,6 +2,8 @@
 title: "Web UI configuration API"
 linkTitle: "Web UI Configuration API"
 description: "The Sensu web configuration API provides HTTP access to the global web UI configuration. This reference includes examples for returning the global web UI configuration and adding or updating the web UI configuration. Read on for the full reference."
+api_title: "Web UI configuration API"
+type: "api"
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/layouts/shortcodes/apitypeListing.html
+++ b/layouts/shortcodes/apitypeListing.html
@@ -1,0 +1,10 @@
+<ul class="grid-list">
+  {{ range (.Site.Pages.ByParam "api_title") }}
+    <!-- Only include pages from the specified version -->
+    <!-- Only include pages with specified frontmatter type "reference" -->
+    {{ if and (eq .Type "api") (.IsDescendant $.Page.CurrentSection.Parent) }}
+      <li><a href="{{ .Permalink }}">{{ .Params.api_title }}</a></li>
+    {{ end }}
+  {{ end }}
+</ul>
+

--- a/static/stylesheets/scss/_layout.scss
+++ b/static/stylesheets/scss/_layout.scss
@@ -105,3 +105,8 @@ main {
     right: 0 !important;
   }
 }
+
+.grid-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}


### PR DESCRIPTION
## Description
Adds a list of available APIs to the top of the API category page. The list is automatically generated with the `apitypeListing` shortcode and automatically formatted into three columns using the `.grid-list` class in the `layout.css` file.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2965