### PR TITLE
Add noindex for pages for all products except Sensu Go

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,6 +26,10 @@
       <meta name="docsearch:version" content="{{ .Page.Params.version }}" />
     {{ end}}
 
+    {{ if not (eq .Params.product "Sensu Go") }}
+    <meta name="robots" content="noindex">
+    {{ end }}
+
     <meta name="twitter:card" content="summary">
     <meta property="og:url" content="{{ .Permalink }}">
     <meta property="og:site_name" content="Sensu Docs">


### PR DESCRIPTION
## Description
Adds conditional statement for applying "noindex" to all docs pages except those marked as `product: "Sensu Go"` in front matter.

## Motivation and Context
Stop search engines from indexing docs pages except those for the Sensu Go product

## Review Instructions
I'm not sure how to test this! I guess we know from the review app that this change isn't breaking the site...