### PR TITLE
Explain web UI merge for event labels from checks and entities

### DIFF
--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -166,7 +166,7 @@ For label-based event searches, the web UI merges check and entity labels into a
 For example, to display events with the `type` label set to `server`, enter this search statement on the **Events** page:
 
 {{< code text >}}
-event.labels.type == server
+event.labels.type == "server"
 {{< /code >}}
 
 This search will retrieve events with the `type` label set to `server`, no matter whether the label is defined in the event's corresponding check or entity configuration.

--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -24,12 +24,12 @@ Web UI search supports two equality-based operators, two set-based operators, on
 
 | operator  | description        | example                |
 | --------- | ------------------ | ---------------------- |
-| `==`      | Equality           | `check.publish == true`
+| `==`      | Equality           | `check.publish == "true"`
 | `!=`      | Inequality         | `check.namespace != "default"`
-| `in`      | Included in        | `linux in check.subscriptions`
-| `notin`   | Not included in    | `slack notin check.handlers`
+| `in`      | Included in        | `"linux" in check.subscriptions`
+| `notin`   | Not included in    | `"slack" notin check.handlers`
 | `matches` | Substring matching | `check.name matches "linux-"`
-| `&&`      | Logical AND        | `check.publish == true && slack in check.handlers`
+| `&&`      | Logical AND        | `check.publish == "true" && "slack" in check.handlers`
 
 For details about operators, see [API response filtering operators][7].
 
@@ -89,25 +89,25 @@ Fields are specific [resource attributes][2] in dot notation.
 For example, this search will retrieve all events for entities with the `linux` subscription:
 
 {{< code text >}}
-linux in event.entity.subscriptions
+"linux" in event.entity.subscriptions
 {{< /code >}}
 
 This search will retrieve all events that whose status is *not* equal to `passing`:
 
 {{< code text >}}
-event.check.state != passing
+event.check.state != "passing"
 {{< /code >}}
 
 To display only events for checks with the subscription `webserver`, enter this search statement on the **Events page**:
 
 {{< code text >}}
-webserver in event.check.subscriptions
+"webserver" in event.check.subscriptions
 {{< /code >}}
 
 To display only checks that use the `slack` handler, enter this search statement on the **Checks page**:
 
 {{< code text >}}
-slack in check.handlers
+"slack" in check.handlers
 {{< /code >}}
 
 ## Search for numbers or special characters
@@ -145,7 +145,7 @@ check.labels.version matches "7"
 To display only checks with the `type` label set to `server`, enter this search statement on the **Checks page**:
 
 {{< code text >}}
-check.labels.type == server
+check.labels.type == "server"
 {{< /code >}}
 
 To search for entities that are labeled for any region in the US (e.g. `us-east-1`, `us-west-1`, and so on):
@@ -176,13 +176,13 @@ This search will retrieve events with the `type` label set to `server`, no matte
 To use the logical AND operator (`&&`) to return checks that include a `linux` subscription and the `slack` handler:
 
 {{< code text >}}
-linux in check.subscriptions && slack in check.handlers
+"linux" in check.subscriptions && "slack" in check.handlers
 {{< /code >}}
 
 To return events that include a `windows` check subscription and any email handler:
 
 {{< code text >}}
-windows in event.check.subscriptions && event.check.handlers matches email
+"windows" in event.check.subscriptions && event.check.handlers matches "email"
 {{< /code >}}
 
 ## Save a search

--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -142,12 +142,6 @@ For example, to search based on a check label `version`, use:
 check.labels.version matches "7"
 {{< /code >}}
 
-To search based on an event label `type`, use:
-
-{{< code text >}}
-event.labels.type == server
-{{< /code >}}
-
 To display only checks with the `type` label set to `server`, enter this search statement on the **Checks page**:
 
 {{< code text >}}
@@ -164,6 +158,18 @@ entity.labels.region matches "us"
 **NOTE**: Web UI searches for label names that include hyphens are not supported.
 Searches that include a hyphenated label name, such as `entity.labels.imported-by`, will return an unsupported token error.
 {{% /notice %}}
+
+### Search for event labels
+
+For label-based event searches, the web UI merges check and entity labels into a single search term: `event.labels.[KEY]`.
+
+For example, to display events with the `type` label set to `server`, enter this search statement on the **Events** page:
+
+{{< code text >}}
+event.labels.type == server
+{{< /code >}}
+
+This search will retrieve events with the `type` label set to `server`, no matter whether the label is defined in the event's corresponding check or entity configuration.
 
 ## Use the logical AND operator
 

--- a/content/sensu-go/6.2/web-ui/search.md
+++ b/content/sensu-go/6.2/web-ui/search.md
@@ -166,7 +166,7 @@ For label-based event searches, the web UI merges check and entity labels into a
 For example, to display events with the `type` label set to `server`, enter this search statement on the **Events** page:
 
 {{< code text >}}
-event.labels.type == server
+event.labels.type == "server"
 {{< /code >}}
 
 This search will retrieve events with the `type` label set to `server`, no matter whether the label is defined in the event's corresponding check or entity configuration.

--- a/content/sensu-go/6.2/web-ui/search.md
+++ b/content/sensu-go/6.2/web-ui/search.md
@@ -24,12 +24,12 @@ Web UI search supports two equality-based operators, two set-based operators, on
 
 | operator  | description        | example                |
 | --------- | ------------------ | ---------------------- |
-| `==`      | Equality           | `check.publish == true`
+| `==`      | Equality           | `check.publish == "true"`
 | `!=`      | Inequality         | `check.namespace != "default"`
-| `in`      | Included in        | `linux in check.subscriptions`
-| `notin`   | Not included in    | `slack notin check.handlers`
+| `in`      | Included in        | `"linux" in check.subscriptions`
+| `notin`   | Not included in    | `"slack" notin check.handlers`
 | `matches` | Substring matching | `check.name matches "linux-"`
-| `&&`      | Logical AND        | `check.publish == true && slack in check.handlers`
+| `&&`      | Logical AND        | `check.publish == "true" && "slack" in check.handlers`
 
 For details about operators, see [API response filtering operators][7].
 
@@ -89,25 +89,25 @@ Fields are specific [resource attributes][2] in dot notation.
 For example, this search will retrieve all events for entities with the `linux` subscription:
 
 {{< code text >}}
-linux in event.entity.subscriptions
+"linux" in event.entity.subscriptions
 {{< /code >}}
 
 This search will retrieve all events that whose status is *not* equal to `passing`:
 
 {{< code text >}}
-event.check.state != passing
+event.check.state != "passing"
 {{< /code >}}
 
 To display only events for checks with the subscription `webserver`, enter this search statement on the **Events page**:
 
 {{< code text >}}
-webserver in event.check.subscriptions
+"webserver" in event.check.subscriptions
 {{< /code >}}
 
 To display only checks that use the `slack` handler, enter this search statement on the **Checks page**:
 
 {{< code text >}}
-slack in check.handlers
+"slack" in check.handlers
 {{< /code >}}
 
 ## Search for numbers or special characters
@@ -145,7 +145,7 @@ check.labels.version matches "7"
 To display only checks with the `type` label set to `server`, enter this search statement on the **Checks page**:
 
 {{< code text >}}
-check.labels.type == server
+check.labels.type == "server"
 {{< /code >}}
 
 To search for entities that are labeled for any region in the US (e.g. `us-east-1`, `us-west-1`, and so on):
@@ -176,13 +176,13 @@ This search will retrieve events with the `type` label set to `server`, no matte
 To use the logical AND operator (`&&`) to return checks that include a `linux` subscription and the `slack` handler:
 
 {{< code text >}}
-linux in check.subscriptions && slack in check.handlers
+"linux" in check.subscriptions && "slack" in check.handlers
 {{< /code >}}
 
 To return events that include a `windows` check subscription and any email handler:
 
 {{< code text >}}
-windows in event.check.subscriptions && event.check.handlers matches email
+"windows" in event.check.subscriptions && event.check.handlers matches "email"
 {{< /code >}}
 
 ## Save a search

--- a/content/sensu-go/6.2/web-ui/search.md
+++ b/content/sensu-go/6.2/web-ui/search.md
@@ -142,12 +142,6 @@ For example, to search based on a check label `version`, use:
 check.labels.version matches "7"
 {{< /code >}}
 
-To search based on an event label `type`, use:
-
-{{< code text >}}
-event.labels.type == server
-{{< /code >}}
-
 To display only checks with the `type` label set to `server`, enter this search statement on the **Checks page**:
 
 {{< code text >}}
@@ -164,6 +158,18 @@ entity.labels.region matches "us"
 **NOTE**: Web UI searches for label names that include hyphens are not supported.
 Searches that include a hyphenated label name, such as `entity.labels.imported-by`, will return an unsupported token error.
 {{% /notice %}}
+
+### Search for event labels
+
+For label-based event searches, the web UI merges check and entity labels into a single search term: `event.labels.[KEY]`.
+
+For example, to display events with the `type` label set to `server`, enter this search statement on the **Events** page:
+
+{{< code text >}}
+event.labels.type == server
+{{< /code >}}
+
+This search will retrieve events with the `type` label set to `server`, no matter whether the label is defined in the event's corresponding check or entity configuration.
 
 ## Use the logical AND operator
 

--- a/content/sensu-go/6.3/web-ui/search.md
+++ b/content/sensu-go/6.3/web-ui/search.md
@@ -166,7 +166,7 @@ For label-based event searches, the web UI merges check and entity labels into a
 For example, to display events with the `type` label set to `server`, enter this search statement on the **Events** page:
 
 {{< code text >}}
-event.labels.type == server
+event.labels.type == "server"
 {{< /code >}}
 
 This search will retrieve events with the `type` label set to `server`, no matter whether the label is defined in the event's corresponding check or entity configuration.

--- a/content/sensu-go/6.3/web-ui/search.md
+++ b/content/sensu-go/6.3/web-ui/search.md
@@ -24,12 +24,12 @@ Web UI search supports two equality-based operators, two set-based operators, on
 
 | operator  | description        | example                |
 | --------- | ------------------ | ---------------------- |
-| `==`      | Equality           | `check.publish == true`
+| `==`      | Equality           | `check.publish == "true"`
 | `!=`      | Inequality         | `check.namespace != "default"`
-| `in`      | Included in        | `linux in check.subscriptions`
-| `notin`   | Not included in    | `slack notin check.handlers`
+| `in`      | Included in        | `"linux" in check.subscriptions`
+| `notin`   | Not included in    | `"slack" notin check.handlers`
 | `matches` | Substring matching | `check.name matches "linux-"`
-| `&&`      | Logical AND        | `check.publish == true && slack in check.handlers`
+| `&&`      | Logical AND        | `check.publish == "true" && "slack" in check.handlers`
 
 For details about operators, see [API response filtering operators][7].
 
@@ -89,25 +89,25 @@ Fields are specific [resource attributes][2] in dot notation.
 For example, this search will retrieve all events for entities with the `linux` subscription:
 
 {{< code text >}}
-linux in event.entity.subscriptions
+"linux" in event.entity.subscriptions
 {{< /code >}}
 
 This search will retrieve all events that whose status is *not* equal to `passing`:
 
 {{< code text >}}
-event.check.state != passing
+event.check.state != "passing"
 {{< /code >}}
 
 To display only events for checks with the subscription `webserver`, enter this search statement on the **Events page**:
 
 {{< code text >}}
-webserver in event.check.subscriptions
+"webserver" in event.check.subscriptions
 {{< /code >}}
 
 To display only checks that use the `slack` handler, enter this search statement on the **Checks page**:
 
 {{< code text >}}
-slack in check.handlers
+"slack" in check.handlers
 {{< /code >}}
 
 ## Search for numbers or special characters
@@ -145,7 +145,7 @@ check.labels.version matches "7"
 To display only checks with the `type` label set to `server`, enter this search statement on the **Checks page**:
 
 {{< code text >}}
-check.labels.type == server
+check.labels.type == "server"
 {{< /code >}}
 
 To search for entities that are labeled for any region in the US (e.g. `us-east-1`, `us-west-1`, and so on):
@@ -176,13 +176,13 @@ This search will retrieve events with the `type` label set to `server`, no matte
 To use the logical AND operator (`&&`) to return checks that include a `linux` subscription and the `slack` handler:
 
 {{< code text >}}
-linux in check.subscriptions && slack in check.handlers
+"linux" in check.subscriptions && "slack" in check.handlers
 {{< /code >}}
 
 To return events that include a `windows` check subscription and any email handler:
 
 {{< code text >}}
-windows in event.check.subscriptions && event.check.handlers matches email
+"windows" in event.check.subscriptions && event.check.handlers matches "email"
 {{< /code >}}
 
 ## Save a search

--- a/content/sensu-go/6.3/web-ui/search.md
+++ b/content/sensu-go/6.3/web-ui/search.md
@@ -142,12 +142,6 @@ For example, to search based on a check label `version`, use:
 check.labels.version matches "7"
 {{< /code >}}
 
-To search based on an event label `type`, use:
-
-{{< code text >}}
-event.labels.type == server
-{{< /code >}}
-
 To display only checks with the `type` label set to `server`, enter this search statement on the **Checks page**:
 
 {{< code text >}}
@@ -164,6 +158,18 @@ entity.labels.region matches "us"
 **NOTE**: Web UI searches for label names that include hyphens are not supported.
 Searches that include a hyphenated label name, such as `entity.labels.imported-by`, will return an unsupported token error.
 {{% /notice %}}
+
+### Search for event labels
+
+For label-based event searches, the web UI merges check and entity labels into a single search term: `event.labels.[KEY]`.
+
+For example, to display events with the `type` label set to `server`, enter this search statement on the **Events** page:
+
+{{< code text >}}
+event.labels.type == server
+{{< /code >}}
+
+This search will retrieve events with the `type` label set to `server`, no matter whether the label is defined in the event's corresponding check or entity configuration.
 
 ## Use the logical AND operator
 


### PR DESCRIPTION
## Description
Explains how the web UI merges event.entity.labels[KEY] and event.check.labels[KEY] into one search term, event.label.[key], for label-based event searches on the Events page.

Affects https://docs.sensu.io/sensu-go/latest/web-ui/search/#search-for-labels for 6.1 through 6.3 versions.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2988
