### PR TITLE
Add agent authentication overview to agent reference

### DIFF
--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -22,11 +22,53 @@ Agent entities are responsible for creating [check and metrics events][7] to sen
 The Sensu agent is available for Linux, macOS, and Windows.
 See the [installation guide][1] to install the agent.
 
+## Agent authentication
+
+The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either built-in basic (username and password) or mutual transport layer security (mTLS) authentication.
+
+### Username and password authentication
+
+The default mechanism for agent authentication is [built-in basic authentication][59] with username and password.
+The Sensu agent uses username and password authentication unless mTLS authentication has been explicitly configured.
+
+For username and password authentication, sensu-agent joins the username and password with a colon and encodes them as a Base64 value.
+Sensu provides the encoded string as the value of the `Authorization` HTTP header &mdash; for example, `Authorization: Basic YWdlbnQ6UEBzc3cwcmQh` &mdash; to authenticate to the Sensu backend.
+
+When using username and password authentication, sensu-agent also sends the following HTTP headers in requests to the backend:
+
+- `Sensu-User`: the username in plaintext
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+### mTLS authentication
+
+When mTLS is configured for both the Sensu agent and backend, the agent uses mTLS authentication instead of the default username and password authentication.
+
+Sensu backends that are configured for mTLS authentication will no longer accept agent authentication via username and password.
+Agents that are configured to use mTLS authentication cannot authenticate with the backend unless the backend is configured for mTLS.
+
+To [configure the agent and backend][58] for mTLS authentication:
+
+- In the backend configuration, specify valid certificate and key files as values for the `agent-auth-cert-file` and `agent-auth-key-file` parameters.
+- In the agent configuration, specify valid certificate and key files as values for the `cert-file` and `key-file` parameters.
+
+The agent and backend will compare the provided certificates with the trusted CA certificate either in the system trust store or specified explicitly as the `agent-auth-trusted-ca-file` in the backend configuration and `trusted-ca-file` in the agent configuration.
+
+When using mTLS authentication, sensu-agent sends the following HTTP headers in requests to the backend:
+
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated, plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.
 For optimal network throughput, agents will attempt to negotiate the use of [Protobuf][47] serialization when communicating with a Sensu backend that supports it.
 This communication is via clear text by default.
+
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 ## Create monitoring events using service checks
@@ -1316,7 +1358,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the agent certificate file used in mTLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
@@ -1342,7 +1384,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the agent key file used in mutual TLS authentication.
+description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
@@ -1779,3 +1821,5 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [55]: ../../commercial/
 [56]: #allow-list
 [57]: ../../reference/filters#reduce-alert-fatigue-for-keepalive-events
+[58]: ../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[59]: ../../operations/control-access/#use-built-in-basic-authentication

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -22,11 +22,53 @@ Agent entities are responsible for creating [check and metrics events][7] to sen
 The Sensu agent is available for Linux, macOS, and Windows.
 See the [installation guide][1] to install the agent.
 
+## Agent authentication
+
+The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either built-in basic (username and password) or mutual transport layer security (mTLS) authentication.
+
+### Username and password authentication
+
+The default mechanism for agent authentication is [built-in basic authentication][59] with username and password.
+The Sensu agent uses username and password authentication unless mTLS authentication has been explicitly configured.
+
+For username and password authentication, sensu-agent joins the username and password with a colon and encodes them as a Base64 value.
+Sensu provides the encoded string as the value of the `Authorization` HTTP header &mdash; for example, `Authorization: Basic YWdlbnQ6UEBzc3cwcmQh` &mdash; to authenticate to the Sensu backend.
+
+When using username and password authentication, sensu-agent also sends the following HTTP headers in requests to the backend:
+
+- `Sensu-User`: the username in plaintext
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+### mTLS authentication
+
+When mTLS is configured for both the Sensu agent and backend, the agent uses mTLS authentication instead of the default username and password authentication.
+
+Sensu backends that are configured for mTLS authentication will no longer accept agent authentication via username and password.
+Agents that are configured to use mTLS authentication cannot authenticate with the backend unless the backend is configured for mTLS.
+
+To [configure the agent and backend][58] for mTLS authentication:
+
+- In the backend configuration, specify valid certificate and key files as values for the `agent-auth-cert-file` and `agent-auth-key-file` parameters.
+- In the agent configuration, specify valid certificate and key files as values for the `cert-file` and `key-file` parameters.
+
+The agent and backend will compare the provided certificates with the trusted CA certificate either in the system trust store or specified explicitly as the `agent-auth-trusted-ca-file` in the backend configuration and `trusted-ca-file` in the agent configuration.
+
+When using mTLS authentication, sensu-agent sends the following HTTP headers in requests to the backend:
+
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated, plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.
 For optimal network throughput, agents will attempt to negotiate the use of [Protobuf][47] serialization when communicating with a Sensu backend that supports it.
 This communication is via clear text by default.
+
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 ## Create observability events using service checks
@@ -1315,7 +1357,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the agent certificate file used in mTLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
@@ -1341,7 +1383,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the agent key file used in mutual TLS authentication.
+description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
@@ -1778,3 +1820,5 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
+[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[59]: ../../../operations/control-access/#use-built-in-basic-authentication

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -22,11 +22,54 @@ Agent entities are responsible for creating [check and metrics events][7] to sen
 The Sensu agent is available for Linux, macOS, and Windows.
 See the [installation guide][1] to install the agent.
 
+
+## Agent authentication
+
+The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either built-in basic (username and password) or mutual transport layer security (mTLS) authentication.
+
+### Username and password authentication
+
+The default mechanism for agent authentication is [built-in basic authentication][59] with username and password.
+The Sensu agent uses username and password authentication unless mTLS authentication has been explicitly configured.
+
+For username and password authentication, sensu-agent joins the username and password with a colon and encodes them as a Base64 value.
+Sensu provides the encoded string as the value of the `Authorization` HTTP header &mdash; for example, `Authorization: Basic YWdlbnQ6UEBzc3cwcmQh` &mdash; to authenticate to the Sensu backend.
+
+When using username and password authentication, sensu-agent also sends the following HTTP headers in requests to the backend:
+
+- `Sensu-User`: the username in plaintext
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+### mTLS authentication
+
+When mTLS is configured for both the Sensu agent and backend, the agent uses mTLS authentication instead of the default username and password authentication.
+
+Sensu backends that are configured for mTLS authentication will no longer accept agent authentication via username and password.
+Agents that are configured to use mTLS authentication cannot authenticate with the backend unless the backend is configured for mTLS.
+
+To [configure the agent and backend][58] for mTLS authentication:
+
+- In the backend configuration, specify valid certificate and key files as values for the `agent-auth-cert-file` and `agent-auth-key-file` parameters.
+- In the agent configuration, specify valid certificate and key files as values for the `cert-file` and `key-file` parameters.
+
+The agent and backend will compare the provided certificates with the trusted CA certificate either in the system trust store or specified explicitly as the `agent-auth-trusted-ca-file` in the backend configuration and `trusted-ca-file` in the agent configuration.
+
+When using mTLS authentication, sensu-agent sends the following HTTP headers in requests to the backend:
+
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated, plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.
 For optimal network throughput, agents will attempt to negotiate the use of [Protobuf][47] serialization when communicating with a Sensu backend that supports it.
 This communication is via clear text by default.
+
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 ## Create observability events using service checks
@@ -1314,7 +1357,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the agent certificate file used in mTLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
@@ -1340,7 +1383,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the agent key file used in mutual TLS authentication.
+description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
@@ -1783,3 +1826,5 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
+[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[59]: ../../../operations/control-access/#use-built-in-basic-authentication

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -29,7 +29,7 @@ The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport
 ### Username and password authentication
 
 The default mechanism for agent authentication is [built-in basic authentication][59] with username and password.
-The Sensu agent uses username and password authentication unless mTLS authentication is configured for both sensu-agent and sensu-backend.
+The Sensu agent uses username and password authentication unless mTLS authentication has been explicitly configured.
 
 For username and password authentication, sensu-agent joins the username and password with a colon and encodes them as a Base64 value.
 Sensu provides the encoded string as the value of the `Authorization` HTTP header &mdash; for example, `Authorization: Basic YWdlbnQ6UEBzc3cwcmQh` &mdash; to authenticate to the Sensu backend.

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -24,11 +24,11 @@ See the [installation guide][1] to install the agent.
 
 ## Agent authentication
 
-The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either username and password or mutual transport layer security (mTLS) authentication.
+The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either built-in basic (username and password) or mutual transport layer security (mTLS) authentication.
 
 ### Username and password authentication
 
-Username and password authentication is the default mechanism for agent authentication.
+The default mechanism for agent authentication is [built-in basic authentication][59] with username and password.
 The Sensu agent uses username and password authentication unless mTLS authentication is configured for both sensu-agent and sensu-backend.
 
 For username and password authentication, sensu-agent joins the username and password with a colon and encodes them as a Base64 value.
@@ -1846,3 +1846,4 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
 [58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[59]: ../../../operations/control-access/#use-built-in-basic-authentication

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -22,11 +22,53 @@ Agent entities are responsible for creating [check and metrics events][7] to sen
 The Sensu agent is available for Linux, macOS, and Windows.
 See the [installation guide][1] to install the agent.
 
+## Agent authentication
+
+The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either built-in basic (username and password) or mutual transport layer security (mTLS) authentication.
+
+### Username and password authentication
+
+The default mechanism for agent authentication is [built-in basic authentication][59] with username and password.
+The Sensu agent uses username and password authentication unless mTLS authentication has been explicitly configured.
+
+For username and password authentication, sensu-agent joins the username and password with a colon and encodes them as a Base64 value.
+Sensu provides the encoded string as the value of the `Authorization` HTTP header &mdash; for example, `Authorization: Basic YWdlbnQ6UEBzc3cwcmQh` &mdash; to authenticate to the Sensu backend.
+
+When using username and password authentication, sensu-agent also sends the following HTTP headers in requests to the backend:
+
+- `Sensu-User`: the username in plaintext
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+### mTLS authentication
+
+When mTLS is configured for both the Sensu agent and backend, the agent uses mTLS authentication instead of the default username and password authentication.
+
+Sensu backends that are configured for mTLS authentication will no longer accept agent authentication via username and password.
+Agents that are configured to use mTLS authentication cannot authenticate with the backend unless the backend is configured for mTLS.
+
+To [configure the agent and backend][58] for mTLS authentication:
+
+- In the backend configuration, specify valid certificate and key files as values for the `agent-auth-cert-file` and `agent-auth-key-file` parameters.
+- In the agent configuration, specify valid certificate and key files as values for the `cert-file` and `key-file` parameters.
+
+The agent and backend will compare the provided certificates with the trusted CA certificate either in the system trust store or specified explicitly as the `agent-auth-trusted-ca-file` in the backend configuration and `trusted-ca-file` in the agent configuration.
+
+When using mTLS authentication, sensu-agent sends the following HTTP headers in requests to the backend:
+
+- `Sensu-AgentName`: the agent's configured name in plaintext
+- `Sensu-Subscriptions`: the agent's subscriptions in a comma-separated, plaintext list
+- `Sensu-Namespace`: the agent's configured namespace in plaintext
+
+If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.
 For optimal network throughput, agents will attempt to negotiate the use of [Protobuf][47] serialization when communicating with a Sensu backend that supports it.
 This communication is via clear text by default.
+
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 {{% notice note %}}
@@ -1340,7 +1382,7 @@ redact:
 
 | cert-file  |      |
 -------------|------
-description  | Path to the agent certificate file used in mutual TLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the agent certificate file used in mTLS authentication. Sensu supports certificate bundles (or chains) as long as the agent (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
@@ -1366,7 +1408,7 @@ trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the agent key file used in mutual TLS authentication.
+description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
@@ -1803,3 +1845,5 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
+[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[59]: ../../../operations/control-access/#use-built-in-basic-authentication


### PR DESCRIPTION
## Description
Adds agent authentication overview toward the beginning of the agent reference to cover username/password authentication and mTLS authentication mechanisms.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2993