### PR TITLE
Separate commands and responses throughout docs - Part 3

### DIFF
--- a/content/sensu-go/6.0/operations/control-access/_index.md
+++ b/content/sensu-go/6.0/operations/control-access/_index.md
@@ -65,7 +65,11 @@ Use sensuctl to verify that your provider configuration was applied successfully
 
 {{< code shell >}}
 sensuctl auth list
+{{< /code >}}
 
+The response will list your authentication provider types and names:
+
+{{< code shell >}}
  Type     Name    
 ────── ────────── 
  ldap   openldap  

--- a/content/sensu-go/6.0/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.0/operations/control-access/use-apikeys.md
@@ -76,27 +76,67 @@ HTTP/1.1 200 OK
 To generate a new API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key grant admin
+sensuctl api-key grant admin
+{{< /code >}}
+
+The response will include the new API key:
+
+{{< code shell >}}
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key:
+To get information about an API key in YAML or JSON format:
 
-{{< code shell >}}
-$ sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include information about the API key in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: APIKey
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
+spec:
+  created_at: 1570718917
+  username: admin
+{{< /code >}}
+
+{{< code json >}}
 {
   "metadata": {
-    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2"
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
   },
   "username": "admin",
-  "created_at": 1570744117
+  "created_at": 1570718917
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 To get a list of all API keys:
 
 {{< code shell >}}
-$ sensuctl api-key list
+sensuctl api-key list
+{{< /code >}}
+
+The response lists all API keys along with the name of the user who created each key and the date and time each key was created:
+
+{{< code shell >}}
                   Name                   Username            Created At            
  ────────────────────────────────────── ────────── ─────────────────────────────── 
   7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2   admin      2019-10-10 14:48:37 -0700 PDT
@@ -105,8 +145,14 @@ $ sensuctl api-key list
 To revoke an API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+{{< /code >}}
+
+The response will confirm that the API key is deleted:
+
+{{< code shell >}}
 Deleted
 {{< /code >}}
+
 
 [1]: ../../../api/auth/

--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -80,12 +80,9 @@ The nodes are named `backend-1`, `backend-2` and `backend-3` with IP addresses `
 Follow the [Install Sensu](../install-sensu/) guide if you have not already done this.
 {{% /notice %}}
 
-**backend-1**
+**Store configuration for backend-1/10.0.0.1**
 
 {{< code yml >}}
-##
-# store configuration for backend-1/10.0.0.1
-##
 etcd-advertise-client-urls: "http://10.0.0.1:2379"
 etcd-listen-client-urls: "http://10.0.0.1:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -96,12 +93,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
-**backend-2**
+**Store configuration for backend-2/10.0.0.2**
 
 {{< code yml >}}
-##
-# store configuration for backend-2/10.0.0.2
-##
 etcd-advertise-client-urls: "http://10.0.0.2:2379"
 etcd-listen-client-urls: "http://10.0.0.2:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -112,12 +106,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
-**backend-3**
+**Store configuration for backend-3/10.0.0.3**
 
 {{< code yml >}}
-##
-# store configuration for backend-3/10.0.0.3
-##
 etcd-advertise-client-urls: "http://10.0.0.3:2379"
 etcd-listen-client-urls: "http://10.0.0.3:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -145,11 +136,9 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-{{< code yml >}}
-##
-# backend-url configuration for all agents connecting to cluster over ws
-##
+Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
 
+{{< code yml >}}
 backend-url:
   - "ws://10.0.0.1:8081"
   - "ws://10.0.0.2:8081"
@@ -170,7 +159,11 @@ Get cluster health status and etcd alarm information:
 
 {{< code shell >}}
 sensuctl cluster health
+{{< /code >}}
 
+The cluster health response will list the health status for each cluster member, similar to this example:
+
+{{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -234,7 +227,11 @@ List the ID, name, peer URLs, and client URLs of all nodes in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-list
+{{< /code >}}
 
+You will receive a sensuctl response that lists all cluster members:
+
+{{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
 a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
@@ -249,7 +246,11 @@ Remove a faulty or decommissioned member node from a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -258,11 +259,9 @@ Removed member 2f7ae42c315f8c2d from cluster
 To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
 For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
 
-In this example, cluster member `backend-4` is faulty:
+In this example, the response indicates that cluster member `backend-4` is faulty:
 
 {{< code shell >}}
-sensuctl cluster health
-
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -277,7 +276,11 @@ To continue this example, you will delete cluster member `backend-4` using its I
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+The response should indicate that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -303,7 +306,11 @@ Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was updated:
+
+{{< code shell >}}
 Updated member with ID c8f63ae435a5e6bf in cluster
 {{< /code >}}
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -306,9 +306,9 @@ Now that you have generated the required certificates and copied them to the app
 
 
 [1]: ../secure-sensu/
-[2]: ../secure-sensu/#secure-etcd-peer-communication
-[3]: ../secure-sensu/#secure-the-api-and-web-ui
-[4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
+[2]: ../secure-sensu/#etcd-peer-communication
+[3]: ../secure-sensu/#sensu-api-and-web-ui
+[4]: ../secure-sensu/#sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
 [7]: https://etcd.io/docs/v3.3.13/op-guide/security/

--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -58,37 +58,52 @@ In this example you'll walk through installing cfssl on a Linux system, which re
 
 This guide assumes that you'll install these certificates in the `/etc/sensu/tls` directory on each system.
 
+1. Download the cfssl executable:
 {{< code shell >}}
-
-# Download cfssl and cfssljson executables and install them in /usr/local/bin:
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /usr/local/bin/cfssl
+{{< /code >}}
+
+2. Download the cfssljson executable:
+{{< code shell >}}
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o /usr/local/bin/cfssljson
+{{< /code >}}
+
+3. Install the cfssl and cfssljson executables in /usr/local/bin::
+{{< code shell >}}
 sudo chmod +x /usr/local/bin/cfssl*
+{{< /code >}}
 
-# Verify executable version:
+4. Verify the cfssl executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssl version
+{{< /code >}}
 
-# Version: 1.4.1
-
-# Runtime: go1.12.12
+5. Verify the cfssljson executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssljson -version
-
-# Version: 1.4.1
-
-# Runtime: go1.12.12
 {{< /code >}}
 
 ### Create a Certificate Authority (CA)
 
-Create a CA with cfssl and cfssljson:
+Follow these steps to create a CA with cfssl and cfssljson:
 
+1. Create /etc/sensu/tls (which does not exist by default):
 {{< code shell >}}
-# Create /etc/sensu/tls -- does not exist by default
 mkdir -p /etc/sensu/tls
+{{< /code >}}
+
+2. Navigate to the new /etc/sensu/tls directory:
+{{< code shell >}}
 cd /etc/sensu/tls
-# Create the Certificate Authority
+{{< /code >}}
+
+3. Create the CA:
+{{< code shell >}}
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
-# Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
+{{< /code >}}
+
+4. Define signing parameters and profiles (the agent profile provides the "client auth" usage required for mTLS):
+{{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
@@ -127,20 +142,31 @@ backend-3        | 10.0.0.3   | backend-3.example.com              | localhost, 
 
 Note that the additional names for localhost and 127.0.0.1 are added here for convenience and not strictly required.
 
-Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend:
+Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend.
+
+- The values provided for the ADDRESS variable will be used to populate the certificate's SAN records.
+For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable.
+- The value provided for the NAME variable will be used to populate the certificate's CN record.
+
+**backend-1**
 
 {{< code shell >}}
-# Value provided for the NAME variable will be used to populate the certificate's CN record
-# Values provided in the ADDRESS variable will be used to populate the certificate's SAN records
-# For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable
 export ADDRESS=localhost,127.0.0.1,10.0.0.1,backend-1
 export NAME=backend-1.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-2**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.2,backend-2
 export NAME=backend-2.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-3**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.3,backend-3
 export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
@@ -157,22 +183,25 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:
+Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:.
+For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -201,11 +230,10 @@ filename           | description                  | required on agent?  |
 `agent-key.pem`    | Backend server private key   | {{< check >}}       |
 `agent.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system:
+Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system.
+To continue the example, the directory listing of /etc/sensu/tls on backend-1 should now include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
@@ -214,11 +242,15 @@ Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding b
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -228,7 +260,7 @@ Before you move on, make sure you have copied the certificates and keys to each 
 
 - [Copy the Certificate Authority (CA) root certificate file][11], `ca.pem`, to each agent and backend.
 - [Copy all backend PEM files][12] to their corresponding backend systems.
-- [Copy all agent PEM files][13]
+- [Copy all agent PEM files][13].
 
 We also recommend installing the CA root certificate in the trust store of both your Sensu systems and those systems used by operators to manage Sensu. 
 
@@ -256,8 +288,7 @@ sudo update-ca-trust
 Import the root CA certificate on the Mac.
 Double-click the root CA certificate to open it in Keychain Access.
 The root CA certificate appears in login.
-Copy the root CA certificate to System.
-You must copy the certificate to System to ensure that it is trusted by all users and local system processes.
+Copy the root CA certificate to System to ensure that it is trusted by all users and local system processes.
 Open the root CA certificate, expand Trust, select Use System Defaults, and save your changes.
 Reopen the root CA certificate, expand Trust, select Always Trust, and save your changes.
 Delete the root CA certificate from login.

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -15,11 +15,13 @@ menu:
 
 As with any piece of software, it is critical to minimize any attack surface the software exposes.
 Sensu is no different.
-This guide describes the components you need to secure to make Sensu production-ready.
 
-Before you can use this guide, you must have [generated the certificates][12] you will need to secure Sensu.
+This reference describes the components you need to secure to make Sensu production-ready, including etcd peer communication, the Sensu API and web UI, and Sensu agent-to-server communication.
+It also describes agent mutual transport layer security (mTLS) authentication, which is required for [secrets management][1].
 
-## Secure etcd peer communication
+Before you can use this reference, you must [generate the certificates][12] you will need to secure Sensu.
+
+## Etcd peer communication
 
 {{% notice warning %}}
 **WARNING**: You must update the default configuration for Sensu's embedded etcd with an explicit, non-default configuration to secure etcd communication in transit.
@@ -27,12 +29,9 @@ If you do not properly configure secure etcd communication, your Sensu configura
 {{% /notice %}}
 
 You can secure etcd peer communication via the configuration at `/etc/sensu/backend.yml`.
-Here are the parameters you'll need to configure:
+Here are the backend store parameters you'll need to configure:
 
 {{< code yml >}}
-##
-# backend store configuration
-##
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
@@ -55,42 +54,34 @@ To properly secure etcd communication, replace the default parameter values in y
 In addition, set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate.
 Because etcd does not require authentication by default, you must set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
-## Secure the API and web UI
+## Sensu API and web UI
 
 The Sensu Go Agent API, HTTP API, and web UI use a common stanza in `/etc/sensu/backend.yml` to provide the certificate, key, and CA file needed to provide secure communication.
-Here are the attributes you'll need to configure.
 
 {{% notice note %}}
 **NOTE**: By changing these parameters, the server will communicate using transport layer security (TLS) and expect agents that connect to it to use the WebSocket secure protocol.
-For communication to continue, you must complete the steps in this section **and** in the [Secure Sensu agent-to-server communication](#secure-sensu-agent-to-server-communication) section.
+For communication to continue, you must complete the configuration in this section **and** in the [Sensu agent-to-server communication](#sensu-agent-to-server-communication) section.
 {{% /notice %}}
 
+Here are the backend secure sockets layer (SSL) attributes you'll need to configure.
+
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
 insecure-skip-tls-verify: false
 {{< /code >}}
 
-Providing these cert-file and key-file parameters will cause the Agent Websocket API and HTTP API to serve requests over SSL/TLS (https).
-As a result, you will also need to specify `https://` schema for the `api-url` parameter:
+Providing these cert-file and key-file parameters will cause the agent WebSocket API and HTTP API to serve requests over SSL/TLS (https).
+As a result, you will also need to specify `https://` schema for the `api-url` parameter for backend API configuration:
 
 {{< code yml >}}
-##
-# backend api configuration
-##
 api-url: "https://localhost:8080"
 {{< /code >}}
 
-You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters:
+You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters for backend SSL configuration:
 
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
@@ -103,32 +94,24 @@ In this example, we provide the path to the cert, key, and CA file.
 After you restart the `sensu-backend` service, the parameters will load and you will able to access the web UI at https://localhost:3000.
 Configuring these attributes will also ensure that agents can communicate securely.
 
-## Secure Sensu agent-to-server communication
+## Sensu agent-to-server communication
 
 {{% notice note %}}
 **NOTE**: If you change the agent configuration to communicate via WebSocket Secure protocol, the agent will no longer communicate over a plaintext connection.
-For communication to continue, you must complete the steps in this section **and** in the [Secure the API and web UI](#secure-the-api-and-web-ui) section.
+For communication to continue, you must complete the steps in this section **and** [secure the Sensu API and web UI](#sensu-api-and-web-ui).
 {{% /notice %}}
 
 By default, an agent uses the insecure `ws://` transport.
-Here's an example from `/etc/sensu/agent.yml`:
+Here's an example for agent configuration in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "ws://127.0.0.1:8081"
 {{< /code >}}
 
-To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema:
+To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "wss://127.0.0.1:8081"
 {{< /code >}}
@@ -170,10 +153,15 @@ For this use case, create a user that matches the Common Name (CN) of the agent'
 To ensure that agents with incorrect CN fields can't access the backend, remove the default `system:agents` group.
 {{% /notice %}}
 
-To view a certificate's CN with openssl:
+To view a certificate's CN with openssl, run:
 
 {{< code bash >}}
-$ openssl x509 -in client.pem -text -noout
+openssl x509 -in client.pem -text -noout
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code bash >}}
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -193,21 +181,16 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modify the backend and agent configuration:
+After you create backend and agent certificates, modify the backend configuration:
 
 {{< code yml >}}
-##
-# backend configuration
-##
 agent-auth-cert-file: "/path/to/backend-1.pem"
 agent-auth-key-file: "/path/to/backend-1-key.pem"
 agent-auth-trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 
+Modify the agent configuration also:
 {{< code yml >}}
-##
-# agent configuration
-##
 cert-file: "/path/to/agent.pem"
 key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"

--- a/content/sensu-go/6.0/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/use-federation.md
@@ -259,10 +259,14 @@ For a consistent experience, repeat the `ClusterRoleBinding` example in this gui
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
 To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+
+{{< code shell >}}
+sensuctl cluster-role-binding info federation-viewer-readonly
+{{< /code >}}
+
 You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
 
 {{< code shell >}}
-$ sensuctl cluster-role-binding info federation-viewer-readonly
 === federation-viewer-readonly
 Name:         federation-viewer-readonly
 Cluster Role: view

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -3,10 +3,10 @@ title: "Migrate from Sensu Core and Sensu Enterprise to Sensu Go"
 linkTitle: "Migrate from Sensu Core and Sensu Enterprise"
 description: "Sensu Go includes important changes to all parts of Sensu as well as many powerful commercial features to make monitoring easier to build, scale to Sensu Go from Sensu Core and Sensu Enterprise. Follow this guide to migrate from Sensu Core or Sensu Enterprise to Sensu Go."
 weight: 20
-version: "6.1"
+version: "6.0"
 product: "Sensu Go"
 menu:
-  sensu-go-6.1:
+  sensu-go-6.0:
     parent: maintain-sensu
 ---
 
@@ -207,17 +207,15 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56].
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 {{< code yml >}}
-# agent configuration: /etc/sensu.agent.yml
-...
 api-port: 4041
 socket-port: 4030
-...
 {{< /code >}}
+
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 Sensu should now be installed and functional. The next step is to translate your Sensu Core configuration to Sensu Go.
 
@@ -227,21 +225,27 @@ Use t [Sensu Translator][18] command line tool to transfer your Sensu Core check
 
 #### 1. Run the translator
 
-Install and run the translator.
+Install dependencies:
 
 {{< code shell >}}
-# Install dependencies
 yum install -q -y rubygems ruby-devel
+{{< /code >}}
 
-# Install sensu-translator
+Install the Sensu translator:
+
+{{< code shell >}}
 gem install sensu-translator
+{{< /code >}}
 
-# Translate all config in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated
-# Option: translate your config in sections according to resource type
+Run the Sensu translator to translate all configuration in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated:
+
+{{< code shell >}}
 sensu-translator -d /etc/sensu/conf.d -o /sensu_config_translated
 {{< /code >}}
 
-If translation is successful, you should see a few callouts followed by `DONE!`.
+As an option, you can also translate your configuration in sections according to resource type.
+
+If translation is successful, you should see a few callouts followed by `DONE!`, similar to this example:
 
 {{< code shell >}}
 Sensu 1.x filter translation is not yet supported
@@ -325,8 +329,9 @@ As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used. Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61]. Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
-{{< code shell >}}
-# Sensu Core hourly filter
+Sensu Core hourly filter:
+
+{{< code json >}}
 {
   "filters": {
     "recurrences": {
@@ -336,19 +341,22 @@ First, review your Core handlers to identify which filters are being used. Then,
     }
   }
 }
+{{< /code >}}
 
-# Sensu Go hourly filter
-  {
-    "metadata": {
-      "name": "hourly",
-      "namespace": "default"
-    },
-    "action": "allow",
-    "expressions": [
-      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-    ],
-    "runtime_assets": null
-  }
+Sensu Go hourly filter:
+
+{{< code json >}}
+{
+  "metadata": {
+    "name": "hourly",
+    "namespace": "default"
+  },
+  "action": "allow",
+  "expressions": [
+    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+  ],
+  "runtime_assets": null
+}
 {{< /code >}}
 
 #### 4. Translate handlers
@@ -383,17 +391,23 @@ _PRO TIP: `sensuctl create` (and `sensuctl delete`) are powerful tools to help y
 
 Access your Sensu Go config using the [Sensu API][17].
 
+Set up a local API testing environment by saving your Sensu credentials and token as environment variables.
+This command requires curl and jq.
+
 {{< code shell >}}
-# Set up a local API testing environment by saving your Sensu credentials
-# and token as environment variables. Requires curl and jq.
 export SENSU_USER=admin && SENSU_PASS=P@ssw0rd!
-
 export SENSU_TOKEN=`curl -XGET -u "$SENSU_USER:$SENSU_PASS" -s http://localhost:8080/auth | jq -r ".access_token"`
+{{< /code >}}
 
-# Return list of all configured checks
+Return a list of all configured checks:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
+{{< /code >}}
 
-# Return list of all configured handlers
+Return a list of all configured handlers:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
 {{< /code >}}
 

--- a/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
@@ -41,10 +41,15 @@ For help with restarting a service, see the [agent reference][5] or [backend ref
 
 #### Increment log level verbosity
 
-Use these commands to increment the log level verbosity at runtime:
+To increment the log level verbosity at runtime for the backend, run:
 
 {{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-backend)
+{{< /code >}}
+
+To increment the log level verbosity at runtime for the agent, run:
+
+{{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-agent)
 {{< /code >}}
 
@@ -61,17 +66,43 @@ To capture these log messages to disk or another logging facility, Sensu service
 For example, logs are sent to the journald when systemd is the service manager, whereas log messages are redirected to `/var/log/sensu` when running under sysv init schemes.
 If you are running systemd as your service manager and would rather have logs written to `/var/log/sensu/`, see [forwarding logs from journald to syslog][11].
 
-The following table lists the common targets for logging and example commands for following those logs.
-You may substitute the name of the desired service (e.g. `backend` or `agent`) for the `${service}` variable.
+For journald targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
 
-| Platform     | Version           | Target | Command to follow log |
-|--------------|-------------------|--------------|-----------------------------------------------|
-| RHEL/Centos  | >= 7       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| RHEL/Centos  | <= 6       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Ubuntu       | >= 15.04   | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Ubuntu       | <= 14.10   | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Debian       | >= 8       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Debian       | <= 7       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS >= 7" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu >= 15.04" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian >= 8" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+For log file targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
+
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS <= 6" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu <= 14.10" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian <= 7" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: Platform versions are listed for reference only and do not supersede the documented [supported platforms](../../../platforms).
@@ -257,15 +288,15 @@ An improperly applied asset filter can prevent the asset from being downloaded b
 
 {{< code json >}}
 {
-    "asset": "check-disk-space",
-    "component": "asset-manager",
-    "entity": "sensu-centos",
-    "filters": [
-        "true == false"
-    ],
-    "level": "debug",
-    "msg": "entity not filtered, not installing asset",
-    "time": "2019-09-12T18:28:05Z"
+  "asset": "check-disk-space",
+  "component": "asset-manager",
+  "entity": "sensu-centos",
+  "filters": [
+    "true == false"
+  ],
+  "level": "debug",
+  "msg": "entity not filtered, not installing asset",
+  "time": "2019-09-12T18:28:05Z"
 }
 {{< /code >}}
 
@@ -483,21 +514,35 @@ To use etcdctl to investigate etcd cluster and data storage issues, first run th
 {{< code shell >}}
 export ETCDCTL_API=3
 export ETCDCTL_CACERT=/etc/sensu/ca.pem
-# skip ETCDCTL_CERT and ETCDCTL_KEY, unless your etcd uses client certificate authentication
-# export ETCDCTL_CERT=/etc/sensu/cert.pem
-# export ETCDCTL_KEY=/etc/sensu/key.pem
 export ETCDCTL_ENDPOINTS="https://backend01:2379,https://backend02:2379,https://backend03:2379"
+{{< /code >}}
+
+If your etcd uses client certificate authentication, run these commands too:
+
+{{< code shell >}}
+export ETCDCTL_CERT=/etc/sensu/cert.pem
+export ETCDCTL_KEY=/etc/sensu/key.pem
 {{< /code >}}
 
 ### View cluster status and alarms
 
 Use the commands listed here to retrieve etcd cluster status and list and clear alarms.
+
+To retrieve etcd cluster status:
+
 {{< code shell >}}
-# get status
 etcdctl endpoint status
-# list alarms
+{{< /code >}}
+
+To retrieve a list of etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm list
-# clear alarms
+{{< /code >}}
+
+To clear etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm dearm
 {{< /code >}}
 
@@ -507,27 +552,41 @@ The etcd default maximum database size is 2 GB.
 If you suspect your etcd database exceeds the maximum size, run this command to confirm cluster size:
 
 {{< code shell >}}
-# get current status with database size
 etcdctl endpoint status
+{{< /code >}}
+
+The response will list the current cluster status and database size:
+
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 2.1GB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 2.1GB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 2.1GB, false, 144, 18619245
 {{< /code >}}
 
-To restore an etcd cluster with a database size that exceeds 2 GB, run these commands:
+To restore an etcd cluster with a database size that exceeds 2 GB:
 
+1. Get the current revision number:
 {{< code shell >}}
-# get current revision number
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
+{{< /code >}}
 
-# compact to revision, substitute revision obtained above for $rev
+2. Compact to revision and substitute the crrent revision for `$rev`:
+{{< code shell >}}
 etcdctl compact $rev
+{{< /code >}}
 
-# defrag to free space
+3. Defragment to free up space:
+{{< code shell >}}
 etcdctl defrag
+{{< /code >}}
 
-# confirm effective
+4. Confirm that the cluster is restored:
+{{< code shell >}}
 etcdctl endpoint status
+{{< /code >}}
+
+   The response should list the current cluster status and database size:
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 1.0 MB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
@@ -544,7 +603,7 @@ Sensu will attempt to recover from these conditions when it can, but this may no
 
 To maximize Sensu Go performance, we recommend that you:
  * Follow our [recommended backend hardware configuration][19].
- * Immplement [documented etcd system tuning practices][14].
+ * Implement [documented etcd system tuning practices][14].
  * [Benchmark your etcd storage volume][15] to establish baseline IOPS for your system.
  * [Scale event storage using PostgreSQL][16] to reduce the overall volume of etcd transactions.
 

--- a/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
@@ -21,39 +21,41 @@ You will not be able to downgrade to a Sensu 5.x version after you upgrade your 
 To upgrade your Sensu Go 5.x deployment to 6.0:
 
 1. [Install][1] the 6.0 packages or Docker image.
-2. Restart the services.
+2. Restart the Sensu agent.
    
-   {{% notice note %}}
+ {{% notice note %}}
    **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
-   {{% /notice %}}
-   
-   {{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+{{% /notice %}}
 
-# Restart the Sensu backend
+  {{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+3. Restart the Sensu backend.
+
+  {{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
-3. Run a single upgrade command on one your Sensu backends to migrate the cluster:
+4. Run a single upgrade command on one your Sensu backends to migrate the cluster:
 
-   {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade
 {{< /code >}}
 
    - Add the `--skip-confirm` flag to skip the confirmation in step 4 and immediately run the upgrade command.
 
-    {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade --skip-confirm
 {{< /code >}}
 
-   {{% notice note %}}
+  {{% notice note %}}
    **NOTE**: If you are deploying a new Sensu 6.0 cluster rather than upgrading from 5.x, you do not need to run the `sensu-backend upgrade` command.
-   {{% /notice %}}
+{{% /notice %}}
 
-4. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
+5. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
 
-5. Wait a few seconds for the upgrade command to run.
+6. Wait a few seconds for the upgrade command to run.
 
 You may notice some inconsistencies in your entity list until the cluster finishes upgrading.
 Despite this, your cluster will continue to publish standard check requests and process events.
@@ -70,11 +72,15 @@ Then, restart the services.
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -122,14 +128,17 @@ See the [backend reference][2] for more information about stopping and starting 
 For Sensu backend binaries, the default `state-dir` in 5.1.0 is now `/var/lib/sensu/sensu-backend` instead of `/var/lib/sensu`.
 To upgrade your Sensu backend binary to 5.1.0, first [download the latest version][1].
 Then, make sure the `/etc/sensu/backend.yml` configuration file specifies a `state-dir`.
-To continue using `/var/lib/sensu` as the `state-dir`, add the following configuration to `/etc/sensu/backend.yml`.
+To continue using `/var/lib/sensu` as the `state-dir` to store backend data, add the following configuration to `/etc/sensu/backend.yml`:
 
 {{< code yml >}}
-# /etc/sensu/backend.yml configuration to store backend data at /var/lib/sensu
 state-dir: "/var/lib/sensu"
 {{< /code >}}
 
-Then restart the backend.
+Then restart the backend:
+
+{{< code shell >}}
+sudo service sensu-backend restart
+{{< /code >}}
 
 
 [1]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.0/operations/monitor-sensu/log-sensu-systemd.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/log-sensu-systemd.md
@@ -30,26 +30,31 @@ Next, set up rsyslog to write the logging data received from journald to `/var/l
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
 The `sensu-backend` is not required if you're only setting up log forwarding for the `sensu-agent` service.
 
+1. For the sensu-backend service, in /etc/rsyslog.d/99-sensu-backend.conf, add:
 {{< code shell >}}
-# For the sensu-backend service, inside /etc/rsyslog.d/99-sensu-backend.conf
 if $programname == 'sensu-backend' then {
         /var/log/sensu/sensu-backend.log
         ~
 }
+{{< /code >}}
 
-# For the sensu-agent service, inside /etc/rsyslog.d/99-sensu-agent.conf
+2. For the sensu-agent service, in /etc/rsyslog.d/99-sensu-agent.conf, add:
+{{< code shell >}}
 if $programname == 'sensu-agent' then {
         /var/log/sensu/sensu-agent.log
         ~
 }
 {{< /code >}}
 
-**On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
+3. **On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
 
-Restart rsyslog and journald to apply the new configuration:
-
+4. Restart journald:
 {{< code shell>}}
 systemctl restart systemd-journald
+{{< /code>}}
+
+5. Restart rsyslog to apply the new configuration:
+{{< code shell>}}
 systemctl restart rsyslog
 {{< /code>}}
 
@@ -66,8 +71,8 @@ These examples rotate the log files `/var/log/sensu/sensu-agent.log` and `/var/l
 The last seven rotated logs are kept and compressed, with the exception of the most recent log.
 After rotation, `rsyslog` is restarted to ensure logging is written to a new file and not the most recent rotated file.
 
+1. In /etc/logrotate.d/sensu-agent.conf, add:
 {{< code shell>}}
-# Inside /etc/logrotate.d/sensu-agent.conf
 /var/log/sensu/sensu-agent.log {
     daily
     rotate 7
@@ -78,8 +83,10 @@ After rotation, `rsyslog` is restarted to ensure logging is written to a new fil
       /bin/systemctl restart rsyslog
     endscript
 }
+{{< /code>}}
 
-# Inside /etc/logrotate.d/sensu-backend.conf
+2. In /etc/logrotate.d/sensu-backend.conf, add:
+{{< code shell>}}
 /var/log/sensu/sensu-backend.log {
     daily
     rotate 7

--- a/content/sensu-go/6.1/operations/control-access/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/_index.md
@@ -65,7 +65,11 @@ Use sensuctl to verify that your provider configuration was applied successfully
 
 {{< code shell >}}
 sensuctl auth list
+{{< /code >}}
 
+The response will list your authentication provider types and names:
+
+{{< code shell >}}
  Type     Name    
 ────── ────────── 
  ldap   openldap  

--- a/content/sensu-go/6.1/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.1/operations/control-access/use-apikeys.md
@@ -76,27 +76,67 @@ HTTP/1.1 200 OK
 To generate a new API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key grant admin
+sensuctl api-key grant admin
+{{< /code >}}
+
+The response will include the new API key:
+
+{{< code shell >}}
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key:
+To get information about an API key in YAML or JSON format:
 
-{{< code shell >}}
-$ sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include information about the API key in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: APIKey
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
+spec:
+  created_at: 1570718917
+  username: admin
+{{< /code >}}
+
+{{< code json >}}
 {
   "metadata": {
-    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2"
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
   },
   "username": "admin",
-  "created_at": 1570744117
+  "created_at": 1570718917
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 To get a list of all API keys:
 
 {{< code shell >}}
-$ sensuctl api-key list
+sensuctl api-key list
+{{< /code >}}
+
+The response lists all API keys along with the name of the user who created each key and the date and time each key was created:
+
+{{< code shell >}}
                   Name                   Username            Created At            
  ────────────────────────────────────── ────────── ─────────────────────────────── 
   7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2   admin      2019-10-10 14:48:37 -0700 PDT
@@ -105,8 +145,14 @@ $ sensuctl api-key list
 To revoke an API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+{{< /code >}}
+
+The response will confirm that the API key is deleted:
+
+{{< code shell >}}
 Deleted
 {{< /code >}}
+
 
 [1]: ../../../api/auth/

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -80,12 +80,9 @@ The nodes are named `backend-1`, `backend-2` and `backend-3` with IP addresses `
 Follow the [Install Sensu](../install-sensu/) guide if you have not already done this.
 {{% /notice %}}
 
-**backend-1**
+**Store configuration for backend-1/10.0.0.1**
 
 {{< code yml >}}
-##
-# store configuration for backend-1/10.0.0.1
-##
 etcd-advertise-client-urls: "http://10.0.0.1:2379"
 etcd-listen-client-urls: "http://10.0.0.1:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -96,12 +93,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
-**backend-2**
+**Store configuration for backend-2/10.0.0.2**
 
 {{< code yml >}}
-##
-# store configuration for backend-2/10.0.0.2
-##
 etcd-advertise-client-urls: "http://10.0.0.2:2379"
 etcd-listen-client-urls: "http://10.0.0.2:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -112,12 +106,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
-**backend-3**
+**Store configuration for backend-3/10.0.0.3**
 
 {{< code yml >}}
-##
-# store configuration for backend-3/10.0.0.3
-##
 etcd-advertise-client-urls: "http://10.0.0.3:2379"
 etcd-listen-client-urls: "http://10.0.0.3:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -145,11 +136,9 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-{{< code yml >}}
-##
-# backend-url configuration for all agents connecting to cluster over ws
-##
+Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
 
+{{< code yml >}}
 backend-url:
   - "ws://10.0.0.1:8081"
   - "ws://10.0.0.2:8081"
@@ -170,7 +159,11 @@ Get cluster health status and etcd alarm information:
 
 {{< code shell >}}
 sensuctl cluster health
+{{< /code >}}
 
+The cluster health response will list the health status for each cluster member, similar to this example:
+
+{{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -234,7 +227,11 @@ List the ID, name, peer URLs, and client URLs of all nodes in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-list
+{{< /code >}}
 
+You will receive a sensuctl response that lists all cluster members:
+
+{{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
 a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
@@ -249,7 +246,11 @@ Remove a faulty or decommissioned member node from a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -258,11 +259,9 @@ Removed member 2f7ae42c315f8c2d from cluster
 To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
 For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
 
-In this example, cluster member `backend-4` is faulty:
+In this example, the response indicates that cluster member `backend-4` is faulty:
 
 {{< code shell >}}
-sensuctl cluster health
-
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -277,7 +276,11 @@ To continue this example, you will delete cluster member `backend-4` using its I
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+The response should indicate that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -303,7 +306,11 @@ Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was updated:
+
+{{< code shell >}}
 Updated member with ID c8f63ae435a5e6bf in cluster
 {{< /code >}}
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -306,9 +306,9 @@ Now that you have generated the required certificates and copied them to the app
 
 
 [1]: ../secure-sensu/
-[2]: ../secure-sensu/#secure-etcd-peer-communication
-[3]: ../secure-sensu/#secure-the-api-and-web-ui
-[4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
+[2]: ../secure-sensu/#etcd-peer-communication
+[3]: ../secure-sensu/#sensu-api-and-web-ui
+[4]: ../secure-sensu/#sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
 [7]: https://etcd.io/docs/v3.3.13/op-guide/security/

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -58,37 +58,52 @@ In this example you'll walk through installing cfssl on a Linux system, which re
 
 This guide assumes that you'll install these certificates in the `/etc/sensu/tls` directory on each system.
 
+1. Download the cfssl executable:
 {{< code shell >}}
-
-# Download cfssl and cfssljson executables and install them in /usr/local/bin:
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /usr/local/bin/cfssl
+{{< /code >}}
+
+2. Download the cfssljson executable:
+{{< code shell >}}
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o /usr/local/bin/cfssljson
+{{< /code >}}
+
+3. Install the cfssl and cfssljson executables in /usr/local/bin::
+{{< code shell >}}
 sudo chmod +x /usr/local/bin/cfssl*
+{{< /code >}}
 
-# Verify executable version:
+4. Verify the cfssl executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssl version
+{{< /code >}}
 
-# Version: 1.4.1
-
-# Runtime: go1.12.12
+5. Verify the cfssljson executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssljson -version
-
-# Version: 1.4.1
-
-# Runtime: go1.12.12
 {{< /code >}}
 
 ### Create a Certificate Authority (CA)
 
-Create a CA with cfssl and cfssljson:
+Follow these steps to create a CA with cfssl and cfssljson:
 
+1. Create /etc/sensu/tls (which does not exist by default):
 {{< code shell >}}
-# Create /etc/sensu/tls -- does not exist by default
 mkdir -p /etc/sensu/tls
+{{< /code >}}
+
+2. Navigate to the new /etc/sensu/tls directory:
+{{< code shell >}}
 cd /etc/sensu/tls
-# Create the Certificate Authority
+{{< /code >}}
+
+3. Create the CA:
+{{< code shell >}}
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
-# Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
+{{< /code >}}
+
+4. Define signing parameters and profiles (the agent profile provides the "client auth" usage required for mTLS):
+{{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
@@ -127,20 +142,31 @@ backend-3        | 10.0.0.3   | backend-3.example.com              | localhost, 
 
 Note that the additional names for localhost and 127.0.0.1 are added here for convenience and not strictly required.
 
-Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend:
+Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend.
+
+- The values provided for the ADDRESS variable will be used to populate the certificate's SAN records.
+For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable.
+- The value provided for the NAME variable will be used to populate the certificate's CN record.
+
+**backend-1**
 
 {{< code shell >}}
-# Value provided for the NAME variable will be used to populate the certificate's CN record
-# Values provided in the ADDRESS variable will be used to populate the certificate's SAN records
-# For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable
 export ADDRESS=localhost,127.0.0.1,10.0.0.1,backend-1
 export NAME=backend-1.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-2**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.2,backend-2
 export NAME=backend-2.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-3**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.3,backend-3
 export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
@@ -157,22 +183,25 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:
+Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:.
+For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -201,11 +230,10 @@ filename           | description                  | required on agent?  |
 `agent-key.pem`    | Backend server private key   | {{< check >}}       |
 `agent.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system:
+Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system.
+To continue the example, the directory listing of /etc/sensu/tls on backend-1 should now include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
@@ -214,11 +242,15 @@ Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding b
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -228,7 +260,7 @@ Before you move on, make sure you have copied the certificates and keys to each 
 
 - [Copy the Certificate Authority (CA) root certificate file][11], `ca.pem`, to each agent and backend.
 - [Copy all backend PEM files][12] to their corresponding backend systems.
-- [Copy all agent PEM files][13]
+- [Copy all agent PEM files][13].
 
 We also recommend installing the CA root certificate in the trust store of both your Sensu systems and those systems used by operators to manage Sensu. 
 
@@ -256,8 +288,7 @@ sudo update-ca-trust
 Import the root CA certificate on the Mac.
 Double-click the root CA certificate to open it in Keychain Access.
 The root CA certificate appears in login.
-Copy the root CA certificate to System.
-You must copy the certificate to System to ensure that it is trusted by all users and local system processes.
+Copy the root CA certificate to System to ensure that it is trusted by all users and local system processes.
 Open the root CA certificate, expand Trust, select Use System Defaults, and save your changes.
 Reopen the root CA certificate, expand Trust, select Always Trust, and save your changes.
 Delete the root CA certificate from login.

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -15,11 +15,13 @@ menu:
 
 As with any piece of software, it is critical to minimize any attack surface the software exposes.
 Sensu is no different.
-This guide describes the components you need to secure to make Sensu production-ready.
 
-Before you can use this guide, you must have [generated the certificates][12] you will need to secure Sensu.
+This reference describes the components you need to secure to make Sensu production-ready, including etcd peer communication, the Sensu API and web UI, and Sensu agent-to-server communication.
+It also describes agent mutual transport layer security (mTLS) authentication, which is required for [secrets management][1].
 
-## Secure etcd peer communication
+Before you can use this reference, you must [generate the certificates][12] you will need to secure Sensu.
+
+## Etcd peer communication
 
 {{% notice warning %}}
 **WARNING**: You must update the default configuration for Sensu's embedded etcd with an explicit, non-default configuration to secure etcd communication in transit.
@@ -27,12 +29,9 @@ If you do not properly configure secure etcd communication, your Sensu configura
 {{% /notice %}}
 
 You can secure etcd peer communication via the configuration at `/etc/sensu/backend.yml`.
-Here are the parameters you'll need to configure:
+Here are the backend store parameters you'll need to configure:
 
 {{< code yml >}}
-##
-# backend store configuration
-##
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
@@ -55,42 +54,34 @@ To properly secure etcd communication, replace the default parameter values in y
 In addition, set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate.
 Because etcd does not require authentication by default, you must set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
-## Secure the API and web UI
+## Sensu API and web UI
 
 The Sensu Go Agent API, HTTP API, and web UI use a common stanza in `/etc/sensu/backend.yml` to provide the certificate, key, and CA file needed to provide secure communication.
-Here are the attributes you'll need to configure.
 
 {{% notice note %}}
 **NOTE**: By changing these parameters, the server will communicate using transport layer security (TLS) and expect agents that connect to it to use the WebSocket secure protocol.
-For communication to continue, you must complete the steps in this section **and** in the [Secure Sensu agent-to-server communication](#secure-sensu-agent-to-server-communication) section.
+For communication to continue, you must complete the configuration in this section **and** in the [Sensu agent-to-server communication](#sensu-agent-to-server-communication) section.
 {{% /notice %}}
 
+Here are the backend secure sockets layer (SSL) attributes you'll need to configure.
+
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
 insecure-skip-tls-verify: false
 {{< /code >}}
 
-Providing these cert-file and key-file parameters will cause the Agent Websocket API and HTTP API to serve requests over SSL/TLS (https).
-As a result, you will also need to specify `https://` schema for the `api-url` parameter:
+Providing these cert-file and key-file parameters will cause the agent WebSocket API and HTTP API to serve requests over SSL/TLS (https).
+As a result, you will also need to specify `https://` schema for the `api-url` parameter for backend API configuration:
 
 {{< code yml >}}
-##
-# backend api configuration
-##
 api-url: "https://localhost:8080"
 {{< /code >}}
 
-You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters:
+You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters for backend SSL configuration:
 
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
@@ -103,32 +94,24 @@ In this example, we provide the path to the cert, key, and CA file.
 After you restart the `sensu-backend` service, the parameters will load and you will able to access the web UI at https://localhost:3000.
 Configuring these attributes will also ensure that agents can communicate securely.
 
-## Secure Sensu agent-to-server communication
+## Sensu agent-to-server communication
 
 {{% notice note %}}
 **NOTE**: If you change the agent configuration to communicate via WebSocket Secure protocol, the agent will no longer communicate over a plaintext connection.
-For communication to continue, you must complete the steps in this section **and** in the [Secure the API and web UI](#secure-the-api-and-web-ui) section.
+For communication to continue, you must complete the steps in this section **and** [secure the Sensu API and web UI](#sensu-api-and-web-ui).
 {{% /notice %}}
 
 By default, an agent uses the insecure `ws://` transport.
-Here's an example from `/etc/sensu/agent.yml`:
+Here's an example for agent configuration in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "ws://127.0.0.1:8081"
 {{< /code >}}
 
-To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema:
+To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "wss://127.0.0.1:8081"
 {{< /code >}}
@@ -170,10 +153,15 @@ For this use case, create a user that matches the Common Name (CN) of the agent'
 To ensure that agents with incorrect CN fields can't access the backend, remove the default `system:agents` group.
 {{% /notice %}}
 
-To view a certificate's CN with openssl:
+To view a certificate's CN with openssl, run:
 
 {{< code bash >}}
-$ openssl x509 -in client.pem -text -noout
+openssl x509 -in client.pem -text -noout
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code bash >}}
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -193,21 +181,16 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modify the backend and agent configuration:
+After you create backend and agent certificates, modify the backend configuration:
 
 {{< code yml >}}
-##
-# backend configuration
-##
 agent-auth-cert-file: "/path/to/backend-1.pem"
 agent-auth-key-file: "/path/to/backend-1-key.pem"
 agent-auth-trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 
+Modify the agent configuration also:
 {{< code yml >}}
-##
-# agent configuration
-##
 cert-file: "/path/to/agent.pem"
 key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"

--- a/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
@@ -259,10 +259,14 @@ For a consistent experience, repeat the `ClusterRoleBinding` example in this gui
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
 To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+
+{{< code shell >}}
+sensuctl cluster-role-binding info federation-viewer-readonly
+{{< /code >}}
+
 You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
 
 {{< code shell >}}
-$ sensuctl cluster-role-binding info federation-viewer-readonly
 === federation-viewer-readonly
 Name:         federation-viewer-readonly
 Cluster Role: view

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -207,17 +207,15 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56].
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 {{< code yml >}}
-# agent configuration: /etc/sensu.agent.yml
-...
 api-port: 4041
 socket-port: 4030
-...
 {{< /code >}}
+
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 Sensu should now be installed and functional. The next step is to translate your Sensu Core configuration to Sensu Go.
 
@@ -227,21 +225,27 @@ Use t [Sensu Translator][18] command line tool to transfer your Sensu Core check
 
 #### 1. Run the translator
 
-Install and run the translator.
+Install dependencies:
 
 {{< code shell >}}
-# Install dependencies
 yum install -q -y rubygems ruby-devel
+{{< /code >}}
 
-# Install sensu-translator
+Install the Sensu translator:
+
+{{< code shell >}}
 gem install sensu-translator
+{{< /code >}}
 
-# Translate all config in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated
-# Option: translate your config in sections according to resource type
+Run the Sensu translator to translate all configuration in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated:
+
+{{< code shell >}}
 sensu-translator -d /etc/sensu/conf.d -o /sensu_config_translated
 {{< /code >}}
 
-If translation is successful, you should see a few callouts followed by `DONE!`.
+As an option, you can also translate your configuration in sections according to resource type.
+
+If translation is successful, you should see a few callouts followed by `DONE!`, similar to this example:
 
 {{< code shell >}}
 Sensu 1.x filter translation is not yet supported
@@ -325,8 +329,9 @@ As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used. Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61]. Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
-{{< code shell >}}
-# Sensu Core hourly filter
+Sensu Core hourly filter:
+
+{{< code json >}}
 {
   "filters": {
     "recurrences": {
@@ -336,19 +341,22 @@ First, review your Core handlers to identify which filters are being used. Then,
     }
   }
 }
+{{< /code >}}
 
-# Sensu Go hourly filter
-  {
-    "metadata": {
-      "name": "hourly",
-      "namespace": "default"
-    },
-    "action": "allow",
-    "expressions": [
-      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-    ],
-    "runtime_assets": null
-  }
+Sensu Go hourly filter:
+
+{{< code json >}}
+{
+  "metadata": {
+    "name": "hourly",
+    "namespace": "default"
+  },
+  "action": "allow",
+  "expressions": [
+    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+  ],
+  "runtime_assets": null
+}
 {{< /code >}}
 
 #### 4. Translate handlers
@@ -383,17 +391,23 @@ _PRO TIP: `sensuctl create` (and `sensuctl delete`) are powerful tools to help y
 
 Access your Sensu Go config using the [Sensu API][17].
 
+Set up a local API testing environment by saving your Sensu credentials and token as environment variables.
+This command requires curl and jq.
+
 {{< code shell >}}
-# Set up a local API testing environment by saving your Sensu credentials
-# and token as environment variables. Requires curl and jq.
 export SENSU_USER=admin && SENSU_PASS=P@ssw0rd!
-
 export SENSU_TOKEN=`curl -XGET -u "$SENSU_USER:$SENSU_PASS" -s http://localhost:8080/auth | jq -r ".access_token"`
+{{< /code >}}
 
-# Return list of all configured checks
+Return a list of all configured checks:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
+{{< /code >}}
 
-# Return list of all configured handlers
+Return a list of all configured handlers:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
 {{< /code >}}
 

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -41,10 +41,15 @@ For help with restarting a service, see the [agent reference][5] or [backend ref
 
 #### Increment log level verbosity
 
-Use these commands to increment the log level verbosity at runtime:
+To increment the log level verbosity at runtime for the backend, run:
 
 {{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-backend)
+{{< /code >}}
+
+To increment the log level verbosity at runtime for the agent, run:
+
+{{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-agent)
 {{< /code >}}
 
@@ -61,17 +66,43 @@ To capture these log messages to disk or another logging facility, Sensu service
 For example, logs are sent to the journald when systemd is the service manager, whereas log messages are redirected to `/var/log/sensu` when running under sysv init schemes.
 If you are running systemd as your service manager and would rather have logs written to `/var/log/sensu/`, see [forwarding logs from journald to syslog][11].
 
-The following table lists the common targets for logging and example commands for following those logs.
-You may substitute the name of the desired service (e.g. `backend` or `agent`) for the `${service}` variable.
+For journald targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
 
-| Platform     | Version           | Target | Command to follow log |
-|--------------|-------------------|--------------|-----------------------------------------------|
-| RHEL/Centos  | >= 7       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| RHEL/Centos  | <= 6       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Ubuntu       | >= 15.04   | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Ubuntu       | <= 14.10   | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Debian       | >= 8       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Debian       | <= 7       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS >= 7" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu >= 15.04" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian >= 8" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+For log file targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
+
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS <= 6" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu <= 14.10" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian <= 7" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: Platform versions are listed for reference only and do not supersede the documented [supported platforms](../../../platforms).
@@ -257,15 +288,15 @@ An improperly applied asset filter can prevent the asset from being downloaded b
 
 {{< code json >}}
 {
-    "asset": "check-disk-space",
-    "component": "asset-manager",
-    "entity": "sensu-centos",
-    "filters": [
-        "true == false"
-    ],
-    "level": "debug",
-    "msg": "entity not filtered, not installing asset",
-    "time": "2019-09-12T18:28:05Z"
+  "asset": "check-disk-space",
+  "component": "asset-manager",
+  "entity": "sensu-centos",
+  "filters": [
+    "true == false"
+  ],
+  "level": "debug",
+  "msg": "entity not filtered, not installing asset",
+  "time": "2019-09-12T18:28:05Z"
 }
 {{< /code >}}
 
@@ -483,21 +514,35 @@ To use etcdctl to investigate etcd cluster and data storage issues, first run th
 {{< code shell >}}
 export ETCDCTL_API=3
 export ETCDCTL_CACERT=/etc/sensu/ca.pem
-# skip ETCDCTL_CERT and ETCDCTL_KEY, unless your etcd uses client certificate authentication
-# export ETCDCTL_CERT=/etc/sensu/cert.pem
-# export ETCDCTL_KEY=/etc/sensu/key.pem
 export ETCDCTL_ENDPOINTS="https://backend01:2379,https://backend02:2379,https://backend03:2379"
+{{< /code >}}
+
+If your etcd uses client certificate authentication, run these commands too:
+
+{{< code shell >}}
+export ETCDCTL_CERT=/etc/sensu/cert.pem
+export ETCDCTL_KEY=/etc/sensu/key.pem
 {{< /code >}}
 
 ### View cluster status and alarms
 
 Use the commands listed here to retrieve etcd cluster status and list and clear alarms.
+
+To retrieve etcd cluster status:
+
 {{< code shell >}}
-# get status
 etcdctl endpoint status
-# list alarms
+{{< /code >}}
+
+To retrieve a list of etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm list
-# clear alarms
+{{< /code >}}
+
+To clear etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm dearm
 {{< /code >}}
 
@@ -507,27 +552,41 @@ The etcd default maximum database size is 2 GB.
 If you suspect your etcd database exceeds the maximum size, run this command to confirm cluster size:
 
 {{< code shell >}}
-# get current status with database size
 etcdctl endpoint status
+{{< /code >}}
+
+The response will list the current cluster status and database size:
+
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 2.1GB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 2.1GB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 2.1GB, false, 144, 18619245
 {{< /code >}}
 
-To restore an etcd cluster with a database size that exceeds 2 GB, run these commands:
+To restore an etcd cluster with a database size that exceeds 2 GB:
 
+1. Get the current revision number:
 {{< code shell >}}
-# get current revision number
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
+{{< /code >}}
 
-# compact to revision, substitute revision obtained above for $rev
+2. Compact to revision and substitute the crrent revision for `$rev`:
+{{< code shell >}}
 etcdctl compact $rev
+{{< /code >}}
 
-# defrag to free space
+3. Defragment to free up space:
+{{< code shell >}}
 etcdctl defrag
+{{< /code >}}
 
-# confirm effective
+4. Confirm that the cluster is restored:
+{{< code shell >}}
 etcdctl endpoint status
+{{< /code >}}
+
+   The response should list the current cluster status and database size:
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 1.0 MB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
@@ -544,7 +603,7 @@ Sensu will attempt to recover from these conditions when it can, but this may no
 
 To maximize Sensu Go performance, we recommend that you:
  * Follow our [recommended backend hardware configuration][19].
- * Immplement [documented etcd system tuning practices][14].
+ * Implement [documented etcd system tuning practices][14].
  * [Benchmark your etcd storage volume][15] to establish baseline IOPS for your system.
  * [Scale event storage using PostgreSQL][16] to reduce the overall volume of etcd transactions.
 

--- a/content/sensu-go/6.1/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/upgrade.md
@@ -19,11 +19,15 @@ To upgrade to Sensu Go 6.1.0 from version 6.0.0 or later, [install the latest pa
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -45,39 +49,41 @@ You will not be able to downgrade to a Sensu 5.x version after you upgrade your 
 To upgrade your Sensu Go 5.x deployment to 6.0:
 
 1. [Install][1] the 6.0 packages or Docker image.
-2. Restart the services.
+2. Restart the Sensu agent.
    
-   {{% notice note %}}
+ {{% notice note %}}
    **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
-   {{% /notice %}}
-   
-   {{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+{{% /notice %}}
 
-# Restart the Sensu backend
+  {{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+3. Restart the Sensu backend.
+
+  {{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
-3. Run a single upgrade command on one your Sensu backends to migrate the cluster:
+4. Run a single upgrade command on one your Sensu backends to migrate the cluster:
 
-   {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade
 {{< /code >}}
 
    - Add the `--skip-confirm` flag to skip the confirmation in step 4 and immediately run the upgrade command.
 
-    {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade --skip-confirm
 {{< /code >}}
 
-   {{% notice note %}}
+  {{% notice note %}}
    **NOTE**: If you are deploying a new Sensu 6.0 cluster rather than upgrading from 5.x, you do not need to run the `sensu-backend upgrade` command.
-   {{% /notice %}}
+{{% /notice %}}
 
-4. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
+5. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
 
-5. Wait a few seconds for the upgrade command to run.
+6. Wait a few seconds for the upgrade command to run.
 
 You may notice some inconsistencies in your entity list until the cluster finishes upgrading.
 Despite this, your cluster will continue to publish standard check requests and process events.
@@ -94,11 +100,15 @@ Then, restart the services.
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -146,14 +156,17 @@ See the [backend reference][2] for more information about stopping and starting 
 For Sensu backend binaries, the default `state-dir` in 5.1.0 is now `/var/lib/sensu/sensu-backend` instead of `/var/lib/sensu`.
 To upgrade your Sensu backend binary to 5.1.0, first [download the latest version][1].
 Then, make sure the `/etc/sensu/backend.yml` configuration file specifies a `state-dir`.
-To continue using `/var/lib/sensu` as the `state-dir`, add the following configuration to `/etc/sensu/backend.yml`.
+To continue using `/var/lib/sensu` as the `state-dir` to store backend data, add the following configuration to `/etc/sensu/backend.yml`:
 
 {{< code yml >}}
-# /etc/sensu/backend.yml configuration to store backend data at /var/lib/sensu
 state-dir: "/var/lib/sensu"
 {{< /code >}}
 
-Then restart the backend.
+Then restart the backend:
+
+{{< code shell >}}
+sudo service sensu-backend restart
+{{< /code >}}
 
 
 [1]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.1/operations/monitor-sensu/log-sensu-systemd.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/log-sensu-systemd.md
@@ -30,26 +30,31 @@ Next, set up rsyslog to write the logging data received from journald to `/var/l
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
 The `sensu-backend` is not required if you're only setting up log forwarding for the `sensu-agent` service.
 
+1. For the sensu-backend service, in /etc/rsyslog.d/99-sensu-backend.conf, add:
 {{< code shell >}}
-# For the sensu-backend service, inside /etc/rsyslog.d/99-sensu-backend.conf
 if $programname == 'sensu-backend' then {
         /var/log/sensu/sensu-backend.log
         ~
 }
+{{< /code >}}
 
-# For the sensu-agent service, inside /etc/rsyslog.d/99-sensu-agent.conf
+2. For the sensu-agent service, in /etc/rsyslog.d/99-sensu-agent.conf, add:
+{{< code shell >}}
 if $programname == 'sensu-agent' then {
         /var/log/sensu/sensu-agent.log
         ~
 }
 {{< /code >}}
 
-**On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
+3. **On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
 
-Restart rsyslog and journald to apply the new configuration:
-
+4. Restart journald:
 {{< code shell>}}
 systemctl restart systemd-journald
+{{< /code>}}
+
+5. Restart rsyslog to apply the new configuration:
+{{< code shell>}}
 systemctl restart rsyslog
 {{< /code>}}
 
@@ -66,8 +71,8 @@ These examples rotate the log files `/var/log/sensu/sensu-agent.log` and `/var/l
 The last seven rotated logs are kept and compressed, with the exception of the most recent log.
 After rotation, `rsyslog` is restarted to ensure logging is written to a new file and not the most recent rotated file.
 
+1. In /etc/logrotate.d/sensu-agent.conf, add:
 {{< code shell>}}
-# Inside /etc/logrotate.d/sensu-agent.conf
 /var/log/sensu/sensu-agent.log {
     daily
     rotate 7
@@ -78,8 +83,10 @@ After rotation, `rsyslog` is restarted to ensure logging is written to a new fil
       /bin/systemctl restart rsyslog
     endscript
 }
+{{< /code>}}
 
-# Inside /etc/logrotate.d/sensu-backend.conf
+2. In /etc/logrotate.d/sensu-backend.conf, add:
+{{< code shell>}}
 /var/log/sensu/sensu-backend.log {
     daily
     rotate 7

--- a/content/sensu-go/6.2/operations/control-access/_index.md
+++ b/content/sensu-go/6.2/operations/control-access/_index.md
@@ -65,7 +65,11 @@ Use sensuctl to verify that your provider configuration was applied successfully
 
 {{< code shell >}}
 sensuctl auth list
+{{< /code >}}
 
+The response will list your authentication provider types and names:
+
+{{< code shell >}}
  Type     Name    
 ────── ────────── 
  ldap   openldap  

--- a/content/sensu-go/6.2/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.2/operations/control-access/use-apikeys.md
@@ -76,27 +76,67 @@ HTTP/1.1 200 OK
 To generate a new API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key grant admin
+sensuctl api-key grant admin
+{{< /code >}}
+
+The response will include the new API key:
+
+{{< code shell >}}
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key:
+To get information about an API key in YAML or JSON format:
 
-{{< code shell >}}
-$ sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include information about the API key in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: APIKey
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
+spec:
+  created_at: 1570718917
+  username: admin
+{{< /code >}}
+
+{{< code json >}}
 {
   "metadata": {
-    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2"
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
   },
   "username": "admin",
-  "created_at": 1570744117
+  "created_at": 1570718917
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 To get a list of all API keys:
 
 {{< code shell >}}
-$ sensuctl api-key list
+sensuctl api-key list
+{{< /code >}}
+
+The response lists all API keys along with the name of the user who created each key and the date and time each key was created:
+
+{{< code shell >}}
                   Name                   Username            Created At            
  ────────────────────────────────────── ────────── ─────────────────────────────── 
   7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2   admin      2019-10-10 14:48:37 -0700 PDT
@@ -105,8 +145,14 @@ $ sensuctl api-key list
 To revoke an API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+{{< /code >}}
+
+The response will confirm that the API key is deleted:
+
+{{< code shell >}}
 Deleted
 {{< /code >}}
+
 
 [1]: ../../../api/auth/

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -80,12 +80,9 @@ The nodes are named `backend-1`, `backend-2` and `backend-3` with IP addresses `
 Follow the [Install Sensu](../install-sensu/) guide if you have not already done this.
 {{% /notice %}}
 
-**backend-1**
+**Store configuration for backend-1/10.0.0.1**
 
 {{< code yml >}}
-##
-# store configuration for backend-1/10.0.0.1
-##
 etcd-advertise-client-urls: "http://10.0.0.1:2379"
 etcd-listen-client-urls: "http://10.0.0.1:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -96,12 +93,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
-**backend-2**
+**Store configuration for backend-2/10.0.0.2**
 
 {{< code yml >}}
-##
-# store configuration for backend-2/10.0.0.2
-##
 etcd-advertise-client-urls: "http://10.0.0.2:2379"
 etcd-listen-client-urls: "http://10.0.0.2:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -112,12 +106,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
-**backend-3**
+**Store configuration for backend-3/10.0.0.3**
 
 {{< code yml >}}
-##
-# store configuration for backend-3/10.0.0.3
-##
 etcd-advertise-client-urls: "http://10.0.0.3:2379"
 etcd-listen-client-urls: "http://10.0.0.3:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -145,11 +136,9 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-{{< code yml >}}
-##
-# backend-url configuration for all agents connecting to cluster over ws
-##
+Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
 
+{{< code yml >}}
 backend-url:
   - "ws://10.0.0.1:8081"
   - "ws://10.0.0.2:8081"
@@ -170,7 +159,11 @@ Get cluster health status and etcd alarm information:
 
 {{< code shell >}}
 sensuctl cluster health
+{{< /code >}}
 
+The cluster health response will list the health status for each cluster member, similar to this example:
+
+{{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -234,7 +227,11 @@ List the ID, name, peer URLs, and client URLs of all nodes in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-list
+{{< /code >}}
 
+You will receive a sensuctl response that lists all cluster members:
+
+{{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
 a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
@@ -249,7 +246,11 @@ Remove a faulty or decommissioned member node from a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -258,11 +259,9 @@ Removed member 2f7ae42c315f8c2d from cluster
 To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
 For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
 
-In this example, cluster member `backend-4` is faulty:
+In this example, the response indicates that cluster member `backend-4` is faulty:
 
 {{< code shell >}}
-sensuctl cluster health
-
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -277,7 +276,11 @@ To continue this example, you will delete cluster member `backend-4` using its I
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+The response should indicate that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -303,7 +306,11 @@ Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was updated:
+
+{{< code shell >}}
 Updated member with ID c8f63ae435a5e6bf in cluster
 {{< /code >}}
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -306,9 +306,9 @@ Now that you have generated the required certificates and copied them to the app
 
 
 [1]: ../secure-sensu/
-[2]: ../secure-sensu/#secure-etcd-peer-communication
-[3]: ../secure-sensu/#secure-the-api-and-web-ui
-[4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
+[2]: ../secure-sensu/#etcd-peer-communication
+[3]: ../secure-sensu/#sensu-api-and-web-ui
+[4]: ../secure-sensu/#sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
 [7]: https://etcd.io/docs/v3.3.13/op-guide/security/

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -58,37 +58,52 @@ In this example you'll walk through installing cfssl on a Linux system, which re
 
 This guide assumes that you'll install these certificates in the `/etc/sensu/tls` directory on each system.
 
+1. Download the cfssl executable:
 {{< code shell >}}
-
-# Download cfssl and cfssljson executables and install them in /usr/local/bin:
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /usr/local/bin/cfssl
+{{< /code >}}
+
+2. Download the cfssljson executable:
+{{< code shell >}}
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o /usr/local/bin/cfssljson
+{{< /code >}}
+
+3. Install the cfssl and cfssljson executables in /usr/local/bin::
+{{< code shell >}}
 sudo chmod +x /usr/local/bin/cfssl*
+{{< /code >}}
 
-# Verify executable version:
+4. Verify the cfssl executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssl version
+{{< /code >}}
 
-# Version: 1.4.1
-
-# Runtime: go1.12.12
+5. Verify the cfssljson executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssljson -version
-
-# Version: 1.4.1
-
-# Runtime: go1.12.12
 {{< /code >}}
 
 ### Create a Certificate Authority (CA)
 
-Create a CA with cfssl and cfssljson:
+Follow these steps to create a CA with cfssl and cfssljson:
 
+1. Create /etc/sensu/tls (which does not exist by default):
 {{< code shell >}}
-# Create /etc/sensu/tls -- does not exist by default
 mkdir -p /etc/sensu/tls
+{{< /code >}}
+
+2. Navigate to the new /etc/sensu/tls directory:
+{{< code shell >}}
 cd /etc/sensu/tls
-# Create the Certificate Authority
+{{< /code >}}
+
+3. Create the CA:
+{{< code shell >}}
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
-# Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
+{{< /code >}}
+
+4. Define signing parameters and profiles (the agent profile provides the "client auth" usage required for mTLS):
+{{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
@@ -127,20 +142,31 @@ backend-3        | 10.0.0.3   | backend-3.example.com              | localhost, 
 
 Note that the additional names for localhost and 127.0.0.1 are added here for convenience and not strictly required.
 
-Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend:
+Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend.
+
+- The values provided for the ADDRESS variable will be used to populate the certificate's SAN records.
+For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable.
+- The value provided for the NAME variable will be used to populate the certificate's CN record.
+
+**backend-1**
 
 {{< code shell >}}
-# Value provided for the NAME variable will be used to populate the certificate's CN record
-# Values provided in the ADDRESS variable will be used to populate the certificate's SAN records
-# For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable
 export ADDRESS=localhost,127.0.0.1,10.0.0.1,backend-1
 export NAME=backend-1.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-2**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.2,backend-2
 export NAME=backend-2.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-3**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.3,backend-3
 export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
@@ -157,22 +183,25 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:
+Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:.
+For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -201,11 +230,10 @@ filename           | description                  | required on agent?  |
 `agent-key.pem`    | Backend server private key   | {{< check >}}       |
 `agent.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system:
+Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system.
+To continue the example, the directory listing of /etc/sensu/tls on backend-1 should now include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
@@ -214,11 +242,15 @@ Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding b
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -228,7 +260,7 @@ Before you move on, make sure you have copied the certificates and keys to each 
 
 - [Copy the Certificate Authority (CA) root certificate file][11], `ca.pem`, to each agent and backend.
 - [Copy all backend PEM files][12] to their corresponding backend systems.
-- [Copy all agent PEM files][13]
+- [Copy all agent PEM files][13].
 
 We also recommend installing the CA root certificate in the trust store of both your Sensu systems and those systems used by operators to manage Sensu. 
 
@@ -256,8 +288,7 @@ sudo update-ca-trust
 Import the root CA certificate on the Mac.
 Double-click the root CA certificate to open it in Keychain Access.
 The root CA certificate appears in login.
-Copy the root CA certificate to System.
-You must copy the certificate to System to ensure that it is trusted by all users and local system processes.
+Copy the root CA certificate to System to ensure that it is trusted by all users and local system processes.
 Open the root CA certificate, expand Trust, select Use System Defaults, and save your changes.
 Reopen the root CA certificate, expand Trust, select Always Trust, and save your changes.
 Delete the root CA certificate from login.

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -15,11 +15,13 @@ menu:
 
 As with any piece of software, it is critical to minimize any attack surface the software exposes.
 Sensu is no different.
-This guide describes the components you need to secure to make Sensu production-ready.
 
-Before you can use this guide, you must have [generated the certificates][12] you will need to secure Sensu.
+This reference describes the components you need to secure to make Sensu production-ready, including etcd peer communication, the Sensu API and web UI, and Sensu agent-to-server communication.
+It also describes agent mutual transport layer security (mTLS) authentication, which is required for [secrets management][1].
 
-## Secure etcd peer communication
+Before you can use this reference, you must [generate the certificates][12] you will need to secure Sensu.
+
+## Etcd peer communication
 
 {{% notice warning %}}
 **WARNING**: You must update the default configuration for Sensu's embedded etcd with an explicit, non-default configuration to secure etcd communication in transit.
@@ -27,12 +29,9 @@ If you do not properly configure secure etcd communication, your Sensu configura
 {{% /notice %}}
 
 You can secure etcd peer communication via the configuration at `/etc/sensu/backend.yml`.
-Here are the parameters you'll need to configure:
+Here are the backend store parameters you'll need to configure:
 
 {{< code yml >}}
-##
-# backend store configuration
-##
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
@@ -55,42 +54,34 @@ To properly secure etcd communication, replace the default parameter values in y
 In addition, set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate.
 Because etcd does not require authentication by default, you must set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
-## Secure the API and web UI
+## Sensu API and web UI
 
 The Sensu Go Agent API, HTTP API, and web UI use a common stanza in `/etc/sensu/backend.yml` to provide the certificate, key, and CA file needed to provide secure communication.
-Here are the attributes you'll need to configure.
 
 {{% notice note %}}
 **NOTE**: By changing these parameters, the server will communicate using transport layer security (TLS) and expect agents that connect to it to use the WebSocket secure protocol.
-For communication to continue, you must complete the steps in this section **and** in the [Secure Sensu agent-to-server communication](#secure-sensu-agent-to-server-communication) section.
+For communication to continue, you must complete the configuration in this section **and** in the [Sensu agent-to-server communication](#sensu-agent-to-server-communication) section.
 {{% /notice %}}
 
+Here are the backend secure sockets layer (SSL) attributes you'll need to configure.
+
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
 insecure-skip-tls-verify: false
 {{< /code >}}
 
-Providing these cert-file and key-file parameters will cause the Agent Websocket API and HTTP API to serve requests over SSL/TLS (https).
-As a result, you will also need to specify `https://` schema for the `api-url` parameter:
+Providing these cert-file and key-file parameters will cause the agent WebSocket API and HTTP API to serve requests over SSL/TLS (https).
+As a result, you will also need to specify `https://` schema for the `api-url` parameter for backend API configuration:
 
 {{< code yml >}}
-##
-# backend api configuration
-##
 api-url: "https://localhost:8080"
 {{< /code >}}
 
-You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters:
+You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters for backend SSL configuration:
 
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
@@ -103,32 +94,24 @@ In this example, we provide the path to the cert, key, and CA file.
 After you restart the `sensu-backend` service, the parameters will load and you will able to access the web UI at https://localhost:3000.
 Configuring these attributes will also ensure that agents can communicate securely.
 
-## Secure Sensu agent-to-server communication
+## Sensu agent-to-server communication
 
 {{% notice note %}}
 **NOTE**: If you change the agent configuration to communicate via WebSocket Secure protocol, the agent will no longer communicate over a plaintext connection.
-For communication to continue, you must complete the steps in this section **and** in the [Secure the API and web UI](#secure-the-api-and-web-ui) section.
+For communication to continue, you must complete the steps in this section **and** [secure the Sensu API and web UI](#sensu-api-and-web-ui).
 {{% /notice %}}
 
 By default, an agent uses the insecure `ws://` transport.
-Here's an example from `/etc/sensu/agent.yml`:
+Here's an example for agent configuration in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "ws://127.0.0.1:8081"
 {{< /code >}}
 
-To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema:
+To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "wss://127.0.0.1:8081"
 {{< /code >}}
@@ -139,7 +122,7 @@ Remember, if you change the configuration to wss, plaintext communication will n
 You can also provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if you are starting the agent via `sensu-agent start`.
 You may include it as part of the agent configuration in `/etc/sensu/agent.yml`: 
 
-{{< code yaml>}}
+{{< code yml>}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
 {{< /code >}}
 
@@ -170,10 +153,15 @@ For this use case, create a user that matches the Common Name (CN) of the agent'
 To ensure that agents with incorrect CN fields can't access the backend, remove the default `system:agents` group.
 {{% /notice %}}
 
-To view a certificate's CN with openssl:
+To view a certificate's CN with openssl, run:
 
 {{< code bash >}}
-$ openssl x509 -in client.pem -text -noout
+openssl x509 -in client.pem -text -noout
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code bash >}}
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -193,21 +181,16 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modify the backend and agent configuration:
+After you create backend and agent certificates, modify the backend configuration:
 
 {{< code yml >}}
-##
-# backend configuration
-##
 agent-auth-cert-file: "/path/to/backend-1.pem"
 agent-auth-key-file: "/path/to/backend-1-key.pem"
 agent-auth-trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 
+Modify the agent configuration also:
 {{< code yml >}}
-##
-# agent configuration
-##
 cert-file: "/path/to/agent.pem"
 key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -259,10 +259,14 @@ For a consistent experience, repeat the `ClusterRoleBinding` example in this gui
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
 To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+
+{{< code shell >}}
+sensuctl cluster-role-binding info federation-viewer-readonly
+{{< /code >}}
+
 You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
 
 {{< code shell >}}
-$ sensuctl cluster-role-binding info federation-viewer-readonly
 === federation-viewer-readonly
 Name:         federation-viewer-readonly
 Cluster Role: view

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -29,7 +29,7 @@ The Sensu Go agent is also available for Windows.
 If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
-Aside from this migration guide, these resources can help you migrate from Sensu Core and Sensu Enterprise to Sensu Go:
+Aside from this migration guide, these resources can help you migrate from Sensu Core or Sensu Enterprise to Sensu Go:
 
 - [**Sensu Community Slack**][46]: Join hundreds of other Sensu users in our Community Slack, where you can ask questions and benefit from tips others picked up during their own Sensu Go migrations.
 - [**Sensu Community Forum**][47]: Drop a question in our dedicated category for migrating to Go.
@@ -207,17 +207,15 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56].
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 {{< code yml >}}
-# agent configuration: /etc/sensu.agent.yml
-...
 api-port: 4041
 socket-port: 4030
-...
 {{< /code >}}
+
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 Sensu should now be installed and functional. The next step is to translate your Sensu Core configuration to Sensu Go.
 
@@ -227,21 +225,27 @@ Use t [Sensu Translator][18] command line tool to transfer your Sensu Core check
 
 #### 1. Run the translator
 
-Install and run the translator.
+Install dependencies:
 
 {{< code shell >}}
-# Install dependencies
 yum install -q -y rubygems ruby-devel
+{{< /code >}}
 
-# Install sensu-translator
+Install the Sensu translator:
+
+{{< code shell >}}
 gem install sensu-translator
+{{< /code >}}
 
-# Translate all config in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated
-# Option: translate your config in sections according to resource type
+Run the Sensu translator to translate all configuration in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated:
+
+{{< code shell >}}
 sensu-translator -d /etc/sensu/conf.d -o /sensu_config_translated
 {{< /code >}}
 
-If translation is successful, you should see a few callouts followed by `DONE!`.
+As an option, you can also translate your configuration in sections according to resource type.
+
+If translation is successful, you should see a few callouts followed by `DONE!`, similar to this example:
 
 {{< code shell >}}
 Sensu 1.x filter translation is not yet supported
@@ -325,8 +329,9 @@ As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used. Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61]. Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
-{{< code shell >}}
-# Sensu Core hourly filter
+Sensu Core hourly filter:
+
+{{< code json >}}
 {
   "filters": {
     "recurrences": {
@@ -336,19 +341,22 @@ First, review your Core handlers to identify which filters are being used. Then,
     }
   }
 }
+{{< /code >}}
 
-# Sensu Go hourly filter
-  {
-    "metadata": {
-      "name": "hourly",
-      "namespace": "default"
-    },
-    "action": "allow",
-    "expressions": [
-      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-    ],
-    "runtime_assets": null
-  }
+Sensu Go hourly filter:
+
+{{< code json >}}
+{
+  "metadata": {
+    "name": "hourly",
+    "namespace": "default"
+  },
+  "action": "allow",
+  "expressions": [
+    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+  ],
+  "runtime_assets": null
+}
 {{< /code >}}
 
 #### 4. Translate handlers
@@ -383,17 +391,23 @@ _PRO TIP: `sensuctl create` (and `sensuctl delete`) are powerful tools to help y
 
 Access your Sensu Go config using the [Sensu API][17].
 
+Set up a local API testing environment by saving your Sensu credentials and token as environment variables.
+This command requires curl and jq.
+
 {{< code shell >}}
-# Set up a local API testing environment by saving your Sensu credentials
-# and token as environment variables. Requires curl and jq.
 export SENSU_USER=admin && SENSU_PASS=P@ssw0rd!
-
 export SENSU_TOKEN=`curl -XGET -u "$SENSU_USER:$SENSU_PASS" -s http://localhost:8080/auth | jq -r ".access_token"`
+{{< /code >}}
 
-# Return list of all configured checks
+Return a list of all configured checks:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
+{{< /code >}}
 
-# Return list of all configured handlers
+Return a list of all configured handlers:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
 {{< /code >}}
 

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -41,10 +41,15 @@ For help with restarting a service, see the [agent reference][5] or [backend ref
 
 #### Increment log level verbosity
 
-Use these commands to increment the log level verbosity at runtime:
+To increment the log level verbosity at runtime for the backend, run:
 
 {{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-backend)
+{{< /code >}}
+
+To increment the log level verbosity at runtime for the agent, run:
+
+{{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-agent)
 {{< /code >}}
 
@@ -61,17 +66,43 @@ To capture these log messages to disk or another logging facility, Sensu service
 For example, logs are sent to the journald when systemd is the service manager, whereas log messages are redirected to `/var/log/sensu` when running under sysv init schemes.
 If you are running systemd as your service manager and would rather have logs written to `/var/log/sensu/`, see [forwarding logs from journald to syslog][11].
 
-The following table lists the common targets for logging and example commands for following those logs.
-You may substitute the name of the desired service (e.g. `backend` or `agent`) for the `${service}` variable.
+For journald targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
 
-| Platform     | Version           | Target | Command to follow log |
-|--------------|-------------------|--------------|-----------------------------------------------|
-| RHEL/Centos  | >= 7       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| RHEL/Centos  | <= 6       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Ubuntu       | >= 15.04   | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Ubuntu       | <= 14.10   | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Debian       | >= 8       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Debian       | <= 7       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS >= 7" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu >= 15.04" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian >= 8" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+For log file targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
+
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS <= 6" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu <= 14.10" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian <= 7" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: Platform versions are listed for reference only and do not supersede the documented [supported platforms](../../../platforms).
@@ -257,15 +288,15 @@ An improperly applied asset filter can prevent the asset from being downloaded b
 
 {{< code json >}}
 {
-    "asset": "check-disk-space",
-    "component": "asset-manager",
-    "entity": "sensu-centos",
-    "filters": [
-        "true == false"
-    ],
-    "level": "debug",
-    "msg": "entity not filtered, not installing asset",
-    "time": "2019-09-12T18:28:05Z"
+  "asset": "check-disk-space",
+  "component": "asset-manager",
+  "entity": "sensu-centos",
+  "filters": [
+    "true == false"
+  ],
+  "level": "debug",
+  "msg": "entity not filtered, not installing asset",
+  "time": "2019-09-12T18:28:05Z"
 }
 {{< /code >}}
 
@@ -483,21 +514,35 @@ To use etcdctl to investigate etcd cluster and data storage issues, first run th
 {{< code shell >}}
 export ETCDCTL_API=3
 export ETCDCTL_CACERT=/etc/sensu/ca.pem
-# skip ETCDCTL_CERT and ETCDCTL_KEY, unless your etcd uses client certificate authentication
-# export ETCDCTL_CERT=/etc/sensu/cert.pem
-# export ETCDCTL_KEY=/etc/sensu/key.pem
 export ETCDCTL_ENDPOINTS="https://backend01:2379,https://backend02:2379,https://backend03:2379"
+{{< /code >}}
+
+If your etcd uses client certificate authentication, run these commands too:
+
+{{< code shell >}}
+export ETCDCTL_CERT=/etc/sensu/cert.pem
+export ETCDCTL_KEY=/etc/sensu/key.pem
 {{< /code >}}
 
 ### View cluster status and alarms
 
 Use the commands listed here to retrieve etcd cluster status and list and clear alarms.
+
+To retrieve etcd cluster status:
+
 {{< code shell >}}
-# get status
 etcdctl endpoint status
-# list alarms
+{{< /code >}}
+
+To retrieve a list of etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm list
-# clear alarms
+{{< /code >}}
+
+To clear etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm dearm
 {{< /code >}}
 
@@ -507,27 +552,41 @@ The etcd default maximum database size is 2 GB.
 If you suspect your etcd database exceeds the maximum size, run this command to confirm cluster size:
 
 {{< code shell >}}
-# get current status with database size
 etcdctl endpoint status
+{{< /code >}}
+
+The response will list the current cluster status and database size:
+
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 2.1GB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 2.1GB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 2.1GB, false, 144, 18619245
 {{< /code >}}
 
-To restore an etcd cluster with a database size that exceeds 2 GB, run these commands:
+To restore an etcd cluster with a database size that exceeds 2 GB:
 
+1. Get the current revision number:
 {{< code shell >}}
-# get current revision number
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
+{{< /code >}}
 
-# compact to revision, substitute revision obtained above for $rev
+2. Compact to revision and substitute the crrent revision for `$rev`:
+{{< code shell >}}
 etcdctl compact $rev
+{{< /code >}}
 
-# defrag to free space
+3. Defragment to free up space:
+{{< code shell >}}
 etcdctl defrag
+{{< /code >}}
 
-# confirm effective
+4. Confirm that the cluster is restored:
+{{< code shell >}}
 etcdctl endpoint status
+{{< /code >}}
+
+   The response should list the current cluster status and database size:
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 1.0 MB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
@@ -546,7 +605,7 @@ To maximize Sensu Go performance, we recommend that you:
  * Follow our [recommended backend hardware configuration][19].
  * Implement [documented etcd system tuning practices][14].
  * [Benchmark your etcd storage volume][15] to establish baseline IOPS for your system.
- * [Scale event storage using PostgreSQL][16] with [round robin scheduling enabled][20] to reduce the overall volume of etcd transactions.
+ * [Scale event storage using PostgreSQL][16] with [round robin scheduling enabled][20] to reduce the overall volume of etcd transactions.  
 
  As your Sensu deployments grow, preventing issues associated with poor datastore performance relies on ongoing collection and review of [Sensu time-series performance metrics][18].
 

--- a/content/sensu-go/6.2/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/upgrade.md
@@ -40,9 +40,8 @@ These commands use a Sensu backend running on `localhost` in the example URL and
 
 1. Get a list of existing namespaces.
 In this example, the existing namespaces are `stage` and `dev`.
-
-   {{< code shell >}}
-$ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/namespaces | jq '[.[].name]'
+{{< code shell >}}
+curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/namespaces | jq '[.[].name]'
 [
    "stage",
    "dev"
@@ -51,9 +50,8 @@ $ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/
 
 2. Print the name and namespace for any checks that reference a namespace that is not specified in the jq expression on the same line.
 Your jq expression should include all of the namespaces you retrieved in step 1 (in this example, `["stage","dev"]`).
-
-   {{< code shell >}}
-$ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/checks | jq '["stage","dev"] as $valid | .[] | select(.metadata.namespace as $in | $valid | index($in) | not) | {name: .metadata.name, namespace: .metadata.namespace}'
+{{< code shell >}}
+curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/checks | jq '["stage","dev"] as $valid | .[] | select(.metadata.namespace as $in | $valid | index($in) | not) | {name: .metadata.name, namespace: .metadata.namespace}'
 {
   "name": "check-cpu",
   "namespace": "test"
@@ -61,21 +59,18 @@ $ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/
 {{< /code >}}
 
 3. Recreate the missing `test` namespace so you can delete the `check-cpu` check.
-
-   {{< code shell >}}
-$ sensuctl namespace create test
+{{< code shell >}}
+sensuctl namespace create test
 {{< /code >}}
 
 4. Delete the `check-cpu` check.
-
-   {{< code shell >}}
-$ sensuctl check delete check-cpu --namespace test
+{{< code shell >}}
+sensuctl check delete check-cpu --namespace test
 {{< /code >}}
 
 5. Delete the `test` namespace, which is now empty after you deleted `check-cpu` in step 4.
-
-   {{< code shell >}}
-$ sensuctl namespace delete test
+{{< code shell >}}
+sensuctl namespace delete test
 {{< /code >}}
 
 After completing these commands, you can upgrade to 6.2.0.
@@ -88,11 +83,15 @@ To upgrade to Sensu Go 6.1.0 from version 6.0.0 or later, [install the latest pa
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -114,39 +113,41 @@ You will not be able to downgrade to a Sensu 5.x version after you upgrade your 
 To upgrade your Sensu Go 5.x deployment to 6.0:
 
 1. [Install][1] the 6.0 packages or Docker image.
-2. Restart the services.
+2. Restart the Sensu agent.
    
-   {{% notice note %}}
+ {{% notice note %}}
    **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
-   {{% /notice %}}
-   
-   {{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+{{% /notice %}}
 
-# Restart the Sensu backend
+  {{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+3. Restart the Sensu backend.
+
+  {{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
-3. Run a single upgrade command on one your Sensu backends to migrate the cluster:
+4. Run a single upgrade command on one your Sensu backends to migrate the cluster:
 
-   {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade
 {{< /code >}}
 
    - Add the `--skip-confirm` flag to skip the confirmation in step 4 and immediately run the upgrade command.
 
-    {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade --skip-confirm
 {{< /code >}}
 
-   {{% notice note %}}
+  {{% notice note %}}
    **NOTE**: If you are deploying a new Sensu 6.0 cluster rather than upgrading from 5.x, you do not need to run the `sensu-backend upgrade` command.
-   {{% /notice %}}
+{{% /notice %}}
 
-4. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
+5. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
 
-5. Wait a few seconds for the upgrade command to run.
+6. Wait a few seconds for the upgrade command to run.
 
 You may notice some inconsistencies in your entity list until the cluster finishes upgrading.
 Despite this, your cluster will continue to publish standard check requests and process events.
@@ -163,11 +164,15 @@ Then, restart the services.
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -215,14 +220,17 @@ See the [backend reference][2] for more information about stopping and starting 
 For Sensu backend binaries, the default `state-dir` in 5.1.0 is now `/var/lib/sensu/sensu-backend` instead of `/var/lib/sensu`.
 To upgrade your Sensu backend binary to 5.1.0, first [download the latest version][1].
 Then, make sure the `/etc/sensu/backend.yml` configuration file specifies a `state-dir`.
-To continue using `/var/lib/sensu` as the `state-dir`, add the following configuration to `/etc/sensu/backend.yml`.
+To continue using `/var/lib/sensu` as the `state-dir` to store backend data, add the following configuration to `/etc/sensu/backend.yml`:
 
 {{< code yml >}}
-# /etc/sensu/backend.yml configuration to store backend data at /var/lib/sensu
 state-dir: "/var/lib/sensu"
 {{< /code >}}
 
-Then restart the backend.
+Then restart the backend:
+
+{{< code shell >}}
+sudo service sensu-backend restart
+{{< /code >}}
 
 
 [1]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.2/operations/monitor-sensu/log-sensu-systemd.md
+++ b/content/sensu-go/6.2/operations/monitor-sensu/log-sensu-systemd.md
@@ -30,26 +30,31 @@ Next, set up rsyslog to write the logging data received from journald to `/var/l
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
 The `sensu-backend` is not required if you're only setting up log forwarding for the `sensu-agent` service.
 
+1. For the sensu-backend service, in /etc/rsyslog.d/99-sensu-backend.conf, add:
 {{< code shell >}}
-# For the sensu-backend service, inside /etc/rsyslog.d/99-sensu-backend.conf
 if $programname == 'sensu-backend' then {
         /var/log/sensu/sensu-backend.log
         ~
 }
+{{< /code >}}
 
-# For the sensu-agent service, inside /etc/rsyslog.d/99-sensu-agent.conf
+2. For the sensu-agent service, in /etc/rsyslog.d/99-sensu-agent.conf, add:
+{{< code shell >}}
 if $programname == 'sensu-agent' then {
         /var/log/sensu/sensu-agent.log
         ~
 }
 {{< /code >}}
 
-**On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
+3. **On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
 
-Restart rsyslog and journald to apply the new configuration:
-
+4. Restart journald:
 {{< code shell>}}
 systemctl restart systemd-journald
+{{< /code>}}
+
+5. Restart rsyslog to apply the new configuration:
+{{< code shell>}}
 systemctl restart rsyslog
 {{< /code>}}
 
@@ -66,8 +71,8 @@ These examples rotate the log files `/var/log/sensu/sensu-agent.log` and `/var/l
 The last seven rotated logs are kept and compressed, with the exception of the most recent log.
 After rotation, `rsyslog` is restarted to ensure logging is written to a new file and not the most recent rotated file.
 
+1. In /etc/logrotate.d/sensu-agent.conf, add:
 {{< code shell>}}
-# Inside /etc/logrotate.d/sensu-agent.conf
 /var/log/sensu/sensu-agent.log {
     daily
     rotate 7
@@ -78,8 +83,10 @@ After rotation, `rsyslog` is restarted to ensure logging is written to a new fil
       /bin/systemctl restart rsyslog
     endscript
 }
+{{< /code>}}
 
-# Inside /etc/logrotate.d/sensu-backend.conf
+2. In /etc/logrotate.d/sensu-backend.conf, add:
+{{< code shell>}}
 /var/log/sensu/sensu-backend.log {
     daily
     rotate 7

--- a/content/sensu-go/6.3/operations/control-access/_index.md
+++ b/content/sensu-go/6.3/operations/control-access/_index.md
@@ -65,7 +65,11 @@ Use sensuctl to verify that your provider configuration was applied successfully
 
 {{< code shell >}}
 sensuctl auth list
+{{< /code >}}
 
+The response will list your authentication provider types and names:
+
+{{< code shell >}}
  Type     Name    
 ────── ────────── 
  ldap   openldap  

--- a/content/sensu-go/6.3/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.3/operations/control-access/use-apikeys.md
@@ -76,27 +76,67 @@ HTTP/1.1 200 OK
 To generate a new API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key grant admin
+sensuctl api-key grant admin
+{{< /code >}}
+
+The response will include the new API key:
+
+{{< code shell >}}
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key:
+To get information about an API key in YAML or JSON format:
 
-{{< code shell >}}
-$ sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include information about the API key in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: APIKey
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
+spec:
+  created_at: 1570718917
+  username: admin
+{{< /code >}}
+
+{{< code json >}}
 {
   "metadata": {
-    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2"
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
   },
   "username": "admin",
-  "created_at": 1570744117
+  "created_at": 1570718917
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 To get a list of all API keys:
 
 {{< code shell >}}
-$ sensuctl api-key list
+sensuctl api-key list
+{{< /code >}}
+
+The response lists all API keys along with the name of the user who created each key and the date and time each key was created:
+
+{{< code shell >}}
                   Name                   Username            Created At            
  ────────────────────────────────────── ────────── ─────────────────────────────── 
   7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2   admin      2019-10-10 14:48:37 -0700 PDT
@@ -105,8 +145,14 @@ $ sensuctl api-key list
 To revoke an API key for the admin user:
 
 {{< code shell >}}
-$ sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+sensuctl api-key revoke 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --skip-confirm
+{{< /code >}}
+
+The response will confirm that the API key is deleted:
+
+{{< code shell >}}
 Deleted
 {{< /code >}}
+
 
 [1]: ../../../api/auth/

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -80,12 +80,9 @@ The nodes are named `backend-1`, `backend-2` and `backend-3` with IP addresses `
 Follow the [Install Sensu](../install-sensu/) guide if you have not already done this.
 {{% /notice %}}
 
-**backend-1**
+**Store configuration for backend-1/10.0.0.1**
 
 {{< code yml >}}
-##
-# store configuration for backend-1/10.0.0.1
-##
 etcd-advertise-client-urls: "http://10.0.0.1:2379"
 etcd-listen-client-urls: "http://10.0.0.1:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -96,12 +93,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-1"
 {{< /code >}}
 
-**backend-2**
+**Store configuration for backend-2/10.0.0.2**
 
 {{< code yml >}}
-##
-# store configuration for backend-2/10.0.0.2
-##
 etcd-advertise-client-urls: "http://10.0.0.2:2379"
 etcd-listen-client-urls: "http://10.0.0.2:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -112,12 +106,9 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-2"
 {{< /code >}}
 
-**backend-3**
+**Store configuration for backend-3/10.0.0.3**
 
 {{< code yml >}}
-##
-# store configuration for backend-3/10.0.0.3
-##
 etcd-advertise-client-urls: "http://10.0.0.3:2379"
 etcd-listen-client-urls: "http://10.0.0.3:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
@@ -145,11 +136,9 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-{{< code yml >}}
-##
-# backend-url configuration for all agents connecting to cluster over ws
-##
+Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
 
+{{< code yml >}}
 backend-url:
   - "ws://10.0.0.1:8081"
   - "ws://10.0.0.2:8081"
@@ -170,7 +159,11 @@ Get cluster health status and etcd alarm information:
 
 {{< code shell >}}
 sensuctl cluster health
+{{< /code >}}
 
+The cluster health response will list the health status for each cluster member, similar to this example:
+
+{{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -234,7 +227,11 @@ List the ID, name, peer URLs, and client URLs of all nodes in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-list
+{{< /code >}}
 
+You will receive a sensuctl response that lists all cluster members:
+
+{{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
 a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
@@ -249,7 +246,11 @@ Remove a faulty or decommissioned member node from a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -258,11 +259,9 @@ Removed member 2f7ae42c315f8c2d from cluster
 To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
 For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
 
-In this example, cluster member `backend-4` is faulty:
+In this example, the response indicates that cluster member `backend-4` is faulty:
 
 {{< code shell >}}
-sensuctl cluster health
-
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
 a32e8f613b529ad4   backend-1                                                        true
@@ -277,7 +276,11 @@ To continue this example, you will delete cluster member `backend-4` using its I
 
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
+{{< /code >}}
 
+The response should indicate that the cluster member was removed:
+
+{{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
@@ -303,7 +306,11 @@ Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
 sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+{{< /code >}}
 
+You will receive a sensuctl response to confirm that the cluster member was updated:
+
+{{< code shell >}}
 Updated member with ID c8f63ae435a5e6bf in cluster
 {{< /code >}}
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -306,9 +306,9 @@ Now that you have generated the required certificates and copied them to the app
 
 
 [1]: ../secure-sensu/
-[2]: ../secure-sensu/#secure-etcd-peer-communication
-[3]: ../secure-sensu/#secure-the-api-and-web-ui
-[4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
+[2]: ../secure-sensu/#etcd-peer-communication
+[3]: ../secure-sensu/#sensu-api-and-web-ui
+[4]: ../secure-sensu/#sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
 [7]: https://etcd.io/docs/v3.3.13/op-guide/security/

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -58,37 +58,52 @@ In this example you'll walk through installing cfssl on a Linux system, which re
 
 This guide assumes that you'll install these certificates in the `/etc/sensu/tls` directory on each system.
 
+1. Download the cfssl executable:
 {{< code shell >}}
-
-# Download cfssl and cfssljson executables and install them in /usr/local/bin:
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /usr/local/bin/cfssl
+{{< /code >}}
+
+2. Download the cfssljson executable:
+{{< code shell >}}
 sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o /usr/local/bin/cfssljson
+{{< /code >}}
+
+3. Install the cfssl and cfssljson executables in /usr/local/bin::
+{{< code shell >}}
 sudo chmod +x /usr/local/bin/cfssl*
+{{< /code >}}
 
-# Verify executable version:
+4. Verify the cfssl executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssl version
+{{< /code >}}
 
-# Version: 1.4.1
-
-# Runtime: go1.12.12
+5. Verify the cfssljson executable is version 1.4.1 and runtime go1.12.12:
+{{< code shell >}}
 cfssljson -version
-
-# Version: 1.4.1
-
-# Runtime: go1.12.12
 {{< /code >}}
 
 ### Create a Certificate Authority (CA)
 
-Create a CA with cfssl and cfssljson:
+Follow these steps to create a CA with cfssl and cfssljson:
 
+1. Create /etc/sensu/tls (which does not exist by default):
 {{< code shell >}}
-# Create /etc/sensu/tls -- does not exist by default
 mkdir -p /etc/sensu/tls
+{{< /code >}}
+
+2. Navigate to the new /etc/sensu/tls directory:
+{{< code shell >}}
 cd /etc/sensu/tls
-# Create the Certificate Authority
+{{< /code >}}
+
+3. Create the CA:
+{{< code shell >}}
 echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
-# Define signing parameters and profiles. Note that agent profile provides the "client auth" usage required for mTLS.
+{{< /code >}}
+
+4. Define signing parameters and profiles (the agent profile provides the "client auth" usage required for mTLS):
+{{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
@@ -127,20 +142,31 @@ backend-3        | 10.0.0.3   | backend-3.example.com              | localhost, 
 
 Note that the additional names for localhost and 127.0.0.1 are added here for convenience and not strictly required.
 
-Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend:
+Use these name and address details to create two `*.pem` files and one `*.csr` file for each backend.
+
+- The values provided for the ADDRESS variable will be used to populate the certificate's SAN records.
+For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable.
+- The value provided for the NAME variable will be used to populate the certificate's CN record.
+
+**backend-1**
 
 {{< code shell >}}
-# Value provided for the NAME variable will be used to populate the certificate's CN record
-# Values provided in the ADDRESS variable will be used to populate the certificate's SAN records
-# For systems with multiple hostnames and IP addresses, add each to the comma-delimited value of the ADDRESS variable
 export ADDRESS=localhost,127.0.0.1,10.0.0.1,backend-1
 export NAME=backend-1.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-2**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.2,backend-2
 export NAME=backend-2.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+{{< /code >}}
 
+**backend-3**
+
+{{< code shell >}}
 export ADDRESS=localhost,127.0.0.1,10.0.0.3,backend-3
 export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
@@ -157,22 +183,25 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:
+Again, make sure to copy all backend PEM files and CA root certificate to the corresponding backend system:.
+For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -201,11 +230,10 @@ filename           | description                  | required on agent?  |
 `agent-key.pem`    | Backend server private key   | {{< check >}}       |
 `agent.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system:
+Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding backend system.
+To continue the example, the directory listing of /etc/sensu/tls on backend-1 should now include:
 
 {{< code shell >}}
-
-# Directory listing of /etc/sensu/tls on backend-1:
 /etc/sensu/tls/
 ├── backend-1-key.pem
 ├── backend-1.pem
@@ -214,11 +242,15 @@ Again, make sure to copy all agent PEM files and `ca.pem` to the corresponding b
 └── ca.pem
 {{< /code >}}
 
-These files should be accessible only by the `sensu` user.
-Use chown and chmod to make it so:
+To make sure these files are accessible only by the `sensu` user, run:
 
 {{< code shell >}}
 chown sensu /etc/sensu/tls/*.pem
+{{< /code >}}
+
+And:
+
+{{< code shell >}}
 chmod 400 /etc/sensu/tls/*.pem
 {{< /code >}}
 
@@ -228,7 +260,7 @@ Before you move on, make sure you have copied the certificates and keys to each 
 
 - [Copy the Certificate Authority (CA) root certificate file][11], `ca.pem`, to each agent and backend.
 - [Copy all backend PEM files][12] to their corresponding backend systems.
-- [Copy all agent PEM files][13]
+- [Copy all agent PEM files][13].
 
 We also recommend installing the CA root certificate in the trust store of both your Sensu systems and those systems used by operators to manage Sensu. 
 
@@ -256,8 +288,7 @@ sudo update-ca-trust
 Import the root CA certificate on the Mac.
 Double-click the root CA certificate to open it in Keychain Access.
 The root CA certificate appears in login.
-Copy the root CA certificate to System.
-You must copy the certificate to System to ensure that it is trusted by all users and local system processes.
+Copy the root CA certificate to System to ensure that it is trusted by all users and local system processes.
 Open the root CA certificate, expand Trust, select Use System Defaults, and save your changes.
 Reopen the root CA certificate, expand Trust, select Always Trust, and save your changes.
 Delete the root CA certificate from login.

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -15,11 +15,13 @@ menu:
 
 As with any piece of software, it is critical to minimize any attack surface the software exposes.
 Sensu is no different.
-This guide describes the components you need to secure to make Sensu production-ready.
 
-Before you can use this guide, you must have [generated the certificates][12] you will need to secure Sensu.
+This reference describes the components you need to secure to make Sensu production-ready, including etcd peer communication, the Sensu API and web UI, and Sensu agent-to-server communication.
+It also describes agent mutual transport layer security (mTLS) authentication, which is required for [secrets management][1].
 
-## Secure etcd peer communication
+Before you can use this reference, you must [generate the certificates][12] you will need to secure Sensu.
+
+## Etcd peer communication
 
 {{% notice warning %}}
 **WARNING**: You must update the default configuration for Sensu's embedded etcd with an explicit, non-default configuration to secure etcd communication in transit.
@@ -27,12 +29,9 @@ If you do not properly configure secure etcd communication, your Sensu configura
 {{% /notice %}}
 
 You can secure etcd peer communication via the configuration at `/etc/sensu/backend.yml`.
-Here are the parameters you'll need to configure:
+Here are the backend store parameters you'll need to configure:
 
 {{< code yml >}}
-##
-# backend store configuration
-##
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
@@ -55,42 +54,34 @@ To properly secure etcd communication, replace the default parameter values in y
 In addition, set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate.
 Because etcd does not require authentication by default, you must set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
-## Secure the API and web UI
+## Sensu API and web UI
 
 The Sensu Go Agent API, HTTP API, and web UI use a common stanza in `/etc/sensu/backend.yml` to provide the certificate, key, and CA file needed to provide secure communication.
-Here are the attributes you'll need to configure.
 
 {{% notice note %}}
 **NOTE**: By changing these parameters, the server will communicate using transport layer security (TLS) and expect agents that connect to it to use the WebSocket secure protocol.
-For communication to continue, you must complete the steps in this section **and** in the [Secure Sensu agent-to-server communication](#secure-sensu-agent-to-server-communication) section.
+For communication to continue, you must complete the configuration in this section **and** in the [Sensu agent-to-server communication](#sensu-agent-to-server-communication) section.
 {{% /notice %}}
 
+Here are the backend secure sockets layer (SSL) attributes you'll need to configure.
+
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
 insecure-skip-tls-verify: false
 {{< /code >}}
 
-Providing these cert-file and key-file parameters will cause the Agent Websocket API and HTTP API to serve requests over SSL/TLS (https).
-As a result, you will also need to specify `https://` schema for the `api-url` parameter:
+Providing these cert-file and key-file parameters will cause the agent WebSocket API and HTTP API to serve requests over SSL/TLS (https).
+As a result, you will also need to specify `https://` schema for the `api-url` parameter for backend API configuration:
 
 {{< code yml >}}
-##
-# backend api configuration
-##
 api-url: "https://localhost:8080"
 {{< /code >}}
 
-You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters:
+You can also specify a certificate and key for the web UI separately from the API using the `dashboard-cert-file` and `dashboard-key-file` parameters for backend SSL configuration:
 
 {{< code yml >}}
-##
-# backend ssl configuration
-##
 cert-file: "/path/to/ssl/cert.pem"
 key-file: "/path/to/ssl/key.pem"
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
@@ -103,32 +94,24 @@ In this example, we provide the path to the cert, key, and CA file.
 After you restart the `sensu-backend` service, the parameters will load and you will able to access the web UI at https://localhost:3000.
 Configuring these attributes will also ensure that agents can communicate securely.
 
-## Secure Sensu agent-to-server communication
+## Sensu agent-to-server communication
 
 {{% notice note %}}
 **NOTE**: If you change the agent configuration to communicate via WebSocket Secure protocol, the agent will no longer communicate over a plaintext connection.
-For communication to continue, you must complete the steps in this section **and** in the [Secure the API and web UI](#secure-the-api-and-web-ui) section.
+For communication to continue, you must complete the steps in this section **and** [secure the Sensu API and web UI](#sensu-api-and-web-ui).
 {{% /notice %}}
 
 By default, an agent uses the insecure `ws://` transport.
-Here's an example from `/etc/sensu/agent.yml`:
+Here's an example for agent configuration in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "ws://127.0.0.1:8081"
 {{< /code >}}
 
-To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema:
+To use WebSocket over SSL/TLS (wss), change the `backend-url` value to the `wss://` schema in `/etc/sensu/agent.yml`:
 
 {{< code yml >}}
----
-##
-# agent configuration
-##
 backend-url:
   - "wss://127.0.0.1:8081"
 {{< /code >}}
@@ -139,7 +122,7 @@ Remember, if you change the configuration to wss, plaintext communication will n
 You can also provide a trusted CA as part of the agent configuration by passing `--trusted-ca-file` if you are starting the agent via `sensu-agent start`.
 You may include it as part of the agent configuration in `/etc/sensu/agent.yml`: 
 
-{{< code yaml>}}
+{{< code yml>}}
 trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
 {{< /code >}}
 
@@ -170,10 +153,15 @@ For this use case, create a user that matches the Common Name (CN) of the agent'
 To ensure that agents with incorrect CN fields can't access the backend, remove the default `system:agents` group.
 {{% /notice %}}
 
-To view a certificate's CN with openssl:
+To view a certificate's CN with openssl, run:
 
 {{< code bash >}}
-$ openssl x509 -in client.pem -text -noout
+openssl x509 -in client.pem -text -noout
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code bash >}}
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -193,21 +181,16 @@ The `Subject:` field indicates the certificate's CN is `client`, so to bind the 
 To enable agent mTLS authentication, create and distribute new certificates and keys according to the [Generate certificates][12] guide.
 Once the TLS certificate and key are in place, [update the agent configuration using `cert-file` and `key-file` security configuration flags][7].
 
-After you create backend and agent certificates, modify the backend and agent configuration:
+After you create backend and agent certificates, modify the backend configuration:
 
 {{< code yml >}}
-##
-# backend configuration
-##
 agent-auth-cert-file: "/path/to/backend-1.pem"
 agent-auth-key-file: "/path/to/backend-1-key.pem"
 agent-auth-trusted-ca-file: "/path/to/ca.pem"
 {{< /code >}}
 
+Modify the agent configuration also:
 {{< code yml >}}
-##
-# agent configuration
-##
 cert-file: "/path/to/agent.pem"
 key-file: "/path/to/agent-key.pem"
 trusted-ca-file: "/path/to/ca.pem"

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -259,10 +259,14 @@ For a consistent experience, repeat the `ClusterRoleBinding` example in this gui
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
 To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+
+{{< code shell >}}
+sensuctl cluster-role-binding info federation-viewer-readonly
+{{< /code >}}
+
 You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
 
 {{< code shell >}}
-$ sensuctl cluster-role-binding info federation-viewer-readonly
 === federation-viewer-readonly
 Name:         federation-viewer-readonly
 Cluster Role: view

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -207,17 +207,15 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56].
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 {{< code yml >}}
-# agent configuration: /etc/sensu.agent.yml
-...
 api-port: 4041
 socket-port: 4030
-...
 {{< /code >}}
+
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
 
 Sensu should now be installed and functional. The next step is to translate your Sensu Core configuration to Sensu Go.
 
@@ -227,21 +225,27 @@ Use t [Sensu Translator][18] command line tool to transfer your Sensu Core check
 
 #### 1. Run the translator
 
-Install and run the translator.
+Install dependencies:
 
 {{< code shell >}}
-# Install dependencies
 yum install -q -y rubygems ruby-devel
+{{< /code >}}
 
-# Install sensu-translator
+Install the Sensu translator:
+
+{{< code shell >}}
 gem install sensu-translator
+{{< /code >}}
 
-# Translate all config in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated
-# Option: translate your config in sections according to resource type
+Run the Sensu translator to translate all configuration in /etc/sensu/conf.d to Sensu Go and output to /sensu_config_translated:
+
+{{< code shell >}}
 sensu-translator -d /etc/sensu/conf.d -o /sensu_config_translated
 {{< /code >}}
 
-If translation is successful, you should see a few callouts followed by `DONE!`.
+As an option, you can also translate your configuration in sections according to resource type.
+
+If translation is successful, you should see a few callouts followed by `DONE!`, similar to this example:
 
 {{< code shell >}}
 Sensu 1.x filter translation is not yet supported
@@ -325,8 +329,9 @@ As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used. Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61]. Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
-{{< code shell >}}
-# Sensu Core hourly filter
+Sensu Core hourly filter:
+
+{{< code json >}}
 {
   "filters": {
     "recurrences": {
@@ -336,19 +341,22 @@ First, review your Core handlers to identify which filters are being used. Then,
     }
   }
 }
+{{< /code >}}
 
-# Sensu Go hourly filter
-  {
-    "metadata": {
-      "name": "hourly",
-      "namespace": "default"
-    },
-    "action": "allow",
-    "expressions": [
-      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-    ],
-    "runtime_assets": null
-  }
+Sensu Go hourly filter:
+
+{{< code json >}}
+{
+  "metadata": {
+    "name": "hourly",
+    "namespace": "default"
+  },
+  "action": "allow",
+  "expressions": [
+    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+  ],
+  "runtime_assets": null
+}
 {{< /code >}}
 
 #### 4. Translate handlers
@@ -383,17 +391,23 @@ _PRO TIP: `sensuctl create` (and `sensuctl delete`) are powerful tools to help y
 
 Access your Sensu Go config using the [Sensu API][17].
 
+Set up a local API testing environment by saving your Sensu credentials and token as environment variables.
+This command requires curl and jq.
+
 {{< code shell >}}
-# Set up a local API testing environment by saving your Sensu credentials
-# and token as environment variables. Requires curl and jq.
 export SENSU_USER=admin && SENSU_PASS=P@ssw0rd!
-
 export SENSU_TOKEN=`curl -XGET -u "$SENSU_USER:$SENSU_PASS" -s http://localhost:8080/auth | jq -r ".access_token"`
+{{< /code >}}
 
-# Return list of all configured checks
+Return a list of all configured checks:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
+{{< /code >}}
 
-# Return list of all configured handlers
+Return a list of all configured handlers:
+
+{{< code shell >}}
 curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/namespaces/default/handlers
 {{< /code >}}
 

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -41,10 +41,15 @@ For help with restarting a service, see the [agent reference][5] or [backend ref
 
 #### Increment log level verbosity
 
-Use these commands to increment the log level verbosity at runtime:
+To increment the log level verbosity at runtime for the backend, run:
 
 {{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-backend)
+{{< /code >}}
+
+To increment the log level verbosity at runtime for the agent, run:
+
+{{< code shell >}}
 kill -s SIGUSR1 $(pidof sensu-agent)
 {{< /code >}}
 
@@ -61,17 +66,43 @@ To capture these log messages to disk or another logging facility, Sensu service
 For example, logs are sent to the journald when systemd is the service manager, whereas log messages are redirected to `/var/log/sensu` when running under sysv init schemes.
 If you are running systemd as your service manager and would rather have logs written to `/var/log/sensu/`, see [forwarding logs from journald to syslog][11].
 
-The following table lists the common targets for logging and example commands for following those logs.
-You may substitute the name of the desired service (e.g. `backend` or `agent`) for the `${service}` variable.
+For journald targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
 
-| Platform     | Version           | Target | Command to follow log |
-|--------------|-------------------|--------------|-----------------------------------------------|
-| RHEL/Centos  | >= 7       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| RHEL/Centos  | <= 6       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Ubuntu       | >= 15.04   | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Ubuntu       | <= 14.10   | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
-| Debian       | >= 8       | journald     | {{< code shell >}}journalctl --follow --unit sensu-${service}{{< /code >}}   |
-| Debian       | <= 7       | log file     | {{< code shell >}}tail --follow /var/log/sensu/sensu-${service}{{< /code >}} |
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS >= 7" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu >= 15.04" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian >= 8" >}}
+journalctl --follow --unit sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+For log file targets, use these commands to follow the logs.
+Replace the `${service}` variable with the name of the desired service (e.g. `backend` or `agent`).
+
+{{< language-toggle >}}
+
+{{< code shell "RHEL/CentOS <= 6" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Ubuntu <= 14.10" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< code shell "Debian <= 7" >}}
+tail --follow /var/log/sensu/sensu-${service}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: Platform versions are listed for reference only and do not supersede the documented [supported platforms](../../../platforms).
@@ -257,15 +288,15 @@ An improperly applied asset filter can prevent the asset from being downloaded b
 
 {{< code json >}}
 {
-    "asset": "check-disk-space",
-    "component": "asset-manager",
-    "entity": "sensu-centos",
-    "filters": [
-        "true == false"
-    ],
-    "level": "debug",
-    "msg": "entity not filtered, not installing asset",
-    "time": "2019-09-12T18:28:05Z"
+  "asset": "check-disk-space",
+  "component": "asset-manager",
+  "entity": "sensu-centos",
+  "filters": [
+    "true == false"
+  ],
+  "level": "debug",
+  "msg": "entity not filtered, not installing asset",
+  "time": "2019-09-12T18:28:05Z"
 }
 {{< /code >}}
 
@@ -483,21 +514,35 @@ To use etcdctl to investigate etcd cluster and data storage issues, first run th
 {{< code shell >}}
 export ETCDCTL_API=3
 export ETCDCTL_CACERT=/etc/sensu/ca.pem
-# skip ETCDCTL_CERT and ETCDCTL_KEY, unless your etcd uses client certificate authentication
-# export ETCDCTL_CERT=/etc/sensu/cert.pem
-# export ETCDCTL_KEY=/etc/sensu/key.pem
 export ETCDCTL_ENDPOINTS="https://backend01:2379,https://backend02:2379,https://backend03:2379"
+{{< /code >}}
+
+If your etcd uses client certificate authentication, run these commands too:
+
+{{< code shell >}}
+export ETCDCTL_CERT=/etc/sensu/cert.pem
+export ETCDCTL_KEY=/etc/sensu/key.pem
 {{< /code >}}
 
 ### View cluster status and alarms
 
 Use the commands listed here to retrieve etcd cluster status and list and clear alarms.
+
+To retrieve etcd cluster status:
+
 {{< code shell >}}
-# get status
 etcdctl endpoint status
-# list alarms
+{{< /code >}}
+
+To retrieve a list of etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm list
-# clear alarms
+{{< /code >}}
+
+To clear etcd alarms:
+
+{{< code shell >}}
 etcdctl alarm dearm
 {{< /code >}}
 
@@ -507,27 +552,41 @@ The etcd default maximum database size is 2 GB.
 If you suspect your etcd database exceeds the maximum size, run this command to confirm cluster size:
 
 {{< code shell >}}
-# get current status with database size
 etcdctl endpoint status
+{{< /code >}}
+
+The response will list the current cluster status and database size:
+
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 2.1GB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 2.1GB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 2.1GB, false, 144, 18619245
 {{< /code >}}
 
-To restore an etcd cluster with a database size that exceeds 2 GB, run these commands:
+To restore an etcd cluster with a database size that exceeds 2 GB:
 
+1. Get the current revision number:
 {{< code shell >}}
-# get current revision number
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
+{{< /code >}}
 
-# compact to revision, substitute revision obtained above for $rev
+2. Compact to revision and substitute the crrent revision for `$rev`:
+{{< code shell >}}
 etcdctl compact $rev
+{{< /code >}}
 
-# defrag to free space
+3. Defragment to free up space:
+{{< code shell >}}
 etcdctl defrag
+{{< /code >}}
 
-# confirm effective
+4. Confirm that the cluster is restored:
+{{< code shell >}}
 etcdctl endpoint status
+{{< /code >}}
+
+   The response should list the current cluster status and database size:
+{{< code shell >}}
 https://backend01:2379, 88db026f7feb72b4, 3.3.22, 1.0 MB, false, 144, 18619245
 https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
@@ -544,9 +603,9 @@ Sensu will attempt to recover from these conditions when it can, but this may no
 
 To maximize Sensu Go performance, we recommend that you:
  * Follow our [recommended backend hardware configuration][19].
- * Immplement [documented etcd system tuning practices][14].
+ * Implement [documented etcd system tuning practices][14].
  * [Benchmark your etcd storage volume][15] to establish baseline IOPS for your system.
- * [Scale event storage using PostgreSQL][16] with [round robin scheduling enabled][20] to reduce the overall volume of etcd transactions.
+ * [Scale event storage using PostgreSQL][16] with [round robin scheduling enabled][20] to reduce the overall volume of etcd transactions.  
 
  As your Sensu deployments grow, preventing issues associated with poor datastore performance relies on ongoing collection and review of [Sensu time-series performance metrics][18].
 

--- a/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
@@ -40,9 +40,8 @@ These commands use a Sensu backend running on `localhost` in the example URL and
 
 1. Get a list of existing namespaces.
 In this example, the existing namespaces are `stage` and `dev`.
-
-   {{< code shell >}}
-$ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/namespaces | jq '[.[].name]'
+{{< code shell >}}
+curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/namespaces | jq '[.[].name]'
 [
    "stage",
    "dev"
@@ -51,9 +50,8 @@ $ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/
 
 2. Print the name and namespace for any checks that reference a namespace that is not specified in the jq expression on the same line.
 Your jq expression should include all of the namespaces you retrieved in step 1 (in this example, `["stage","dev"]`).
-
-   {{< code shell >}}
-$ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/checks | jq '["stage","dev"] as $valid | .[] | select(.metadata.namespace as $in | $valid | index($in) | not) | {name: .metadata.name, namespace: .metadata.namespace}'
+{{< code shell >}}
+curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/v2/checks | jq '["stage","dev"] as $valid | .[] | select(.metadata.namespace as $in | $valid | index($in) | not) | {name: .metadata.name, namespace: .metadata.namespace}'
 {
   "name": "check-cpu",
   "namespace": "test"
@@ -61,21 +59,18 @@ $ curl -s -H "Authorization: Key $SENSU_API_KEY" http://localhost:8080/api/core/
 {{< /code >}}
 
 3. Recreate the missing `test` namespace so you can delete the `check-cpu` check.
-
-   {{< code shell >}}
-$ sensuctl namespace create test
+{{< code shell >}}
+sensuctl namespace create test
 {{< /code >}}
 
 4. Delete the `check-cpu` check.
-
-   {{< code shell >}}
-$ sensuctl check delete check-cpu --namespace test
+{{< code shell >}}
+sensuctl check delete check-cpu --namespace test
 {{< /code >}}
 
 5. Delete the `test` namespace, which is now empty after you deleted `check-cpu` in step 4.
-
-   {{< code shell >}}
-$ sensuctl namespace delete test
+{{< code shell >}}
+sensuctl namespace delete test
 {{< /code >}}
 
 After completing these commands, you can upgrade to 6.2.0.
@@ -88,11 +83,15 @@ To upgrade to Sensu Go 6.1.0 from version 6.0.0 or later, [install the latest pa
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -114,39 +113,41 @@ You will not be able to downgrade to a Sensu 5.x version after you upgrade your 
 To upgrade your Sensu Go 5.x deployment to 6.0:
 
 1. [Install][1] the 6.0 packages or Docker image.
-2. Restart the services.
+2. Restart the Sensu agent.
    
-   {{% notice note %}}
+ {{% notice note %}}
    **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
-   {{% /notice %}}
-   
-   {{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+{{% /notice %}}
 
-# Restart the Sensu backend
+  {{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+3. Restart the Sensu backend.
+
+  {{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
-3. Run a single upgrade command on one your Sensu backends to migrate the cluster:
+4. Run a single upgrade command on one your Sensu backends to migrate the cluster:
 
-   {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade
 {{< /code >}}
 
    - Add the `--skip-confirm` flag to skip the confirmation in step 4 and immediately run the upgrade command.
 
-    {{< code shell >}}
+  {{< code shell >}}
 sensu-backend upgrade --skip-confirm
 {{< /code >}}
 
-   {{% notice note %}}
+  {{% notice note %}}
    **NOTE**: If you are deploying a new Sensu 6.0 cluster rather than upgrading from 5.x, you do not need to run the `sensu-backend upgrade` command.
-   {{% /notice %}}
+{{% /notice %}}
 
-4. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
+5. Enter `y` or `n` to confirm if you did *not* add the `--skip-confirm` flag. Otherwise, skip this step.
 
-5. Wait a few seconds for the upgrade command to run.
+6. Wait a few seconds for the upgrade command to run.
 
 You may notice some inconsistencies in your entity list until the cluster finishes upgrading.
 Despite this, your cluster will continue to publish standard check requests and process events.
@@ -163,11 +164,15 @@ Then, restart the services.
 **NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
 {{% /notice %}}
 
-{{< code shell >}}
-# Restart the Sensu agent
-sudo service sensu-agent restart
+To restart the Sensu agent, run:
 
-# Restart the Sensu backend
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
 sudo service sensu-backend restart
 {{< /code >}}
 
@@ -215,14 +220,17 @@ See the [backend reference][2] for more information about stopping and starting 
 For Sensu backend binaries, the default `state-dir` in 5.1.0 is now `/var/lib/sensu/sensu-backend` instead of `/var/lib/sensu`.
 To upgrade your Sensu backend binary to 5.1.0, first [download the latest version][1].
 Then, make sure the `/etc/sensu/backend.yml` configuration file specifies a `state-dir`.
-To continue using `/var/lib/sensu` as the `state-dir`, add the following configuration to `/etc/sensu/backend.yml`.
+To continue using `/var/lib/sensu` as the `state-dir` to store backend data, add the following configuration to `/etc/sensu/backend.yml`:
 
 {{< code yml >}}
-# /etc/sensu/backend.yml configuration to store backend data at /var/lib/sensu
 state-dir: "/var/lib/sensu"
 {{< /code >}}
 
-Then restart the backend.
+Then restart the backend:
+
+{{< code shell >}}
+sudo service sensu-backend restart
+{{< /code >}}
 
 
 [1]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.3/operations/monitor-sensu/log-sensu-systemd.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/log-sensu-systemd.md
@@ -30,26 +30,31 @@ Next, set up rsyslog to write the logging data received from journald to `/var/l
 In this example, the `sensu-backend` and `sensu-agent` logging data is sent to individual files named after the service.
 The `sensu-backend` is not required if you're only setting up log forwarding for the `sensu-agent` service.
 
+1. For the sensu-backend service, in /etc/rsyslog.d/99-sensu-backend.conf, add:
 {{< code shell >}}
-# For the sensu-backend service, inside /etc/rsyslog.d/99-sensu-backend.conf
 if $programname == 'sensu-backend' then {
         /var/log/sensu/sensu-backend.log
         ~
 }
+{{< /code >}}
 
-# For the sensu-agent service, inside /etc/rsyslog.d/99-sensu-agent.conf
+2. For the sensu-agent service, in /etc/rsyslog.d/99-sensu-agent.conf, add:
+{{< code shell >}}
 if $programname == 'sensu-agent' then {
         /var/log/sensu/sensu-agent.log
         ~
 }
 {{< /code >}}
 
-**On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
+3. **On Ubuntu systems**, run `chown -R syslog:adm /var/log/sensu` so syslog can write to that directory.
 
-Restart rsyslog and journald to apply the new configuration:
-
+4. Restart journald:
 {{< code shell>}}
 systemctl restart systemd-journald
+{{< /code>}}
+
+5. Restart rsyslog to apply the new configuration:
+{{< code shell>}}
 systemctl restart rsyslog
 {{< /code>}}
 
@@ -66,8 +71,8 @@ These examples rotate the log files `/var/log/sensu/sensu-agent.log` and `/var/l
 The last seven rotated logs are kept and compressed, with the exception of the most recent log.
 After rotation, `rsyslog` is restarted to ensure logging is written to a new file and not the most recent rotated file.
 
+1. In /etc/logrotate.d/sensu-agent.conf, add:
 {{< code shell>}}
-# Inside /etc/logrotate.d/sensu-agent.conf
 /var/log/sensu/sensu-agent.log {
     daily
     rotate 7
@@ -78,8 +83,10 @@ After rotation, `rsyslog` is restarted to ensure logging is written to a new fil
       /bin/systemctl restart rsyslog
     endscript
 }
+{{< /code>}}
 
-# Inside /etc/logrotate.d/sensu-backend.conf
+2. In /etc/logrotate.d/sensu-backend.conf, add:
+{{< code shell>}}
 /var/log/sensu/sensu-backend.log {
     daily
     rotate 7


### PR DESCRIPTION
## Description
Part 3 -- Separates commands into individual code blocks and separates commands from responses throughout the docs to clarify instructions and make it easier for readers to copy and paste our code examples.

## Motivation and Context
Monitoring as code project