### PR TITLE
Add CRL and OCSP revocation check info

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
@@ -154,7 +154,7 @@ For more information, see [Get started with commercial features][5].
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3] and [Create a read-only user][4].
 
-Sensu can also use mutual transport layer security (mTLS) authentication for connecting agents to backends.
+Alternately, Sensu agents can use mTLS for authenticating to the backend websocket transport.
 When agent mTLS authentication is enabled, agents do not need to send password credentials to backends when they connect.
 To use [secrets management][1], Sensu agents must be secured with mTLS.
 In addition, when using mTLS authentication, agents do not require an explicit user in Sensu.
@@ -213,6 +213,10 @@ trusted-ca-file: "/path/to/ca.pem"
 
 You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
+
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Next step: Run a Sensu cluster
 

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -63,6 +63,10 @@ When using mTLS authentication, sensu-agent sends the following HTTP headers in 
 
 If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
 
+#### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -260,6 +260,10 @@ This is because the Go standard library assumes that the first certificate liste
 If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
 You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
 
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mutual transport layer security (mTLS), etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -530,7 +534,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
 -------------|------
-description  | URLs of CRLs for agent certificate authentication.
+description  | URLs of CRLs for agent certificate authentication. The Sensu backend uses this list to perform a revocation check for agent mTLS.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -63,6 +63,10 @@ When using mTLS authentication, sensu-agent sends the following HTTP headers in 
 
 If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
 
+#### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -260,6 +260,10 @@ This is because the Go standard library assumes that the first certificate liste
 If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
 You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
 
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mutual transport layer security (mTLS), etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -534,7 +538,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
 -------------|------
-description  | URLs of CRLs for agent certificate authentication.
+description  | URLs of CRLs for agent certificate authentication. The Sensu backend uses this list to perform a revocation check for agent mTLS.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -156,7 +156,7 @@ For more information, see [Get started with commercial features][5].
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3] and [Create a read-only user][4].
 
-Sensu can also use mutual transport layer security (mTLS) authentication for connecting agents to backends.
+Alternately, Sensu agents can use mTLS for authenticating to the backend websocket transport.
 When agent mTLS authentication is enabled, agents do not need to send password credentials to backends when they connect.
 To use [secrets management][1], Sensu agents must be secured with mTLS.
 In addition, when using mTLS authentication, agents do not require an explicit user in Sensu.
@@ -215,6 +215,10 @@ trusted-ca-file: "/path/to/ca.pem"
 
 You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
+
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Next step: Run a Sensu cluster
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -64,6 +64,10 @@ When using mTLS authentication, sensu-agent sends the following HTTP headers in 
 
 If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
 
+#### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -260,6 +260,10 @@ This is because the Go standard library assumes that the first certificate liste
 If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
 You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
 
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mutual transport layer security (mTLS), etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -549,7 +553,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
 -------------|------
-description  | URLs of CRLs for agent certificate authentication.
+description  | URLs of CRLs for agent certificate authentication. The Sensu backend uses this list to perform a revocation check for agent mTLS.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -156,7 +156,7 @@ For more information, see [Get started with commercial features][5].
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3] and [Create a read-only user][4].
 
-Sensu can also use mutual transport layer security (mTLS) authentication for connecting agents to backends.
+Alternately, Sensu agents can use mTLS for authenticating to the backend websocket transport.
 When agent mTLS authentication is enabled, agents do not need to send password credentials to backends when they connect.
 To use [secrets management][1], Sensu agents must be secured with mTLS.
 In addition, when using mTLS authentication, agents do not require an explicit user in Sensu.
@@ -215,6 +215,10 @@ trusted-ca-file: "/path/to/ca.pem"
 
 You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
+
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Next step: Run a Sensu cluster
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -63,6 +63,10 @@ When using mTLS authentication, sensu-agent sends the following HTTP headers in 
 
 If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
 
+#### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -65,7 +65,7 @@ If the Sensu agent is configured for mTLS authentication, it will not send the `
 
 #### Certificate revocation check
 
-The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Communication between the agent and backend
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -260,6 +260,10 @@ This is because the Go standard library assumes that the first certificate liste
 If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
 You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
 
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mutual transport layer security (mTLS), etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -549,7 +553,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
 -------------|------
-description  | URLs of CRLs for agent certificate authentication.
+description  | URLs of CRLs for agent certificate authentication. The Sensu backend uses this list to perform a revocation check for agent mTLS.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -141,7 +141,7 @@ For more information, see [Get started with commercial features][5].
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3] and [Create a read-only user][4].
 
-Sensu can also use mutual transport layer security (mTLS) authentication for connecting agents to backends.
+Sensu can also use mTLS authentication for connecting agents to backends.
 When agent mTLS authentication is enabled, agents do not need to send password credentials to backends when they connect.
 To use [secrets management][1], Sensu agents must be secured with mTLS.
 In addition, when using mTLS authentication, agents do not require an explicit user in Sensu.
@@ -200,6 +200,10 @@ trusted-ca-file: "/path/to/ca.pem"
 
 You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
+
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Next step: Run a Sensu cluster
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -141,7 +141,7 @@ For more information, see [Get started with commercial features][5].
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3] and [Create a read-only user][4].
 
-Sensu can also use mTLS authentication for connecting agents to backends.
+Alternately, Sensu agents can use mTLS for authenticating to the backend websocket transport.
 When agent mTLS authentication is enabled, agents do not need to send password credentials to backends when they connect.
 To use [secrets management][1], Sensu agents must be secured with mTLS.
 In addition, when using mTLS authentication, agents do not require an explicit user in Sensu.
@@ -203,7 +203,7 @@ However, deployments can also use the same certificates and keys for etcd peer a
 
 ### Certificate revocation check
 
-The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Next step: Run a Sensu cluster
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -63,6 +63,10 @@ When using mTLS authentication, sensu-agent sends the following HTTP headers in 
 
 If the Sensu agent is configured for mTLS authentication, it will not send the `Authorization` HTTP header.
 
+#### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ## Communication between the agent and backend
 
 The Sensu agent uses [WebSocket][45] (ws) protocol to send and receive JSON messages with the Sensu backend.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -260,6 +260,10 @@ This is because the Go standard library assumes that the first certificate liste
 If you send the server certificate alone instead of sending the whole bundle with the server certificate first, you will see a `certificate not signed by trusted authority` error.
 You must present the whole chain to the remote so it can determine whether it trusts the server certificate through the chain.
 
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mutual transport layer security (mTLS), etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
+
 ### Configuration summary
 
 {{< code text >}}
@@ -549,7 +553,7 @@ agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
 -------------|------
-description  | URLs of CRLs for agent certificate authentication.
+description  | URLs of CRLs for agent certificate authentication. The Sensu backend uses this list to perform a revocation check for agent mTLS.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -156,7 +156,7 @@ For more information, see [Get started with commercial features][5].
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3] and [Create a read-only user][4].
 
-Sensu can also use mutual transport layer security (mTLS) authentication for connecting agents to backends.
+Alternately, Sensu agents can use mTLS for authenticating to the backend websocket transport.
 When agent mTLS authentication is enabled, agents do not need to send password credentials to backends when they connect.
 To use [secrets management][1], Sensu agents must be secured with mTLS.
 In addition, when using mTLS authentication, agents do not require an explicit user in Sensu.
@@ -215,6 +215,10 @@ trusted-ca-file: "/path/to/ca.pem"
 
 You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
+
+### Certificate revocation check
+
+The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for agent mTLS, etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
 ## Next step: Run a Sensu cluster
 


### PR DESCRIPTION
## Description
Adds brief information about backend CRL and OCSP revocation checking in agent reference, backend reference, and Secure Sensu.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2986

## Review Instructions
I'm not sure about the clarification I added for the `agent-auth-crl-urls` flag description in the backend reference doc. It also seems like the info I added may be too brief to be useful, but I'm not sure what I should add.