### PR TITLE
Separate commands and responses throughout docs - Part 2

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -707,10 +707,14 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
 - `json` format for use with the [events API][16]
 
-{{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
 {{< /code >}}
+{{< /language-toggle >}}
 
 ### Delete events
 
@@ -794,8 +798,8 @@ Within a sequence of only OK or only non-OK events, Sensu increments `occurrence
 
 The following table shows the occurrences attributes for a series of example events:
 
-| event sequence   | `occurrences`   | `occurrences_watermark` |
-| -----------------| --------------- | ----------------------- |
+| event sequence    | `occurrences`   | `occurrences_watermark` |
+| ----------------- | --------------- | ----------------------- |
 |1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
 |2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
 |3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -79,7 +79,6 @@ Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secur
 
 Sensu uses the [publish/subscribe pattern of communication][15], which allows automated registration and deregistration of ephemeral systems.
 At the core of this model are Sensu [subscriptions][28]: a list of roles and responsibilities assigned to the system (for example, a webserver or database).
-
 These subscriptions determine which [monitoring checks][14] the agent will execute.
 For an agent to execute a service check, you must specify the same subscription in the [agent configuration][28] and the [check definition][14].
 
@@ -284,16 +283,16 @@ For more information, see the [StatsD documentation][21].
 ### Configure the StatsD listener
 
 To configure the StatsD listener, specify the [`statsd-event-handlers` configuration flag][22] in the [agent configuration][24], and start the agent.
+For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
-# Start an agent that sends StatsD metrics to InfluxDB
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
 Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
-# Start an agent with a customized address and flush interval
 sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host 123.4.5.11 --statsd-metrics-port 8125
 {{< /code >}}
 
@@ -377,21 +376,27 @@ name         |
 description  | Check name.
 required     | true
 type         | String
-example      | {{< code shell >}}"name": "check-mysql-status"{{< /code >}}
+example      | {{< code json >}}{
+  "name": "check-mysql-status"
+}{{< /code >}}
 
 status       | 
 -------------|------
 description  | Check execution exit status code. An exit status code of `0` (zero) indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`. Exit status codes other than `0`, `1`, and `2` indicate an `UNKNOWN` or custom status.
 required     | true
 type         | Integer
-example      | {{< code shell >}}"status": 0{{< /code >}}
+example      | {{< code json >}}{
+  "status": 0
+}{{< /code >}}
 
 output       | 
 -------------|------
 description  | Output produced by the check `command`.
 required     | true
 type         | String
-example      | {{< code shell >}}"output": "CheckHttp OK: 200, 78572 bytes"{{< /code >}}
+example      | {{< code json >}}{
+  "output": "CheckHttp OK: 200, 78572 bytes"
+}{{< /code >}}
 
 source       | 
 -------------|------
@@ -399,7 +404,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"source": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "source": "sensu-docs-site"
+}{{< /code >}}
 
 client       | 
 -------------|------
@@ -409,7 +416,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"client": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "client": "sensu-docs-site"
+}{{< /code >}}
 
 executed     | 
 -------------|------
@@ -417,21 +426,27 @@ description  | Time at which the check was executed. In seconds since the Unix e
 required     | false
 default      | The time the event was received by the agent.
 type         | Integer
-example      | {{< code shell >}}"executed": 1458934742{{< /code >}}
+example      | {{< code json >}}{
+  "executed": 1458934742
+}{{< /code >}}
 
 duration     | 
 -------------|------
 description  | Amount of time it took to execute the check. In seconds.
 required     | false
 type         | Float
-example      | {{< code shell >}}"duration": 1.903135228{{< /code >}}
+example      | {{< code json >}}{
+  "duration": 1.903135228
+}{{< /code >}}
 
 command      | 
 -------------|------
 description  | Command executed to produce the event. Use the `command` attribute to add context to the event data. Sensu does not execute the command included in this attribute.
 required     | false
 type         | String
-example      | {{< code shell >}}"command": "check-http.rb -u https://sensuapp.org"{{< /code >}}
+example      | {{< code json >}}{
+  "command": "check-http.rb -u https://sensuapp.org"
+}{{< /code >}}
 
 interval     | 
 -------------|------
@@ -439,14 +454,18 @@ description  | Interval used to produce the event. Use the `interval` attribute 
 required     | false
 default      | `1`
 type         | Integer
-example      | {{< code shell >}}"interval": 60{{< /code >}}
+example      | {{< code json >}}{
+  "interval": 60
+}{{< /code >}}
 
 handlers     | 
 -------------|------
 description  | Array of Sensu handler names to use for handling the event. Each handler name in the array must be a string.
 required     | false
 type         | Array
-example      | {{< code shell >}}"handlers": ["slack", "influxdb"]{{< /code >}}
+example      | {{< code json >}}{
+  "handlers": ["slack", "influxdb"]
+}{{< /code >}}
 
 ## Keepalive monitoring
 
@@ -730,13 +749,17 @@ sensu-agent service uninstall
 
 ### Get help
 
-The `sensu-agent` tool provides general and command-specific help flags:
+The `sensu-agent` tool provides general and command-specific help flags.
+
+To see sensu-agent commands, run:
 
 {{< code shell >}}
-# Show sensu-agent commands
 sensu-agent help
+{{< /code >}}
 
-# Show options for the sensu-agent start subcommand
+To see options for a specific command (in this case, sensu-agent start), run: 
+
+{{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
@@ -811,8 +834,15 @@ As of 5.20.2, the `--discover-processes` flag is not available, and new events w
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
+To view configuration information for the sensu-agent start command, run:
+
+{{< code shell >}}
+sensu-agent start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-agent start:
+
 {{< code text >}}
-$ sensu-agent start --help
 start the sensu agent
 
 Usage:
@@ -893,12 +923,10 @@ description       | Path to yaml or json file that contains the allow list of ch
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
-
 
 | annotations|      |
 -------------|------
@@ -909,15 +937,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -925,12 +952,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-burst-limit 100
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -938,10 +963,9 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-rate-limit 1.39
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a name="backend-handshake-timeout"></a>
@@ -952,10 +976,9 @@ description   | Number of seconds the Sensu agent should wait when negotiating a
 type          | Integer
 default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-handshake-timeout 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-handshake-timeout 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a name="backend-heartbeat-interval"></a>
@@ -966,10 +989,9 @@ description   | Interval at which the agent should send heartbeats to the Sensu 
 type          | Integer
 default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-interval 45
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a name="backend-heartbeat-timeout"></a>
@@ -980,12 +1002,10 @@ description   | Number of seconds the agent should wait for a response to a hear
 type          | Integer
 default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-timeout 60
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
-
 
 | backend-url |      |
 --------------|------
@@ -995,16 +1015,15 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --backend-url ws://0.0.0.0:8081
 sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-url:
   - "ws://0.0.0.0:8081"
   - "ws://0.0.0.0:8082"
-  {{< /code >}}
-
+{{< /code >}}
 
 <a name="cache-dir"></a>
 
@@ -1014,10 +1033,9 @@ description   | Path to store cached data.
 type          | String
 default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `C:\ProgramData\sensu\cache\sensu-agent`</li></ul>
 environment variable | `SENSU_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --cache-dir /cache/sensu-agent
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a name="config-file"></a>
@@ -1028,7 +1046,7 @@ description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
 environment variable | The config file path cannot be set by an environment variable.
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
@@ -1041,10 +1059,9 @@ description   | When set to `true`, disables [dynamic runtime assets][29] for th
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-assets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-assets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a name="discover-processes"></a>
@@ -1059,10 +1076,9 @@ Instead, the field will be empty: `"processes": null`.
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --discover-processes
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --discover-processes{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 | labels     |      |
@@ -1074,13 +1090,13 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 labels:
-  proxy_type: "website"
+  proxy_type: website
 {{< /code >}}
 
 <a name="name"></a>
@@ -1091,11 +1107,10 @@ description   | Entity name assigned to the agent entity.
 type          | String
 default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --name agent-01
-
-# /etc/sensu/agent.yml example
-name: "agent-01" {{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --name agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+name: "agent-01"{{< /code >}}
 
 <a name="log-level"></a>
 
@@ -1105,11 +1120,10 @@ description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `de
 type          | String
 default       | `info`
 environment variable | `SENSU_LOG_LEVEL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --log-level debug
-
-# /etc/sensu/agent.yml example
-log-level: "debug"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --log-level debug{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+log-level: debug{{< /code >}}
 
 <a name="subscriptions-flag"></a>
 
@@ -1118,15 +1132,15 @@ log-level: "debug"{{< /code >}}
 description     | Array of agent subscriptions that determine which monitoring checks the agent will execute. The subscriptions array items must be strings.
 type            | List
 environment variable | `SENSU_SUBSCRIPTIONS`
-example         | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 subscriptions:
   - disk-checks
-  - process-checks{{< /code >}}
-
+  - process-checks
+{{< /code >}}
 
 ### API configuration flags
 
@@ -1136,12 +1150,10 @@ description   | Bind address for the Sensu agent HTTP API.
 type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-host: "0.0.0.0"{{< /code >}}
-
 
 | api-port    |      |
 --------------|------
@@ -1149,12 +1161,10 @@ description   | Listening port for the Sensu agent HTTP API.
 type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-port 4041
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-port 4041{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-port: 4041{{< /code >}}
-
 
 | disable-api |      |
 --------------|------
@@ -1162,12 +1172,10 @@ description   | `true` to disable the agent HTTP API. Otherwise, `false`.
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DISABLE_API`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-api
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-api{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-api: true{{< /code >}}
-
 
 | events-burst-limit | |
 --------------|------
@@ -1175,12 +1183,10 @@ description   | Maximum amount of burst allowed in a rate interval for the [agen
 type          | Integer
 default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-burst-limit 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-burst-limit 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
-
 
 | events-rate-limit | |
 --------------|------
@@ -1188,12 +1194,10 @@ description   | Maximum number of events per second that can be transmitted to t
 type          | Float
 default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-rate-limit 20.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-rate-limit 20.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
-
 
 ### Ephemeral agent configuration flags
 
@@ -1205,26 +1209,22 @@ description   | `true` if a deregistration event should be created upon Sensu ag
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DEREGISTER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --deregister
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 deregister: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
 description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --deregistration-handler deregister
-
-# /etc/sensu/agent.yml example
-deregistration-handler: "deregister"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+deregistration-handler: deregister{{< /code >}}
 
 <a name="detect-cloud-provider-flag"></a>
-
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1232,12 +1232,10 @@ description              | `true` to enable cloud provider detection mechanisms.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --detect-cloud-provider false
-
-# /etc/sensu/agent.yml example
-detect-cloud-provider: "false"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --detect-cloud-provider false{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+detect-cloud-provider: false{{< /code >}}
 
 ### Keepalive configuration flags
 
@@ -1248,10 +1246,9 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-critical-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a name="keepalive-handlers-flag"></a>
@@ -1262,12 +1259,13 @@ description         | [Keepalive event handlers][52] to use for the entity, spec
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-handlers slack,email
-
-# /etc/sensu/agent.yml example
-keepalive-handlers: slack,email{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-handlers slack,email{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+keepalive-handlers:
+- slack
+- email
+{{< /code >}}
 
 | keepalive-interval |      |
 ---------------------|------
@@ -1275,12 +1273,10 @@ description          | Number of seconds between keepalive events.
 type                 | Integer
 default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
-example              | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
-
 
 | keepalive-warning-timeout |      |
 --------------------|------
@@ -1289,12 +1285,10 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-warning-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -1307,12 +1301,10 @@ Entities can only belong to a [single namespace](../../../operations/control-acc
 type           | String
 default        | `default`
 environment variable   | `SENSU_NAMESPACE`
-example        | {{< code shell >}}# Command line example
-sensu-agent start --namespace ops
-
-# /etc/sensu/agent.yml example
-namespace: "ops"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --namespace ops{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+namespace: ops{{< /code >}}
 
 | user |      |
 --------------|------
@@ -1320,12 +1312,10 @@ description   | [Sensu RBAC username][39] used by the agent. Agents require get,
 type          | String
 default       | `agent`
 environment variable   | `SENSU_USER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --user agent-01
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --user agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
-
 
 | password    |      |
 --------------|------
@@ -1333,12 +1323,10 @@ description   | [Sensu RBAC password][39] used by the agent.
 type          | String
 default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --password secure-password
-
-# /etc/sensu/agent.yml example
-password: "secure-password"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --password secure-password{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+password: secure-password{{< /code >}}
 
 | redact      |      |
 --------------|------
@@ -1349,15 +1337,13 @@ They are not logged or displayed via the Sensu API.
 type          | List
 default       | By default, Sensu redacts the following fields: `password`, `passwd`, `pass`, `api_key`, `api_token`, `access_key`, `secret_key`, `private_key`, `secret`.
 environment variable   | `SENSU_REDACT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --redact secret,ec2_access_key
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --redact secret,ec2_access_key{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
 {{< /code >}}
-
 
 | cert-file  |      |
 -------------|------
@@ -1365,12 +1351,10 @@ description  | Path to the agent certificate file used in mTLS authentication. S
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cert-file /path/to/agent.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cert-file: "/path/to/agent.pem"{{< /code >}}
-
 
 | trusted-ca-file |      |
 ------------------|------
@@ -1378,12 +1362,10 @@ description       | SSL/TLS certificate authority.
 type              | String
 default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -1391,13 +1373,10 @@ description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-key.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --key-file /path/to/agent-key.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 key-file: "/path/to/agent-key.pem"{{< /code >}}
-
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -1407,10 +1386,9 @@ description                | Skip SSL verification. {{% notice warning %}}
 type                       | Boolean
 default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-agent start --insecure-skip-tls-verify
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -1424,10 +1402,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-fips
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-fips{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1439,12 +1416,10 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-openssl
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-openssl{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
-
 
 ### Socket configuration flags
 
@@ -1454,12 +1429,10 @@ description   | Address to bind the Sensu agent socket to.
 type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-host: "0.0.0.0"{{< /code >}}
-
 
 | socket-port |      |
 --------------|------
@@ -1467,12 +1440,10 @@ description   | Port the Sensu agent socket listens on.
 type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-port 4030
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-port 4030{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-port: 4030{{< /code >}}
-
 
 | disable-sockets |      |
 ------------------|------
@@ -1480,12 +1451,10 @@ description       | `true` to disable the agent TCP and UDP event sockets. Othew
 type              | Boolean
 default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --disable-sockets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-sockets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
-
 
 ### StatsD configuration flags
 
@@ -1495,28 +1464,25 @@ description      | `true` to disable the [StatsD][21] listener and metrics serve
 type             | Boolean
 default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
-example          | {{< code shell >}}# Command line example
-sensu-agent start --statsd-disable
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-disable{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
-
 
 | statsd-event-handlers |      |
 ------------------------|------
 description             | List of event handlers for StatsD metrics.
 type                    | List
 environment variable    | `SENSU_STATSD_EVENT_HANDLERS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
 {{< /code >}}
-
 
 | statsd-flush-interval  |      |
 -------------------------|------
@@ -1524,12 +1490,10 @@ description              | Number of seconds between [StatsD flushes][23].
 type                     | Integer
 default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --statsd-flush-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-flush-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
-
 
 | statsd-metrics-host |      |
 ----------------------|------
@@ -1537,12 +1501,10 @@ description           | Address used for the StatsD metrics server.
 type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-host: "0.0.0.0"{{< /code >}}
-
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1550,10 +1512,9 @@ description           | Port used for the StatsD metrics server.
 type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-port 6125
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-port: 6125{{< /code >}}
 
 ### Allow list configuration commands
@@ -1568,28 +1529,65 @@ Use these commands to build your allow list configuration file.
 description           | Command to allow the Sensu agent to run as a check or a hook.
 required              | true
 type                  | String
-example               | {{< code shell >}}"exec": "/usr/local/bin/check_memory.sh"{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+exec: "/usr/local/bin/check_memory.sh"
+{{< /code >}}
+{{< code json >}}
+{
+  "exec": "/usr/local/bin/check_memory.sh"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | sha512 |      |
 ----------------------|------
 description           | Checksum of the check or hook executable.
 required              | false
 type                  | String
-example               | {{< code shell >}}"sha512": "4f926bf4328..."{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+sha512: 4f926bf4328...
+{{< /code >}}
+{{< code json >}}
+{
+  "sha512": "4f926bf4328..."
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | args |      |
 ----------------------|------
 description           | Arguments for the `exec` command.
 required              | true
 type                  | Array
-example               | {{< code shell >}}"args": ["foo"]{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+args:
+- foo
+{{< /code >}}
+{{< code json >}}
+{
+  "args": ["foo"]
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | enable_env |      |
 ----------------------|------
 description           | `true` to enable environment variables. Otherwise, `false`.
 required              | false
 type                  | Boolean
-example               | {{< code shell >}}"enable_env": true{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+enable_env: true
+{{< /code >}}
+{{< code json >}}
+{
+  "enable_env": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 #### Example allow list configuration file
 
@@ -1746,6 +1744,12 @@ This includes your checks and plugins.
 For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file, it will be available to use in your check configurations as `$SENSU_TEST_VAR`.
 
 #### Use environment variables to specify an HTTP proxy for agent use
+
+{{% notice important %}}
+**IMPORTANT**: To use HTTP proxy environment variables, upgrade to Sensu Go 6.1.4 or later.
+In earlier versions of Sensu Go 6.1, the agent will not respect HTTP proxy environment variables when `trusted-ca-file` is configured.
+Upgrade to Sensu Go 6.1.4 or later to avoid this issue.
+{{% /notice %}}
 
 If an HTTP proxy is required to access the internet in your compute environment, you may need to configure the Sensu agent to successfully download dynamic runtime assets or execute commands that depend on internet access.
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -128,11 +128,15 @@ sensu-backend init
 **NOTE**: Make sure the Sensu backend is running before you run `sensu-backend init`.
 {{% /notice %}}
 
-You can also run the `sensu-backend init` command in interactive mode if you prefer to respond to prompts for your username and password:
+You can also run the `sensu-backend init` command in interactive mode:
 
 {{< code shell >}}
 sensu-backend init --interactive
+{{< /code >}}
 
+You will receive prompts for your username and password in interactive mode:
+
+{{< code shell >}}
 Admin Username: YOUR_USERNAME
 Admin Password: YOUR_PASSWORD
 {{< /code >}}
@@ -233,13 +237,17 @@ sensu-backend version
 
 ### Get help
 
-The `sensu-backend` tool provides general and command-specific help flags:
+The `sensu-backend` tool provides general and command-specific help flags.
+
+To see sensu-backend commands, run:
 
 {{< code shell >}}
-# Show sensu-backend commands
 sensu-backend help
+{{< /code >}}
 
-# Show options for the sensu-backend start subcommand
+To see options for a specific command (in this case, sensu-backend start), run: 
+
+{{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
@@ -280,8 +288,15 @@ The Sensu backend checks certificate revocation list (CRL) and Online Certificat
 
 ### Configuration summary
 
+To view configuration information for the sensu-backend start command, run:
+
+{{< code shell >}}
+sensu-backend start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-backend start:
+
 {{< code text >}}
-$ sensu-backend start --help
 start the sensu backend
 
 Usage:
@@ -359,7 +374,6 @@ discovery instead of the static `--initial-cluster method`
       --no-embed-etcd                              don't embed etcd; use external etcd instead
 {{< /code >}}
 
-
 ### General configuration flags
 
 {{% notice note %}}
@@ -375,15 +389,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | api-listen-address  |      |
 -------------|------
@@ -391,12 +404,10 @@ description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-listen-address [::]:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-listen-address [::]:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
-
 
 | api-url  |      |
 -------------|------
@@ -404,12 +415,10 @@ description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_API_URL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-url http://localhost:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-url http://localhost:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -417,12 +426,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-burst-limit 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -430,12 +437,10 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-rate-limit 1.39
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
-
 
 | cache-dir   |      |
 --------------|------
@@ -443,12 +448,10 @@ description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --cache-dir /cache/sensu-backend
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-backend"{{< /code >}}
-
 
 | config-file |      |
 --------------|------
@@ -456,7 +459,7 @@ description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
 environment variable | The config file path cannot be set by an environment variable.
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
@@ -469,12 +472,10 @@ description | If `true`, enable debugging and profiling features for use with th
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
-example     | {{< code shell >}}# Command line example
-sensu-backend start --debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 debug: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
@@ -482,12 +483,10 @@ description              | Name of the default event handler to use when process
 type                     | String
 default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line example
-sensu-backend start --deregistration-handler deregister
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
-
 
 | labels     |      |
 -------------|------
@@ -498,15 +497,14 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
 {{< /code >}}
-
 
 | log-level  |      |
 -------------|------
@@ -514,12 +512,10 @@ description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `deb
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --log-level debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --log-level debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
-
 
 | state-dir  |      |
 -------------|------
@@ -527,13 +523,12 @@ description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
 environment variable | `SENSU_BACKEND_STATE_DIR`
-example      | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
-
 
 ### Agent communication configuration flags
 
@@ -543,12 +538,10 @@ description  | TLS certificate in PEM format for agent certificate authenticatio
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
-
 
 | agent-auth-crl-urls |      |
 -------------|------
@@ -556,12 +549,10 @@ description  | URLs of CRLs for agent certificate authentication. The Sensu back
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
-
 
 | agent-auth-key-file |      |
 -------------|------
@@ -569,12 +560,10 @@ description  | TLS certificate key in PEM format for agent certificate authentic
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-key-file: /path/to/ssl/key.pem{{< /code >}}
-
 
 | agent-auth-trusted-ca-file |      |
 -------------|------
@@ -582,12 +571,10 @@ description  | TLS CA certificate bundle in PEM format for agent certificate aut
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /code >}}
-
 
 | agent-host   |      |
 ---------------|------
@@ -595,12 +582,10 @@ description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by 
 type           | String
 default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
-example        | {{< code shell >}}# Command line example
-sensu-backend start --agent-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
-
 
 | agent-port |      |
 -------------|------
@@ -608,12 +593,10 @@ description  | Agent listener port.
 type         | Integer
 default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-port 8081
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-port 8081{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -623,12 +606,10 @@ description  | Path to the primary backend certificate file. Specifies a fallbac
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cert-file: "/path/to/ssl/cert.pem"{{< /code >}}
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -638,12 +619,10 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 type                       | Boolean
 default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-backend start --insecure-skip-tls-verify
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
-
 
 <a name="jwt-attributes"></a>
 
@@ -655,12 +634,10 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-private-key-file /path/to/key/private.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
-
 
 | jwt-public-key-file |      |
 -------------|------
@@ -671,12 +648,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-public-key-file /path/to/key/public.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -684,10 +659,9 @@ description  | Path to the primary backend key file. Specifies a fallback SSL/TL
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -701,10 +675,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-fips
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-fips{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -716,10 +689,9 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-openssl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-openssl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -728,12 +700,10 @@ description       | Path to the primary backend CA file. Specifies a fallback SS
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 ### Web UI configuration flags
 
@@ -743,12 +713,10 @@ description  | Web UI TLS certificate in PEM format. This certificate secures co
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/cert.pem"{{< /code >}}
-
 
 | dashboard-host |      |
 -----------------|------
@@ -756,12 +724,10 @@ description      | Web UI listener host.
 type             | String
 default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
-
 
 | dashboard-key-file | |
 -------------|------
@@ -769,12 +735,10 @@ description  | Web UI TLS certificate key in PEM format. This key secures commun
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-key-file /path/to/tls/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-key-file /path/to/tls/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/key.pem"{{< /code >}}
-
 
 | dashboard-port |      |
 -----------------|------
@@ -782,12 +746,10 @@ description      | Web UI listener port.
 type             | Integer
 default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-port 4000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-port 4000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-port: 4000{{< /code >}}
-
 
 ### Datastore and cluster configuration flags
 
@@ -801,16 +763,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
 {{< /code >}}
-
 
 | etcd-cert-file |      |
 -----------------|------
@@ -818,12 +779,10 @@ description      | Path to the etcd client API TLS certificate file. Secures com
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-cert-file ./client.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
-
 
 <a name="etcd-cipher-suites"></a>
 
@@ -843,16 +802,15 @@ etcd-cipher-suites:
 {{< /code >}}
 type                    | List
 environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-
 
 | etcd-client-cert-auth |      |
 ------------------------|------
@@ -860,12 +818,10 @@ description             | If `true`, enable client certificate authentication. O
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
-
 
 | etcd-client-urls      |      |
 ------------------------|------
@@ -873,16 +829,15 @@ description             | List of client URLs to use when a sensu-backend is not
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -890,14 +845,12 @@ description             | Exposes [etcd's embedded auto-discovery features][19].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
-
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -905,14 +858,12 @@ description             | Exposes [etcd's embedded auto-discovery features][17].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery-srv example.org
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
-
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
@@ -920,16 +871,15 @@ description                        | List of this member's peer URLs to advertis
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
-example                            | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-initial-cluster |      |
 -----------------------|------
@@ -937,12 +887,10 @@ description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
-
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
@@ -950,12 +898,10 @@ description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-state existing
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
-
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
@@ -963,22 +909,19 @@ description                  | Unique token for the etcd cluster. Provide the sa
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
-
 
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-key-file ./client-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
 <a name="etcd-listen-client-urls"></a>
@@ -989,16 +932,15 @@ description               | List of URLs to listen on for client traffic. Sensu'
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
@@ -1006,16 +948,15 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-name      |      |
 -----------------|------
@@ -1023,24 +964,20 @@ description      | Human-readable name for this member.
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-name backend-0
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-name backend-0{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
-
 
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
-example               | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-cert-file ./backend-0.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-cert-file ./backend-0.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
-
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
@@ -1048,36 +985,30 @@ description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
-
 
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
-example              | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-key-file ./backend-0-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
-
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
-example                     | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
@@ -1085,12 +1016,10 @@ description            | Path to the client server TLS trusted CA certificate fi
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | no-embed-etcd  |      |
 -----------------|------
@@ -1098,12 +1027,10 @@ description      | If `true`, do not embed etcd (use external etcd instead). Oth
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --no-embed-etcd
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --no-embed-etcd{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
-
 
 ### Advanced configuration options
 
@@ -1115,13 +1042,10 @@ description            | Number of incoming events that can be buffered before b
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-buffer-size 100
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
-
 
 | eventd-workers       |      |
 -----------------------|------
@@ -1131,12 +1055,10 @@ description            | Number of workers spawned for processing incoming event
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
-
 
 | keepalived-buffer-size |      |
 -----------------------|------
@@ -1146,12 +1068,10 @@ description            | Number of incoming keepalives that can be buffered befo
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
-
 
 | keepalived-workers |      |
 -----------------------|------
@@ -1160,12 +1080,10 @@ description            | Number of workers spawned for processing incoming keepa
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
-
 
 | pipelined-buffer-size |      |
 -----------------------|------
@@ -1175,12 +1093,10 @@ description            | Number of events to handle that can be buffered before 
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
-
 
 | pipelined-workers |      |
 -----------------------|------
@@ -1190,12 +1106,10 @@ description            | Number of workers spawned for handling events through t
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
-
 
 | etcd-election-timeout |      |
 -----------------------|------
@@ -1205,12 +1119,10 @@ description            | Time that a follower node will go without hearing a hea
 type                   | Integer
 default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-election-timeout 1000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-election-timeout 1000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
-
 
 | etcd-heartbeat-interval |      |
 -----------------------|------
@@ -1219,12 +1131,10 @@ description            | Interval at which the etcd leader will notify followers
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-heartbeat-interval 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
-
 
 | etcd-max-request-bytes |      |
 -----------------------|------
@@ -1234,12 +1144,10 @@ description            | Maximum etcd request size in bytes that can be sent to 
 type                   | Integer
 default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-max-request-bytes 1572864
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
-
 
 | etcd-quota-backend-bytes |      |
 -----------------------|------
@@ -1249,10 +1157,9 @@ description            | Maximum etcd database size in bytes. Increasing this va
 type                   | Integer
 default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-quota-backend-bytes 4294967296
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 ### Configuration via environment variables
@@ -1366,20 +1273,16 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
-
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-buffer-size 100000
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-buffer-size 100000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
-
 
 | event-log-file |      |
 -----------------------|------
@@ -1388,13 +1291,10 @@ description            | Path to the event log file. {{% notice warning %}}
 {{% /notice %}}
 type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-file /var/log/sensu/events.log
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
-
 
 ### Log rotation
 

--- a/content/sensu-go/6.0/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/license.md
@@ -28,11 +28,15 @@ To activate your license with sensuctl:
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
-Use sensuctl to view your license details at any time.
+Use sensuctl to view your license details at any time:
 
 {{< code shell >}}
-# Active license
 sensuctl license info
+{{< /code >}}
+
+For an active license, the response should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -43,9 +47,11 @@ Issuer:       Sensu, Inc.
 Issued:       2020-02-15 15:01:44 -0500 -0500
 Valid:        true
 Valid Until:  2021-02-15 00:00:00 -0800 -0800
+{{< /code >}}
 
-# No license found
-sensuctl license info
+This response means you do not have an active license:
+
+{{< code shell >}}
 Error: not found
 {{< /code >}}
 
@@ -67,10 +73,16 @@ If you use only 1,500 agent entities, you can have 8,500 proxy entities before y
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.
 
-In tabular format, the entity count and limit are included in the response title:
+In tabular format, the entity count and limit are included in the response title.
+To view license info in tabular format, run:
 
 {{< code shell >}}
 sensuctl license info --format tabular
+{{< /code >}}
+
+The response in tabular format should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -90,13 +102,22 @@ For example:
 === You are currently using 10/unlimited total entities, 5/unlimited agent entities, and 5/unlimited proxy entities
 {{< /code >}}
 
-In other formats (e.g. YAML and JSON), the entity count and limit are included as labels:
+To view license details in YAML or JSON, run:
+
+{{< language-toggle >}}
+{{< code shell "YML" >}}
+sensuctl license info --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl license info --format json
+{{< /code >}}
+{{< /language-toggle >}}
+
+In YAML and JSON formats, the entity count and limit are included as labels:
 
 {{< language-toggle >}}
 
-{{< code shell "YML" >}}
-sensuctl license info --format yaml
-
+{{< code yml >}}
 type: LicenseFile
 api_version: licensing/v2
 metadata:
@@ -111,9 +132,7 @@ spec:
 [...]
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl license info --format json
-
+{{< code json >}}
 {
   "type": "LicenseFile",
   "api_version": "licensing/v2",

--- a/content/sensu-go/6.0/sensuctl/environment-variables.md
+++ b/content/sensu-go/6.0/sensuctl/environment-variables.md
@@ -25,7 +25,7 @@ SENSU_TRUSTED_CA_FILE            Path to a trusted CA file if set in sensuctl
 SENSU_INSECURE_SKIP_TLS_VERIFY   Boolean value that can be set to skip TLS verification
 {{< /code >}}
 
-These examples demonstrate how to use sensuctl to export and set environment variables:
+These examples demonstrate how to use sensuctl to export and set environment variables and configure your shell:
 
 {{< language-toggle >}}
 
@@ -38,6 +38,7 @@ export SENSU_ACCESS_TOKEN_EXPIRES_AT="1567716187"
 export SENSU_REFRESH_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 export SENSU_TRUSTED_CA_FILE=""
 export SENSU_INSECURE_SKIP_TLS_VERIFY="true"
+eval $(sensuctl env)
 {{< /code >}}
 
 {{< code cmd >}}
@@ -49,6 +50,7 @@ SET SENSU_ACCESS_TOKEN_EXPIRES_AT=1567716676
 SET SENSU_REFRESH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x
 SET SENSU_TRUSTED_CA_FILE=
 SET SENSU_INSECURE_SKIP_TLS_VERIFY=true
+@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
 {{< /code >}}
 
 {{< code powershell >}}
@@ -60,23 +62,6 @@ $Env:SENSU_ACCESS_TOKEN_EXPIRES_AT = "1567716738"
 $Env:SENSU_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 $Env:SENSU_TRUSTED_CA_FILE = ""
 $Env:SENSU_INSECURE_SKIP_TLS_VERIFY = "true"
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Run these commands to configure your shell:
-
-{{< language-toggle >}}
-
-{{< code bash >}}
-eval $(sensuctl env)
-{{< /code >}}
-
-{{< code cmd >}}
-@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
-{{< /code >}}
-
-{{< code powershell >}}
 & sensuctl env --shell powershell | Invoke-Expression
 {{< /code >}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -707,10 +707,14 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
 - `json` format for use with the [events API][16]
 
-{{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
 {{< /code >}}
+{{< /language-toggle >}}
 
 ### Delete events
 
@@ -794,8 +798,8 @@ Within a sequence of only OK or only non-OK events, Sensu increments `occurrence
 
 The following table shows the occurrences attributes for a series of example events:
 
-| event sequence   | `occurrences`   | `occurrences_watermark` |
-| -----------------| --------------- | ----------------------- |
+| event sequence    | `occurrences`   | `occurrences_watermark` |
+| ----------------- | --------------- | ----------------------- |
 |1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
 |2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
 |3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -22,7 +22,6 @@ Agent entities are responsible for creating [check and metrics events][7] to sen
 The Sensu agent is available for Linux, macOS, and Windows.
 See the [installation guide][1] to install the agent.
 
-
 ## Agent authentication
 
 The Sensu agent authenticates to the Sensu backend via [WebSocket][45] transport by either built-in basic (username and password) or mutual transport layer security (mTLS) authentication.
@@ -284,16 +283,16 @@ For more information, see the [StatsD documentation][21].
 ### Configure the StatsD listener
 
 To configure the StatsD listener, specify the [`statsd-event-handlers` configuration flag][22] in the [agent configuration][24], and start the agent.
+For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
-# Start an agent that sends StatsD metrics to InfluxDB
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
 Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
-# Start an agent with a customized address and flush interval
 sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host 123.4.5.11 --statsd-metrics-port 8125
 {{< /code >}}
 
@@ -377,21 +376,27 @@ name         |
 description  | Check name.
 required     | true
 type         | String
-example      | {{< code shell >}}"name": "check-mysql-status"{{< /code >}}
+example      | {{< code json >}}{
+  "name": "check-mysql-status"
+}{{< /code >}}
 
 status       | 
 -------------|------
 description  | Check execution exit status code. An exit status code of `0` (zero) indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`. Exit status codes other than `0`, `1`, and `2` indicate an `UNKNOWN` or custom status.
 required     | true
 type         | Integer
-example      | {{< code shell >}}"status": 0{{< /code >}}
+example      | {{< code json >}}{
+  "status": 0
+}{{< /code >}}
 
 output       | 
 -------------|------
 description  | Output produced by the check `command`.
 required     | true
 type         | String
-example      | {{< code shell >}}"output": "CheckHttp OK: 200, 78572 bytes"{{< /code >}}
+example      | {{< code json >}}{
+  "output": "CheckHttp OK: 200, 78572 bytes"
+}{{< /code >}}
 
 source       | 
 -------------|------
@@ -399,7 +404,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"source": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "source": "sensu-docs-site"
+}{{< /code >}}
 
 client       | 
 -------------|------
@@ -409,7 +416,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"client": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "client": "sensu-docs-site"
+}{{< /code >}}
 
 executed     | 
 -------------|------
@@ -417,21 +426,27 @@ description  | Time at which the check was executed. In seconds since the Unix e
 required     | false
 default      | The time the event was received by the agent.
 type         | Integer
-example      | {{< code shell >}}"executed": 1458934742{{< /code >}}
+example      | {{< code json >}}{
+  "executed": 1458934742
+}{{< /code >}}
 
 duration     | 
 -------------|------
 description  | Amount of time it took to execute the check. In seconds.
 required     | false
 type         | Float
-example      | {{< code shell >}}"duration": 1.903135228{{< /code >}}
+example      | {{< code json >}}{
+  "duration": 1.903135228
+}{{< /code >}}
 
 command      | 
 -------------|------
 description  | Command executed to produce the event. Use the `command` attribute to add context to the event data. Sensu does not execute the command included in this attribute.
 required     | false
 type         | String
-example      | {{< code shell >}}"command": "check-http.rb -u https://sensuapp.org"{{< /code >}}
+example      | {{< code json >}}{
+  "command": "check-http.rb -u https://sensuapp.org"
+}{{< /code >}}
 
 interval     | 
 -------------|------
@@ -439,14 +454,18 @@ description  | Interval used to produce the event. Use the `interval` attribute 
 required     | false
 default      | `1`
 type         | Integer
-example      | {{< code shell >}}"interval": 60{{< /code >}}
+example      | {{< code json >}}{
+  "interval": 60
+}{{< /code >}}
 
 handlers     | 
 -------------|------
 description  | Array of Sensu handler names to use for handling the event. Each handler name in the array must be a string.
 required     | false
 type         | Array
-example      | {{< code shell >}}"handlers": ["slack", "influxdb"]{{< /code >}}
+example      | {{< code json >}}{
+  "handlers": ["slack", "influxdb"]
+}{{< /code >}}
 
 ## Keepalive monitoring
 
@@ -730,13 +749,17 @@ sensu-agent service uninstall
 
 ### Get help
 
-The `sensu-agent` tool provides general and command-specific help flags:
+The `sensu-agent` tool provides general and command-specific help flags.
+
+To see sensu-agent commands, run:
 
 {{< code shell >}}
-# Show sensu-agent commands
 sensu-agent help
+{{< /code >}}
 
-# Show options for the sensu-agent start subcommand
+To see options for a specific command (in this case, sensu-agent start), run: 
+
+{{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
@@ -811,8 +834,15 @@ As of 5.20.2, the `--discover-processes` flag is not available, and new events w
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
+To view configuration information for the sensu-agent start command, run:
+
+{{< code shell >}}
+sensu-agent start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-agent start:
+
 {{< code text >}}
-$ sensu-agent start --help
 start the sensu agent
 
 Usage:
@@ -893,12 +923,10 @@ description       | Path to yaml or json file that contains the allow list of ch
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
-
 
 | annotations|      |
 -------------|------
@@ -909,15 +937,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -925,12 +952,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-burst-limit 100
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -938,10 +963,9 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-rate-limit 1.39
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a name="backend-handshake-timeout"></a>
@@ -952,10 +976,9 @@ description   | Number of seconds the Sensu agent should wait when negotiating a
 type          | Integer
 default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-handshake-timeout 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-handshake-timeout 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a name="backend-heartbeat-interval"></a>
@@ -966,10 +989,9 @@ description   | Interval at which the agent should send heartbeats to the Sensu 
 type          | Integer
 default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-interval 45
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a name="backend-heartbeat-timeout"></a>
@@ -980,12 +1002,10 @@ description   | Number of seconds the agent should wait for a response to a hear
 type          | Integer
 default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-timeout 60
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
-
 
 | backend-url |      |
 --------------|------
@@ -995,16 +1015,15 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --backend-url ws://0.0.0.0:8081
 sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-url:
   - "ws://0.0.0.0:8081"
   - "ws://0.0.0.0:8082"
-  {{< /code >}}
-
+{{< /code >}}
 
 <a name="cache-dir"></a>
 
@@ -1014,10 +1033,9 @@ description   | Path to store cached data.
 type          | String
 default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `C:\ProgramData\sensu\cache\sensu-agent`</li></ul>
 environment variable | `SENSU_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --cache-dir /cache/sensu-agent
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a name="config-file"></a>
@@ -1028,7 +1046,7 @@ description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
 environment variable | The config file path cannot be set by an environment variable.
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
@@ -1041,10 +1059,9 @@ description   | When set to `true`, disables [dynamic runtime assets][29] for th
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-assets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-assets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a name="discover-processes"></a>
@@ -1059,10 +1076,9 @@ Instead, the field will be empty: `"processes": null`.
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --discover-processes
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --discover-processes{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 | labels     |      |
@@ -1074,13 +1090,13 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 labels:
-  proxy_type: "website"
+  proxy_type: website
 {{< /code >}}
 
 <a name="name"></a>
@@ -1091,11 +1107,10 @@ description   | Entity name assigned to the agent entity.
 type          | String
 default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --name agent-01
-
-# /etc/sensu/agent.yml example
-name: "agent-01" {{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --name agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+name: "agent-01"{{< /code >}}
 
 <a name="log-level"></a>
 
@@ -1105,11 +1120,10 @@ description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `de
 type          | String
 default       | `info`
 environment variable | `SENSU_LOG_LEVEL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --log-level debug
-
-# /etc/sensu/agent.yml example
-log-level: "debug"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --log-level debug{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+log-level: debug{{< /code >}}
 
 <a name="subscriptions-flag"></a>
 
@@ -1118,15 +1132,15 @@ log-level: "debug"{{< /code >}}
 description     | Array of agent subscriptions that determine which monitoring checks the agent will execute. The subscriptions array items must be strings.
 type            | List
 environment variable | `SENSU_SUBSCRIPTIONS`
-example         | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 subscriptions:
   - disk-checks
-  - process-checks{{< /code >}}
-
+  - process-checks
+{{< /code >}}
 
 ### API configuration flags
 
@@ -1136,12 +1150,10 @@ description   | Bind address for the Sensu agent HTTP API.
 type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-host: "0.0.0.0"{{< /code >}}
-
 
 | api-port    |      |
 --------------|------
@@ -1149,12 +1161,10 @@ description   | Listening port for the Sensu agent HTTP API.
 type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-port 4041
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-port 4041{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-port: 4041{{< /code >}}
-
 
 | disable-api |      |
 --------------|------
@@ -1162,12 +1172,10 @@ description   | `true` to disable the agent HTTP API. Otherwise, `false`.
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DISABLE_API`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-api
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-api{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-api: true{{< /code >}}
-
 
 | events-burst-limit | |
 --------------|------
@@ -1175,12 +1183,10 @@ description   | Maximum amount of burst allowed in a rate interval for the [agen
 type          | Integer
 default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-burst-limit 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-burst-limit 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
-
 
 | events-rate-limit | |
 --------------|------
@@ -1188,12 +1194,10 @@ description   | Maximum number of events per second that can be transmitted to t
 type          | Float
 default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-rate-limit 20.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-rate-limit 20.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
-
 
 ### Ephemeral agent configuration flags
 
@@ -1205,26 +1209,22 @@ description   | `true` if a deregistration event should be created upon Sensu ag
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DEREGISTER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --deregister
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 deregister: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
 description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --deregistration-handler deregister
-
-# /etc/sensu/agent.yml example
-deregistration-handler: "deregister"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+deregistration-handler: deregister{{< /code >}}
 
 <a name="detect-cloud-provider-flag"></a>
-
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1232,12 +1232,10 @@ description              | `true` to enable cloud provider detection mechanisms.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --detect-cloud-provider false
-
-# /etc/sensu/agent.yml example
-detect-cloud-provider: "false"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --detect-cloud-provider false{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+detect-cloud-provider: false{{< /code >}}
 
 ### Keepalive configuration flags
 
@@ -1248,10 +1246,9 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-critical-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a name="keepalive-handlers-flag"></a>
@@ -1262,12 +1259,13 @@ description         | [Keepalive event handlers][52] to use for the entity, spec
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-handlers slack,email
-
-# /etc/sensu/agent.yml example
-keepalive-handlers: slack,email{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-handlers slack,email{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+keepalive-handlers:
+- slack
+- email
+{{< /code >}}
 
 | keepalive-interval |      |
 ---------------------|------
@@ -1275,12 +1273,10 @@ description          | Number of seconds between keepalive events.
 type                 | Integer
 default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
-example              | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
-
 
 | keepalive-warning-timeout |      |
 --------------------|------
@@ -1289,12 +1285,10 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-warning-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -1307,12 +1301,10 @@ Entities can only belong to a [single namespace](../../../operations/control-acc
 type           | String
 default        | `default`
 environment variable   | `SENSU_NAMESPACE`
-example        | {{< code shell >}}# Command line example
-sensu-agent start --namespace ops
-
-# /etc/sensu/agent.yml example
-namespace: "ops"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --namespace ops{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+namespace: ops{{< /code >}}
 
 | user |      |
 --------------|------
@@ -1320,12 +1312,10 @@ description   | [Sensu RBAC username][39] used by the agent. Agents require get,
 type          | String
 default       | `agent`
 environment variable   | `SENSU_USER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --user agent-01
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --user agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
-
 
 | password    |      |
 --------------|------
@@ -1333,12 +1323,10 @@ description   | [Sensu RBAC password][39] used by the agent.
 type          | String
 default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --password secure-password
-
-# /etc/sensu/agent.yml example
-password: "secure-password"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --password secure-password{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+password: secure-password{{< /code >}}
 
 | redact      |      |
 --------------|------
@@ -1349,15 +1337,13 @@ They are not logged or displayed via the Sensu API.
 type          | List
 default       | By default, Sensu redacts the following fields: `password`, `passwd`, `pass`, `api_key`, `api_token`, `access_key`, `secret_key`, `private_key`, `secret`.
 environment variable   | `SENSU_REDACT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --redact secret,ec2_access_key
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --redact secret,ec2_access_key{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
 {{< /code >}}
-
 
 | cert-file  |      |
 -------------|------
@@ -1365,12 +1351,10 @@ description  | Path to the agent certificate file used in mTLS authentication. S
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cert-file /path/to/agent.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cert-file: "/path/to/agent.pem"{{< /code >}}
-
 
 | trusted-ca-file |      |
 ------------------|------
@@ -1378,12 +1362,10 @@ description       | SSL/TLS certificate authority.
 type              | String
 default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -1391,13 +1373,10 @@ description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-key.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --key-file /path/to/agent-key.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 key-file: "/path/to/agent-key.pem"{{< /code >}}
-
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -1407,10 +1386,9 @@ description                | Skip SSL verification. {{% notice warning %}}
 type                       | Boolean
 default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-agent start --insecure-skip-tls-verify
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -1424,10 +1402,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-fips
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-fips{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1439,12 +1416,10 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-openssl
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-openssl{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
-
 
 ### Socket configuration flags
 
@@ -1454,12 +1429,10 @@ description   | Address to bind the Sensu agent socket to.
 type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-host: "0.0.0.0"{{< /code >}}
-
 
 | socket-port |      |
 --------------|------
@@ -1467,12 +1440,10 @@ description   | Port the Sensu agent socket listens on.
 type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-port 4030
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-port 4030{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-port: 4030{{< /code >}}
-
 
 | disable-sockets |      |
 ------------------|------
@@ -1480,12 +1451,10 @@ description       | `true` to disable the agent TCP and UDP event sockets. Othew
 type              | Boolean
 default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --disable-sockets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-sockets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
-
 
 ### StatsD configuration flags
 
@@ -1495,28 +1464,25 @@ description      | `true` to disable the [StatsD][21] listener and metrics serve
 type             | Boolean
 default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
-example          | {{< code shell >}}# Command line example
-sensu-agent start --statsd-disable
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-disable{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
-
 
 | statsd-event-handlers |      |
 ------------------------|------
 description             | List of event handlers for StatsD metrics.
 type                    | List
 environment variable    | `SENSU_STATSD_EVENT_HANDLERS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
 {{< /code >}}
-
 
 | statsd-flush-interval  |      |
 -------------------------|------
@@ -1524,12 +1490,10 @@ description              | Number of seconds between [StatsD flushes][23].
 type                     | Integer
 default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --statsd-flush-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-flush-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
-
 
 | statsd-metrics-host |      |
 ----------------------|------
@@ -1537,12 +1501,10 @@ description           | Address used for the StatsD metrics server.
 type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-host: "0.0.0.0"{{< /code >}}
-
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1550,10 +1512,9 @@ description           | Port used for the StatsD metrics server.
 type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-port 6125
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-port: 6125{{< /code >}}
 
 ### Allow list configuration commands
@@ -1568,28 +1529,65 @@ Use these commands to build your allow list configuration file.
 description           | Command to allow the Sensu agent to run as a check or a hook.
 required              | true
 type                  | String
-example               | {{< code shell >}}"exec": "/usr/local/bin/check_memory.sh"{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+exec: "/usr/local/bin/check_memory.sh"
+{{< /code >}}
+{{< code json >}}
+{
+  "exec": "/usr/local/bin/check_memory.sh"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | sha512 |      |
 ----------------------|------
 description           | Checksum of the check or hook executable.
 required              | false
 type                  | String
-example               | {{< code shell >}}"sha512": "4f926bf4328..."{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+sha512: 4f926bf4328...
+{{< /code >}}
+{{< code json >}}
+{
+  "sha512": "4f926bf4328..."
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | args |      |
 ----------------------|------
 description           | Arguments for the `exec` command.
 required              | true
 type                  | Array
-example               | {{< code shell >}}"args": ["foo"]{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+args:
+- foo
+{{< /code >}}
+{{< code json >}}
+{
+  "args": ["foo"]
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | enable_env |      |
 ----------------------|------
 description           | `true` to enable environment variables. Otherwise, `false`.
 required              | false
 type                  | Boolean
-example               | {{< code shell >}}"enable_env": true{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+enable_env: true
+{{< /code >}}
+{{< code json >}}
+{
+  "enable_env": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 #### Example allow list configuration file
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -128,11 +128,15 @@ sensu-backend init
 **NOTE**: Make sure the Sensu backend is running before you run `sensu-backend init`.
 {{% /notice %}}
 
-You can also run the `sensu-backend init` command in interactive mode if you prefer to respond to prompts for your username and password:
+You can also run the `sensu-backend init` command in interactive mode:
 
 {{< code shell >}}
 sensu-backend init --interactive
+{{< /code >}}
 
+You will receive prompts for your username and password in interactive mode:
+
+{{< code shell >}}
 Admin Username: YOUR_USERNAME
 Admin Password: YOUR_PASSWORD
 {{< /code >}}
@@ -233,13 +237,17 @@ sensu-backend version
 
 ### Get help
 
-The `sensu-backend` tool provides general and command-specific help flags:
+The `sensu-backend` tool provides general and command-specific help flags.
+
+To see sensu-backend commands, run:
 
 {{< code shell >}}
-# Show sensu-backend commands
 sensu-backend help
+{{< /code >}}
 
-# Show options for the sensu-backend start subcommand
+To see options for a specific command (in this case, sensu-backend start), run: 
+
+{{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
@@ -280,8 +288,15 @@ The Sensu backend checks certificate revocation list (CRL) and Online Certificat
 
 ### Configuration summary
 
+To view configuration information for the sensu-backend start command, run:
+
+{{< code shell >}}
+sensu-backend start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-backend start:
+
 {{< code text >}}
-$ sensu-backend start --help
 start the sensu backend
 
 Usage:
@@ -360,7 +375,6 @@ discovery instead of the static `--initial-cluster method`
       --no-embed-etcd                              don't embed etcd; use external etcd instead
 {{< /code >}}
 
-
 ### General configuration flags
 
 {{% notice note %}}
@@ -376,15 +390,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | api-listen-address  |      |
 -------------|------
@@ -392,12 +405,10 @@ description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-listen-address [::]:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-listen-address [::]:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
-
 
 <a name="api-request-limit"></a>
 
@@ -407,10 +418,9 @@ description  | Maximum size for API request bodies. In bytes.
 type         | Integer
 default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-request-limit 1024000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-request-limit 1024000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
@@ -419,12 +429,10 @@ description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_API_URL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-url http://localhost:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-url http://localhost:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -432,12 +440,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-burst-limit 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -445,12 +451,10 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-rate-limit 1.39
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
-
 
 | cache-dir   |      |
 --------------|------
@@ -458,12 +462,10 @@ description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --cache-dir /cache/sensu-backend
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-backend"{{< /code >}}
-
 
 | config-file |      |
 --------------|------
@@ -471,7 +473,7 @@ description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
 environment variable | The config file path cannot be set by an environment variable.
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
@@ -484,12 +486,10 @@ description | If `true`, enable debugging and profiling features for use with th
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
-example     | {{< code shell >}}# Command line example
-sensu-backend start --debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 debug: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
@@ -497,12 +497,10 @@ description              | Name of the default event handler to use when process
 type                     | String
 default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line example
-sensu-backend start --deregistration-handler deregister
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
-
 
 | labels     |      |
 -------------|------
@@ -513,15 +511,14 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
 {{< /code >}}
-
 
 | log-level  |      |
 -------------|------
@@ -529,12 +526,10 @@ description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `deb
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --log-level debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --log-level debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
-
 
 | state-dir  |      |
 -------------|------
@@ -542,13 +537,12 @@ description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
 environment variable | `SENSU_BACKEND_STATE_DIR`
-example      | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
-
 
 ### Agent communication configuration flags
 
@@ -558,12 +552,10 @@ description  | TLS certificate in PEM format for agent certificate authenticatio
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
-
 
 | agent-auth-crl-urls |      |
 -------------|------
@@ -571,12 +563,10 @@ description  | URLs of CRLs for agent certificate authentication. The Sensu back
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
-
 
 | agent-auth-key-file |      |
 -------------|------
@@ -584,12 +574,10 @@ description  | TLS certificate key in PEM format for agent certificate authentic
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-key-file: /path/to/ssl/key.pem{{< /code >}}
-
 
 | agent-auth-trusted-ca-file |      |
 -------------|------
@@ -597,12 +585,10 @@ description  | TLS CA certificate bundle in PEM format for agent certificate aut
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /code >}}
-
 
 | agent-host   |      |
 ---------------|------
@@ -610,12 +596,10 @@ description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by 
 type           | String
 default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
-example        | {{< code shell >}}# Command line example
-sensu-backend start --agent-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
-
 
 | agent-port |      |
 -------------|------
@@ -623,12 +607,10 @@ description  | Agent listener port.
 type         | Integer
 default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-port 8081
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-port 8081{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -638,12 +620,10 @@ description  | Path to the primary backend certificate file. Specifies a fallbac
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cert-file: "/path/to/ssl/cert.pem"{{< /code >}}
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -653,12 +633,10 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 type                       | Boolean
 default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-backend start --insecure-skip-tls-verify
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
-
 
 <a name="jwt-attributes"></a>
 
@@ -670,12 +648,10 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-private-key-file /path/to/key/private.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
-
 
 | jwt-public-key-file |      |
 -------------|------
@@ -686,12 +662,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-public-key-file /path/to/key/public.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -699,10 +673,9 @@ description  | Path to the primary backend key file. Specifies a fallback SSL/TL
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -716,10 +689,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-fips
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-fips{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -731,10 +703,9 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-openssl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-openssl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -743,12 +714,10 @@ description       | Path to the primary backend CA file. Specifies a fallback SS
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 ### Web UI configuration flags
 
@@ -758,12 +727,10 @@ description  | Web UI TLS certificate in PEM format. This certificate secures co
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/cert.pem"{{< /code >}}
-
 
 | dashboard-host |      |
 -----------------|------
@@ -771,12 +738,10 @@ description      | Web UI listener host.
 type             | String
 default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
-
 
 | dashboard-key-file | |
 -------------|------
@@ -784,12 +749,10 @@ description  | Web UI TLS certificate key in PEM format. This key secures commun
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-key-file /path/to/tls/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-key-file /path/to/tls/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/key.pem"{{< /code >}}
-
 
 | dashboard-port |      |
 -----------------|------
@@ -797,12 +760,10 @@ description      | Web UI listener port.
 type             | Integer
 default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-port 4000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-port 4000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-port: 4000{{< /code >}}
-
 
 ### Datastore and cluster configuration flags
 
@@ -816,16 +777,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
 {{< /code >}}
-
 
 | etcd-cert-file |      |
 -----------------|------
@@ -833,12 +793,10 @@ description      | Path to the etcd client API TLS certificate file. Secures com
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-cert-file ./client.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
-
 
 <a name="etcd-cipher-suites"></a>
 
@@ -858,16 +816,15 @@ etcd-cipher-suites:
 {{< /code >}}
 type                    | List
 environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-
 
 | etcd-client-cert-auth |      |
 ------------------------|------
@@ -875,12 +832,10 @@ description             | If `true`, enable client certificate authentication. O
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
-
 
 | etcd-client-urls      |      |
 ------------------------|------
@@ -888,16 +843,15 @@ description             | List of client URLs to use when a sensu-backend is not
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -905,14 +859,12 @@ description             | Exposes [etcd's embedded auto-discovery features][19].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
-
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -920,14 +872,12 @@ description             | Exposes [etcd's embedded auto-discovery features][17].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery-srv example.org
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
-
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
@@ -935,16 +885,15 @@ description                        | List of this member's peer URLs to advertis
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
-example                            | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-initial-cluster |      |
 -----------------------|------
@@ -952,12 +901,10 @@ description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
-
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
@@ -965,12 +912,10 @@ description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-state existing
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
-
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
@@ -978,22 +923,19 @@ description                  | Unique token for the etcd cluster. Provide the sa
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
-
 
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-key-file ./client-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
 <a name="etcd-listen-client-urls"></a>
@@ -1004,16 +946,15 @@ description               | List of URLs to listen on for client traffic. Sensu'
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
@@ -1021,16 +962,15 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-name      |      |
 -----------------|------
@@ -1038,24 +978,20 @@ description      | Human-readable name for this member.
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-name backend-0
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-name backend-0{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
-
 
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
-example               | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-cert-file ./backend-0.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-cert-file ./backend-0.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
-
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
@@ -1063,36 +999,30 @@ description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
-
 
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
-example              | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-key-file ./backend-0-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
-
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
-example                     | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
@@ -1100,12 +1030,10 @@ description            | Path to the client server TLS trusted CA certificate fi
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | no-embed-etcd  |      |
 -----------------|------
@@ -1113,12 +1041,10 @@ description      | If `true`, do not embed etcd (use external etcd instead). Oth
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --no-embed-etcd
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --no-embed-etcd{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
-
 
 ### Advanced configuration options
 
@@ -1130,13 +1056,10 @@ description            | Number of incoming events that can be buffered before b
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-buffer-size 100
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
-
 
 | eventd-workers       |      |
 -----------------------|------
@@ -1146,12 +1069,10 @@ description            | Number of workers spawned for processing incoming event
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
-
 
 | keepalived-buffer-size |      |
 -----------------------|------
@@ -1161,12 +1082,10 @@ description            | Number of incoming keepalives that can be buffered befo
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
-
 
 | keepalived-workers |      |
 -----------------------|------
@@ -1175,12 +1094,10 @@ description            | Number of workers spawned for processing incoming keepa
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
-
 
 | pipelined-buffer-size |      |
 -----------------------|------
@@ -1190,12 +1107,10 @@ description            | Number of events to handle that can be buffered before 
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
-
 
 | pipelined-workers |      |
 -----------------------|------
@@ -1205,12 +1120,10 @@ description            | Number of workers spawned for handling events through t
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
-
 
 | etcd-election-timeout |      |
 -----------------------|------
@@ -1220,12 +1133,10 @@ description            | Time that a follower node will go without hearing a hea
 type                   | Integer
 default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-election-timeout 1000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-election-timeout 1000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
-
 
 | etcd-heartbeat-interval |      |
 -----------------------|------
@@ -1234,12 +1145,10 @@ description            | Interval at which the etcd leader will notify followers
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-heartbeat-interval 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
-
 
 | etcd-max-request-bytes |      |
 -----------------------|------
@@ -1249,12 +1158,10 @@ description            | Maximum etcd request size in bytes that can be sent to 
 type                   | Integer
 default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-max-request-bytes 1572864
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
-
 
 | etcd-quota-backend-bytes |      |
 -----------------------|------
@@ -1264,10 +1171,9 @@ description            | Maximum etcd database size in bytes. Increasing this va
 type                   | Integer
 default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-quota-backend-bytes 4294967296
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 ### Configuration via environment variables
@@ -1381,20 +1287,16 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
-
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-buffer-size 100000
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-buffer-size 100000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
-
 
 | event-log-file |      |
 -----------------------|------
@@ -1403,13 +1305,10 @@ description            | Path to the event log file. {{% notice warning %}}
 {{% /notice %}}
 type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-file /var/log/sensu/events.log
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
-
 
 ### Log rotation
 

--- a/content/sensu-go/6.1/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/license.md
@@ -28,11 +28,15 @@ To activate your license with sensuctl:
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
-Use sensuctl to view your license details at any time.
+Use sensuctl to view your license details at any time:
 
 {{< code shell >}}
-# Active license
 sensuctl license info
+{{< /code >}}
+
+For an active license, the response should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -43,9 +47,11 @@ Issuer:       Sensu, Inc.
 Issued:       2020-02-15 15:01:44 -0500 -0500
 Valid:        true
 Valid Until:  2021-02-15 00:00:00 -0800 -0800
+{{< /code >}}
 
-# No license found
-sensuctl license info
+This response means you do not have an active license:
+
+{{< code shell >}}
 Error: not found
 {{< /code >}}
 
@@ -67,10 +73,16 @@ If you use only 1,500 agent entities, you can have 8,500 proxy entities before y
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.
 
-In tabular format, the entity count and limit are included in the response title:
+In tabular format, the entity count and limit are included in the response title.
+To view license info in tabular format, run:
 
 {{< code shell >}}
 sensuctl license info --format tabular
+{{< /code >}}
+
+The response in tabular format should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -90,13 +102,22 @@ For example:
 === You are currently using 10/unlimited total entities, 5/unlimited agent entities, and 5/unlimited proxy entities
 {{< /code >}}
 
-In other formats (e.g. YAML and JSON), the entity count and limit are included as labels:
+To view license details in YAML or JSON, run:
+
+{{< language-toggle >}}
+{{< code shell "YML" >}}
+sensuctl license info --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl license info --format json
+{{< /code >}}
+{{< /language-toggle >}}
+
+In YAML and JSON formats, the entity count and limit are included as labels:
 
 {{< language-toggle >}}
 
-{{< code shell "YML" >}}
-sensuctl license info --format yaml
-
+{{< code yml >}}
 type: LicenseFile
 api_version: licensing/v2
 metadata:
@@ -111,9 +132,7 @@ spec:
 [...]
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl license info --format json
-
+{{< code json >}}
 {
   "type": "LicenseFile",
   "api_version": "licensing/v2",

--- a/content/sensu-go/6.1/sensuctl/environment-variables.md
+++ b/content/sensu-go/6.1/sensuctl/environment-variables.md
@@ -25,7 +25,7 @@ SENSU_TRUSTED_CA_FILE            Path to a trusted CA file if set in sensuctl
 SENSU_INSECURE_SKIP_TLS_VERIFY   Boolean value that can be set to skip TLS verification
 {{< /code >}}
 
-These examples demonstrate how to use sensuctl to export and set environment variables:
+These examples demonstrate how to use sensuctl to export and set environment variables and configure your shell:
 
 {{< language-toggle >}}
 
@@ -38,6 +38,7 @@ export SENSU_ACCESS_TOKEN_EXPIRES_AT="1567716187"
 export SENSU_REFRESH_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 export SENSU_TRUSTED_CA_FILE=""
 export SENSU_INSECURE_SKIP_TLS_VERIFY="true"
+eval $(sensuctl env)
 {{< /code >}}
 
 {{< code cmd >}}
@@ -49,6 +50,7 @@ SET SENSU_ACCESS_TOKEN_EXPIRES_AT=1567716676
 SET SENSU_REFRESH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x
 SET SENSU_TRUSTED_CA_FILE=
 SET SENSU_INSECURE_SKIP_TLS_VERIFY=true
+@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
 {{< /code >}}
 
 {{< code powershell >}}
@@ -60,23 +62,6 @@ $Env:SENSU_ACCESS_TOKEN_EXPIRES_AT = "1567716738"
 $Env:SENSU_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 $Env:SENSU_TRUSTED_CA_FILE = ""
 $Env:SENSU_INSECURE_SKIP_TLS_VERIFY = "true"
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Run these commands to configure your shell:
-
-{{< language-toggle >}}
-
-{{< code bash >}}
-eval $(sensuctl env)
-{{< /code >}}
-
-{{< code cmd >}}
-@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
-{{< /code >}}
-
-{{< code powershell >}}
 & sensuctl env --shell powershell | Invoke-Expression
 {{< /code >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -713,10 +713,14 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
 - `json` format for use with the [events API][16]
 
-{{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
 {{< /code >}}
+{{< /language-toggle >}}
 
 ### Delete events
 
@@ -800,8 +804,8 @@ Within a sequence of only OK or only non-OK events, Sensu increments `occurrence
 
 The following table shows the occurrences attributes for a series of example events:
 
-| event sequence   | `occurrences`   | `occurrences_watermark` |
-| -----------------| --------------- | ----------------------- |
+| event sequence    | `occurrences`   | `occurrences_watermark` |
+| ----------------- | --------------- | ----------------------- |
 |1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
 |2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
 |3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -287,16 +287,16 @@ For more information, see the [StatsD documentation][21].
 ### Configure the StatsD listener
 
 To configure the StatsD listener, specify the [`statsd-event-handlers` configuration flag][22] in the [agent configuration][24], and start the agent.
+For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
-# Start an agent that sends StatsD metrics to InfluxDB
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
 Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
-# Start an agent with a customized address and flush interval
 sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host 123.4.5.11 --statsd-metrics-port 8125
 {{< /code >}}
 
@@ -380,21 +380,27 @@ name         |
 description  | Check name.
 required     | true
 type         | String
-example      | {{< code shell >}}"name": "check-mysql-status"{{< /code >}}
+example      | {{< code json >}}{
+  "name": "check-mysql-status"
+}{{< /code >}}
 
 status       | 
 -------------|------
 description  | Check execution exit status code. An exit status code of `0` (zero) indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`. Exit status codes other than `0`, `1`, and `2` indicate an `UNKNOWN` or custom status.
 required     | true
 type         | Integer
-example      | {{< code shell >}}"status": 0{{< /code >}}
+example      | {{< code json >}}{
+  "status": 0
+}{{< /code >}}
 
 output       | 
 -------------|------
 description  | Output produced by the check `command`.
 required     | true
 type         | String
-example      | {{< code shell >}}"output": "CheckHttp OK: 200, 78572 bytes"{{< /code >}}
+example      | {{< code json >}}{
+  "output": "CheckHttp OK: 200, 78572 bytes"
+}{{< /code >}}
 
 source       | 
 -------------|------
@@ -402,7 +408,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"source": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "source": "sensu-docs-site"
+}{{< /code >}}
 
 client       | 
 -------------|------
@@ -412,7 +420,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"client": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "client": "sensu-docs-site"
+}{{< /code >}}
 
 executed     | 
 -------------|------
@@ -420,21 +430,27 @@ description  | Time at which the check was executed. In seconds since the Unix e
 required     | false
 default      | The time the event was received by the agent.
 type         | Integer
-example      | {{< code shell >}}"executed": 1458934742{{< /code >}}
+example      | {{< code json >}}{
+  "executed": 1458934742
+}{{< /code >}}
 
 duration     | 
 -------------|------
 description  | Amount of time it took to execute the check. In seconds.
 required     | false
 type         | Float
-example      | {{< code shell >}}"duration": 1.903135228{{< /code >}}
+example      | {{< code json >}}{
+  "duration": 1.903135228
+}{{< /code >}}
 
 command      | 
 -------------|------
 description  | Command executed to produce the event. Use the `command` attribute to add context to the event data. Sensu does not execute the command included in this attribute.
 required     | false
 type         | String
-example      | {{< code shell >}}"command": "check-http.rb -u https://sensuapp.org"{{< /code >}}
+example      | {{< code json >}}{
+  "command": "check-http.rb -u https://sensuapp.org"
+}{{< /code >}}
 
 interval     | 
 -------------|------
@@ -442,14 +458,18 @@ description  | Interval used to produce the event. Use the `interval` attribute 
 required     | false
 default      | `1`
 type         | Integer
-example      | {{< code shell >}}"interval": 60{{< /code >}}
+example      | {{< code json >}}{
+  "interval": 60
+}{{< /code >}}
 
 handlers     | 
 -------------|------
 description  | Array of Sensu handler names to use for handling the event. Each handler name in the array must be a string.
 required     | false
 type         | Array
-example      | {{< code shell >}}"handlers": ["slack", "influxdb"]{{< /code >}}
+example      | {{< code json >}}{
+  "handlers": ["slack", "influxdb"]
+}{{< /code >}}
 
 ## Keepalive monitoring
 
@@ -733,13 +753,17 @@ sensu-agent service uninstall
 
 ### Get help
 
-The `sensu-agent` tool provides general and command-specific help flags:
+The `sensu-agent` tool provides general and command-specific help flags.
+
+To see sensu-agent commands, run:
 
 {{< code shell >}}
-# Show sensu-agent commands
 sensu-agent help
+{{< /code >}}
 
-# Show options for the sensu-agent start subcommand
+To see options for a specific command (in this case, sensu-agent start), run: 
+
+{{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
@@ -814,8 +838,15 @@ As of 5.20.2, the `--discover-processes` flag is not available, and new events w
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
+To view configuration information for the sensu-agent start command, run:
+
+{{< code shell >}}
+sensu-agent start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-agent start:
+
 {{< code text >}}
-$ sensu-agent start --help
 start the sensu agent
 
 Usage:
@@ -901,12 +932,10 @@ required     | false
 type         | Boolean
 default      | false
 environment variable | `SENSU_AGENT_MANAGED_ENTITY`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --agent-managed-entity
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --agent-managed-entity{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
-
 
 <a name="allow-list"></a>
 
@@ -916,12 +945,10 @@ description       | Path to yaml or json file that contains the allow list of ch
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
-
 
 | annotations|      |
 -------------|------
@@ -932,15 +959,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -948,12 +974,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-burst-limit 100
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -961,10 +985,9 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-rate-limit 1.39
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a name="backend-handshake-timeout"></a>
@@ -975,10 +998,9 @@ description   | Number of seconds the Sensu agent should wait when negotiating a
 type          | Integer
 default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-handshake-timeout 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-handshake-timeout 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a name="backend-heartbeat-interval"></a>
@@ -989,10 +1011,9 @@ description   | Interval at which the agent should send heartbeats to the Sensu 
 type          | Integer
 default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-interval 45
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a name="backend-heartbeat-timeout"></a>
@@ -1003,12 +1024,10 @@ description   | Number of seconds the agent should wait for a response to a hear
 type          | Integer
 default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-timeout 60
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
-
 
 | backend-url |      |
 --------------|------
@@ -1018,16 +1037,15 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --backend-url ws://0.0.0.0:8081
 sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-url:
   - "ws://0.0.0.0:8081"
   - "ws://0.0.0.0:8082"
-  {{< /code >}}
-
+{{< /code >}}
 
 <a name="cache-dir"></a>
 
@@ -1037,10 +1055,9 @@ description   | Path to store cached data.
 type          | String
 default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `C:\ProgramData\sensu\cache\sensu-agent`</li></ul>
 environment variable | `SENSU_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --cache-dir /cache/sensu-agent
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a name="config-file"></a>
@@ -1051,7 +1068,7 @@ description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
 environment variable | `SENSU_CONFIG_FILE`
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
@@ -1064,10 +1081,9 @@ description   | When set to `true`, disables [dynamic runtime assets][29] for th
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-assets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-assets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a name="discover-processes"></a>
@@ -1082,10 +1098,9 @@ Instead, the field will be empty: `"processes": null`.
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --discover-processes
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --discover-processes{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 <a name="labels"></a>
@@ -1099,13 +1114,13 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 labels:
-  proxy_type: "website"
+  proxy_type: website
 {{< /code >}}
 
 <a name="name"></a>
@@ -1116,11 +1131,10 @@ description   | Entity name assigned to the agent entity.
 type          | String
 default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --name agent-01
-
-# /etc/sensu/agent.yml example
-name: "agent-01" {{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --name agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+name: "agent-01"{{< /code >}}
 
 <a name="log-level"></a>
 
@@ -1130,11 +1144,10 @@ description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `de
 type          | String
 default       | `info`
 environment variable | `SENSU_LOG_LEVEL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --log-level debug
-
-# /etc/sensu/agent.yml example
-log-level: "debug"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --log-level debug{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+log-level: debug{{< /code >}}
 
 <a name="subscriptions-flag"></a>
 
@@ -1143,15 +1156,15 @@ log-level: "debug"{{< /code >}}
 description     | Array of agent subscriptions that determine which monitoring checks the agent will execute. The subscriptions array items must be strings.
 type            | List
 environment variable | `SENSU_SUBSCRIPTIONS`
-example         | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 subscriptions:
   - disk-checks
-  - process-checks{{< /code >}}
-
+  - process-checks
+{{< /code >}}
 
 ### API configuration flags
 
@@ -1161,12 +1174,10 @@ description   | Bind address for the Sensu agent HTTP API.
 type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-host: "0.0.0.0"{{< /code >}}
-
 
 | api-port    |      |
 --------------|------
@@ -1174,12 +1185,10 @@ description   | Listening port for the Sensu agent HTTP API.
 type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-port 4041
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-port 4041{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-port: 4041{{< /code >}}
-
 
 | disable-api |      |
 --------------|------
@@ -1187,12 +1196,10 @@ description   | `true` to disable the agent HTTP API. Otherwise, `false`.
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DISABLE_API`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-api
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-api{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-api: true{{< /code >}}
-
 
 | events-burst-limit | |
 --------------|------
@@ -1200,12 +1207,10 @@ description   | Maximum amount of burst allowed in a rate interval for the [agen
 type          | Integer
 default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-burst-limit 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-burst-limit 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
-
 
 | events-rate-limit | |
 --------------|------
@@ -1213,12 +1218,10 @@ description   | Maximum number of events per second that can be transmitted to t
 type          | Float
 default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-rate-limit 20.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-rate-limit 20.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
-
 
 ### Ephemeral agent configuration flags
 
@@ -1230,26 +1233,22 @@ description   | `true` if a deregistration event should be created upon Sensu ag
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DEREGISTER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --deregister
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 deregister: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
 description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line examples
-sensu-agent start --deregistration-handler deregister
-
-# /etc/sensu/agent.yml examples
-deregistration-handler: "deregister"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+deregistration-handler: deregister{{< /code >}}
 
 <a name="detect-cloud-provider-flag"></a>
-
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1257,12 +1256,10 @@ description              | `true` to enable cloud provider detection mechanisms.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --detect-cloud-provider false
-
-# /etc/sensu/agent.yml example
-detect-cloud-provider: "false"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --detect-cloud-provider false{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+detect-cloud-provider: false{{< /code >}}
 
 ### Keepalive configuration flags
 
@@ -1273,10 +1270,9 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-critical-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a name="keepalive-handlers-flag"></a>
@@ -1287,12 +1283,13 @@ description         | [Keepalive event handlers][52] to use for the entity, spec
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-handlers slack,email
-
-# /etc/sensu/agent.yml example
-keepalive-handlers: slack,email{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-handlers slack,email{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+keepalive-handlers:
+- slack
+- email
+{{< /code >}}
 
 | keepalive-interval |      |
 ---------------------|------
@@ -1300,12 +1297,10 @@ description          | Number of seconds between keepalive events.
 type                 | Integer
 default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
-example              | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
-
 
 | keepalive-warning-timeout |      |
 --------------------|------
@@ -1314,12 +1309,10 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-warning-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -1332,12 +1325,10 @@ Entities can only belong to a [single namespace](../../../operations/control-acc
 type           | String
 default        | `default`
 environment variable   | `SENSU_NAMESPACE`
-example        | {{< code shell >}}# Command line example
-sensu-agent start --namespace ops
-
-# /etc/sensu/agent.yml example
-namespace: "ops"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --namespace ops{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+namespace: ops{{< /code >}}
 
 | user |      |
 --------------|------
@@ -1345,12 +1336,10 @@ description   | [Sensu RBAC username][39] used by the agent. Agents require get,
 type          | String
 default       | `agent`
 environment variable   | `SENSU_USER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --user agent-01
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --user agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
-
 
 | password    |      |
 --------------|------
@@ -1358,12 +1347,10 @@ description   | [Sensu RBAC password][39] used by the agent.
 type          | String
 default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --password secure-password
-
-# /etc/sensu/agent.yml example
-password: "secure-password"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --password secure-password{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+password: secure-password{{< /code >}}
 
 | redact      |      |
 --------------|------
@@ -1374,15 +1361,13 @@ They are not logged or displayed via the Sensu API.
 type          | List
 default       | By default, Sensu redacts the following fields: `password`, `passwd`, `pass`, `api_key`, `api_token`, `access_key`, `secret_key`, `private_key`, `secret`.
 environment variable   | `SENSU_REDACT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --redact secret,ec2_access_key
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --redact secret,ec2_access_key{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
 {{< /code >}}
-
 
 | cert-file  |      |
 -------------|------
@@ -1390,12 +1375,10 @@ description  | Path to the agent certificate file used in mTLS authentication. S
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cert-file /path/to/agent.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cert-file: "/path/to/agent.pem"{{< /code >}}
-
 
 | trusted-ca-file |      |
 ------------------|------
@@ -1403,12 +1386,10 @@ description       | SSL/TLS certificate authority.
 type              | String
 default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -1416,13 +1397,10 @@ description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-key.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --key-file /path/to/agent-key.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 key-file: "/path/to/agent-key.pem"{{< /code >}}
-
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -1432,10 +1410,9 @@ description                | Skip SSL verification. {{% notice warning %}}
 type                       | Boolean
 default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-agent start --insecure-skip-tls-verify
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -1449,10 +1426,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-fips
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-fips{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1464,12 +1440,10 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-openssl
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-openssl{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
-
 
 ### Socket configuration flags
 
@@ -1479,12 +1453,10 @@ description   | Address to bind the Sensu agent socket to.
 type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-host: "0.0.0.0"{{< /code >}}
-
 
 | socket-port |      |
 --------------|------
@@ -1492,12 +1464,10 @@ description   | Port the Sensu agent socket listens on.
 type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-port 4030
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-port 4030{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-port: 4030{{< /code >}}
-
 
 | disable-sockets |      |
 ------------------|------
@@ -1505,12 +1475,10 @@ description       | `true` to disable the agent TCP and UDP event sockets. Othew
 type              | Boolean
 default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --disable-sockets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-sockets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
-
 
 ### StatsD configuration flags
 
@@ -1520,28 +1488,25 @@ description      | `true` to disable the [StatsD][21] listener and metrics serve
 type             | Boolean
 default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
-example          | {{< code shell >}}# Command line example
-sensu-agent start --statsd-disable
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-disable{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
-
 
 | statsd-event-handlers |      |
 ------------------------|------
 description             | List of event handlers for StatsD metrics.
 type                    | List
 environment variable    | `SENSU_STATSD_EVENT_HANDLERS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
 {{< /code >}}
-
 
 | statsd-flush-interval  |      |
 -------------------------|------
@@ -1549,12 +1514,10 @@ description              | Number of seconds between [StatsD flushes][23].
 type                     | Integer
 default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --statsd-flush-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-flush-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
-
 
 | statsd-metrics-host |      |
 ----------------------|------
@@ -1562,12 +1525,10 @@ description           | Address used for the StatsD metrics server.
 type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-host: "0.0.0.0"{{< /code >}}
-
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1575,10 +1536,9 @@ description           | Port used for the StatsD metrics server.
 type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-port 6125
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-port: 6125{{< /code >}}
 
 ### Allow list configuration commands
@@ -1593,28 +1553,65 @@ Use these commands to build your allow list configuration file.
 description           | Command to allow the Sensu agent to run as a check or a hook.
 required              | true
 type                  | String
-example               | {{< code shell >}}"exec": "/usr/local/bin/check_memory.sh"{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+exec: "/usr/local/bin/check_memory.sh"
+{{< /code >}}
+{{< code json >}}
+{
+  "exec": "/usr/local/bin/check_memory.sh"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | sha512 |      |
 ----------------------|------
 description           | Checksum of the check or hook executable.
 required              | false
 type                  | String
-example               | {{< code shell >}}"sha512": "4f926bf4328..."{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+sha512: 4f926bf4328...
+{{< /code >}}
+{{< code json >}}
+{
+  "sha512": "4f926bf4328..."
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | args |      |
 ----------------------|------
 description           | Arguments for the `exec` command.
 required              | true
 type                  | Array
-example               | {{< code shell >}}"args": ["foo"]{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+args:
+- foo
+{{< /code >}}
+{{< code json >}}
+{
+  "args": ["foo"]
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | enable_env |      |
 ----------------------|------
 description           | `true` to enable environment variables. Otherwise, `false`.
 required              | false
 type                  | Boolean
-example               | {{< code shell >}}"enable_env": true{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+enable_env: true
+{{< /code >}}
+{{< code json >}}
+{
+  "enable_env": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 #### Example allow list configuration file
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -128,11 +128,15 @@ sensu-backend init
 **NOTE**: Make sure the Sensu backend is running before you run `sensu-backend init`.
 {{% /notice %}}
 
-You can also run the `sensu-backend init` command in interactive mode if you prefer to respond to prompts for your username and password:
+You can also run the `sensu-backend init` command in interactive mode:
 
 {{< code shell >}}
 sensu-backend init --interactive
+{{< /code >}}
 
+You will receive prompts for your username and password in interactive mode:
+
+{{< code shell >}}
 Admin Username: YOUR_USERNAME
 Admin Password: YOUR_PASSWORD
 {{< /code >}}
@@ -233,13 +237,17 @@ sensu-backend version
 
 ### Get help
 
-The `sensu-backend` tool provides general and command-specific help flags:
+The `sensu-backend` tool provides general and command-specific help flags.
+
+To see sensu-backend commands, run:
 
 {{< code shell >}}
-# Show sensu-backend commands
 sensu-backend help
+{{< /code >}}
 
-# Show options for the sensu-backend start subcommand
+To see options for a specific command (in this case, sensu-backend start), run: 
+
+{{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
@@ -280,8 +288,15 @@ The Sensu backend checks certificate revocation list (CRL) and Online Certificat
 
 ### Configuration summary
 
+To view configuration information for the sensu-backend start command, run:
+
+{{< code shell >}}
+sensu-backend start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-backend start:
+
 {{< code text >}}
-$ sensu-backend start --help
 start the sensu backend
 
 Usage:
@@ -360,7 +375,6 @@ discovery instead of the static `--initial-cluster method`
       --no-embed-etcd                              don't embed etcd; use external etcd instead
 {{< /code >}}
 
-
 ### General configuration flags
 
 {{% notice note %}}
@@ -376,15 +390,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | api-listen-address  |      |
 -------------|------
@@ -392,12 +405,10 @@ description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-listen-address [::]:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-listen-address [::]:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
-
 
 <a name="api-request-limit"></a>
 
@@ -407,10 +418,9 @@ description  | Maximum size for API request bodies. In bytes.
 type         | Integer
 default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-request-limit 1024000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-request-limit 1024000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
@@ -419,12 +429,10 @@ description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_API_URL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-url http://localhost:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-url http://localhost:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -432,12 +440,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-burst-limit 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -445,12 +451,10 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-rate-limit 1.39
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
-
 
 | cache-dir   |      |
 --------------|------
@@ -458,12 +462,10 @@ description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --cache-dir /cache/sensu-backend
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-backend"{{< /code >}}
-
 
 | config-file |      |
 --------------|------
@@ -471,7 +473,7 @@ description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
 environment variable | `SENSU_BACKEND_CONFIG_FILE`
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
@@ -484,12 +486,10 @@ description | If `true`, enable debugging and profiling features for use with th
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
-example     | {{< code shell >}}# Command line example
-sensu-backend start --debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 debug: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
@@ -497,12 +497,10 @@ description              | Name of the default event handler to use when process
 type                     | String
 default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line examples
-sensu-backend start --deregistration-handler deregister
-
-# /etc/sensu/backend.yml examples
+command line example   | {{< code shell >}}
+sensu-backend start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
-
 
 | labels     |      |
 -------------|------
@@ -513,15 +511,14 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
 {{< /code >}}
-
 
 | log-level  |      |
 -------------|------
@@ -529,12 +526,10 @@ description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `deb
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --log-level debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --log-level debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
-
 
 | state-dir  |      |
 -------------|------
@@ -542,13 +537,12 @@ description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
 environment variable | `SENSU_BACKEND_STATE_DIR`
-example      | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
-
 
 ### Agent communication configuration flags
 
@@ -558,12 +552,10 @@ description  | TLS certificate in PEM format for agent certificate authenticatio
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
-
 
 | agent-auth-crl-urls |      |
 -------------|------
@@ -571,12 +563,10 @@ description  | URLs of CRLs for agent certificate authentication. The Sensu back
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
-
 
 | agent-auth-key-file |      |
 -------------|------
@@ -584,12 +574,10 @@ description  | TLS certificate key in PEM format for agent certificate authentic
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-key-file: /path/to/ssl/key.pem{{< /code >}}
-
 
 | agent-auth-trusted-ca-file |      |
 -------------|------
@@ -597,12 +585,10 @@ description  | TLS CA certificate bundle in PEM format for agent certificate aut
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /code >}}
-
 
 | agent-host   |      |
 ---------------|------
@@ -610,12 +596,10 @@ description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by 
 type           | String
 default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
-example        | {{< code shell >}}# Command line example
-sensu-backend start --agent-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
-
 
 | agent-port |      |
 -------------|------
@@ -623,12 +607,10 @@ description  | Agent listener port.
 type         | Integer
 default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-port 8081
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-port 8081{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -638,12 +620,10 @@ description  | Path to the primary backend certificate file. Specifies a fallbac
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cert-file: "/path/to/ssl/cert.pem"{{< /code >}}
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -653,12 +633,10 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 type                       | Boolean
 default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-backend start --insecure-skip-tls-verify
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
-
 
 <a name="jwt-attributes"></a>
 
@@ -670,12 +648,10 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-private-key-file /path/to/key/private.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
-
 
 | jwt-public-key-file |      |
 -------------|------
@@ -686,12 +662,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-public-key-file /path/to/key/public.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -699,10 +673,9 @@ description  | Path to the primary backend key file. Specifies a fallback SSL/TL
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -716,10 +689,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-fips
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-fips{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -731,10 +703,9 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-openssl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-openssl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -743,12 +714,10 @@ description       | Path to the primary backend CA file. Specifies a fallback SS
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 ### Web UI configuration flags
 
@@ -758,12 +727,10 @@ description  | Web UI TLS certificate in PEM format. This certificate secures co
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/cert.pem"{{< /code >}}
-
 
 | dashboard-host |      |
 -----------------|------
@@ -771,12 +738,10 @@ description      | Web UI listener host.
 type             | String
 default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
-
 
 | dashboard-key-file | |
 -------------|------
@@ -784,12 +749,10 @@ description  | Web UI TLS certificate key in PEM format. This key secures commun
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-key-file /path/to/tls/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-key-file /path/to/tls/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/key.pem"{{< /code >}}
-
 
 | dashboard-port |      |
 -----------------|------
@@ -797,12 +760,10 @@ description      | Web UI listener port.
 type             | Integer
 default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-port 4000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-port 4000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-port: 4000{{< /code >}}
-
 
 ### Datastore and cluster configuration flags
 
@@ -816,16 +777,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
 {{< /code >}}
-
 
 | etcd-cert-file |      |
 -----------------|------
@@ -833,12 +793,10 @@ description      | Path to the etcd client API TLS certificate file. Secures com
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-cert-file ./client.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
-
 
 <a name="etcd-cipher-suites"></a>
 
@@ -858,16 +816,15 @@ etcd-cipher-suites:
 {{< /code >}}
 type                    | List
 environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-
 
 | etcd-client-cert-auth |      |
 ------------------------|------
@@ -875,12 +832,10 @@ description             | If `true`, enable client certificate authentication. O
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
-
 
 | etcd-client-urls      |      |
 ------------------------|------
@@ -888,16 +843,15 @@ description             | List of client URLs to use when a sensu-backend is not
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -905,14 +859,12 @@ description             | Exposes [etcd's embedded auto-discovery features][19].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
-
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -920,14 +872,12 @@ description             | Exposes [etcd's embedded auto-discovery features][17].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery-srv example.org
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
-
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
@@ -935,16 +885,15 @@ description                        | List of this member's peer URLs to advertis
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
-example                            | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-initial-cluster |      |
 -----------------------|------
@@ -952,12 +901,10 @@ description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
-
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
@@ -965,12 +912,10 @@ description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-state existing
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
-
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
@@ -978,22 +923,19 @@ description                  | Unique token for the etcd cluster. Provide the sa
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
-
 
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-key-file ./client-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
 <a name="etcd-listen-client-urls"></a>
@@ -1004,16 +946,15 @@ description               | List of URLs to listen on for client traffic. Sensu'
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
@@ -1021,16 +962,15 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-name      |      |
 -----------------|------
@@ -1038,24 +978,20 @@ description      | Human-readable name for this member.
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-name backend-0
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-name backend-0{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
-
 
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
-example               | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-cert-file ./backend-0.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-cert-file ./backend-0.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
-
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
@@ -1063,36 +999,30 @@ description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
-
 
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
-example              | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-key-file ./backend-0-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
-
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
-example                     | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
@@ -1100,12 +1030,10 @@ description            | Path to the client server TLS trusted CA certificate fi
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | no-embed-etcd  |      |
 -----------------|------
@@ -1113,12 +1041,10 @@ description      | If `true`, do not embed etcd (use external etcd instead). Oth
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --no-embed-etcd
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --no-embed-etcd{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
-
 
 ### Advanced configuration options
 
@@ -1130,13 +1056,10 @@ description            | Number of incoming events that can be buffered before b
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-buffer-size 100
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
-
 
 | eventd-workers       |      |
 -----------------------|------
@@ -1146,12 +1069,10 @@ description            | Number of workers spawned for processing incoming event
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
-
 
 | keepalived-buffer-size |      |
 -----------------------|------
@@ -1161,12 +1082,10 @@ description            | Number of incoming keepalives that can be buffered befo
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
-
 
 | keepalived-workers |      |
 -----------------------|------
@@ -1175,12 +1094,10 @@ description            | Number of workers spawned for processing incoming keepa
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
-
 
 | pipelined-buffer-size |      |
 -----------------------|------
@@ -1190,12 +1107,10 @@ description            | Number of events to handle that can be buffered before 
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
-
 
 | pipelined-workers |      |
 -----------------------|------
@@ -1205,12 +1120,10 @@ description            | Number of workers spawned for handling events through t
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
-
 
 | etcd-election-timeout |      |
 -----------------------|------
@@ -1220,12 +1133,10 @@ description            | Time that a follower node will go without hearing a hea
 type                   | Integer
 default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-election-timeout 1000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-election-timeout 1000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
-
 
 | etcd-heartbeat-interval |      |
 -----------------------|------
@@ -1234,12 +1145,10 @@ description            | Interval at which the etcd leader will notify followers
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-heartbeat-interval 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
-
 
 | etcd-max-request-bytes |      |
 -----------------------|------
@@ -1249,12 +1158,10 @@ description            | Maximum etcd request size in bytes that can be sent to 
 type                   | Integer
 default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-max-request-bytes 1572864
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
-
 
 | etcd-quota-backend-bytes |      |
 -----------------------|------
@@ -1264,10 +1171,9 @@ description            | Maximum etcd database size in bytes. Increasing this va
 type                   | Integer
 default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-quota-backend-bytes 4294967296
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 ### Configuration via environment variables
@@ -1381,20 +1287,16 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
-
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-buffer-size 100000
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-buffer-size 100000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
-
 
 | event-log-file |      |
 -----------------------|------
@@ -1403,13 +1305,10 @@ description            | Path to the event log file. {{% notice warning %}}
 {{% /notice %}}
 type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-file /var/log/sensu/events.log
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
-
 
 ### Log rotation
 

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -28,11 +28,15 @@ To activate your license with sensuctl:
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
-Use sensuctl to view your license details at any time.
+Use sensuctl to view your license details at any time:
 
 {{< code shell >}}
-# Active license
 sensuctl license info
+{{< /code >}}
+
+For an active license, the response should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -43,9 +47,11 @@ Issuer:       Sensu, Inc.
 Issued:       2020-02-15 15:01:44 -0500 -0500
 Valid:        true
 Valid Until:  2021-02-15 00:00:00 -0800 -0800
+{{< /code >}}
 
-# No license found
-sensuctl license info
+This response means you do not have an active license:
+
+{{< code shell >}}
 Error: not found
 {{< /code >}}
 
@@ -67,10 +73,16 @@ If you use only 1,500 agent entities, you can have 8,500 proxy entities before y
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.
 
-In tabular format, the entity count and limit are included in the response title:
+In tabular format, the entity count and limit are included in the response title.
+To view license info in tabular format, run:
 
 {{< code shell >}}
 sensuctl license info --format tabular
+{{< /code >}}
+
+The response in tabular format should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -90,13 +102,22 @@ For example:
 === You are currently using 10/unlimited total entities, 5/unlimited agent entities, and 5/unlimited proxy entities
 {{< /code >}}
 
-In other formats (e.g. YAML and JSON), the entity count and limit are included as labels:
+To view license details in YAML or JSON, run:
+
+{{< language-toggle >}}
+{{< code shell "YML" >}}
+sensuctl license info --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl license info --format json
+{{< /code >}}
+{{< /language-toggle >}}
+
+In YAML and JSON formats, the entity count and limit are included as labels:
 
 {{< language-toggle >}}
 
-{{< code shell "YML" >}}
-sensuctl license info --format yaml
-
+{{< code yml >}}
 type: LicenseFile
 api_version: licensing/v2
 metadata:
@@ -111,9 +132,7 @@ spec:
 [...]
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl license info --format json
-
+{{< code json >}}
 {
   "type": "LicenseFile",
   "api_version": "licensing/v2",

--- a/content/sensu-go/6.2/sensuctl/environment-variables.md
+++ b/content/sensu-go/6.2/sensuctl/environment-variables.md
@@ -25,7 +25,7 @@ SENSU_TRUSTED_CA_FILE            Path to a trusted CA file if set in sensuctl
 SENSU_INSECURE_SKIP_TLS_VERIFY   Boolean value that can be set to skip TLS verification
 {{< /code >}}
 
-These examples demonstrate how to use sensuctl to export and set environment variables:
+These examples demonstrate how to use sensuctl to export and set environment variables and configure your shell:
 
 {{< language-toggle >}}
 
@@ -38,6 +38,7 @@ export SENSU_ACCESS_TOKEN_EXPIRES_AT="1567716187"
 export SENSU_REFRESH_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 export SENSU_TRUSTED_CA_FILE=""
 export SENSU_INSECURE_SKIP_TLS_VERIFY="true"
+eval $(sensuctl env)
 {{< /code >}}
 
 {{< code cmd >}}
@@ -49,6 +50,7 @@ SET SENSU_ACCESS_TOKEN_EXPIRES_AT=1567716676
 SET SENSU_REFRESH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x
 SET SENSU_TRUSTED_CA_FILE=
 SET SENSU_INSECURE_SKIP_TLS_VERIFY=true
+@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
 {{< /code >}}
 
 {{< code powershell >}}
@@ -60,23 +62,6 @@ $Env:SENSU_ACCESS_TOKEN_EXPIRES_AT = "1567716738"
 $Env:SENSU_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 $Env:SENSU_TRUSTED_CA_FILE = ""
 $Env:SENSU_INSECURE_SKIP_TLS_VERIFY = "true"
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Run these commands to configure your shell:
-
-{{< language-toggle >}}
-
-{{< code bash >}}
-eval $(sensuctl env)
-{{< /code >}}
-
-{{< code cmd >}}
-@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
-{{< /code >}}
-
-{{< code powershell >}}
 & sensuctl env --shell powershell | Invoke-Expression
 {{< /code >}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -713,10 +713,14 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
 - `json` format for use with the [events API][16]
 
-{{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
 {{< /code >}}
+{{< /language-toggle >}}
 
 ### Delete events
 
@@ -800,8 +804,8 @@ Within a sequence of only OK or only non-OK events, Sensu increments `occurrence
 
 The following table shows the occurrences attributes for a series of example events:
 
-| event sequence   | `occurrences`   | `occurrences_watermark` |
-| -----------------| --------------- | ----------------------- |
+| event sequence    | `occurrences`   | `occurrences_watermark` |
+| ----------------- | --------------- | ----------------------- |
 |1. OK event        | `occurrences: 1`| `occurrences_watermark: 1`
 |2. OK event        | `occurrences: 2`| `occurrences_watermark: 2`
 |3. WARNING event   | `occurrences: 1`| `occurrences_watermark: 1`

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -287,16 +287,16 @@ For more information, see the [StatsD documentation][21].
 ### Configure the StatsD listener
 
 To configure the StatsD listener, specify the [`statsd-event-handlers` configuration flag][22] in the [agent configuration][24], and start the agent.
+For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
-# Start an agent that sends StatsD metrics to InfluxDB
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
 Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
-# Start an agent with a customized address and flush interval
 sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host 123.4.5.11 --statsd-metrics-port 8125
 {{< /code >}}
 
@@ -380,21 +380,27 @@ name         |
 description  | Check name.
 required     | true
 type         | String
-example      | {{< code shell >}}"name": "check-mysql-status"{{< /code >}}
+example      | {{< code json >}}{
+  "name": "check-mysql-status"
+}{{< /code >}}
 
 status       | 
 -------------|------
 description  | Check execution exit status code. An exit status code of `0` (zero) indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`. Exit status codes other than `0`, `1`, and `2` indicate an `UNKNOWN` or custom status.
 required     | true
 type         | Integer
-example      | {{< code shell >}}"status": 0{{< /code >}}
+example      | {{< code json >}}{
+  "status": 0
+}{{< /code >}}
 
 output       | 
 -------------|------
 description  | Output produced by the check `command`.
 required     | true
 type         | String
-example      | {{< code shell >}}"output": "CheckHttp OK: 200, 78572 bytes"{{< /code >}}
+example      | {{< code json >}}{
+  "output": "CheckHttp OK: 200, 78572 bytes"
+}{{< /code >}}
 
 source       | 
 -------------|------
@@ -402,7 +408,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"source": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "source": "sensu-docs-site"
+}{{< /code >}}
 
 client       | 
 -------------|------
@@ -412,7 +420,9 @@ description  | Name of the Sensu entity associated with the event. Use this attr
 required     | false
 default      | The agent entity that receives the event data.
 type         | String
-example      | {{< code shell >}}"client": "sensu-docs-site"{{< /code >}}
+example      | {{< code json >}}{
+  "client": "sensu-docs-site"
+}{{< /code >}}
 
 executed     | 
 -------------|------
@@ -420,21 +430,27 @@ description  | Time at which the check was executed. In seconds since the Unix e
 required     | false
 default      | The time the event was received by the agent.
 type         | Integer
-example      | {{< code shell >}}"executed": 1458934742{{< /code >}}
+example      | {{< code json >}}{
+  "executed": 1458934742
+}{{< /code >}}
 
 duration     | 
 -------------|------
 description  | Amount of time it took to execute the check. In seconds.
 required     | false
 type         | Float
-example      | {{< code shell >}}"duration": 1.903135228{{< /code >}}
+example      | {{< code json >}}{
+  "duration": 1.903135228
+}{{< /code >}}
 
 command      | 
 -------------|------
 description  | Command executed to produce the event. Use the `command` attribute to add context to the event data. Sensu does not execute the command included in this attribute.
 required     | false
 type         | String
-example      | {{< code shell >}}"command": "check-http.rb -u https://sensuapp.org"{{< /code >}}
+example      | {{< code json >}}{
+  "command": "check-http.rb -u https://sensuapp.org"
+}{{< /code >}}
 
 interval     | 
 -------------|------
@@ -442,14 +458,18 @@ description  | Interval used to produce the event. Use the `interval` attribute 
 required     | false
 default      | `1`
 type         | Integer
-example      | {{< code shell >}}"interval": 60{{< /code >}}
+example      | {{< code json >}}{
+  "interval": 60
+}{{< /code >}}
 
 handlers     | 
 -------------|------
 description  | Array of Sensu handler names to use for handling the event. Each handler name in the array must be a string.
 required     | false
 type         | Array
-example      | {{< code shell >}}"handlers": ["slack", "influxdb"]{{< /code >}}
+example      | {{< code json >}}{
+  "handlers": ["slack", "influxdb"]
+}{{< /code >}}
 
 ## Keepalive monitoring
 
@@ -733,13 +753,17 @@ sensu-agent service uninstall
 
 ### Get help
 
-The `sensu-agent` tool provides general and command-specific help flags:
+The `sensu-agent` tool provides general and command-specific help flags.
+
+To see sensu-agent commands, run:
 
 {{< code shell >}}
-# Show sensu-agent commands
 sensu-agent help
+{{< /code >}}
 
-# Show options for the sensu-agent start subcommand
+To see options for a specific command (in this case, sensu-agent start), run: 
+
+{{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
@@ -814,8 +838,15 @@ As of 5.20.2, the `--discover-processes` flag is not available, and new events w
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
+To view configuration information for the sensu-agent start command, run:
+
+{{< code shell >}}
+sensu-agent start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-agent start:
+
 {{< code text >}}
-$ sensu-agent start --help
 start the sensu agent
 
 Usage:
@@ -901,12 +932,10 @@ required     | false
 type         | Boolean
 default      | false
 environment variable | `SENSU_AGENT_MANAGED_ENTITY`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --agent-managed-entity
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --agent-managed-entity{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
-
 
 <a name="allow-list"></a>
 
@@ -916,12 +945,10 @@ description       | Path to yaml or json file that contains the allow list of ch
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
-
 
 | annotations|      |
 -------------|------
@@ -932,15 +959,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -948,12 +974,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-burst-limit 100
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -961,10 +985,9 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --assets-rate-limit 1.39
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a name="backend-handshake-timeout"></a>
@@ -975,10 +998,9 @@ description   | Number of seconds the Sensu agent should wait when negotiating a
 type          | Integer
 default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-handshake-timeout 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-handshake-timeout 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a name="backend-heartbeat-interval"></a>
@@ -989,10 +1011,9 @@ description   | Interval at which the agent should send heartbeats to the Sensu 
 type          | Integer
 default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-interval 45
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a name="backend-heartbeat-timeout"></a>
@@ -1003,12 +1024,10 @@ description   | Number of seconds the agent should wait for a response to a hear
 type          | Integer
 default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --backend-heartbeat-timeout 60
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
-
 
 | backend-url |      |
 --------------|------
@@ -1018,16 +1037,15 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --backend-url ws://0.0.0.0:8081
 sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 backend-url:
   - "ws://0.0.0.0:8081"
   - "ws://0.0.0.0:8082"
-  {{< /code >}}
-
+{{< /code >}}
 
 <a name="cache-dir"></a>
 
@@ -1037,10 +1055,9 @@ description   | Path to store cached data.
 type          | String
 default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `C:\ProgramData\sensu\cache\sensu-agent`</li></ul>
 environment variable | `SENSU_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --cache-dir /cache/sensu-agent
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a name="config-file"></a>
@@ -1051,7 +1068,7 @@ description   | Path to Sensu agent configuration file.
 type          | String
 default       | <ul><li>Linux: `/etc/sensu/agent.yml`</li><li>FreeBSD: `/usr/local/etc/sensu/agent.yml`</li><li>Windows: `C:\ProgramData\sensu\config\agent.yml`</li></ul>
 environment variable | `SENSU_CONFIG_FILE`
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
@@ -1064,10 +1081,9 @@ description   | When set to `true`, disables [dynamic runtime assets][29] for th
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-assets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-assets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a name="discover-processes"></a>
@@ -1082,10 +1098,9 @@ Instead, the field will be empty: `"processes": null`.
 type          | Boolean
 default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --discover-processes
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --discover-processes{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 <a name="labels"></a>
@@ -1099,13 +1114,13 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 labels:
-  proxy_type: "website"
+  proxy_type: website
 {{< /code >}}
 
 <a name="name"></a>
@@ -1116,11 +1131,10 @@ description   | Entity name assigned to the agent entity.
 type          | String
 default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --name agent-01
-
-# /etc/sensu/agent.yml example
-name: "agent-01" {{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --name agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+name: "agent-01"{{< /code >}}
 
 <a name="log-level"></a>
 
@@ -1130,11 +1144,10 @@ description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `de
 type          | String
 default       | `info`
 environment variable | `SENSU_LOG_LEVEL`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --log-level debug
-
-# /etc/sensu/agent.yml example
-log-level: "debug"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --log-level debug{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+log-level: debug{{< /code >}}
 
 <a name="subscriptions-flag"></a>
 
@@ -1143,15 +1156,15 @@ log-level: "debug"{{< /code >}}
 description     | Array of agent subscriptions that determine which monitoring checks the agent will execute. The subscriptions array items must be strings.
 type            | List
 environment variable | `SENSU_SUBSCRIPTIONS`
-example         | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 subscriptions:
   - disk-checks
-  - process-checks{{< /code >}}
-
+  - process-checks
+{{< /code >}}
 
 ### API configuration flags
 
@@ -1161,12 +1174,10 @@ description   | Bind address for the Sensu agent HTTP API.
 type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-host: "0.0.0.0"{{< /code >}}
-
 
 | api-port    |      |
 --------------|------
@@ -1174,12 +1185,10 @@ description   | Listening port for the Sensu agent HTTP API.
 type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --api-port 4041
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --api-port 4041{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 api-port: 4041{{< /code >}}
-
 
 | disable-api |      |
 --------------|------
@@ -1187,12 +1196,10 @@ description   | `true` to disable the agent HTTP API. Otherwise, `false`.
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DISABLE_API`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --disable-api
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-api{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-api: true{{< /code >}}
-
 
 | events-burst-limit | |
 --------------|------
@@ -1200,12 +1207,10 @@ description   | Maximum amount of burst allowed in a rate interval for the [agen
 type          | Integer
 default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-burst-limit 20
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-burst-limit 20{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
-
 
 | events-rate-limit | |
 --------------|------
@@ -1213,12 +1218,10 @@ description   | Maximum number of events per second that can be transmitted to t
 type          | Float
 default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --events-rate-limit 20.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --events-rate-limit 20.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
-
 
 ### Ephemeral agent configuration flags
 
@@ -1230,26 +1233,22 @@ description   | `true` if a deregistration event should be created upon Sensu ag
 type          | Boolean
 default       | `false`
 environment variable | `SENSU_DEREGISTER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --deregister
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 deregister: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
 description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --deregistration-handler deregister
-
-# /etc/sensu/agent.yml example
-deregistration-handler: "deregister"{{< /code >}}
+command line example   | {{< code shell >}}
+sensu-agent start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+deregistration-handler: deregister{{< /code >}}
 
 <a name="detect-cloud-provider-flag"></a>
-
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1257,12 +1256,10 @@ description              | `true` to enable cloud provider detection mechanisms.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --detect-cloud-provider false
-
-# /etc/sensu/agent.yml example
-detect-cloud-provider: "false"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --detect-cloud-provider false{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+detect-cloud-provider: false{{< /code >}}
 
 ### Keepalive configuration flags
 
@@ -1273,10 +1270,9 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-critical-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a name="keepalive-handlers-flag"></a>
@@ -1287,12 +1283,13 @@ description         | [Keepalive event handlers][52] to use for the entity, spec
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-handlers slack,email
-
-# /etc/sensu/agent.yml example
-keepalive-handlers: slack,email{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-handlers slack,email{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+keepalive-handlers:
+- slack
+- email
+{{< /code >}}
 
 | keepalive-interval |      |
 ---------------------|------
@@ -1300,12 +1297,10 @@ description          | Number of seconds between keepalive events.
 type                 | Integer
 default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
-example              | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
-
 
 | keepalive-warning-timeout |      |
 --------------------|------
@@ -1314,12 +1309,10 @@ description         | Number of seconds after a missing keepalive event until th
 type                | Integer
 default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
-example             | {{< code shell >}}# Command line example
-sensu-agent start --keepalive-warning-timeout 300
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -1332,12 +1325,10 @@ Entities can only belong to a [single namespace](../../../operations/control-acc
 type           | String
 default        | `default`
 environment variable   | `SENSU_NAMESPACE`
-example        | {{< code shell >}}# Command line example
-sensu-agent start --namespace ops
-
-# /etc/sensu/agent.yml example
-namespace: "ops"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --namespace ops{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+namespace: ops{{< /code >}}
 
 | user |      |
 --------------|------
@@ -1345,12 +1336,10 @@ description   | [Sensu RBAC username][39] used by the agent. Agents require get,
 type          | String
 default       | `agent`
 environment variable   | `SENSU_USER`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --user agent-01
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --user agent-01{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
-
 
 | password    |      |
 --------------|------
@@ -1358,12 +1347,10 @@ description   | [Sensu RBAC password][39] used by the agent.
 type          | String
 default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --password secure-password
-
-# /etc/sensu/agent.yml example
-password: "secure-password"{{< /code >}}
-
+command line example   | {{< code shell >}}
+sensu-agent start --password secure-password{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
+password: secure-password{{< /code >}}
 
 | redact      |      |
 --------------|------
@@ -1374,15 +1361,13 @@ They are not logged or displayed via the Sensu API.
 type          | List
 default       | By default, Sensu redacts the following fields: `password`, `passwd`, `pass`, `api_key`, `api_token`, `access_key`, `secret_key`, `private_key`, `secret`.
 environment variable   | `SENSU_REDACT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --redact secret,ec2_access_key
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --redact secret,ec2_access_key{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
 {{< /code >}}
-
 
 | cert-file  |      |
 -------------|------
@@ -1390,12 +1375,10 @@ description  | Path to the agent certificate file used in mTLS authentication. S
 type         | String
 default      | `""`
 environment variable | `SENSU_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --cert-file /path/to/agent.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --cert-file /path/to/agent.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 cert-file: "/path/to/agent.pem"{{< /code >}}
-
 
 | trusted-ca-file |      |
 ------------------|------
@@ -1403,12 +1386,10 @@ description       | SSL/TLS certificate authority.
 type              | String
 default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -1416,13 +1397,10 @@ description  | Path to the agent key file used in mTLS authentication.
 type         | String
 default      | `""`
 environment variable | `SENSU_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-agent start --key-file /path/to/agent-key.pem
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --key-file /path/to/agent-key.pem{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 key-file: "/path/to/agent-key.pem"{{< /code >}}
-
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -1432,10 +1410,9 @@ description                | Skip SSL verification. {{% notice warning %}}
 type                       | Boolean
 default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-agent start --insecure-skip-tls-verify
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -1449,10 +1426,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-fips
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-fips{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1464,12 +1440,10 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --require-openssl
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --require-openssl{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
-
 
 ### Socket configuration flags
 
@@ -1479,12 +1453,10 @@ description   | Address to bind the Sensu agent socket to.
 type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-host: "0.0.0.0"{{< /code >}}
-
 
 | socket-port |      |
 --------------|------
@@ -1492,12 +1464,10 @@ description   | Port the Sensu agent socket listens on.
 type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
-example       | {{< code shell >}}# Command line example
-sensu-agent start --socket-port 4030
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --socket-port 4030{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 socket-port: 4030{{< /code >}}
-
 
 | disable-sockets |      |
 ------------------|------
@@ -1505,12 +1475,10 @@ description       | `true` to disable the agent TCP and UDP event sockets. Othew
 type              | Boolean
 default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
-example           | {{< code shell >}}# Command line example
-sensu-agent start --disable-sockets
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --disable-sockets{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
-
 
 ### StatsD configuration flags
 
@@ -1520,28 +1488,25 @@ description      | `true` to disable the [StatsD][21] listener and metrics serve
 type             | Boolean
 default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
-example          | {{< code shell >}}# Command line example
-sensu-agent start --statsd-disable
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-disable{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
-
 
 | statsd-event-handlers |      |
 ------------------------|------
 description             | List of event handlers for StatsD metrics.
 type                    | List
 environment variable    | `SENSU_STATSD_EVENT_HANDLERS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
-
-# /etc/sensu/agent.yml example
+{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
 {{< /code >}}
-
 
 | statsd-flush-interval  |      |
 -------------------------|------
@@ -1549,12 +1514,10 @@ description              | Number of seconds between [StatsD flushes][23].
 type                     | Integer
 default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
-example                  | {{< code shell >}}# Command line example
-sensu-agent start --statsd-flush-interval 30
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-flush-interval 30{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
-
 
 | statsd-metrics-host |      |
 ----------------------|------
@@ -1562,12 +1525,10 @@ description           | Address used for the StatsD metrics server.
 type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-host 0.0.0.0
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-host: "0.0.0.0"{{< /code >}}
-
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1575,10 +1536,9 @@ description           | Port used for the StatsD metrics server.
 type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
-example               | {{< code shell >}}# Command line example
-sensu-agent start --statsd-metrics-port 6125
-
-# /etc/sensu/agent.yml example
+command line example   | {{< code shell >}}
+sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+/etc/sensu/agent.yml example | {{< code shell >}}
 statsd-metrics-port: 6125{{< /code >}}
 
 ### Allow list configuration commands
@@ -1593,28 +1553,65 @@ Use these commands to build your allow list configuration file.
 description           | Command to allow the Sensu agent to run as a check or a hook.
 required              | true
 type                  | String
-example               | {{< code shell >}}"exec": "/usr/local/bin/check_memory.sh"{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+exec: "/usr/local/bin/check_memory.sh"
+{{< /code >}}
+{{< code json >}}
+{
+  "exec": "/usr/local/bin/check_memory.sh"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | sha512 |      |
 ----------------------|------
 description           | Checksum of the check or hook executable.
 required              | false
 type                  | String
-example               | {{< code shell >}}"sha512": "4f926bf4328..."{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+sha512: 4f926bf4328...
+{{< /code >}}
+{{< code json >}}
+{
+  "sha512": "4f926bf4328..."
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | args |      |
 ----------------------|------
 description           | Arguments for the `exec` command.
 required              | true
 type                  | Array
-example               | {{< code shell >}}"args": ["foo"]{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+args:
+- foo
+{{< /code >}}
+{{< code json >}}
+{
+  "args": ["foo"]
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | enable_env |      |
 ----------------------|------
 description           | `true` to enable environment variables. Otherwise, `false`.
 required              | false
 type                  | Boolean
-example               | {{< code shell >}}"enable_env": true{{< /code >}}
+example               | {{< language-toggle >}}
+{{< code yml >}}
+enable_env: true
+{{< /code >}}
+{{< code json >}}
+{
+  "enable_env": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 #### Example allow list configuration file
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -128,11 +128,15 @@ sensu-backend init
 **NOTE**: Make sure the Sensu backend is running before you run `sensu-backend init`.
 {{% /notice %}}
 
-You can also run the `sensu-backend init` command in interactive mode if you prefer to respond to prompts for your username and password:
+You can also run the `sensu-backend init` command in interactive mode:
 
 {{< code shell >}}
 sensu-backend init --interactive
+{{< /code >}}
 
+You will receive prompts for your username and password in interactive mode:
+
+{{< code shell >}}
 Admin Username: YOUR_USERNAME
 Admin Password: YOUR_PASSWORD
 {{< /code >}}
@@ -233,13 +237,17 @@ sensu-backend version
 
 ### Get help
 
-The `sensu-backend` tool provides general and command-specific help flags:
+The `sensu-backend` tool provides general and command-specific help flags.
+
+To see sensu-backend commands, run:
 
 {{< code shell >}}
-# Show sensu-backend commands
 sensu-backend help
+{{< /code >}}
 
-# Show options for the sensu-backend start subcommand
+To see options for a specific command (in this case, sensu-backend start), run: 
+
+{{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
@@ -280,8 +288,15 @@ The Sensu backend checks certificate revocation list (CRL) and Online Certificat
 
 ### Configuration summary
 
+To view configuration information for the sensu-backend start command, run:
+
+{{< code shell >}}
+sensu-backend start --help
+{{< /code >}}
+
+The response will list command information and configuration flags for sensu-backend start:
+
 {{< code text >}}
-$ sensu-backend start --help
 start the sensu backend
 
 Usage:
@@ -360,7 +375,6 @@ discovery instead of the static `--initial-cluster method`
       --no-embed-etcd                              don't embed etcd; use external etcd instead
 {{< /code >}}
 
-
 ### General configuration flags
 
 {{% notice note %}}
@@ -376,15 +390,14 @@ required     | false
 type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_ANNOTATIONS`
-example      | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
-
 
 | api-listen-address  |      |
 -------------|------
@@ -392,12 +405,10 @@ description  | Address the API daemon will listen for requests on.
 type         | String
 default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-listen-address [::]:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-listen-address [::]:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
-
 
 <a name="api-request-limit"></a>
 
@@ -407,10 +418,9 @@ description  | Maximum size for API request bodies. In bytes.
 type         | Integer
 default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-request-limit 1024000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-request-limit 1024000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
@@ -419,12 +429,10 @@ description  | URL used to connect to the API.
 type         | String
 default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_API_URL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --api-url http://localhost:8080
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --api-url http://localhost:8080{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
-
 
 | assets-burst-limit   |      |
 --------------|------
@@ -432,12 +440,10 @@ description   | Maximum amount of burst allowed in a rate interval when fetching
 type          | Integer
 default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-burst-limit 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-burst-limit 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
-
 
 | assets-rate-limit   |      |
 --------------|------
@@ -445,12 +451,10 @@ description   | Maximum number of dynamic runtime assets to fetch per second. Th
 type          | Float
 default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --assets-rate-limit 1.39
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --assets-rate-limit 1.39{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
-
 
 | cache-dir   |      |
 --------------|------
@@ -458,12 +462,10 @@ description   | Path to store cached data.
 type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
-example       | {{< code shell >}}# Command line example
-sensu-backend start --cache-dir /cache/sensu-backend
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-backend"{{< /code >}}
-
 
 | config-file |      |
 --------------|------
@@ -471,7 +473,7 @@ description   | Path to Sensu backend config file.
 type          | String
 default       | `/etc/sensu/backend.yml`
 environment variable | `SENSU_BACKEND_CONFIG_FILE`
-example       | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
@@ -484,12 +486,10 @@ description | If `true`, enable debugging and profiling features for use with th
 type        | Boolean
 default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
-example     | {{< code shell >}}# Command line example
-sensu-backend start --debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 debug: true{{< /code >}}
-
 
 | deregistration-handler |      |
 -------------------------|------
@@ -497,12 +497,10 @@ description              | Name of the default event handler to use when process
 type                     | String
 default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
-example                  | {{< code shell >}}# Command line example
-sensu-backend start --deregistration-handler deregister
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --deregistration-handler deregister{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
-
 
 | labels     |      |
 -------------|------
@@ -513,15 +511,14 @@ required     | false
 type         | Map of key-value pairs. Keys can contain only letters, numbers, and underscores and must start with a letter. Values can be any valid UTF-8 string.
 default      | `null`
 environment variable | `SENSU_BACKEND_LABELS`
-example               | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
 {{< /code >}}
-
 
 | log-level  |      |
 -------------|------
@@ -529,12 +526,10 @@ description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `deb
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --log-level debug
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --log-level debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
-
 
 | state-dir  |      |
 -------------|------
@@ -542,13 +537,12 @@ description  | Path to Sensu state storage: `/var/lib/sensu/sensu-backend`.
 type         | String
 required     | true
 environment variable | `SENSU_BACKEND_STATE_DIR`
-example      | {{< code shell >}}# Command line example
+command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
-
 
 ### Agent communication configuration flags
 
@@ -558,12 +552,10 @@ description  | TLS certificate in PEM format for agent certificate authenticatio
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-cert-file: /path/to/ssl/cert.pem{{< /code >}}
-
 
 | agent-auth-crl-urls |      |
 -------------|------
@@ -571,12 +563,10 @@ description  | URLs of CRLs for agent certificate authentication. The Sensu back
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
-
 
 | agent-auth-key-file |      |
 -------------|------
@@ -584,12 +574,10 @@ description  | TLS certificate key in PEM format for agent certificate authentic
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-key-file: /path/to/ssl/key.pem{{< /code >}}
-
 
 | agent-auth-trusted-ca-file |      |
 -------------|------
@@ -597,12 +585,10 @@ description  | TLS CA certificate bundle in PEM format for agent certificate aut
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /code >}}
-
 
 | agent-host   |      |
 ---------------|------
@@ -610,12 +596,10 @@ description    | Agent listener host. Listens on all IPv4 and IPv6 addresses by 
 type           | String
 default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
-example        | {{< code shell >}}# Command line example
-sensu-backend start --agent-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
-
 
 | agent-port |      |
 -------------|------
@@ -623,12 +607,10 @@ description  | Agent listener port.
 type         | Integer
 default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --agent-port 8081
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --agent-port 8081{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
-
 
 ### Security configuration flags
 
@@ -638,12 +620,10 @@ description  | Path to the primary backend certificate file. Specifies a fallbac
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --cert-file /path/to/ssl/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --cert-file /path/to/ssl/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 cert-file: "/path/to/ssl/cert.pem"{{< /code >}}
-
 
 | insecure-skip-tls-verify |      |
 ---------------------------|------
@@ -653,12 +633,10 @@ description                | If `true`, skip SSL verification. Otherwise, `false
 type                       | Boolean
 default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
-example                    | {{< code shell >}}# Command line example
-sensu-backend start --insecure-skip-tls-verify
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --insecure-skip-tls-verify{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
-
 
 <a name="jwt-attributes"></a>
 
@@ -670,12 +648,10 @@ description  | Path to the PEM-encoded private key to use to sign JSON Web Token
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-private-key-file /path/to/key/private.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
-
 
 | jwt-public-key-file |      |
 -------------|------
@@ -686,12 +662,10 @@ type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
-example      | {{< code shell >}}# Command line example
-sensu-backend start --jwt-public-key-file /path/to/key/public.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
-
 
 | key-file   |      |
 -------------|------
@@ -699,10 +673,9 @@ description  | Path to the primary backend key file. Specifies a fallback SSL/TL
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --key-file /path/to/ssl/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
 <a name="fips-openssl"></a>
@@ -716,10 +689,9 @@ description       | Require Federal Information Processing Standard (FIPS) suppo
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-fips
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-fips{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -731,10 +703,9 @@ description       | Use OpenSSL instead of Go's standard cryptography library. L
 type              | Boolean
 default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --require-openssl
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --require-openssl{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -743,12 +714,10 @@ description       | Path to the primary backend CA file. Specifies a fallback SS
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
-example           | {{< code shell >}}# Command line example
-sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --trusted-ca-file /path/to/trusted-certificate-authorities.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"{{< /code >}}
-
 
 ### Web UI configuration flags
 
@@ -758,12 +727,10 @@ description  | Web UI TLS certificate in PEM format. This certificate secures co
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-cert-file /path/to/tls/cert.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/cert.pem"{{< /code >}}
-
 
 | dashboard-host |      |
 -----------------|------
@@ -771,12 +738,10 @@ description      | Web UI listener host.
 type             | String
 default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-host 127.0.0.1
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
-
 
 | dashboard-key-file | |
 -------------|------
@@ -784,12 +749,10 @@ description  | Web UI TLS certificate key in PEM format. This key secures commun
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
-example      | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-key-file /path/to/tls/key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-key-file /path/to/tls/key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/key.pem"{{< /code >}}
-
 
 | dashboard-port |      |
 -----------------|------
@@ -797,12 +760,10 @@ description      | Web UI listener port.
 type             | Integer
 default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --dashboard-port 4000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --dashboard-port 4000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 dashboard-port: 4000{{< /code >}}
-
 
 ### Datastore and cluster configuration flags
 
@@ -816,16 +777,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
-example       | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
 {{< /code >}}
-
 
 | etcd-cert-file |      |
 -----------------|------
@@ -833,12 +793,10 @@ description      | Path to the etcd client API TLS certificate file. Secures com
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-cert-file ./client.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
-
 
 <a name="etcd-cipher-suites"></a>
 
@@ -858,16 +816,15 @@ etcd-cipher-suites:
 {{< /code >}}
 type                    | List
 environment variable | `SENSU_BACKEND_ETCD_CIPHER_SUITES`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-
 
 | etcd-client-cert-auth |      |
 ------------------------|------
@@ -875,12 +832,10 @@ description             | If `true`, enable client certificate authentication. O
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
-
 
 | etcd-client-urls      |      |
 ------------------------|------
@@ -888,16 +843,15 @@ description             | List of client URLs to use when a sensu-backend is not
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -905,14 +859,12 @@ description             | Exposes [etcd's embedded auto-discovery features][19].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
-
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -920,14 +872,12 @@ description             | Exposes [etcd's embedded auto-discovery features][17].
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
-example                 | {{< code shell >}}# Command line example
-sensu-backend start --etcd-discovery-srv example.org
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
-
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
@@ -935,16 +885,15 @@ description                        | List of this member's peer URLs to advertis
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
-example                            | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-initial-cluster |      |
 -----------------------|------
@@ -952,12 +901,10 @@ description            | Initial cluster configuration for bootstrapping.
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
-
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
@@ -965,12 +912,10 @@ description                  | Initial cluster state (`new` or `existing`).
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-state existing
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
-
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
@@ -978,22 +923,19 @@ description                  | Unique token for the etcd cluster. Provide the sa
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
-
 
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-key-file ./client-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
 <a name="etcd-listen-client-urls"></a>
@@ -1004,16 +946,15 @@ description               | List of URLs to listen on for client traffic. Sensu'
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
-example                   | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
-
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
@@ -1021,16 +962,15 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
-example                 | {{< code shell >}}# Command line examples
+command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
-
-# /etc/sensu/backend.yml example
+{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
-
 
 | etcd-name      |      |
 -----------------|------
@@ -1038,24 +978,20 @@ description      | Human-readable name for this member.
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --etcd-name backend-0
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-name backend-0{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
-
 
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
-example               | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-cert-file ./backend-0.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-cert-file ./backend-0.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
-
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
@@ -1063,36 +999,30 @@ description                  | Enable peer client certificate authentication.
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
-example                      | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-client-cert-auth
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
-
 
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
-example              | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-key-file ./backend-0-key.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-key-file ./backend-0-key.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
-
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
-example                     | {{< code shell >}}# Command line example
-sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
@@ -1100,12 +1030,10 @@ description            | Path to the client server TLS trusted CA certificate fi
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-trusted-ca-file ./ca.pem
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
-
 
 | no-embed-etcd  |      |
 -----------------|------
@@ -1113,12 +1041,10 @@ description      | If `true`, do not embed etcd (use external etcd instead). Oth
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
-example          | {{< code shell >}}# Command line example
-sensu-backend start --no-embed-etcd
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --no-embed-etcd{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
-
 
 ### Advanced configuration options
 
@@ -1130,13 +1056,10 @@ description            | Number of incoming events that can be buffered before b
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-buffer-size 100
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
-
 
 | eventd-workers       |      |
 -----------------------|------
@@ -1146,12 +1069,10 @@ description            | Number of workers spawned for processing incoming event
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --eventd-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --eventd-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
-
 
 | keepalived-buffer-size |      |
 -----------------------|------
@@ -1161,12 +1082,10 @@ description            | Number of incoming keepalives that can be buffered befo
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
-
 
 | keepalived-workers |      |
 -----------------------|------
@@ -1175,12 +1094,10 @@ description            | Number of workers spawned for processing incoming keepa
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --keepalived-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --keepalived-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
-
 
 | pipelined-buffer-size |      |
 -----------------------|------
@@ -1190,12 +1107,10 @@ description            | Number of events to handle that can be buffered before 
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-buffer-size 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-buffer-size 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
-
 
 | pipelined-workers |      |
 -----------------------|------
@@ -1205,12 +1120,10 @@ description            | Number of workers spawned for handling events through t
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --pipelined-workers 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --pipelined-workers 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
-
 
 | etcd-election-timeout |      |
 -----------------------|------
@@ -1220,12 +1133,10 @@ description            | Time that a follower node will go without hearing a hea
 type                   | Integer
 default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-election-timeout 1000
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-election-timeout 1000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
-
 
 | etcd-heartbeat-interval |      |
 -----------------------|------
@@ -1234,12 +1145,10 @@ description            | Interval at which the etcd leader will notify followers
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-heartbeat-interval 100
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
-
 
 | etcd-max-request-bytes |      |
 -----------------------|------
@@ -1249,12 +1158,10 @@ description            | Maximum etcd request size in bytes that can be sent to 
 type                   | Integer
 default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-max-request-bytes 1572864
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
-
 
 | etcd-quota-backend-bytes |      |
 -----------------------|------
@@ -1264,10 +1171,9 @@ description            | Maximum etcd database size in bytes. Increasing this va
 type                   | Integer
 default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --etcd-quota-backend-bytes 4294967296
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 ### Configuration via environment variables
@@ -1381,20 +1287,16 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
-
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
 type                   | Integer
 default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-buffer-size 100000
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-buffer-size 100000{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
-
 
 | event-log-file |      |
 -----------------------|------
@@ -1403,13 +1305,10 @@ description            | Path to the event log file. {{% notice warning %}}
 {{% /notice %}}
 type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
-example                | {{< code shell >}}# Command line example
-sensu-backend start --event-log-file /var/log/sensu/events.log
-
-
-# /etc/sensu/backend.yml example
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
-
 
 ### Log rotation
 

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -28,11 +28,15 @@ To activate your license with sensuctl:
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
-Use sensuctl to view your license details at any time.
+Use sensuctl to view your license details at any time:
 
 {{< code shell >}}
-# Active license
 sensuctl license info
+{{< /code >}}
+
+For an active license, the response should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -43,9 +47,11 @@ Issuer:       Sensu, Inc.
 Issued:       2020-02-15 15:01:44 -0500 -0500
 Valid:        true
 Valid Until:  2021-02-15 00:00:00 -0800 -0800
+{{< /code >}}
 
-# No license found
-sensuctl license info
+This response means you do not have an active license:
+
+{{< code shell >}}
 Error: not found
 {{< /code >}}
 
@@ -67,10 +73,16 @@ If you use only 1,500 agent entities, you can have 8,500 proxy entities before y
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.
 
-In tabular format, the entity count and limit are included in the response title:
+In tabular format, the entity count and limit are included in the response title.
+To view license info in tabular format, run:
 
 {{< code shell >}}
 sensuctl license info --format tabular
+{{< /code >}}
+
+The response in tabular format should be similar to this example:
+
+{{< code shell >}}
 === You are currently using 10/100 total entities, 5/50 agent entities, and 5/50 proxy entities
 Account Name: Training Team - Sensu
 Account ID:   123
@@ -90,13 +102,22 @@ For example:
 === You are currently using 10/unlimited total entities, 5/unlimited agent entities, and 5/unlimited proxy entities
 {{< /code >}}
 
-In other formats (e.g. YAML and JSON), the entity count and limit are included as labels:
+To view license details in YAML or JSON, run:
+
+{{< language-toggle >}}
+{{< code shell "YML" >}}
+sensuctl license info --format yaml
+{{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl license info --format json
+{{< /code >}}
+{{< /language-toggle >}}
+
+In YAML and JSON formats, the entity count and limit are included as labels:
 
 {{< language-toggle >}}
 
-{{< code shell "YML" >}}
-sensuctl license info --format yaml
-
+{{< code yml >}}
 type: LicenseFile
 api_version: licensing/v2
 metadata:
@@ -111,9 +132,7 @@ spec:
 [...]
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl license info --format json
-
+{{< code json >}}
 {
   "type": "LicenseFile",
   "api_version": "licensing/v2",

--- a/content/sensu-go/6.3/sensuctl/environment-variables.md
+++ b/content/sensu-go/6.3/sensuctl/environment-variables.md
@@ -25,7 +25,7 @@ SENSU_TRUSTED_CA_FILE            Path to a trusted CA file if set in sensuctl
 SENSU_INSECURE_SKIP_TLS_VERIFY   Boolean value that can be set to skip TLS verification
 {{< /code >}}
 
-These examples demonstrate how to use sensuctl to export and set environment variables:
+These examples demonstrate how to use sensuctl to export and set environment variables and configure your shell:
 
 {{< language-toggle >}}
 
@@ -38,6 +38,7 @@ export SENSU_ACCESS_TOKEN_EXPIRES_AT="1567716187"
 export SENSU_REFRESH_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 export SENSU_TRUSTED_CA_FILE=""
 export SENSU_INSECURE_SKIP_TLS_VERIFY="true"
+eval $(sensuctl env)
 {{< /code >}}
 
 {{< code cmd >}}
@@ -49,6 +50,7 @@ SET SENSU_ACCESS_TOKEN_EXPIRES_AT=1567716676
 SET SENSU_REFRESH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x
 SET SENSU_TRUSTED_CA_FILE=
 SET SENSU_INSECURE_SKIP_TLS_VERIFY=true
+@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
 {{< /code >}}
 
 {{< code powershell >}}
@@ -60,23 +62,6 @@ $Env:SENSU_ACCESS_TOKEN_EXPIRES_AT = "1567716738"
 $Env:SENSU_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
 $Env:SENSU_TRUSTED_CA_FILE = ""
 $Env:SENSU_INSECURE_SKIP_TLS_VERIFY = "true"
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Run these commands to configure your shell:
-
-{{< language-toggle >}}
-
-{{< code bash >}}
-eval $(sensuctl env)
-{{< /code >}}
-
-{{< code cmd >}}
-@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
-{{< /code >}}
-
-{{< code powershell >}}
 & sensuctl env --shell powershell | Invoke-Expression
 {{< /code >}}
 


### PR DESCRIPTION
## Description
Part 2 -- Separates commands into individual code blocks and separates commands from responses throughout the docs to clarify instructions and make it easier for readers to copy and paste our code examples.

## Motivation and Context
Monitoring as code project