### PR TITLE
Fix typo in Secure Sensu doc

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
@@ -176,7 +176,7 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modfiy the backend and agent configuration:
+After you create backend and agent certificates, modify the backend and agent configuration:
 
 {{< code yml >}}
 ##

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -178,7 +178,7 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modfiy the backend and agent configuration:
+After you create backend and agent certificates, modify the backend and agent configuration:
 
 {{< code yml >}}
 ##

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -178,7 +178,7 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modfiy the backend and agent configuration:
+After you create backend and agent certificates, modify the backend and agent configuration:
 
 {{< code yml >}}
 ##

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -178,7 +178,7 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modfiy the backend and agent configuration:
+After you create backend and agent certificates, modify the backend and agent configuration:
 
 {{< code yml >}}
 ##

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -178,7 +178,7 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modfiy the backend and agent configuration:
+After you create backend and agent certificates, modify the backend and agent configuration:
 
 {{< code yml >}}
 ##


### PR DESCRIPTION
## Description
Found typo "modfiy" instead of "modify" in Secure Sensu doc while working on something else.