### PR TITLE
Correct statement about etcd version 3.4.0 in datastore reference

### DIFF
--- a/content/sensu-go/5.21/reference/datastore.md
+++ b/content/sensu-go/5.21/reference/datastore.md
@@ -26,7 +26,7 @@ Sensu can be configured to disable the embedded etcd database and use one or mor
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
 Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.3.x series.
-etcd versions 3.4.0 and later are not supported.
+etcd version 3.4.0 is compatible with Sensu but may result in slower performance than the 3.3.x series.
 
 ## Scale event storage
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
@@ -27,7 +27,7 @@ Sensu can be configured to disable the embedded etcd database and use one or mor
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
 Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.3.x series.
-etcd versions 3.4.0 and later are not supported.
+etcd version 3.4.0 is compatible with Sensu but may result in slower performance than the 3.3.x series.
 
 ## Scale event storage
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -27,7 +27,7 @@ Sensu can be configured to disable the embedded etcd database and use one or mor
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
 Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.3.x series.
-etcd versions 3.4.0 and later are not supported.
+etcd version 3.4.0 is compatible with Sensu but may result in slower performance than the 3.3.x series.
 
 ## Scale event storage
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
@@ -27,7 +27,7 @@ Sensu can be configured to disable the embedded etcd database and use one or mor
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
 Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.3.x series.
-etcd versions 3.4.0 and later are not supported.
+etcd version 3.4.0 is compatible with Sensu but may result in slower performance than the 3.3.x series.
 
 ## Scale event storage
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -27,7 +27,7 @@ Sensu can be configured to disable the embedded etcd database and use one or mor
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
 Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.3.x series.
-etcd versions 3.4.0 and later are not supported.
+etcd version 3.4.0 is compatible with Sensu but may result in slower performance than the 3.3.x series.
 
 ## Scale event storage
 


### PR DESCRIPTION
## Description
In the datastore reference doc, correct the statement that 3.4.0 is not supported to explain that etcd version 3.4.0 is compatible with Sensu but is slower than the 3.3.x series.

## Motivation and Context
Comment from Justin: https://github.com/sensu/sensu-docs/pull/2792#discussion_r578019587