### PR TITLE
Add algorithm detail and fix JWT link in sensuctl overview pages

### DIFF
--- a/content/sensu-go/5.21/sensuctl/_index.md
+++ b/content/sensu-go/5.21/sensuctl/_index.md
@@ -34,7 +34,7 @@ When prompted, type the [Sensu backend URL][6] and your [Sensu access credential
 {{< /code >}}
 
 Sensuctl uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][14].
-The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
+The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 
 Upon successful authentication, sensuctl stores the access and refresh tokens in a "cluster" configuration file under the current user's home directory.
@@ -347,3 +347,4 @@ create  delete  import  list
 [13]: create-manage-resources/#update-resources
 [14]: ../api/auth/
 [15]: https://en.wikipedia.org/wiki/Bcrypt
+[16]: https://tools.ietf.org/html/rfc7519

--- a/content/sensu-go/6.0/sensuctl/_index.md
+++ b/content/sensu-go/6.0/sensuctl/_index.md
@@ -34,7 +34,7 @@ When prompted, type the [Sensu backend URL][6] and your [Sensu access credential
 {{< /code >}}
 
 Sensuctl uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][14].
-The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
+The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 
 Upon successful authentication, sensuctl stores the access and refresh tokens in a "cluster" configuration file under the current user's home directory.
@@ -347,3 +347,4 @@ create  delete  import  list
 [13]: create-manage-resources/#update-resources
 [14]: ../api/auth/
 [15]: https://en.wikipedia.org/wiki/Bcrypt
+[16]: https://tools.ietf.org/html/rfc7519

--- a/content/sensu-go/6.1/sensuctl/_index.md
+++ b/content/sensu-go/6.1/sensuctl/_index.md
@@ -34,7 +34,7 @@ When prompted, type the [Sensu backend URL][6] and your [Sensu access credential
 {{< /code >}}
 
 Sensuctl uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][14].
-The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
+The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 
 Upon successful authentication, sensuctl stores the access and refresh tokens in a "cluster" configuration file under the current user's home directory.
@@ -347,3 +347,4 @@ create  delete  import  list
 [13]: create-manage-resources/#update-resources
 [14]: ../api/auth/
 [15]: https://en.wikipedia.org/wiki/Bcrypt
+[16]: https://tools.ietf.org/html/rfc7519

--- a/content/sensu-go/6.2/sensuctl/_index.md
+++ b/content/sensu-go/6.2/sensuctl/_index.md
@@ -27,7 +27,7 @@ This starts the prompts for interactive sensuctl setup.
 When prompted, choose the authentication method you wish to use: username/password or OIDC.
 
 Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the [Sensu authentication API][14].
-The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
+The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 
 Upon successful authentication, sensuctl stores the access and refresh tokens in a "cluster" configuration file under the current user's home directory.

--- a/content/sensu-go/6.3/sensuctl/_index.md
+++ b/content/sensu-go/6.3/sensuctl/_index.md
@@ -27,7 +27,7 @@ This starts the prompts for interactive sensuctl setup.
 When prompted, choose the authentication method you wish to use: username/password or OIDC.
 
 Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the [Sensu authentication API][14].
-The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
+The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 
 Upon successful authentication, sensuctl stores the access and refresh tokens in a "cluster" configuration file under the current user's home directory.
@@ -400,6 +400,7 @@ create  delete  import  list
 [13]: create-manage-resources/#update-resources
 [14]: ../api/auth/
 [15]: https://en.wikipedia.org/wiki/Bcrypt
+[16]: https://tools.ietf.org/html/rfc7519
 [17]: ../operations/control-access/ldap-auth
 [18]: ../operations/control-access/ad-auth
 [19]: ../commercial/


### PR DESCRIPTION
## Description

Fixes a link for JavaScript Web Tokens which is currently linking to install instructions, and adds a detail regarding the JWT signing algorithm 

## Motivation and Context

Fix broken link, document signing algorithm
