### PR TITLE
fix agent websocket default port number in backend reference

### DIFF
--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -23,7 +23,7 @@ See the [installation guide][1] to install the backend.
 ## Backend transport
 
 The Sensu backend listens for agent communications via [WebSocket][30] transport.
-By default, this transport operates on port 8080.
+By default, this transport operates on port 8081.
 The agent subscriptions are used to determine which check execution requests the backend publishes via the transport.
 Sensu agents locally execute checks as requested by the backend and publish check results back to the transport to be processed.
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -23,7 +23,7 @@ See the [installation guide][1] to install the backend.
 ## Backend transport
 
 The Sensu backend listens for agent communications via [WebSocket][30] transport.
-By default, this transport operates on port 8080.
+By default, this transport operates on port 8081.
 The agent subscriptions are used to determine which check execution requests the backend publishes via the transport.
 Sensu agents locally execute checks as requested by the backend and publish check results back to the transport to be processed.
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -23,7 +23,7 @@ See the [installation guide][1] to install the backend.
 ## Backend transport
 
 The Sensu backend listens for agent communications via [WebSocket][30] transport.
-By default, this transport operates on port 8080.
+By default, this transport operates on port 8081.
 The agent subscriptions are used to determine which check execution requests the backend publishes via the transport.
 Sensu agents locally execute checks as requested by the backend and publish check results back to the transport to be processed.
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -23,7 +23,7 @@ See the [installation guide][1] to install the backend.
 ## Backend transport
 
 The Sensu backend listens for agent communications via [WebSocket][30] transport.
-By default, this transport operates on port 8080.
+By default, this transport operates on port 8081.
 The agent subscriptions are used to determine which check execution requests the backend publishes via the transport.
 Sensu agents locally execute checks as requested by the backend and publish check results back to the transport to be processed.
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -23,7 +23,7 @@ See the [installation guide][1] to install the backend.
 ## Backend transport
 
 The Sensu backend listens for agent communications via [WebSocket][30] transport.
-By default, this transport operates on port 8080.
+By default, this transport operates on port 8081.
 The agent subscriptions are used to determine which check execution requests the backend publishes via the transport.
 Sensu agents locally execute checks as requested by the backend and publish check results back to the transport to be processed.
 


### PR DESCRIPTION
## Description

Corrects description of default port for agent websocket transport in backend reference.

## Motivation and Context

Fix a mistake I suggested in code review.

![](https://media.giphy.com/media/LmxMG06puk3WPA9ZBk/giphy.gif)


## Review Instructions
<!--- Optional -->
