### PR TITLE
Add suggestion to enable round robin with PostgreSQL in Troubleshooting

### DIFF
--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -544,9 +544,9 @@ Sensu will attempt to recover from these conditions when it can, but this may no
 
 To maximize Sensu Go performance, we recommend that you:
  * Follow our [recommended backend hardware configuration][19].
- * Immplement [documented etcd system tuning practices][14].
+ * Implement [documented etcd system tuning practices][14].
  * [Benchmark your etcd storage volume][15] to establish baseline IOPS for your system.
- * [Scale event storage using PostgreSQL][16] to reduce the overall volume of etcd transactions.
+ * [Scale event storage using PostgreSQL][16] with [round robin scheduling enabled][20] to reduce the overall volume of etcd transactions.
 
  As your Sensu deployments grow, preventing issues associated with poor datastore performance relies on ongoing collection and review of [Sensu time-series performance metrics][18].
 
@@ -614,3 +614,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage
 [18]: ../../../api/metrics/
 [19]: ../../deploy-sensu/hardware-requirements/#backend-recommended-configuration
+[20]: ../../deploy-sensu/datastore/#round-robin-postgresql

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -546,7 +546,7 @@ To maximize Sensu Go performance, we recommend that you:
  * Follow our [recommended backend hardware configuration][19].
  * Immplement [documented etcd system tuning practices][14].
  * [Benchmark your etcd storage volume][15] to establish baseline IOPS for your system.
- * [Scale event storage using PostgreSQL][16] to reduce the overall volume of etcd transactions.
+ * [Scale event storage using PostgreSQL][16] with [round robin scheduling enabled][20] to reduce the overall volume of etcd transactions.
 
  As your Sensu deployments grow, preventing issues associated with poor datastore performance relies on ongoing collection and review of [Sensu time-series performance metrics][18].
 
@@ -614,3 +614,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage
 [18]: ../../../api/metrics/
 [19]: ../../deploy-sensu/hardware-requirements/#backend-recommended-configuration
+[20]: ../../deploy-sensu/datastore/#round-robin-postgresql


### PR DESCRIPTION
## Description
Adds suggestion to use PostgreSQL datastore with `enable_round_robin: true` in https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/troubleshoot/#datastore-performance for 6.2 and 6.2

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2917