### PR TITLE
Fix redirects for Core and Enterprise migration pages

### DIFF
--- a/static.json
+++ b/static.json
@@ -15,7 +15,7 @@
             "url": "/sensu-go/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-core/latest/migration$": {
+        "~ ^/sensu-core/latest/migration/?$": {
             "url": "/sensu-go/latest/operations/maintain-sensu/migrate",
             "status": 301
         },
@@ -31,7 +31,7 @@
             "url": "/sensu-enterprise/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-enterprise/latest/migration$": {
+        "~ ^/sensu-enterprise/latest/migration/?$": {
             "url": "/sensu-go/latest/operations/maintain-sensu/migrate",
             "status": 301
         },
@@ -43,7 +43,7 @@
             "url": "/sensu-enterprise-dashboard/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-go/latest/guides/create-a-ready-only-user$": {
+        "~ ^/sensu-go/latest/guides/create-a-ready-only-user/?$": {
             "url": "/sensu-go/latest/operations/control-access/create-read-only-user",
             "status": 301
         },


### PR DESCRIPTION
## Description
Update redirects for Core and Enterprise migration pages

## Motivation and Context
Redirects introduced in https://github.com/sensu/sensu-docs/pull/2998 don't seem to be working in production
