### PR TITLE
Create namespaces reference

### DIFF
--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -1185,7 +1185,7 @@ Deleting an asset does not delete the archive or downloaded files on disk.
 You must remove the archive and downloaded files from the asset cache manually.
 
 [1]: ../sensu-query-expressions/
-[2]: ../rbac#namespaces
+[2]: ../namespaces/
 [3]: ../tokens/#manage-assets
 [4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
 [5]: #metadata-attributes

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -1495,7 +1495,7 @@ The asset reference includes an [example check definition that uses the asset pa
 [23]: ../../guides/extract-metrics-with-checks/
 [24]: ../events/
 [25]: #metadata-attributes
-[26]: ../rbac#namespaces
+[26]: ../namespaces/
 [27]: ../filters/
 [28]: ../../guides/monitor-external-resources/
 [29]: https://bonsai.sensu.io

--- a/content/sensu-go/5.21/reference/entities.md
+++ b/content/sensu-go/5.21/reference/entities.md
@@ -1540,7 +1540,7 @@ spec:
 [2]: #deregistration-attributes
 [3]: #network-attributes
 [4]: #networkinterface-attributes
-[5]: ../rbac#namespaces
+[5]: ../namespaces/
 [6]: ../filters/
 [7]: ../tokens/
 [8]: #metadata-attributes

--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -1858,7 +1858,7 @@ spec:
 [23]: ../../guides/reduce-alert-fatigue/
 [24]: ../filters/
 [25]: ../checks/#check-result-specification
-[26]: ../rbac#namespaces
+[26]: ../namespaces/
 [27]: ../filters/#handle-state-change-only
 [28]: ../filters/#handle-repeated-events
 [29]: #metadata-attributes

--- a/content/sensu-go/5.21/reference/filters.md
+++ b/content/sensu-go/5.21/reference/filters.md
@@ -1014,7 +1014,7 @@ spec:
 [7]: #built-in-filter-is_incident
 [8]: ../backend/
 [9]: ../events/
-[10]: ../rbac#namespaces
+[10]: ../namespaces/
 [11]: #metadata-attributes
 [12]: ../hooks/
 [13]: ../../guides/extract-metrics-with-checks/

--- a/content/sensu-go/5.21/reference/handlers.md
+++ b/content/sensu-go/5.21/reference/handlers.md
@@ -989,7 +989,7 @@ spec:
 [6]: #socket-attributes
 [7]: ../assets/
 [8]: #metadata-attributes
-[9]: ../rbac#namespaces
+[9]: ../namespaces/
 [10]: ../../api#response-filtering
 [11]: ../../sensuctl/filter-responses/
 [12]: ../agent#keepalive-monitoring

--- a/content/sensu-go/5.21/reference/hooks.md
+++ b/content/sensu-go/5.21/reference/hooks.md
@@ -506,7 +506,7 @@ spec:
 
 [1]: ../../sensuctl/create-manage-resources/#create-resources
 [2]: #metadata-attributes
-[3]: ../rbac#namespaces
+[3]: ../namespaces/
 [4]: ../filters/
 [5]: ../assets/
 [6]: ../checks#check-hooks-attribute

--- a/content/sensu-go/5.21/reference/mutators.md
+++ b/content/sensu-go/5.21/reference/mutators.md
@@ -545,7 +545,7 @@ spec:
 
 [1]: ../assets/
 [2]: #metadata-attributes
-[3]: ../rbac#namespaces
+[3]: ../namespaces/
 [4]: ../../guides/install-check-executables-with-assets/
 [5]: ../../sensuctl/create-manage-resources/#create-resources
 [6]: #spec-attributes

--- a/content/sensu-go/5.21/reference/namespaces.md
+++ b/content/sensu-go/5.21/reference/namespaces.md
@@ -1,0 +1,264 @@
+---
+title: "Namespaces reference"
+linkTitle: "Namespaces"
+reference_title: "Namespaces"
+type: "reference"
+description: "Namespaces partition resources within Sensu so that teams and projects can use Sensu's role-based access control (RBAC) to share a Sensu instance. Use namespaces with RBAC to authorize user access to Sensu resources. Read the reference doc to learn about namespaces."
+weight: 75
+version: "5.21"
+product: "Sensu Go"
+menu: 
+  sensu-go-5.21:
+    parent: reference
+---
+
+Namespaces partition resources within Sensu.
+Sensu entities, checks, handlers, and other [namespaced resources][5] belong to a single namespace.
+
+Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
+A Sensu instance can have multiple namespaces, each with their own set of managed resources.
+Resource names must be unique within a namespace but do not need to be unique across namespaces.
+
+Namespace configuration applies to [sensuctl][2], the [API][6], and the [web UI][3].
+To create and manage namespaces, [configure sensuctl][9] as the [default `admin` user][7] or create a [cluster role][8] with `namespaces` permissions.
+
+## Namespace example
+
+This example shows the resource definition for a `production` namespace.
+You can use this example with [`sensuctl create`][10] to create a `production` namespace in your Sensu deployment:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Namespace
+api_version: core/v2
+metadata: {}
+spec:
+  name: production
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Namespace",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for namespaces
+
+**Use namespaces for isolation, not organization**
+
+Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
+Agents cannot belong to two namespaces or execute checks in two different namespaces.
+To organize resources, use labels rather than multiple namespaces.
+
+## Default namespaces
+
+Every [Sensu backend][1] includes a `default` namespace.
+All resources created without a specified namespace are created within the `default` namespace.
+
+## Manage namespaces
+
+You can use [sensuctl][2] to view, create, and delete namespaces.
+To get help with managing namespaces with sensuctl:
+
+{{< code shell >}}
+sensuctl namespace help
+{{< /code >}}
+
+### View namespaces
+
+Use [sensuctl][2] to view all namespaces within Sensu:
+
+{{< code shell >}}
+sensuctl namespace list
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% /notice %}}
+
+### Create namespaces
+
+Use [sensuctl][2] to create a namespace.
+For example, the following command creates a namespace called `production`:
+
+{{< code shell >}}
+sensuctl namespace create production
+{{< /code >}}
+
+Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+
+### Delete namespaces
+
+To delete a namespace:
+
+{{< code shell >}}
+sensuctl namespace delete [NAMESPACE-NAME]
+{{< /code >}}
+
+### Assign a resource to a namespace
+
+You can assign a resource to a namespace in the resource definition.
+Only resources that belong to a [namespaced resource type][5] (like checks, filters, and handlers) can be assigned to a namespace.
+
+For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check-cpu
+  namespace: production
+spec:
+  check_hooks: null
+  command: check-cpu.sh -w 75 -c 90
+  handlers:
+  - slack
+  interval: 30
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check-cpu",
+    "namespace": "production"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.sh -w 75 -c 90",
+    "handlers": ["slack"],
+    "interval": 30,
+    "subscriptions": ["system"],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+See the [reference docs][4] for the corresponding [resource type][5] to create resource definitions.
+
+{{% notice protip %}}
+**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
+{{% /notice %}}
+
+## Namespace specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. Namespaces should always be type `Namespace`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Namespace
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Namespace"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. The `api_version` should always be `core/v2`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the namespace. For namespaces, the metatdata should always be empty.
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+metadata: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "metadata": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the namespace's [spec attributes][11].
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+spec:
+  name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
+
+name         | 
+-------------|------ 
+description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "production"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+
+[1]: ../backend/
+[2]: ../../sensuctl/
+[3]: ../../web-ui/
+[4]: ../
+[5]: ../rbac/#namespaced-resource-types
+[6]: ../../api/
+[7]: ../rbac/#default-users
+[8]: ../rbac/#cluster-roles
+[9]: ../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[10]: ../../sensuctl/create-manage-resources/#create-resources
+[11]: #spec-attributes
+[12]: ../agent/#labels

--- a/content/sensu-go/5.21/reference/rbac.md
+++ b/content/sensu-go/5.21/reference/rbac.md
@@ -13,171 +13,13 @@ menu:
 ---
 
 Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
-RBAC allows you to specify actions users are allowed to take against resources, within namespaces or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
+RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
-- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (e.g. get and delete) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace. **Cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
 
 RBAC configuration applies to [sensuctl][2], the [API][19], and the [web UI][3].
-
-## Namespaces
-
-Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
-A Sensu instance can have multiple namespaces, each with their own set of managed resources.
-Resource names must be unique within a namespace but do not need to be unique across namespaces.
-
-To create and manage namespaces, [configure sensuctl][26] as the [default `admin` user][20] or create a [cluster role][21] with `namespaces` permissions.
-
-### Default namespaces
-
-Every [Sensu backend][1] includes a `default` namespace.
-All resources created without a specified namespace are created within the `default` namespace.
-
-### Manage namespaces
-
-You can use [sensuctl][2] to view, create, and delete namespaces.
-To get help with managing namespaces with sensuctl:
-
-{{< code shell >}}
-sensuctl namespace help
-{{< /code >}}
-
-#### View namespaces
-
-You can use [sensuctl][2] to view all namespaces within Sensu:
-
-{{< code shell >}}
-sensuctl namespace list
-{{< /code >}}
-
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
-{{% /notice %}}
-
-#### Create namespaces
-
-You can use [sensuctl][2] to create a namespace.
-For example, the following command creates a namespace called `production`:
-
-{{< code shell >}}
-sensuctl namespace create production
-{{< /code >}}
-
-Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-
-#### Delete namespaces
-
-To delete a namespace:
-
-{{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
-{{< /code >}}
-
-#### Assign a resource to a namespace
-
-You can assign a resource to a namespace in the resource definition.
-Only resources that belong to a [namespaced resource type][17] (like checks, filters, and handlers) can be assigned to a namespace.
-
-For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: CheckConfig
-api_version: core/v2
-metadata:
-  name: check-cpu
-  namespace: production
-spec:
-  check_hooks: null
-  command: check-cpu.sh -w 75 -c 90
-  handlers:
-  - slack
-  interval: 30
-  subscriptions:
-  - system
-  timeout: 0
-  ttl: 0
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "CheckConfig",
-  "api_version": "core/v2",
-  "metadata": {
-    "name": "check-cpu",
-    "namespace": "production"
-  },
-  "spec": {
-    "check_hooks": null,
-    "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": ["slack"],
-    "interval": 30,
-    "subscriptions": ["system"],
-    "timeout": 0,
-    "ttl": 0
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-See the [reference docs][16] for the corresponding [resource type][17] to create resource definitions.
-
-{{% notice protip %}}
-**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
-{{% /notice %}}
-
-### Namespace specification
-
-#### Attributes
-
-name         | 
--------------|------ 
-description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: production
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "production"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-### Namespace example
-
-This example is in `yml` and `wrapped-json` formats for use with [`sensuctl create`][31]:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: Namespace
-api_version: core/v2
-metadata: {}
-spec:
-  name: default
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "Namespace",
-  "api_version": "core/v2",
-  "metadata": {},
-  "spec": {
-    "name": "default"
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Resources
 
@@ -186,7 +28,7 @@ You can use resource types to configure permissions in Sensu roles and cluster r
 
 ### Namespaced resource types
 
-Namespaced resources must belong to a single namespace.
+Namespaced resources must belong to a single [namespace][12].
 You can access namespaced resources by [roles][13] and [cluster roles][21].
 
 | type | description |
@@ -1826,6 +1668,7 @@ spec:
 [9]: ../handlers/
 [10]: ../hooks/
 [11]: ../mutators/
+[12]: ../namespaces/
 [13]: #roles-and-cluster-roles
 [14]: ../silencing/
 [16]: ../

--- a/content/sensu-go/5.21/reference/searches.md
+++ b/content/sensu-go/5.21/reference/searches.md
@@ -511,6 +511,6 @@ spec:
 [5]: #metadata-attributes
 [6]: ../../sensuctl/create-manage-resources/#create-resources
 [7]: #spec-attributes
-[8]: ../rbac#namespaces
+[8]: ../namespaces/
 [9]: ../../api/#field-selector
 [10]: ../../api/#label-selector

--- a/content/sensu-go/5.21/reference/secrets.md
+++ b/content/sensu-go/5.21/reference/secrets.md
@@ -307,7 +307,7 @@ The `database` secret contains a key called `password`, and its value is the pas
 [6]: ../rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes
-[9]: ../rbac/#namespaces
+[9]: ../namespaces/
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../../operations/manage-secrets/secrets-management/
 [12]: #metadata-attributes

--- a/content/sensu-go/5.21/reference/silencing.md
+++ b/content/sensu-go/5.21/reference/silencing.md
@@ -593,7 +593,7 @@ name: '*:mysql_status'
 
 
 [1]: ../events/#attributes
-[2]: ../rbac#namespaces
+[2]: ../namespaces/
 [3]: #metadata-attributes
 [4]: ../../sensuctl/create-manage-resources/#create-resources
 [5]: #spec-attributes

--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -542,7 +542,7 @@ Sensuctl supports the following formats:
 [18]: ../../reference/hooks/
 [19]: ../../reference/mutators/
 [20]: ../../reference/silencing/
-[21]: ../../reference/rbac#namespaces
+[21]: ../../reference/namespaces/
 [22]: ../../reference/rbac#users
 [23]: #subcommands
 [24]: ../../reference/secrets-providers/

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -1539,7 +1539,7 @@ spec:
 [2]: #deregistration-attributes
 [3]: #network-attributes
 [4]: #networkinterface-attributes
-[5]: ../../../operations/control-access/rbac#namespaces
+[5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/
 [8]: #metadata-attributes

--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -1868,7 +1868,7 @@ spec:
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/#handle-state-change-only
 [28]: ../../observe-filter/filters/#handle-repeated-events
 [29]: #metadata-attributes

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/filters.md
@@ -1094,7 +1094,7 @@ spec:
 [7]: #built-in-filter-is_incident
 [8]: ../../observe-schedule/backend/
 [9]: ../../observe-events/events/
-[10]: ../../../operations/control-access/rbac#namespaces
+[10]: ../../../operations/control-access/namespaces/
 [11]: #metadata-attributes
 [12]: ../../observe-schedule/hooks/
 [13]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handlers.md
@@ -992,7 +992,7 @@ spec:
 [6]: #socket-attributes
 [7]: ../../../plugins/assets/
 [8]: #metadata-attributes
-[9]: ../../../operations/control-access/rbac#namespaces
+[9]: ../../../operations/control-access/namespaces/
 [10]: ../../../api#response-filtering
 [11]: ../../../sensuctl/filter-responses/
 [12]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/silencing.md
@@ -594,7 +594,7 @@ name: '*:mysql_status'
 
 
 [1]: ../../observe-events/events/#attributes
-[2]: ../../../operations/control-access/rbac#namespaces
+[2]: ../../../operations/control-access/namespaces/
 [3]: #metadata-attributes
 [4]: ../../../sensuctl/create-manage-resources/#create-resources
 [5]: #spec-attributes

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
@@ -1481,7 +1481,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [23]: ../collect-metrics-with-checks/
 [24]: ../../observe-events/events/
 [25]: #metadata-attributes
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/
 [28]: ../../observe-entities/monitor-external-resources/
 [29]: https://bonsai.sensu.io

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/hooks.md
@@ -507,7 +507,7 @@ spec:
 
 [1]: ../../../sensuctl/create-manage-resources/#create-resources
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../observe-filter/filters/
 [5]: ../../../plugins/assets/
 [6]: ../checks#check-hooks-attribute

--- a/content/sensu-go/6.0/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-transform/mutators.md
@@ -548,7 +548,7 @@ spec:
 
 [1]: ../../../plugins/assets/
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../../operations/deploy-sensu/use-assets-to-install-plugins/
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: #spec-attributes

--- a/content/sensu-go/6.0/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.0/operations/control-access/namespaces.md
@@ -1,0 +1,264 @@
+---
+title: "Namespaces reference"
+linkTitle: "Namespaces Reference"
+reference_title: "Namespaces"
+type: "reference"
+description: "Namespaces partition resources within Sensu so that teams and projects can use Sensu's role-based access control (RBAC) to share a Sensu instance. Use namespaces with RBAC to authorize user access to Sensu resources. Read the reference doc to learn about namespaces."
+weight: 75
+version: "6.0"
+product: "Sensu Go"
+menu:
+  sensu-go-6.0:
+    parent: control-access
+---
+
+Namespaces partition resources within Sensu.
+Sensu entities, checks, handlers, and other [namespaced resources][5] belong to a single namespace.
+
+Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
+A Sensu instance can have multiple namespaces, each with their own set of managed resources.
+Resource names must be unique within a namespace but do not need to be unique across namespaces.
+
+Namespace configuration applies to [sensuctl][2], the [API][6], and the [web UI][3].
+To create and manage namespaces, [configure sensuctl][9] as the [default `admin` user][7] or create a [cluster role][8] with `namespaces` permissions.
+
+## Namespace example
+
+This example shows the resource definition for a `production` namespace.
+You can use this example with [`sensuctl create`][10] to create a `production` namespace in your Sensu deployment:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Namespace
+api_version: core/v2
+metadata: {}
+spec:
+  name: production
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Namespace",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for namespaces
+
+**Use namespaces for isolation, not organization**
+
+Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
+Agents cannot belong to two namespaces or execute checks in two different namespaces.
+To organize resources, use labels rather than multiple namespaces.
+
+## Default namespaces
+
+Every [Sensu backend][1] includes a `default` namespace.
+All resources created without a specified namespace are created within the `default` namespace.
+
+## Manage namespaces
+
+You can use [sensuctl][2] to view, create, and delete namespaces.
+To get help with managing namespaces with sensuctl:
+
+{{< code shell >}}
+sensuctl namespace help
+{{< /code >}}
+
+### View namespaces
+
+Use [sensuctl][2] to view all namespaces within Sensu:
+
+{{< code shell >}}
+sensuctl namespace list
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% /notice %}}
+
+### Create namespaces
+
+Use [sensuctl][2] to create a namespace.
+For example, the following command creates a namespace called `production`:
+
+{{< code shell >}}
+sensuctl namespace create production
+{{< /code >}}
+
+Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+
+### Delete namespaces
+
+To delete a namespace:
+
+{{< code shell >}}
+sensuctl namespace delete [NAMESPACE-NAME]
+{{< /code >}}
+
+### Assign a resource to a namespace
+
+You can assign a resource to a namespace in the resource definition.
+Only resources that belong to a [namespaced resource type][5] (like checks, filters, and handlers) can be assigned to a namespace.
+
+For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check-cpu
+  namespace: production
+spec:
+  check_hooks: null
+  command: check-cpu.sh -w 75 -c 90
+  handlers:
+  - slack
+  interval: 30
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check-cpu",
+    "namespace": "production"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.sh -w 75 -c 90",
+    "handlers": ["slack"],
+    "interval": 30,
+    "subscriptions": ["system"],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+See the [reference docs][4] for the corresponding [resource type][5] to create resource definitions.
+
+{{% notice protip %}}
+**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
+{{% /notice %}}
+
+## Namespace specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. Namespaces should always be type `Namespace`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Namespace
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Namespace"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. The `api_version` should always be `core/v2`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the namespace. For namespaces, the metatdata should always be empty.
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+metadata: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "metadata": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the namespace's [spec attributes][11].
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+spec:
+  name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
+
+name         | 
+-------------|------ 
+description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "production"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+
+[1]: ../../../observability-pipeline/observe-schedule/backend/
+[2]: ../../../sensuctl/
+[3]: ../../../web-ui/
+[4]: ../../../reference/
+[5]: ../rbac/#namespaced-resource-types
+[6]: ../../../api/
+[7]: ../rbac/#default-users
+[8]: ../rbac/#cluster-roles
+[9]: ../../deploy-sensu/install-sensu/#install-sensuctl
+[10]: ../../../sensuctl/create-manage-resources/#create-resources
+[11]: #spec-attributes
+[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.0/operations/control-access/rbac.md
+++ b/content/sensu-go/6.0/operations/control-access/rbac.md
@@ -13,171 +13,13 @@ menu:
 ---
 
 Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
-RBAC allows you to specify actions users are allowed to take against resources, within namespaces or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
+RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
-- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (e.g. get and delete) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace. **Cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
 
 RBAC configuration applies to [sensuctl][2], the [API][19], and the [web UI][3].
-
-## Namespaces
-
-Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
-A Sensu instance can have multiple namespaces, each with their own set of managed resources.
-Resource names must be unique within a namespace but do not need to be unique across namespaces.
-
-To create and manage namespaces, [configure sensuctl][26] as the [default `admin` user][20] or create a [cluster role][21] with `namespaces` permissions.
-
-### Default namespaces
-
-Every [Sensu backend][1] includes a `default` namespace.
-All resources created without a specified namespace are created within the `default` namespace.
-
-### Manage namespaces
-
-You can use [sensuctl][2] to view, create, and delete namespaces.
-To get help with managing namespaces with sensuctl:
-
-{{< code shell >}}
-sensuctl namespace help
-{{< /code >}}
-
-#### View namespaces
-
-You can use [sensuctl][2] to view all namespaces within Sensu:
-
-{{< code shell >}}
-sensuctl namespace list
-{{< /code >}}
-
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
-{{% /notice %}}
-
-#### Create namespaces
-
-You can use [sensuctl][2] to create a namespace.
-For example, the following command creates a namespace called `production`:
-
-{{< code shell >}}
-sensuctl namespace create production
-{{< /code >}}
-
-Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-
-#### Delete namespaces
-
-To delete a namespace:
-
-{{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
-{{< /code >}}
-
-#### Assign a resource to a namespace
-
-You can assign a resource to a namespace in the resource definition.
-Only resources that belong to a [namespaced resource type][17] (like checks, filters, and handlers) can be assigned to a namespace.
-
-For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: CheckConfig
-api_version: core/v2
-metadata:
-  name: check-cpu
-  namespace: production
-spec:
-  check_hooks: null
-  command: check-cpu.sh -w 75 -c 90
-  handlers:
-  - slack
-  interval: 30
-  subscriptions:
-  - system
-  timeout: 0
-  ttl: 0
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "CheckConfig",
-  "api_version": "core/v2",
-  "metadata": {
-    "name": "check-cpu",
-    "namespace": "production"
-  },
-  "spec": {
-    "check_hooks": null,
-    "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": ["slack"],
-    "interval": 30,
-    "subscriptions": ["system"],
-    "timeout": 0,
-    "ttl": 0
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-See the [reference docs][16] for the corresponding [resource type][17] to create resource definitions.
-
-{{% notice protip %}}
-**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
-{{% /notice %}}
-
-### Namespace specification
-
-#### Attributes
-
-name         | 
--------------|------ 
-description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: production
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "production"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-### Namespace example
-
-This example is in `yml` and `wrapped-json` formats for use with [`sensuctl create`][31]:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: Namespace
-api_version: core/v2
-metadata: {}
-spec:
-  name: default
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "Namespace",
-  "api_version": "core/v2",
-  "metadata": {},
-  "spec": {
-    "name": "default"
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Resources
 
@@ -186,7 +28,7 @@ You can use resource types to configure permissions in Sensu roles and cluster r
 
 ### Namespaced resource types
 
-Namespaced resources must belong to a single namespace.
+Namespaced resources must belong to a single [namespace][12].
 You can access namespaced resources by [roles][13] and [cluster roles][21].
 
 | type | description |
@@ -1826,6 +1668,7 @@ spec:
 [9]: ../../../observability-pipeline/observe-process/handlers/
 [10]: ../../../observability-pipeline/observe-schedule/hooks/
 [11]: ../../../observability-pipeline/observe-transform/mutators/
+[12]: ../namespaces/
 [13]: #roles-and-cluster-roles
 [14]: ../../../observability-pipeline/observe-process/silencing/
 [16]: ../../../reference/

--- a/content/sensu-go/6.0/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.0/operations/manage-secrets/secrets.md
@@ -307,7 +307,7 @@ The `database` secret contains a key called `password`, and its value is the pas
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes
-[9]: ../../control-access/rbac/#namespaces
+[9]: ../../control-access/namespaces/
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes

--- a/content/sensu-go/6.0/plugins/assets.md
+++ b/content/sensu-go/6.0/plugins/assets.md
@@ -1186,7 +1186,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 
 
 [1]: ../../observability-pipeline/observe-filter/sensu-query-expressions/
-[2]: ../../operations/control-access/rbac#namespaces
+[2]: ../../operations/control-access/namespaces/
 [3]: ../../observability-pipeline/observe-schedule/tokens/#manage-dynamic-runtime-assets
 [4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
 [5]: #metadata-attributes

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -544,7 +544,7 @@ Sensuctl supports the following formats:
 [18]: ../../observability-pipeline/observe-schedule/hooks/
 [19]: ../../observability-pipeline/observe-transform/mutators/
 [20]: ../../observability-pipeline/observe-process/silencing/
-[21]: ../../operations/control-access/rbac#namespaces
+[21]: ../../operations/control-access/namespaces/
 [22]: ../../operations/control-access/rbac#users
 [23]: #subcommands
 [24]: ../../operations/manage-secrets/secrets-providers/

--- a/content/sensu-go/6.0/web-ui/searches.md
+++ b/content/sensu-go/6.0/web-ui/searches.md
@@ -512,6 +512,6 @@ spec:
 [5]: #metadata-attributes
 [6]: ../../sensuctl/create-manage-resources/#create-resources
 [7]: #spec-attributes
-[8]: ../../operations/control-access/rbac#namespaces
+[8]: ../../operations/control-access/namespaces/
 [9]: ../../api/#field-selector
 [10]: ../../api/#label-selector

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -1539,7 +1539,7 @@ spec:
 [2]: #deregistration-attributes
 [3]: #network-attributes
 [4]: #networkinterface-attributes
-[5]: ../../../operations/control-access/rbac#namespaces
+[5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/
 [8]: #metadata-attributes

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -1868,7 +1868,7 @@ spec:
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/#handle-state-change-only
 [28]: ../../observe-filter/filters/#handle-repeated-events
 [29]: #metadata-attributes

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/filters.md
@@ -1094,7 +1094,7 @@ spec:
 [7]: #built-in-filter-is_incident
 [8]: ../../observe-schedule/backend/
 [9]: ../../observe-events/events/
-[10]: ../../../operations/control-access/rbac#namespaces
+[10]: ../../../operations/control-access/namespaces/
 [11]: #metadata-attributes
 [12]: ../../observe-schedule/hooks/
 [13]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
@@ -992,7 +992,7 @@ spec:
 [6]: #socket-attributes
 [7]: ../../../plugins/assets/
 [8]: #metadata-attributes
-[9]: ../../../operations/control-access/rbac#namespaces
+[9]: ../../../operations/control-access/namespaces/
 [10]: ../../../api#response-filtering
 [11]: ../../../sensuctl/filter-responses/
 [12]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/silencing.md
@@ -594,7 +594,7 @@ name: '*:mysql_status'
 
 
 [1]: ../../observe-events/events/#attributes
-[2]: ../../../operations/control-access/rbac#namespaces
+[2]: ../../../operations/control-access/namespaces/
 [3]: #metadata-attributes
 [4]: ../../../sensuctl/create-manage-resources/#create-resources
 [5]: #spec-attributes

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
@@ -1578,7 +1578,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [23]: ../collect-metrics-with-checks/
 [24]: ../../observe-events/events/
 [25]: #metadata-attributes
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/
 [28]: ../../observe-entities/monitor-external-resources/
 [29]: https://bonsai.sensu.io

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/hooks.md
@@ -507,7 +507,7 @@ spec:
 
 [1]: ../../../sensuctl/create-manage-resources/#create-resources
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../observe-filter/filters/
 [5]: ../../../plugins/assets/
 [6]: ../checks#check-hooks-attribute

--- a/content/sensu-go/6.1/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-transform/mutators.md
@@ -548,7 +548,7 @@ spec:
 
 [1]: ../../../plugins/assets/
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../../plugins/use-assets-to-install-plugins/
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: #spec-attributes

--- a/content/sensu-go/6.1/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.1/operations/control-access/namespaces.md
@@ -1,0 +1,264 @@
+---
+title: "Namespaces reference"
+linkTitle: "Namespaces Reference"
+reference_title: "Namespaces"
+type: "reference"
+description: "Namespaces partition resources within Sensu so that teams and projects can use Sensu's role-based access control (RBAC) to share a Sensu instance. Use namespaces with RBAC to authorize user access to Sensu resources. Read the reference doc to learn about namespaces."
+weight: 75
+version: "6.1"
+product: "Sensu Go"
+menu:
+  sensu-go-6.1:
+    parent: control-access
+---
+
+Namespaces partition resources within Sensu.
+Sensu entities, checks, handlers, and other [namespaced resources][5] belong to a single namespace.
+
+Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
+A Sensu instance can have multiple namespaces, each with their own set of managed resources.
+Resource names must be unique within a namespace but do not need to be unique across namespaces.
+
+Namespace configuration applies to [sensuctl][2], the [API][6], and the [web UI][3].
+To create and manage namespaces, [configure sensuctl][9] as the [default `admin` user][7] or create a [cluster role][8] with `namespaces` permissions.
+
+## Namespace example
+
+This example shows the resource definition for a `production` namespace.
+You can use this example with [`sensuctl create`][10] to create a `production` namespace in your Sensu deployment:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Namespace
+api_version: core/v2
+metadata: {}
+spec:
+  name: production
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Namespace",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for namespaces
+
+**Use namespaces for isolation, not organization**
+
+Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
+Agents cannot belong to two namespaces or execute checks in two different namespaces.
+To organize resources, use labels rather than multiple namespaces.
+
+## Default namespaces
+
+Every [Sensu backend][1] includes a `default` namespace.
+All resources created without a specified namespace are created within the `default` namespace.
+
+## Manage namespaces
+
+You can use [sensuctl][2] to view, create, and delete namespaces.
+To get help with managing namespaces with sensuctl:
+
+{{< code shell >}}
+sensuctl namespace help
+{{< /code >}}
+
+### View namespaces
+
+Use [sensuctl][2] to view all namespaces within Sensu:
+
+{{< code shell >}}
+sensuctl namespace list
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% /notice %}}
+
+### Create namespaces
+
+Use [sensuctl][2] to create a namespace.
+For example, the following command creates a namespace called `production`:
+
+{{< code shell >}}
+sensuctl namespace create production
+{{< /code >}}
+
+Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+
+### Delete namespaces
+
+To delete a namespace:
+
+{{< code shell >}}
+sensuctl namespace delete [NAMESPACE-NAME]
+{{< /code >}}
+
+### Assign a resource to a namespace
+
+You can assign a resource to a namespace in the resource definition.
+Only resources that belong to a [namespaced resource type][5] (like checks, filters, and handlers) can be assigned to a namespace.
+
+For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check-cpu
+  namespace: production
+spec:
+  check_hooks: null
+  command: check-cpu.sh -w 75 -c 90
+  handlers:
+  - slack
+  interval: 30
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check-cpu",
+    "namespace": "production"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.sh -w 75 -c 90",
+    "handlers": ["slack"],
+    "interval": 30,
+    "subscriptions": ["system"],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+See the [reference docs][4] for the corresponding [resource type][5] to create resource definitions.
+
+{{% notice protip %}}
+**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
+{{% /notice %}}
+
+## Namespace specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. Namespaces should always be type `Namespace`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Namespace
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Namespace"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. The `api_version` should always be `core/v2`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the namespace. For namespaces, the metatdata should always be empty.
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+metadata: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "metadata": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the namespace's [spec attributes][11].
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+spec:
+  name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
+
+name         | 
+-------------|------ 
+description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "production"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+
+[1]: ../../../observability-pipeline/observe-schedule/backend/
+[2]: ../../../sensuctl/
+[3]: ../../../web-ui/
+[4]: ../../../reference/
+[5]: ../rbac/#namespaced-resource-types
+[6]: ../../../api/
+[7]: ../rbac/#default-users
+[8]: ../rbac/#cluster-roles
+[9]: ../../deploy-sensu/install-sensu/#install-sensuctl
+[10]: ../../../sensuctl/create-manage-resources/#create-resources
+[11]: #spec-attributes
+[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.1/operations/control-access/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/rbac.md
@@ -13,171 +13,13 @@ menu:
 ---
 
 Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
-RBAC allows you to specify actions users are allowed to take against resources, within namespaces or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
+RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
-- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (e.g. get and delete) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace. **Cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
 
 RBAC configuration applies to [sensuctl][2], the [API][19], and the [web UI][3].
-
-## Namespaces
-
-Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
-A Sensu instance can have multiple namespaces, each with their own set of managed resources.
-Resource names must be unique within a namespace but do not need to be unique across namespaces.
-
-To create and manage namespaces, [configure sensuctl][26] as the [default `admin` user][20] or create a [cluster role][21] with `namespaces` permissions.
-
-### Default namespaces
-
-Every [Sensu backend][1] includes a `default` namespace.
-All resources created without a specified namespace are created within the `default` namespace.
-
-### Manage namespaces
-
-You can use [sensuctl][2] to view, create, and delete namespaces.
-To get help with managing namespaces with sensuctl:
-
-{{< code shell >}}
-sensuctl namespace help
-{{< /code >}}
-
-#### View namespaces
-
-You can use [sensuctl][2] to view all namespaces within Sensu:
-
-{{< code shell >}}
-sensuctl namespace list
-{{< /code >}}
-
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
-{{% /notice %}}
-
-#### Create namespaces
-
-You can use [sensuctl][2] to create a namespace.
-For example, the following command creates a namespace called `production`:
-
-{{< code shell >}}
-sensuctl namespace create production
-{{< /code >}}
-
-Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-
-#### Delete namespaces
-
-To delete a namespace:
-
-{{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
-{{< /code >}}
-
-#### Assign a resource to a namespace
-
-You can assign a resource to a namespace in the resource definition.
-Only resources that belong to a [namespaced resource type][17] (like checks, filters, and handlers) can be assigned to a namespace.
-
-For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: CheckConfig
-api_version: core/v2
-metadata:
-  name: check-cpu
-  namespace: production
-spec:
-  check_hooks: null
-  command: check-cpu.sh -w 75 -c 90
-  handlers:
-  - slack
-  interval: 30
-  subscriptions:
-  - system
-  timeout: 0
-  ttl: 0
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "CheckConfig",
-  "api_version": "core/v2",
-  "metadata": {
-    "name": "check-cpu",
-    "namespace": "production"
-  },
-  "spec": {
-    "check_hooks": null,
-    "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": ["slack"],
-    "interval": 30,
-    "subscriptions": ["system"],
-    "timeout": 0,
-    "ttl": 0
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-See the [reference docs][16] for the corresponding [resource type][17] to create resource definitions.
-
-{{% notice protip %}}
-**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
-{{% /notice %}}
-
-### Namespace specification
-
-#### Attributes
-
-name         | 
--------------|------ 
-description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: production
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "production"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-### Namespace example
-
-This example is in `yml` and `wrapped-json` formats for use with [`sensuctl create`][31]:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: Namespace
-api_version: core/v2
-metadata: {}
-spec:
-  name: default
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "Namespace",
-  "api_version": "core/v2",
-  "metadata": {},
-  "spec": {
-    "name": "default"
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Resources
 
@@ -186,7 +28,7 @@ You can use resource types to configure permissions in Sensu roles and cluster r
 
 ### Namespaced resource types
 
-Namespaced resources must belong to a single namespace.
+Namespaced resources must belong to a single [namespace][12].
 You can access namespaced resources by [roles][13] and [cluster roles][21].
 
 | type | description |
@@ -1826,6 +1668,7 @@ spec:
 [9]: ../../../observability-pipeline/observe-process/handlers/
 [10]: ../../../observability-pipeline/observe-schedule/hooks/
 [11]: ../../../observability-pipeline/observe-transform/mutators/
+[12]: ../namespaces/
 [13]: #roles-and-cluster-roles
 [14]: ../../../observability-pipeline/observe-process/silencing/
 [16]: ../../../reference/

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets.md
@@ -318,7 +318,7 @@ The database secret contains a key called `password,` and its value is the passw
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes
-[9]: ../../control-access/rbac/#namespaces
+[9]: ../../control-access/namespaces/
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes

--- a/content/sensu-go/6.1/plugins/assets.md
+++ b/content/sensu-go/6.1/plugins/assets.md
@@ -1186,7 +1186,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 
 
 [1]: ../../observability-pipeline/observe-filter/sensu-query-expressions/
-[2]: ../../operations/control-access/rbac#namespaces
+[2]: ../../operations/control-access/namespaces/
 [3]: ../../observability-pipeline/observe-schedule/tokens/#manage-dynamic-runtime-assets
 [4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
 [5]: #metadata-attributes

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -546,7 +546,7 @@ Sensuctl supports the following formats:
 [18]: ../../observability-pipeline/observe-schedule/hooks/
 [19]: ../../observability-pipeline/observe-transform/mutators/
 [20]: ../../observability-pipeline/observe-process/silencing/
-[21]: ../../operations/control-access/rbac#namespaces
+[21]: ../../operations/control-access/namespaces/
 [22]: ../../operations/control-access/rbac#users
 [23]: #subcommands
 [24]: ../../operations/manage-secrets/secrets-providers/

--- a/content/sensu-go/6.1/web-ui/searches-reference.md
+++ b/content/sensu-go/6.1/web-ui/searches-reference.md
@@ -474,4 +474,4 @@ spec:
 [5]: #metadata-attributes
 [6]: ../../sensuctl/create-manage-resources/#create-resources
 [7]: #spec-attributes
-[8]: ../../operations/control-access/rbac#namespaces
+[8]: ../../operations/control-access/namespaces/

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -1557,7 +1557,7 @@ spec:
 [2]: #deregistration-attributes
 [3]: #network-attributes
 [4]: #networkinterface-attributes
-[5]: ../../../operations/control-access/rbac#namespaces
+[5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/
 [8]: #metadata-attributes

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -1896,7 +1896,7 @@ spec:
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/#handle-state-change-only
 [28]: ../../observe-filter/filters/#handle-repeated-events
 [29]: #metadata-attributes

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
@@ -1093,7 +1093,7 @@ spec:
 [7]: #built-in-filter-is_incident
 [8]: ../../observe-schedule/backend/
 [9]: ../../observe-events/events/
-[10]: ../../../operations/control-access/rbac#namespaces
+[10]: ../../../operations/control-access/namespaces/
 [11]: #metadata-attributes
 [12]: ../../observe-schedule/hooks/
 [13]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -992,7 +992,7 @@ spec:
 [6]: #socket-attributes
 [7]: ../../../plugins/assets/
 [8]: #metadata-attributes
-[9]: ../../../operations/control-access/rbac#namespaces
+[9]: ../../../operations/control-access/namespaces/
 [10]: ../../../api#response-filtering
 [11]: ../../../sensuctl/filter-responses/
 [12]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/silencing.md
@@ -594,7 +594,7 @@ name: '*:mysql_status'
 
 
 [1]: ../../observe-events/events/#attributes
-[2]: ../../../operations/control-access/rbac#namespaces
+[2]: ../../../operations/control-access/namespaces/
 [3]: #metadata-attributes
 [4]: ../../../sensuctl/create-manage-resources/#create-resources
 [5]: #spec-attributes

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
@@ -1604,7 +1604,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [23]: ../collect-metrics-with-checks/
 [24]: ../../observe-events/events/
 [25]: #metadata-attributes
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/
 [28]: ../../observe-entities/monitor-external-resources/
 [29]: https://bonsai.sensu.io

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/hooks.md
@@ -507,7 +507,7 @@ spec:
 
 [1]: ../../../sensuctl/create-manage-resources/#create-resources
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../observe-filter/filters/
 [5]: ../../../plugins/assets/
 [6]: ../checks#check-hooks-attribute

--- a/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
@@ -548,7 +548,7 @@ spec:
 
 [1]: ../../../plugins/assets/
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../../plugins/use-assets-to-install-plugins/
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: #spec-attributes

--- a/content/sensu-go/6.2/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.2/operations/control-access/namespaces.md
@@ -1,0 +1,255 @@
+---
+title: "Namespaces reference"
+linkTitle: "Namespaces Reference"
+reference_title: "Namespaces"
+type: "reference"
+description: "Namespaces partition resources within Sensu so that teams and projects can use Sensu's role-based access control (RBAC) to share a Sensu instance. Use namespaces with RBAC to authorize user access to Sensu resources. Read the reference doc to learn about namespaces."
+weight: 75
+version: "6.2"
+product: "Sensu Go"
+menu:
+  sensu-go-6.2:
+    parent: control-access
+---
+
+Namespaces partition resources within Sensu.
+Sensu entities, checks, handlers, and other [namespaced resources][5] belong to a single namespace.
+
+Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
+A Sensu instance can have multiple namespaces, each with their own set of managed resources.
+Resource names must be unique within a namespace but do not need to be unique across namespaces.
+
+Namespace configuration applies to [sensuctl][2], the [API][6], and the [web UI][3].
+To create and manage namespaces, [configure sensuctl][9] as the [default `admin` user][7] or create a [cluster role][8] with `namespaces` permissions.
+
+## Namespace example
+
+This example shows the resource definition for a `production` namespace.
+You can use this example with [`sensuctl create`][10] to create a `production` namespace in your Sensu deployment:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Namespace
+api_version: core/v2
+metadata: {}
+spec:
+  name: production
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Namespace",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Default namespaces
+
+Every [Sensu backend][1] includes a `default` namespace.
+All resources created without a specified namespace are created within the `default` namespace.
+
+## Manage namespaces
+
+You can use [sensuctl][2] to view, create, and delete namespaces.
+To get help with managing namespaces with sensuctl:
+
+{{< code shell >}}
+sensuctl namespace help
+{{< /code >}}
+
+### View namespaces
+
+Use [sensuctl][2] to view all namespaces within Sensu:
+
+{{< code shell >}}
+sensuctl namespace list
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% /notice %}}
+
+### Create namespaces
+
+Use [sensuctl][2] to create a namespace.
+For example, the following command creates a namespace called `production`:
+
+{{< code shell >}}
+sensuctl namespace create production
+{{< /code >}}
+
+Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+
+### Delete namespaces
+
+To delete a namespace:
+
+{{< code shell >}}
+sensuctl namespace delete [NAMESPACE-NAME]
+{{< /code >}}
+
+### Assign a resource to a namespace
+
+You can assign a resource to a namespace in the resource definition.
+Only resources that belong to a [namespaced resource type][5] (like checks, filters, and handlers) can be assigned to a namespace.
+
+For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check-cpu
+  namespace: production
+spec:
+  check_hooks: null
+  command: check-cpu.sh -w 75 -c 90
+  handlers:
+  - slack
+  interval: 30
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check-cpu",
+    "namespace": "production"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.sh -w 75 -c 90",
+    "handlers": ["slack"],
+    "interval": 30,
+    "subscriptions": ["system"],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+See the [reference docs][4] for the corresponding [resource type][5] to create resource definitions.
+
+{{% notice protip %}}
+**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
+{{% /notice %}}
+
+## Namespace specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. Namespaces should always be type `Namespace`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Namespace
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Namespace"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. The `api_version` should always be `core/v2`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the namespace. For namespaces, the metatdata should always be empty.
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+metadata: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "metadata": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the namespace's [spec attributes][11].
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+spec:
+  name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
+
+name         | 
+-------------|------ 
+description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "production"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+
+[1]: ../../../observability-pipeline/observe-schedule/backend/
+[2]: ../../../sensuctl/
+[3]: ../../../web-ui/
+[4]: ../../../reference/
+[5]: ../rbac/#namespaced-resource-types
+[6]: ../../../api/
+[7]: ../rbac/#default-users
+[8]: ../rbac/#cluster-roles
+[9]: ../../deploy-sensu/install-sensu/#install-sensuctl
+[10]: ../../../sensuctl/create-manage-resources/#create-resources
+[11]: #spec-attributes

--- a/content/sensu-go/6.2/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.2/operations/control-access/namespaces.md
@@ -51,6 +51,14 @@ spec:
 
 {{< /language-toggle >}}
 
+## Best practices for namespaces
+
+**Use namespaces for isolation, not organization**
+
+Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
+Agents cannot belong to two namespaces or execute checks in two different namespaces.
+To organize resources, use labels rather than multiple namespaces.
+
 ## Default namespaces
 
 Every [Sensu backend][1] includes a `default` namespace.
@@ -253,3 +261,4 @@ name: production
 [9]: ../../deploy-sensu/install-sensu/#install-sensuctl
 [10]: ../../../sensuctl/create-manage-resources/#create-resources
 [11]: #spec-attributes
+[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -13,171 +13,13 @@ menu:
 ---
 
 Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
-RBAC allows you to specify actions users are allowed to take against resources, within namespaces or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
+RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
-- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (e.g. get and delete) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace. **Cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
 
 RBAC configuration applies to [sensuctl][2], the [API][19], and the [web UI][3].
-
-## Namespaces
-
-Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
-A Sensu instance can have multiple namespaces, each with their own set of managed resources.
-Resource names must be unique within a namespace but do not need to be unique across namespaces.
-
-To create and manage namespaces, [configure sensuctl][26] as the [default `admin` user][20] or create a [cluster role][21] with `namespaces` permissions.
-
-### Default namespaces
-
-Every [Sensu backend][1] includes a `default` namespace.
-All resources created without a specified namespace are created within the `default` namespace.
-
-### Manage namespaces
-
-You can use [sensuctl][2] to view, create, and delete namespaces.
-To get help with managing namespaces with sensuctl:
-
-{{< code shell >}}
-sensuctl namespace help
-{{< /code >}}
-
-#### View namespaces
-
-You can use [sensuctl][2] to view all namespaces within Sensu:
-
-{{< code shell >}}
-sensuctl namespace list
-{{< /code >}}
-
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
-{{% /notice %}}
-
-#### Create namespaces
-
-You can use [sensuctl][2] to create a namespace.
-For example, the following command creates a namespace called `production`:
-
-{{< code shell >}}
-sensuctl namespace create production
-{{< /code >}}
-
-Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-
-#### Delete namespaces
-
-To delete a namespace:
-
-{{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
-{{< /code >}}
-
-#### Assign a resource to a namespace
-
-You can assign a resource to a namespace in the resource definition.
-Only resources that belong to a [namespaced resource type][17] (like checks, filters, and handlers) can be assigned to a namespace.
-
-For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: CheckConfig
-api_version: core/v2
-metadata:
-  name: check-cpu
-  namespace: production
-spec:
-  check_hooks: null
-  command: check-cpu.sh -w 75 -c 90
-  handlers:
-  - slack
-  interval: 30
-  subscriptions:
-  - system
-  timeout: 0
-  ttl: 0
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "CheckConfig",
-  "api_version": "core/v2",
-  "metadata": {
-    "name": "check-cpu",
-    "namespace": "production"
-  },
-  "spec": {
-    "check_hooks": null,
-    "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": ["slack"],
-    "interval": 30,
-    "subscriptions": ["system"],
-    "timeout": 0,
-    "ttl": 0
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-See the [reference docs][16] for the corresponding [resource type][17] to create resource definitions.
-
-{{% notice protip %}}
-**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
-{{% /notice %}}
-
-### Namespace specification
-
-#### Attributes
-
-name         | 
--------------|------ 
-description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: production
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "production"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-### Namespace example
-
-This example is in `yml` and `wrapped-json` formats for use with [`sensuctl create`][31]:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: Namespace
-api_version: core/v2
-metadata: {}
-spec:
-  name: default
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "Namespace",
-  "api_version": "core/v2",
-  "metadata": {},
-  "spec": {
-    "name": "default"
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Resources
 
@@ -186,7 +28,7 @@ You can use resource types to configure permissions in Sensu roles and cluster r
 
 ### Namespaced resource types
 
-Namespaced resources must belong to a single namespace.
+Namespaced resources must belong to a single [namespace][12].
 You can access namespaced resources by [roles][13] and [cluster roles][21].
 
 | type | description |
@@ -1826,6 +1668,7 @@ spec:
 [9]: ../../../observability-pipeline/observe-process/handlers/
 [10]: ../../../observability-pipeline/observe-schedule/hooks/
 [11]: ../../../observability-pipeline/observe-transform/mutators/
+[12]: ../namespaces/
 [13]: #roles-and-cluster-roles
 [14]: ../../../observability-pipeline/observe-process/silencing/
 [16]: ../../../reference/

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets.md
@@ -318,7 +318,7 @@ The database secret contains a key called `password,` and its value is the passw
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes
-[9]: ../../control-access/rbac/#namespaces
+[9]: ../../control-access/namespaces/
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes

--- a/content/sensu-go/6.2/plugins/assets.md
+++ b/content/sensu-go/6.2/plugins/assets.md
@@ -1186,7 +1186,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 
 
 [1]: ../../observability-pipeline/observe-filter/sensu-query-expressions/
-[2]: ../../operations/control-access/rbac#namespaces
+[2]: ../../operations/control-access/namespaces/
 [3]: ../../observability-pipeline/observe-schedule/tokens/#manage-dynamic-runtime-assets
 [4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
 [5]: #metadata-attributes

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -564,7 +564,7 @@ Sensuctl supports the following formats:
 [18]: ../../observability-pipeline/observe-schedule/hooks/
 [19]: ../../observability-pipeline/observe-transform/mutators/
 [20]: ../../observability-pipeline/observe-process/silencing/
-[21]: ../../operations/control-access/rbac#namespaces
+[21]: ../../operations/control-access/namespaces/
 [22]: ../../operations/control-access/rbac#users
 [23]: #subcommands
 [24]: ../../operations/manage-secrets/secrets-providers/

--- a/content/sensu-go/6.2/web-ui/searches-reference.md
+++ b/content/sensu-go/6.2/web-ui/searches-reference.md
@@ -474,4 +474,4 @@ spec:
 [5]: #metadata-attributes
 [6]: ../../sensuctl/create-manage-resources/#create-resources
 [7]: #spec-attributes
-[8]: ../../operations/control-access/rbac#namespaces
+[8]: ../../operations/control-access/namespaces/

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -1557,7 +1557,7 @@ spec:
 [2]: #deregistration-attributes
 [3]: #network-attributes
 [4]: #networkinterface-attributes
-[5]: ../../../operations/control-access/rbac#namespaces
+[5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/
 [8]: #metadata-attributes

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -1896,7 +1896,7 @@ spec:
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/#handle-state-change-only
 [28]: ../../observe-filter/filters/#handle-repeated-events
 [29]: #metadata-attributes

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -1093,7 +1093,7 @@ spec:
 [7]: #built-in-filter-is_incident
 [8]: ../../observe-schedule/backend/
 [9]: ../../observe-events/events/
-[10]: ../../../operations/control-access/rbac#namespaces
+[10]: ../../../operations/control-access/namespaces/
 [11]: #metadata-attributes
 [12]: ../../observe-schedule/hooks/
 [13]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -992,7 +992,7 @@ spec:
 [6]: #socket-attributes
 [7]: ../../../plugins/assets/
 [8]: #metadata-attributes
-[9]: ../../../operations/control-access/rbac#namespaces
+[9]: ../../../operations/control-access/namespaces/
 [10]: ../../../api#response-filtering
 [11]: ../../../sensuctl/filter-responses/
 [12]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/silencing.md
@@ -594,7 +594,7 @@ name: '*:mysql_status'
 
 
 [1]: ../../observe-events/events/#attributes
-[2]: ../../../operations/control-access/rbac#namespaces
+[2]: ../../../operations/control-access/namespaces/
 [3]: #metadata-attributes
 [4]: ../../../sensuctl/create-manage-resources/#create-resources
 [5]: #spec-attributes

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -1604,7 +1604,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [23]: ../collect-metrics-with-checks/
 [24]: ../../observe-events/events/
 [25]: #metadata-attributes
-[26]: ../../../operations/control-access/rbac#namespaces
+[26]: ../../../operations/control-access/namespaces/
 [27]: ../../observe-filter/filters/
 [28]: ../../observe-entities/monitor-external-resources/
 [29]: https://bonsai.sensu.io

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
@@ -507,7 +507,7 @@ spec:
 
 [1]: ../../../sensuctl/create-manage-resources/#create-resources
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../observe-filter/filters/
 [5]: ../../../plugins/assets/
 [6]: ../checks#check-hooks-attribute

--- a/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
@@ -548,7 +548,7 @@ spec:
 
 [1]: ../../../plugins/assets/
 [2]: #metadata-attributes
-[3]: ../../../operations/control-access/rbac#namespaces
+[3]: ../../../operations/control-access/namespaces/
 [4]: ../../../plugins/use-assets-to-install-plugins/
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: #spec-attributes

--- a/content/sensu-go/6.3/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.3/operations/control-access/namespaces.md
@@ -1,0 +1,264 @@
+---
+title: "Namespaces reference"
+linkTitle: "Namespaces Reference"
+reference_title: "Namespaces"
+type: "reference"
+description: "Namespaces partition resources within Sensu so that teams and projects can use Sensu's role-based access control (RBAC) to share a Sensu instance. Use namespaces with RBAC to authorize user access to Sensu resources. Read the reference doc to learn about namespaces."
+weight: 75
+version: "6.3"
+product: "Sensu Go"
+menu:
+  sensu-go-6.3:
+    parent: control-access
+---
+
+Namespaces partition resources within Sensu.
+Sensu entities, checks, handlers, and other [namespaced resources][5] belong to a single namespace.
+
+Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
+A Sensu instance can have multiple namespaces, each with their own set of managed resources.
+Resource names must be unique within a namespace but do not need to be unique across namespaces.
+
+Namespace configuration applies to [sensuctl][2], the [API][6], and the [web UI][3].
+To create and manage namespaces, [configure sensuctl][9] as the [default `admin` user][7] or create a [cluster role][8] with `namespaces` permissions.
+
+## Namespace example
+
+This example shows the resource definition for a `production` namespace.
+You can use this example with [`sensuctl create`][10] to create a `production` namespace in your Sensu deployment:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Namespace
+api_version: core/v2
+metadata: {}
+spec:
+  name: production
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Namespace",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for namespaces
+
+**Use namespaces for isolation, not organization**
+
+Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
+Agents cannot belong to two namespaces or execute checks in two different namespaces.
+To organize resources, use labels rather than multiple namespaces.
+
+## Default namespaces
+
+Every [Sensu backend][1] includes a `default` namespace.
+All resources created without a specified namespace are created within the `default` namespace.
+
+## Manage namespaces
+
+You can use [sensuctl][2] to view, create, and delete namespaces.
+To get help with managing namespaces with sensuctl:
+
+{{< code shell >}}
+sensuctl namespace help
+{{< /code >}}
+
+### View namespaces
+
+Use [sensuctl][2] to view all namespaces within Sensu:
+
+{{< code shell >}}
+sensuctl namespace list
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% /notice %}}
+
+### Create namespaces
+
+Use [sensuctl][2] to create a namespace.
+For example, the following command creates a namespace called `production`:
+
+{{< code shell >}}
+sensuctl namespace create production
+{{< /code >}}
+
+Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+
+### Delete namespaces
+
+To delete a namespace:
+
+{{< code shell >}}
+sensuctl namespace delete [NAMESPACE-NAME]
+{{< /code >}}
+
+### Assign a resource to a namespace
+
+You can assign a resource to a namespace in the resource definition.
+Only resources that belong to a [namespaced resource type][5] (like checks, filters, and handlers) can be assigned to a namespace.
+
+For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check-cpu
+  namespace: production
+spec:
+  check_hooks: null
+  command: check-cpu.sh -w 75 -c 90
+  handlers:
+  - slack
+  interval: 30
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check-cpu",
+    "namespace": "production"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.sh -w 75 -c 90",
+    "handlers": ["slack"],
+    "interval": 30,
+    "subscriptions": ["system"],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+See the [reference docs][4] for the corresponding [resource type][5] to create resource definitions.
+
+{{% notice protip %}}
+**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
+{{% /notice %}}
+
+## Namespace specification
+
+### Top-level attributes
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. Namespaces should always be type `Namespace`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Namespace
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Namespace"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+api_version  | 
+-------------|------
+description  | Top-level attribute that specifies the Sensu API group and version. The `api_version` should always be `core/v2`.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+metadata     | 
+-------------|------
+description  | Top-level collection of metadata about the namespace. For namespaces, the metatdata should always be empty.
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+metadata: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "metadata": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+spec         | 
+-------------|------
+description  | Top-level map that includes the namespace's [spec attributes][11].
+required     | true
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+spec:
+  name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "spec": {
+    "name": "production"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
+
+name         | 
+-------------|------ 
+description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: production
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "production"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+
+[1]: ../../../observability-pipeline/observe-schedule/backend/
+[2]: ../../../sensuctl/
+[3]: ../../../web-ui/
+[4]: ../../../reference/
+[5]: ../rbac/#namespaced-resource-types
+[6]: ../../../api/
+[7]: ../rbac/#default-users
+[8]: ../rbac/#cluster-roles
+[9]: ../../deploy-sensu/install-sensu/#install-sensuctl
+[10]: ../../../sensuctl/create-manage-resources/#create-resources
+[11]: #spec-attributes
+[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -13,171 +13,13 @@ menu:
 ---
 
 Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
-RBAC allows you to specify actions users are allowed to take against resources, within namespaces or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
+RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
-- **Namespaces** partition resources within Sensu. Sensu entities, checks, handlers, and other [namespaced resources][17] belong to a single namespace.
 - **Roles** create sets of permissions (e.g. get and delete) tied to resource types. **Cluster roles** apply permissions across namespaces and include access to [cluster-wide resources][18] like users and namespaces. 
 - **Users** represent a person or agent that interacts with Sensu. Users can belong to one or more **groups**.
 - **Role bindings** assign a role to a set of users and groups within a namespace. **Cluster role bindings** assign a cluster role to a set of users and groups cluster-wide.
 
 RBAC configuration applies to [sensuctl][2], the [API][19], and the [web UI][3].
-
-## Namespaces
-
-Namespaces help teams use different resources (like entities, checks, and handlers) within Sensu and impose their own controls on those resources.
-A Sensu instance can have multiple namespaces, each with their own set of managed resources.
-Resource names must be unique within a namespace but do not need to be unique across namespaces.
-
-To create and manage namespaces, [configure sensuctl][26] as the [default `admin` user][20] or create a [cluster role][21] with `namespaces` permissions.
-
-### Default namespaces
-
-Every [Sensu backend][1] includes a `default` namespace.
-All resources created without a specified namespace are created within the `default` namespace.
-
-### Manage namespaces
-
-You can use [sensuctl][2] to view, create, and delete namespaces.
-To get help with managing namespaces with sensuctl:
-
-{{< code shell >}}
-sensuctl namespace help
-{{< /code >}}
-
-#### View namespaces
-
-You can use [sensuctl][2] to view all namespaces within Sensu:
-
-{{< code shell >}}
-sensuctl namespace list
-{{< /code >}}
-
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
-{{% /notice %}}
-
-#### Create namespaces
-
-You can use [sensuctl][2] to create a namespace.
-For example, the following command creates a namespace called `production`:
-
-{{< code shell >}}
-sensuctl namespace create production
-{{< /code >}}
-
-Namespace names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-
-#### Delete namespaces
-
-To delete a namespace:
-
-{{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
-{{< /code >}}
-
-#### Assign a resource to a namespace
-
-You can assign a resource to a namespace in the resource definition.
-Only resources that belong to a [namespaced resource type][17] (like checks, filters, and handlers) can be assigned to a namespace.
-
-For example, to assign a check called `check-cpu` to the `production` namespace, include the `namespace` attribute in the check definition:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: CheckConfig
-api_version: core/v2
-metadata:
-  name: check-cpu
-  namespace: production
-spec:
-  check_hooks: null
-  command: check-cpu.sh -w 75 -c 90
-  handlers:
-  - slack
-  interval: 30
-  subscriptions:
-  - system
-  timeout: 0
-  ttl: 0
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "CheckConfig",
-  "api_version": "core/v2",
-  "metadata": {
-    "name": "check-cpu",
-    "namespace": "production"
-  },
-  "spec": {
-    "check_hooks": null,
-    "command": "check-cpu.sh -w 75 -c 90",
-    "handlers": ["slack"],
-    "interval": 30,
-    "subscriptions": ["system"],
-    "timeout": 0,
-    "ttl": 0
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-See the [reference docs][16] for the corresponding [resource type][17] to create resource definitions.
-
-{{% notice protip %}}
-**PRO TIP**: If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation. This allows you to replicate resources across namespaces without manual editing. See the [sensuctl reference](../../../sensuctl/create-manage-resources/#create-resources-across-namespaces) for more information.
-{{% /notice %}}
-
-### Namespace specification
-
-#### Attributes
-
-name         | 
--------------|------ 
-description  | Name of the namespace. Names can contain alphanumeric characters and hyphens and must begin and end with an alphanumeric character.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: production
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "production"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-### Namespace example
-
-This example is in `yml` and `wrapped-json` formats for use with [`sensuctl create`][31]:
-
-{{< language-toggle >}}
-
-{{< code yml >}}
----
-type: Namespace
-api_version: core/v2
-metadata: {}
-spec:
-  name: default
-{{< /code >}}
-
-{{< code json >}}
-{
-  "type": "Namespace",
-  "api_version": "core/v2",
-  "metadata": {},
-  "spec": {
-    "name": "default"
-  }
-}
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Resources
 
@@ -186,7 +28,7 @@ You can use resource types to configure permissions in Sensu roles and cluster r
 
 ### Namespaced resource types
 
-Namespaced resources must belong to a single namespace.
+Namespaced resources must belong to a single [namespace][12].
 You can access namespaced resources by [roles][13] and [cluster roles][21].
 
 | type | description |
@@ -1826,6 +1668,7 @@ spec:
 [9]: ../../../observability-pipeline/observe-process/handlers/
 [10]: ../../../observability-pipeline/observe-schedule/hooks/
 [11]: ../../../observability-pipeline/observe-transform/mutators/
+[12]: ../namespaces/
 [13]: #roles-and-cluster-roles
 [14]: ../../../observability-pipeline/observe-process/silencing/
 [16]: ../../../reference/

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets.md
@@ -318,7 +318,7 @@ The database secret contains a key called `password,` and its value is the passw
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes
-[9]: ../../control-access/rbac/#namespaces
+[9]: ../../control-access/namespaces/
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes

--- a/content/sensu-go/6.3/plugins/assets.md
+++ b/content/sensu-go/6.3/plugins/assets.md
@@ -1186,7 +1186,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 
 
 [1]: ../../observability-pipeline/observe-filter/sensu-query-expressions/
-[2]: ../../operations/control-access/rbac#namespaces
+[2]: ../../operations/control-access/namespaces/
 [3]: ../../observability-pipeline/observe-schedule/tokens/#manage-dynamic-runtime-assets
 [4]: https://bonsai.sensu.io/assets/samroy92/sensu-plugins-windows
 [5]: #metadata-attributes

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -564,7 +564,7 @@ Sensuctl supports the following formats:
 [18]: ../../observability-pipeline/observe-schedule/hooks/
 [19]: ../../observability-pipeline/observe-transform/mutators/
 [20]: ../../observability-pipeline/observe-process/silencing/
-[21]: ../../operations/control-access/rbac#namespaces
+[21]: ../../operations/control-access/namespaces/
 [22]: ../../operations/control-access/rbac#users
 [23]: #subcommands
 [24]: ../../operations/manage-secrets/secrets-providers/

--- a/content/sensu-go/6.3/web-ui/searches-reference.md
+++ b/content/sensu-go/6.3/web-ui/searches-reference.md
@@ -474,4 +474,4 @@ spec:
 [5]: #metadata-attributes
 [6]: ../../sensuctl/create-manage-resources/#create-resources
 [7]: #spec-attributes
-[8]: ../../operations/control-access/rbac#namespaces
+[8]: ../../operations/control-access/namespaces/


### PR DESCRIPTION
## Description
Adds a namespaces reference in Operations > Control Access. The content is mainly pulled from https://docs.sensu.io/sensu-go/latest/operations/control-access/rbac/#namespaces, although I added to the specification so that it includes the type, api_version, metadata, and spec tables (this makes it consistent with other reference docs).

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2966

## Review Instructions
I fixed all the links -- just need to think through redirect. I don't think I can redirect down to the heading level.