### PR TITLE
Update instruction for adding a cluster member

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
@@ -1,6 +1,8 @@
 ---
 title: "Run a Sensu cluster"
 linkTitle: "Run a Sensu Cluster"
+guide_title: "Run a Sensu cluster"
+type: "guide"
 description: "Clustering improves Sensu's availability, reliability, and durability. It can help you cope with the loss of a backend node, prevent data loss, and distribute the network load of agents. Read the guide to configure a Sensu cluster."
 weight: 70
 version: "5.21"
@@ -13,7 +15,7 @@ menu:
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to run a Sensu cluster.
 
-A Sensu cluster is a group of [at least three][1] sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of at least three sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 Creating a Sensu cluster ultimately configures an [etcd cluster][2].
 
 Clustering improves Sensu's availability, reliability, and durability.
@@ -28,7 +30,7 @@ No matter whether you deploy a single backend or a clustered configuration, begi
 The first step in setting up TLS is to [generate the certificates you need][13].
 Then, follow our [Secure Sensu][16] guide to make Sensu production-ready.
 
-After you've secured Sensu, continue reading this document to set up a clustered configuration.
+After you've secured Sensu, continue reading this document to [set up][2] and [update][1] a clustered configuration.
 
 {{% notice note %}}
 **NOTE**: We recommend using a load balancer to evenly distribute agent connections across a cluster.
@@ -37,7 +39,7 @@ After you've secured Sensu, continue reading this document to set up a clustered
 ## Configure a cluster
 
 The sensu-backend arguments for its store mirror the [etcd configuration flags][3], but the Sensu flags are prefixed with `etcd`.
-For more detailed descriptions of the different arguments, see the [etcd docs][4] or the [Sensu backend reference][15].
+For more detailed descriptions of the different arguments, see the [etcd documentation][4] or the [Sensu backend reference][15].
 
 You can configure a Sensu cluster in a couple different ways &mdash; we'll show you a few below &mdash; but you should adhere to some etcd cluster guidelines as well:
 
@@ -90,7 +92,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.1:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
@@ -106,7 +108,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.2:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
@@ -122,12 +124,14 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.3:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
 {{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.
+**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+Specify the same `etcd-initial-cluster-token` value for all three backends.
+This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}
 
 After you configure each node as described in these examples, start each sensu-backend:
@@ -176,16 +180,52 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 ### Add a cluster member
 
-Add a new member node to an existing cluster:
+To add a new member node to an existing cluster:
 
-{{< code shell >}}
+1. Configure the new node's store in its `/etc/sensu/backend.yml` configuration file.
+For the new node `backend-4` with IP address `10.0.0.4`:
+
+   {{< code yml >}}
+etcd-advertise-client-urls: "http://10.0.0.4:2379"
+etcd-listen-client-urls: "http://10.0.0.4:2379"
+etcd-listen-peer-urls: "http://0.0.0.0:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
+etcd-initial-cluster-state: "existing"
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
+etcd-name: "backend-4"
+{{< /code >}}
+
+   {{% notice note %}}
+**NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+{{% /notice %}}
+
+2. Run the sensuctl command to add the new cluster member:
+
+   {{< code shell >}}
 sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+{{< /code >}}
 
+   You will receive a sensuctl response to confirm that the new member was added:
+
+   {{< code shell >}}
 added member 2f7ae42c315f8c2d to cluster
+{{< /code >}}
 
-ETCD_NAME="backend-4"
-ETCD_INITIAL_CLUSTER="backend-4=https://10.0.0.4:2380,backend-1=https://10.0.0.1:2380,backend-2=https://10.0.0.2:2380,backend-3=https://10.0.0.3:2380"
-ETCD_INITIAL_CLUSTER_STATE="existing"
+3. Start the new backend:
+
+   {{< code shell >}}
+sudo systemctl start sensu-backend
+{{< /code >}}
+
+4. Add the new cluster member's WebSocket backend-url in `/etc/sensu/agent.yml` for all agents that connect to the cluster over WebSocket:
+
+   {{< code yml >}}
+backend-url:
+  - "ws://10.0.0.1:8081"
+  - "ws://10.0.0.2:8081"
+  - "ws://10.0.0.3:8081"
+  - "ws://10.0.0.4:8081"
 {{< /code >}}
 
 ### List cluster members
@@ -336,18 +376,18 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 See the [etcd recovery guide][9] for disaster recovery information.
 
 
-[1]: https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.4.0/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.4.0/op-guide/configuration/
-[4]: https://etcd.io/docs/
-[5]: https://etcd.io/docs/v3.4.0/platforms/
+[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
+[4]: https://etcd.io/docs/v3.3.13/
+[5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.4.0/op-guide/failures/
-[9]: https://etcd.io/docs/v3.4.0/op-guide/recovery/
+[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
+[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.4.0/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.4.0/op-guide/
+[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/v3.3.13/op-guide/
 [13]: ../generate-certificates/
 [14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [15]: ../../../reference/backend/
@@ -356,3 +396,4 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [18]: https://github.com/etcd-io/etcd/blob/a621d807f061e1dd635033a8d6bc261461429e27/Documentation/v2/admin_guide.md#optimal-cluster-size
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
+[21]: ../install-sensu/

--- a/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
@@ -160,6 +160,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../../../reference/datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../../../reference/datastore/#scale-event-storage

--- a/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
@@ -278,7 +278,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
@@ -230,7 +230,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../../reference/rbac/
 [4]: ../../control-access/create-read-only-user/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [7]: ../../../reference/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/5.21/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/troubleshoot.md
@@ -598,7 +598,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../reference/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [5]: ../../../reference/agent/#restart-the-service
 [6]: ../../../reference/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -608,7 +608,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../../reference/datastore/#scale-event-storage
 [17]: ../../../reference/datastore/#use-default-event-storage

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -937,15 +937,15 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Initial cluster token for the etcd cluster during bootstrap.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token sensu
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
 
 # /etc/sensu/backend.yml example
-etcd-initial-cluster-token: "sensu"{{< /code >}}
+etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 
 | etcd-key-file  |      |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -945,15 +945,15 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Initial cluster token for the etcd cluster during bootstrap.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token sensu
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
 
 # /etc/sensu/backend.yml example
-etcd-initial-cluster-token: "sensu"{{< /code >}}
+etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 
 | etcd-key-file  |      |

--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -15,7 +15,7 @@ menu:
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to run a Sensu cluster.
 
-A Sensu cluster is a group of [at least three][1] sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of at least three sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 Creating a Sensu cluster ultimately configures an [etcd cluster][2].
 
 Clustering improves Sensu's availability, reliability, and durability.
@@ -30,7 +30,7 @@ No matter whether you deploy a single backend or a clustered configuration, begi
 The first step in setting up TLS is to [generate the certificates you need][13].
 Then, follow our [Secure Sensu][16] guide to make Sensu production-ready.
 
-After you've secured Sensu, continue reading this document to set up a clustered configuration.
+After you've secured Sensu, continue reading this document to [set up][2] and [update][1] a clustered configuration.
 
 {{% notice note %}}
 **NOTE**: We recommend using a load balancer to evenly distribute agent connections across a cluster.
@@ -39,7 +39,7 @@ After you've secured Sensu, continue reading this document to set up a clustered
 ## Configure a cluster
 
 The sensu-backend arguments for its store mirror the [etcd configuration flags][3], but the Sensu flags are prefixed with `etcd`.
-For more detailed descriptions of the different arguments, see the [etcd docs][4] or the [Sensu backend reference][15].
+For more detailed descriptions of the different arguments, see the [etcd documentation][4] or the [Sensu backend reference][15].
 
 You can configure a Sensu cluster in a couple different ways &mdash; we'll show you a few below &mdash; but you should adhere to some etcd cluster guidelines as well:
 
@@ -92,7 +92,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.1:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
@@ -108,7 +108,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.2:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
@@ -124,12 +124,14 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.3:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
 {{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.
+**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+Specify the same `etcd-initial-cluster-token` value for all three backends.
+This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}
 
 After you configure each node as described in these examples, start each sensu-backend:
@@ -178,16 +180,52 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 ### Add a cluster member
 
-Add a new member node to an existing cluster:
+To add a new member node to an existing cluster:
 
-{{< code shell >}}
+1. Configure the new node's store in its `/etc/sensu/backend.yml` configuration file.
+For the new node `backend-4` with IP address `10.0.0.4`:
+
+   {{< code yml >}}
+etcd-advertise-client-urls: "http://10.0.0.4:2379"
+etcd-listen-client-urls: "http://10.0.0.4:2379"
+etcd-listen-peer-urls: "http://0.0.0.0:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
+etcd-initial-cluster-state: "existing"
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
+etcd-name: "backend-4"
+{{< /code >}}
+
+   {{% notice note %}}
+**NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+{{% /notice %}}
+
+2. Run the sensuctl command to add the new cluster member:
+
+   {{< code shell >}}
 sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+{{< /code >}}
 
+   You will receive a sensuctl response to confirm that the new member was added:
+
+   {{< code shell >}}
 added member 2f7ae42c315f8c2d to cluster
+{{< /code >}}
 
-ETCD_NAME="backend-4"
-ETCD_INITIAL_CLUSTER="backend-4=https://10.0.0.4:2380,backend-1=https://10.0.0.1:2380,backend-2=https://10.0.0.2:2380,backend-3=https://10.0.0.3:2380"
-ETCD_INITIAL_CLUSTER_STATE="existing"
+3. Start the new backend:
+
+   {{< code shell >}}
+sudo systemctl start sensu-backend
+{{< /code >}}
+
+4. Add the new cluster member's WebSocket backend-url in `/etc/sensu/agent.yml` for all agents that connect to the cluster over WebSocket:
+
+   {{< code yml >}}
+backend-url:
+  - "ws://10.0.0.1:8081"
+  - "ws://10.0.0.2:8081"
+  - "ws://10.0.0.3:8081"
+  - "ws://10.0.0.4:8081"
 {{< /code >}}
 
 ### List cluster members
@@ -338,18 +376,18 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 See the [etcd recovery guide][9] for disaster recovery information.
 
 
-[1]: https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.4.0/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.4.0/op-guide/configuration/
-[4]: https://etcd.io/docs/
-[5]: https://etcd.io/docs/v3.4.0/platforms/
+[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
+[4]: https://etcd.io/docs/v3.3.13/
+[5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.4.0/op-guide/failures/
-[9]: https://etcd.io/docs/v3.4.0/op-guide/recovery/
+[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
+[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.4.0/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.4.0/op-guide/
+[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/v3.3.13/op-guide/
 [13]: ../generate-certificates/
 [14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
@@ -358,3 +396,4 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [18]: https://github.com/etcd-io/etcd/blob/a621d807f061e1dd635033a8d6bc261461429e27/Documentation/v2/admin_guide.md#optimal-cluster-size
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
+[21]: ../install-sensu/

--- a/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
@@ -160,6 +160,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -280,7 +280,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -232,7 +232,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../../control-access/create-read-only-user/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
@@ -598,7 +598,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -608,7 +608,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -960,15 +960,15 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Initial cluster token for the etcd cluster during bootstrap.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token sensu
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
 
 # /etc/sensu/backend.yml example
-etcd-initial-cluster-token: "sensu"{{< /code >}}
+etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 
 | etcd-key-file  |      |

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -15,7 +15,7 @@ menu:
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to run a Sensu cluster.
 
-A Sensu cluster is a group of [at least three][1] sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of at least three sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 Creating a Sensu cluster ultimately configures an [etcd cluster][2].
 
 Clustering improves Sensu's availability, reliability, and durability.
@@ -30,7 +30,7 @@ No matter whether you deploy a single backend or a clustered configuration, begi
 The first step in setting up TLS is to [generate the certificates you need][13].
 Then, follow our [Secure Sensu][16] guide to make Sensu production-ready.
 
-After you've secured Sensu, continue reading this document to set up a clustered configuration.
+After you've secured Sensu, continue reading this document to [set up][2] and [update][1] a clustered configuration.
 
 {{% notice note %}}
 **NOTE**: We recommend using a load balancer to evenly distribute agent connections across a cluster.
@@ -39,7 +39,7 @@ After you've secured Sensu, continue reading this document to set up a clustered
 ## Configure a cluster
 
 The sensu-backend arguments for its store mirror the [etcd configuration flags][3], but the Sensu flags are prefixed with `etcd`.
-For more detailed descriptions of the different arguments, see the [etcd docs][4] or the [Sensu backend reference][15].
+For more detailed descriptions of the different arguments, see the [etcd documentation][4] or the [Sensu backend reference][15].
 
 You can configure a Sensu cluster in a couple different ways &mdash; we'll show you a few below &mdash; but you should adhere to some etcd cluster guidelines as well:
 
@@ -92,7 +92,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.1:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
@@ -108,7 +108,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.2:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
@@ -124,12 +124,14 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.3:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
 {{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.
+**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+Specify the same `etcd-initial-cluster-token` value for all three backends.
+This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}
 
 After you configure each node as described in these examples, start each sensu-backend:
@@ -178,16 +180,52 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 ### Add a cluster member
 
-Add a new member node to an existing cluster:
+To add a new member node to an existing cluster:
 
-{{< code shell >}}
+1. Configure the new node's store in its `/etc/sensu/backend.yml` configuration file.
+For the new node `backend-4` with IP address `10.0.0.4`:
+
+   {{< code yml >}}
+etcd-advertise-client-urls: "http://10.0.0.4:2379"
+etcd-listen-client-urls: "http://10.0.0.4:2379"
+etcd-listen-peer-urls: "http://0.0.0.0:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
+etcd-initial-cluster-state: "existing"
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
+etcd-name: "backend-4"
+{{< /code >}}
+
+   {{% notice note %}}
+**NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+{{% /notice %}}
+
+2. Run the sensuctl command to add the new cluster member:
+
+   {{< code shell >}}
 sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+{{< /code >}}
 
+   You will receive a sensuctl response to confirm that the new member was added:
+
+   {{< code shell >}}
 added member 2f7ae42c315f8c2d to cluster
+{{< /code >}}
 
-ETCD_NAME="backend-4"
-ETCD_INITIAL_CLUSTER="backend-4=https://10.0.0.4:2380,backend-1=https://10.0.0.1:2380,backend-2=https://10.0.0.2:2380,backend-3=https://10.0.0.3:2380"
-ETCD_INITIAL_CLUSTER_STATE="existing"
+3. Start the new backend:
+
+   {{< code shell >}}
+sudo systemctl start sensu-backend
+{{< /code >}}
+
+4. Add the new cluster member's WebSocket backend-url in `/etc/sensu/agent.yml` for all agents that connect to the cluster over WebSocket:
+
+   {{< code yml >}}
+backend-url:
+  - "ws://10.0.0.1:8081"
+  - "ws://10.0.0.2:8081"
+  - "ws://10.0.0.3:8081"
+  - "ws://10.0.0.4:8081"
 {{< /code >}}
 
 ### List cluster members
@@ -338,18 +376,18 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 See the [etcd recovery guide][9] for disaster recovery information.
 
 
-[1]: https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.4.0/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.4.0/op-guide/configuration/
-[4]: https://etcd.io/docs/
-[5]: https://etcd.io/docs/v3.4.0/platforms/
+[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
+[4]: https://etcd.io/docs/v3.3.13/
+[5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.4.0/op-guide/failures/
-[9]: https://etcd.io/docs/v3.4.0/op-guide/recovery/
+[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
+[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.4.0/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.4.0/op-guide/
+[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/v3.3.13/op-guide/
 [13]: ../generate-certificates/
 [14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
@@ -358,3 +396,4 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [18]: https://github.com/etcd-io/etcd/blob/a621d807f061e1dd635033a8d6bc261461429e27/Documentation/v2/admin_guide.md#optimal-cluster-size
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
+[21]: ../install-sensu/

--- a/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
@@ -159,6 +159,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -280,7 +280,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -232,7 +232,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../../control-access/create-read-only-user/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -598,7 +598,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -608,7 +608,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -960,15 +960,15 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Initial cluster token for the etcd cluster during bootstrap.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token sensu
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
 
 # /etc/sensu/backend.yml example
-etcd-initial-cluster-token: "sensu"{{< /code >}}
+etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 
 | etcd-key-file  |      |

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -169,16 +169,32 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 ### Add a cluster member
 
-Add a new member node to an existing cluster:
+To add a new member node to an existing cluster:
 
-{{< code shell >}}
+1. Configure the new node's store in its `/etc/sensu/backend.yml` configuration file.
+For the new node `backend-4` with IP address `10.0.0.4`:
+
+   {{< code yml >}}
+etcd-advertise-client-urls: "http://10.0.0.4:2379"
+etcd-listen-client-urls: "http://10.0.0.4:2379"
+etcd-listen-peer-urls: "http://0.0.0.0:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
+etcd-initial-cluster-state: "existing"
+etcd-initial-cluster-token: ""
+etcd-name: "backend-4"
+{{< /code >}}
+
+2. Run the sensuctl command to add the new cluster member:
+
+   {{< code shell >}}
 sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+{{< /code >}}
 
+   You will receive a sensuctl response to confirm that the new member was added:
+
+   {{< code shell >}}
 added member 2f7ae42c315f8c2d to cluster
-
-ETCD_NAME="backend-4"
-ETCD_INITIAL_CLUSTER="backend-4=https://10.0.0.4:2380,backend-1=https://10.0.0.1:2380,backend-2=https://10.0.0.2:2380,backend-3=https://10.0.0.3:2380"
-ETCD_INITIAL_CLUSTER_STATE="existing"
 {{< /code >}}
 
 ### List cluster members
@@ -344,3 +360,4 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [18]: https://github.com/etcd-io/etcd/blob/a621d807f061e1dd635033a8d6bc261461429e27/Documentation/v2/admin_guide.md#optimal-cluster-size
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
+[21]: ../install-sensu/

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -218,6 +218,16 @@ added member 2f7ae42c315f8c2d to cluster
 sudo systemctl start sensu-backend
 {{< /code >}}
 
+4. Add the new cluster member's WebSocket backend-url in `/etc/sensu/agent.yml` for all agents that connect to the cluster over WebSocket:
+
+   {{< code yml >}}
+backend-url:
+  - "ws://10.0.0.1:8081"
+  - "ws://10.0.0.2:8081"
+  - "ws://10.0.0.3:8081"
+  - "ws://10.0.0.4:8081"
+{{< /code >}}
+
 ### List cluster members
 
 List the ID, name, peer URLs, and client URLs of all nodes in a cluster:

--- a/content/sensu-go/6.2/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/deployment-architecture.md
@@ -159,6 +159,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -280,7 +280,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -232,7 +232,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../../control-access/create-read-only-user/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -598,7 +598,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -608,7 +608,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -960,15 +960,15 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Initial cluster token for the etcd cluster during bootstrap.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token sensu
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
 
 # /etc/sensu/backend.yml example
-etcd-initial-cluster-token: "sensu"{{< /code >}}
+etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 
 | etcd-key-file  |      |

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -15,7 +15,7 @@ menu:
 
 To deploy Sensu for use outside of a local development environment, first decide whether you want to run a Sensu cluster.
 
-A Sensu cluster is a group of [at least three][1] sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
+A Sensu cluster is a group of at least three sensu-backend nodes, each connected to a shared database provided either by Sensu’s embedded etcd or an external etcd cluster.
 Creating a Sensu cluster ultimately configures an [etcd cluster][2].
 
 Clustering improves Sensu's availability, reliability, and durability.
@@ -30,7 +30,7 @@ No matter whether you deploy a single backend or a clustered configuration, begi
 The first step in setting up TLS is to [generate the certificates you need][13].
 Then, follow our [Secure Sensu][16] guide to make Sensu production-ready.
 
-After you've secured Sensu, continue reading this document to set up a clustered configuration.
+After you've secured Sensu, continue reading this document to [set up][2] and [update][1] a clustered configuration.
 
 {{% notice note %}}
 **NOTE**: We recommend using a load balancer to evenly distribute agent connections across a cluster.
@@ -39,7 +39,7 @@ After you've secured Sensu, continue reading this document to set up a clustered
 ## Configure a cluster
 
 The sensu-backend arguments for its store mirror the [etcd configuration flags][3], but the Sensu flags are prefixed with `etcd`.
-For more detailed descriptions of the different arguments, see the [etcd docs][4] or the [Sensu backend reference][15].
+For more detailed descriptions of the different arguments, see the [etcd documentation][4] or the [Sensu backend reference][15].
 
 You can configure a Sensu cluster in a couple different ways &mdash; we'll show you a few below &mdash; but you should adhere to some etcd cluster guidelines as well:
 
@@ -92,7 +92,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.1:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
@@ -108,7 +108,7 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.2:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
@@ -124,12 +124,14 @@ etcd-listen-peer-urls: "http://0.0.0.0:2380"
 etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.3:2380"
 etcd-initial-cluster-state: "new"
-etcd-initial-cluster-token: ""
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
 {{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.
+**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+Specify the same `etcd-initial-cluster-token` value for all three backends.
+This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}
 
 After you configure each node as described in these examples, start each sensu-backend:
@@ -178,16 +180,52 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 ### Add a cluster member
 
-Add a new member node to an existing cluster:
+To add a new member node to an existing cluster:
 
-{{< code shell >}}
+1. Configure the new node's store in its `/etc/sensu/backend.yml` configuration file.
+For the new node `backend-4` with IP address `10.0.0.4`:
+
+   {{< code yml >}}
+etcd-advertise-client-urls: "http://10.0.0.4:2379"
+etcd-listen-client-urls: "http://10.0.0.4:2379"
+etcd-listen-peer-urls: "http://0.0.0.0:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
+etcd-initial-cluster-state: "existing"
+etcd-initial-cluster-token: "unique_token_for_this_cluster"
+etcd-name: "backend-4"
+{{< /code >}}
+
+   {{% notice note %}}
+**NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+{{% /notice %}}
+
+2. Run the sensuctl command to add the new cluster member:
+
+   {{< code shell >}}
 sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+{{< /code >}}
 
+   You will receive a sensuctl response to confirm that the new member was added:
+
+   {{< code shell >}}
 added member 2f7ae42c315f8c2d to cluster
+{{< /code >}}
 
-ETCD_NAME="backend-4"
-ETCD_INITIAL_CLUSTER="backend-4=https://10.0.0.4:2380,backend-1=https://10.0.0.1:2380,backend-2=https://10.0.0.2:2380,backend-3=https://10.0.0.3:2380"
-ETCD_INITIAL_CLUSTER_STATE="existing"
+3. Start the new backend:
+
+   {{< code shell >}}
+sudo systemctl start sensu-backend
+{{< /code >}}
+
+4. Add the new cluster member's WebSocket backend-url in `/etc/sensu/agent.yml` for all agents that connect to the cluster over WebSocket:
+
+   {{< code yml >}}
+backend-url:
+  - "ws://10.0.0.1:8081"
+  - "ws://10.0.0.2:8081"
+  - "ws://10.0.0.3:8081"
+  - "ws://10.0.0.4:8081"
 {{< /code >}}
 
 ### List cluster members
@@ -338,18 +376,18 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 See the [etcd recovery guide][9] for disaster recovery information.
 
 
-[1]: https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.4.0/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.4.0/op-guide/configuration/
-[4]: https://etcd.io/docs/
-[5]: https://etcd.io/docs/v3.4.0/platforms/
+[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
+[4]: https://etcd.io/docs/v3.3.13/
+[5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.4.0/op-guide/failures/
-[9]: https://etcd.io/docs/v3.4.0/op-guide/recovery/
+[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
+[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.4.0/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.4.0/op-guide/
+[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/v3.3.13/op-guide/
 [13]: ../generate-certificates/
 [14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
@@ -358,3 +396,4 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [18]: https://github.com/etcd-io/etcd/blob/a621d807f061e1dd635033a8d6bc261461429e27/Documentation/v2/admin_guide.md#optimal-cluster-size
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
+[21]: ../install-sensu/

--- a/content/sensu-go/6.3/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/deployment-architecture.md
@@ -159,6 +159,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -280,7 +280,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -232,7 +232,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../../control-access/create-read-only-user/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -598,7 +598,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.4.0/op-guide/security/
+[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -608,7 +608,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.4.0/tuning/#disk
+[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage


### PR DESCRIPTION
## Description
Revises the instructions for adding a new cluster member, which currently indicate that users need to configure environment variables: https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/cluster-sensu/#add-a-cluster-member

Also:
- Updates description for etcd-initial-cluster-token
- Adds example etcd-initial-cluster-token through cluster-sensu
- Updates etcd doc links to use 3.3.13 instead of 3.4.0
- Adds a link to etcd runtime reconfiguration page in the cluster-sensu introduction text

## Motivation and Context
https://sensu.slack.com/archives/C3MHLUP46/p1613167421105900

## Review Instructions
Do we need to add a step 4 to add backend-4 URL for the agent? See https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/cluster-sensu/#add-sensu-agents-to-clusters
