### PR TITLE
Update links in integrations to use the catalog templates

### DIFF
--- a/content/sensu-go/6.0/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/ansible.md
@@ -43,7 +43,7 @@ The [documentation site][8] includes installation instructions, example playbook
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/ansible-tower.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.0/plugins/supported-integrations/aws-ec2.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/aws-ec2.md
@@ -37,4 +37,4 @@ You can also add the [Sensu EC2 Handler plugin][4] with a dynamic runtime asset 
 [5]: ../../assets
 [6]: ../../../commercial/
 [7]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/deregistration/aws-ec2.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/deregistration/aws-ec2.yaml

--- a/content/sensu-go/6.0/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/elasticsearch.md
@@ -40,7 +40,7 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/elasticsearch.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.0/plugins/supported-integrations/email.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/email.md
@@ -26,7 +26,9 @@ The [Sensu Email Handler plugin][4] supports the login authentication mechanisms
 
 ## Get the plugin
 
-Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
+For a turnkey experience with the Sensu Email Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send email alerts.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -42,3 +44,4 @@ Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/up-and-running/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/email.yaml

--- a/content/sensu-go/6.0/plugins/supported-integrations/graphite.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/graphite.md
@@ -34,5 +34,5 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 [2]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-graphite-handler
 [3]: ../../assets/
 [4]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[5]: https://github.com/sensu-community/monitoring-pipelines/blob/master/metric-storage/graphite.yaml
+[5]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/graphite.yaml
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/influxdb.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/influxdb.md
@@ -34,7 +34,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/influxdb.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/influxdb.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/jira.md
@@ -35,7 +35,7 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/jira-servicedesk.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.0/plugins/supported-integrations/pagerduty.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/pagerduty.md
@@ -38,7 +38,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/pagerduty.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/pagerduty.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [5]: ../../assets/
 [6]: ../../use-assets-to-install-plugins/

--- a/content/sensu-go/6.0/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/rundeck.md
@@ -40,9 +40,9 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck-webhook.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/saltstack.md
@@ -37,7 +37,7 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/saltstack.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.0/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/servicenow.md
@@ -40,10 +40,10 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/servicenow-events.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/servicenow-incident.yaml
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/entity-registration/servicenow-cmdb.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/slack.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/slack.md
@@ -24,7 +24,9 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Get the plugin
 
-Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
+For a turnkey experience with the Sensu Slack Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send alerts to Slack channels.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -40,3 +42,4 @@ Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/learn-in-15/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/slack.yaml

--- a/content/sensu-go/6.0/plugins/supported-integrations/wavefront.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/wavefront.md
@@ -32,7 +32,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/wavefront.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/wavefront.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-wavefront-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/ansible.md
@@ -43,7 +43,7 @@ The [documentation site][8] includes installation instructions, example playbook
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/ansible-tower.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.1/plugins/supported-integrations/aws-ec2.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/aws-ec2.md
@@ -37,4 +37,4 @@ You can also add the [Sensu EC2 Handler plugin][4] with a dynamic runtime asset 
 [5]: ../../assets
 [6]: ../../../commercial/
 [7]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/deregistration/aws-ec2.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/deregistration/aws-ec2.yaml

--- a/content/sensu-go/6.1/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/elasticsearch.md
@@ -40,7 +40,7 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/elasticsearch.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.1/plugins/supported-integrations/email.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/email.md
@@ -26,7 +26,9 @@ The [Sensu Email Handler plugin][4] supports the login authentication mechanisms
 
 ## Get the plugin
 
-Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
+For a turnkey experience with the Sensu Email Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send email alerts.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -42,3 +44,4 @@ Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/up-and-running/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/email.yaml

--- a/content/sensu-go/6.1/plugins/supported-integrations/graphite.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/graphite.md
@@ -34,5 +34,5 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 [2]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-graphite-handler
 [3]: ../../assets/
 [4]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[5]: https://github.com/sensu-community/monitoring-pipelines/blob/master/metric-storage/graphite.yaml
+[5]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/graphite.yaml
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/influxdb.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/influxdb.md
@@ -34,7 +34,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/influxdb.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/influxdb.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/jira.md
@@ -35,7 +35,7 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/jira-servicedesk.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.1/plugins/supported-integrations/pagerduty.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/pagerduty.md
@@ -38,7 +38,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/pagerduty.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/pagerduty.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [5]: ../../assets/
 [6]: ../../use-assets-to-install-plugins/

--- a/content/sensu-go/6.1/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/rundeck.md
@@ -40,9 +40,9 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck-webhook.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/saltstack.md
@@ -37,7 +37,7 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/saltstack.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.1/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/servicenow.md
@@ -40,10 +40,10 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/servicenow-events.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/servicenow-incident.yaml
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/entity-registration/servicenow-cmdb.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/slack.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/slack.md
@@ -24,7 +24,9 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Get the plugin
 
-Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
+For a turnkey experience with the Sensu Slack Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send alerts to Slack channels.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -40,3 +42,4 @@ Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/learn-in-15/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/slack.yaml

--- a/content/sensu-go/6.1/plugins/supported-integrations/wavefront.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/wavefront.md
@@ -32,7 +32,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/wavefront.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/wavefront.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-wavefront-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/ansible.md
@@ -43,7 +43,7 @@ The [documentation site][8] includes installation instructions, example playbook
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/ansible-tower.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.2/plugins/supported-integrations/aws-ec2.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/aws-ec2.md
@@ -37,4 +37,4 @@ You can also add the [Sensu EC2 Handler plugin][4] with a dynamic runtime asset 
 [5]: ../../assets
 [6]: ../../../commercial/
 [7]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/deregistration/aws-ec2.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/deregistration/aws-ec2.yaml

--- a/content/sensu-go/6.2/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/elasticsearch.md
@@ -40,7 +40,7 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/elasticsearch.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.2/plugins/supported-integrations/email.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/email.md
@@ -26,7 +26,9 @@ The [Sensu Email Handler plugin][4] supports the login authentication mechanisms
 
 ## Get the plugin
 
-Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
+For a turnkey experience with the Sensu Email Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send email alerts.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -42,3 +44,4 @@ Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/up-and-running/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/email.yaml

--- a/content/sensu-go/6.2/plugins/supported-integrations/graphite.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/graphite.md
@@ -34,5 +34,5 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 [2]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-graphite-handler
 [3]: ../../assets/
 [4]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[5]: https://github.com/sensu-community/monitoring-pipelines/blob/master/metric-storage/graphite.yaml
+[5]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/graphite.yaml
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/influxdb.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/influxdb.md
@@ -34,7 +34,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/influxdb.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/influxdb.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/jira.md
@@ -35,7 +35,7 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/jira-servicedesk.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.2/plugins/supported-integrations/pagerduty.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/pagerduty.md
@@ -38,7 +38,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/pagerduty.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/pagerduty.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [5]: ../../assets/
 [6]: ../../use-assets-to-install-plugins/

--- a/content/sensu-go/6.2/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/rundeck.md
@@ -40,9 +40,9 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck-webhook.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/saltstack.md
@@ -37,7 +37,7 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/saltstack.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.2/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/servicenow.md
@@ -40,10 +40,10 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/servicenow-events.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/servicenow-incident.yaml
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/entity-registration/servicenow-cmdb.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/slack.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/slack.md
@@ -24,7 +24,9 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Get the plugin
 
-Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
+For a turnkey experience with the Sensu Slack Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send alerts to Slack channels.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -40,3 +42,4 @@ Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/learn-in-15/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/slack.yaml

--- a/content/sensu-go/6.2/plugins/supported-integrations/wavefront.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/wavefront.md
@@ -32,7 +32,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/wavefront.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/wavefront.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-wavefront-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/ansible.md
@@ -43,7 +43,7 @@ The [documentation site][8] includes installation instructions, example playbook
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/ansible-tower.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.3/plugins/supported-integrations/aws-ec2.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/aws-ec2.md
@@ -37,4 +37,4 @@ You can also add the [Sensu EC2 Handler plugin][4] with a dynamic runtime asset 
 [5]: ../../assets
 [6]: ../../../commercial/
 [7]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/deregistration/aws-ec2.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/deregistration/aws-ec2.yaml

--- a/content/sensu-go/6.3/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/elasticsearch.md
@@ -40,7 +40,7 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/elasticsearch.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.3/plugins/supported-integrations/email.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/email.md
@@ -26,7 +26,9 @@ The [Sensu Email Handler plugin][4] supports the login authentication mechanisms
 
 ## Get the plugin
 
-Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
+For a turnkey experience with the Sensu Email Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send email alerts.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing email workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -42,3 +44,4 @@ Add the [Sensu Email Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/up-and-running/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/email.yaml

--- a/content/sensu-go/6.3/plugins/supported-integrations/graphite.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/graphite.md
@@ -34,5 +34,5 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 [2]: https://bonsai.sensu.io/assets/nixwiz/sensu-go-graphite-handler
 [3]: ../../assets/
 [4]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags
-[5]: https://github.com/sensu-community/monitoring-pipelines/blob/master/metric-storage/graphite.yaml
+[5]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/graphite.yaml
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/influxdb.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/influxdb.md
@@ -34,7 +34,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/influxdb.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/influxdb.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/jira.md
@@ -35,7 +35,7 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/jira-servicedesk.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.3/plugins/supported-integrations/pagerduty.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/pagerduty.md
@@ -38,7 +38,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/pagerduty.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/pagerduty.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [5]: ../../assets/
 [6]: ../../use-assets-to-install-plugins/

--- a/content/sensu-go/6.3/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/rundeck.md
@@ -40,9 +40,9 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck-webhook.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/rundeck.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/saltstack.md
@@ -37,7 +37,7 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/remediation/saltstack.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
 [5]: ../../assets
 [6]: ../../../commercial/

--- a/content/sensu-go/6.3/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/servicenow.md
@@ -40,10 +40,10 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/event-storage/servicenow-events.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
 [5]: ../../assets
 [6]: ../../../commercial/
-[7]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/incident-management/servicenow-incident.yaml
-[8]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/entity-registration/servicenow-cmdb.yaml
+[7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/slack.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/slack.md
@@ -24,7 +24,9 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Get the plugin
 
-Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
+For a turnkey experience with the Sensu Slack Handler plugin, use our curated, configurable [quick-start template][8] to integrate Sensu with your existing workflows and send alerts to Slack channels.
+
+To build your own workflow or integrate Sensu with existing workflows, add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai, the Sensu asset hub, to build your own workflow or integrate Sensu with your existing Slack workflows.
 [Dynamic runtime assets][5] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 ## More resources
@@ -40,3 +42,4 @@ Add the [Sensu Slack Handler plugin][4] with a dynamic runtime asset from Bonsai
 [5]: ../../assets/
 [6]: ../../../learn/learn-in-15/
 [7]: ../../../operations/manage-secrets/
+[8]: https://github.com/sensu/catalog/blob/main/pipelines/alert/slack.yaml

--- a/content/sensu-go/6.3/plugins/supported-integrations/wavefront.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/wavefront.md
@@ -32,7 +32,7 @@ To build your own workflow or integrate Sensu with existing workflows, add the [
 
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
-[3]: https://github.com/sensu-community/monitoring-pipelines/blob/latest/metric-storage/wavefront.yaml
+[3]: https://github.com/sensu/catalog/blob/main/pipelines/metric-storage/wavefront.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-wavefront-handler
 [5]: ../../assets/
 [6]: ../../../operations/manage-secrets/


### PR DESCRIPTION
## Description
Updates links throughout integrations pages to use the sensu/catalog repo rather than sensu-community.

## Motivation and Context
Notice from Todd
