### PR TITLE
Separate commands and responses throughout docs - Part 4

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -37,6 +37,11 @@ Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP dynamic runtim
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-http:5.1.1
 added asset: sensu-plugins/sensu-plugins-http:5.1.1
 
@@ -53,6 +58,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -63,10 +73,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][17] and register the asset using `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Use sensuctl to confirm that both the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+Use sensuctl to confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  sensu-plugins-http         //assets.bonsai.sensu.io/.../sensu-plugins-http_5.1.1_centos_linux_amd64.tar.gz         31023af  
@@ -152,6 +167,11 @@ Use sensuctl to confirm that Sensu added the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should list `check-sensu-site`:
+
+{{< code shell >}}
        Name                     Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                     Assets                Hooks   Publish?   Stdin?  
 ────────────────── ────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
  check-sensu-site   check-http.rb -u https://sensu.io         60                0     0   proxy                      sensu-plugins-http,sensu-ruby-runtime             true     false
@@ -175,24 +195,31 @@ sudo service sensu-agent restart
 
 ### Validate the check
 
-Use sensuctl to confirm that Sensu created the proxy entity `sensu-site`:
+Use sensuctl to confirm that Sensu created `sensu-site`.
+It might take a few moments for Sensu to execute the check and create the proxy entity.
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the `sensu-site` proxy entity:
+
+{{< code shell >}}
       ID        Class    OS           Subscriptions                   Last Seen            
 ────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
 sensu-centos   agent   linux   proxy,entity:sensu-centos   2019-01-16 21:50:03 +0000 UTC  
 sensu-site     proxy           entity:sensu-site           N/A  
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: It might take a few moments for Sensu to execute the check and create the proxy entity.
-{{% /notice %}}
-
 Then, use sensuctl to confirm that Sensu is monitoring `sensu-site` with the `check-sensu-site` check:
 
 {{< code shell >}}
 sensuctl event info sensu-site check-sensu-site
+{{< /code >}}
+
+The response should list `check-sensu-site` status and history data for the `sensu-site` proxy entity:
+
+{{< code shell >}}
 === sensu-site - check-sensu-site
 Entity:    sensu-site
 Check:     check-sensu-site
@@ -340,6 +367,11 @@ Use sensuctl to confirm that the entities were added:
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the new `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
         ID           Class    OS           Subscriptions                   Last Seen            
 ─────────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
  github-site         proxy                                       N/A                            
@@ -431,6 +463,12 @@ Use sensuctl to confirm that Sensu created the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should include the `check-http` check:
+
+{{< code shell >}}
+sensuctl check list
        Name                      Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                   Assets                  Hooks   Publish?   Stdin?
 ───────────────── ─────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
   check-http        check-http.rb -u {{ .labels.url }}         60                0     0   proxy                     sensu-plugins-http,sensu-ruby-runtime           true       false                                     
@@ -449,6 +487,11 @@ Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io,
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list check status data for the `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
       Entity                Check          Output   Status   Silenced             Timestamp            
 ─────────────────── ───────────────────── ──────── ──────── ────────── ─────────────────────────────── 
 github-site         check-http                           0   false      2019-01-17 17:10:31 +0000 UTC  

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -66,6 +66,11 @@ Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] dynamic 
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 added asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
@@ -52,6 +52,11 @@ To add the has-contact dynamic runtime asset to Sensu, use [`sensuctl asset add`
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.2.0 -r contact-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.2.0
 added asset: sensu/sensu-go-has-contact-filter:0.2.0
 
@@ -133,6 +138,11 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 
@@ -152,14 +162,12 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run this example:
+To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+
+- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
 {{< code shell >}}
-# Edit before running:
-# 1. Add your SLACK_WEBHOOK_URL
-# 2. Make sure the Slack channels specified in the
-#    command` attributes match channels available
-#    to receive test alerts in your Slack instance.
 echo '---
 type: Handler
 api_version: core/v2
@@ -344,6 +352,7 @@ In this example, the `dev` label in the check configuration overrides the `ops` 
 
 Now that you've set up contact routing for two example teams, you can create additional filters, handlers, and labels to represent your team's contacts.
 Learn how to use Sensu to [Reduce alert fatigue][11].
+
 
 [1]: ../../../operations/deploy-sensu/install-sensu#install-the-sensu-backend
 [2]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
@@ -92,33 +92,43 @@ Use the template toolkit command to print a list of the available event attribut
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
-	.Entity{
-    	.EntityClass: "agent",
-    	.System:      .System{
-	[...]
-	.Check{
-    	.Command:           "",
-    	.Handlers:          {"keepalive"},
-    	.HighFlapThreshold: 0x0,
-	[...]
+    .Entity{
+        .EntityClass: "agent",
+        .System:      .System{
+    [...]
+    .Check{
+        .Command:           "",
+        .Handlers:          {"keepalive"},
+        .HighFlapThreshold: 0x0,
+    [...]
 {{< /code >}}
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
 sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
     .Entity:{
         .EntityClass:        "proxy",
         .System:             .System{
-	[...]
+    [...]
     .Check:{
         .Command:           "health.sh",
         .Handlers:          {"slack"},
@@ -134,6 +144,11 @@ For example, to test the output for the `{{.Check.Name}}` attribute for the even
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --template "{{.Check.Name}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 executing command with --template {{.Check.Name}}
 Template String Output: keepalive
@@ -145,6 +160,11 @@ You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate te
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 Executing command with --template Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}
 Template String Output: Server: "webserver01 Check: check-http Status: passing"
 {{< /code >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/plan-maintenance.md
@@ -55,11 +55,9 @@ Use sensuctl to verify that the silenced entry against the entity `i-424242` was
 sensuctl silenced info 'entity:i-424242:check-http'
 {{< /code >}}
 
-After the silenced entry starts to take effect, events that are silenced will be marked as such in `sensuctl events`:
+After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
-sensuctl event list
-
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
    i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
@@ -72,6 +70,7 @@ sensuctl event list
 ## Next steps
 
 Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+
 
 [1]: ../handlers/
 [2]: ../silencing/#silence-all-checks-on-a-specific-entity

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -29,6 +29,11 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
 added asset: sensu/sensu-influxdb-handler:3.1.2
 
@@ -130,10 +135,17 @@ spec:
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
 For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
 
-Update the output metric format and output metric handlers to use the check with InfluxDB:
+Update the output metric format and output metric handlers to use the check with InfluxDB:.
+
+To update the output metric format, run:
 
 {{< code shell >}}
 sensuctl check set-output-metric-format collect-metrics influxdb_line
+{{< /code >}}
+
+To update the output metric handlers, run:
+
+{{< code shell >}}
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
@@ -33,6 +33,11 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler -r email-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 no version specified, using latest: 0.6.0
 fetching bonsai asset: sensu/sensu-email-handler:0.6.0
 added asset: sensu/sensu-email-handler:0.6.0
@@ -271,6 +276,7 @@ Now that you know how to apply a handler to a check and take action on events:
 - Check out the [Reduce alert fatigue][7] guide.
 
 You can also follow our [Up and running with Sensu Go][9] interactive tutorial to set up the Sensu Go email handler and test a similar workflow with the addition of a Sensu agent for producing events using scheduled checks.
+
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
@@ -28,6 +28,11 @@ Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -50,7 +50,6 @@ sensuctl check set-hooks nginx_process  \
 
 Verify that the check hook is behaving properly against a specific event with `sensuctl`.
 It might take a few moments after you assign the check hook for the check to be scheduled on the entity and the result sent back to the Sensu backend.
-The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -63,6 +62,8 @@ sensuctl event info i-424242 nginx_process --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -113,7 +114,11 @@ This example uses sensuctl to query event info and send the response to `jq` so 
 
 {{< code shell >}}
 sensuctl event info i-424242 nginx_process --format json | jq -r '.check.hooks[0].output' 
+{{< /code >}}
 
+This example output is truncated for brevity, but it reflects the output of the `ps aux` command specified in the check hook you created:
+
+{{< code shell >}}
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.3  46164  6704 ?        Ss   Nov17   0:11 /usr/lib/systemd/systemd --switched-root --system --deserialize 20
 root         2  0.0  0.0      0     0 ?        S    Nov17   0:00 [kthreadd]
@@ -123,11 +128,11 @@ root         8  0.0  0.0      0     0 ?        S    Nov17   0:00 [rcu_bh]
 root         9  0.0  0.0      0     0 ?        S    Nov17   0:34 [rcu_sched]
 {{< /code >}}
 
-Although this output is truncated in the interest of brevity, it reflects the output of the `ps aux` command specified in the check hook you created.
 Now when you are alerted that Nginx is not running, you can review the check hook output to confirm this is true with no need to start up an SSH session to investigate.
 
 ## Next steps
 
 To learn more about data collection with check hooks, read the [hooks reference][1].
+
 
 [1]: ../hooks/

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -34,7 +34,7 @@ Use sensuctl to register the Sensu Disk Checks Plugin dynamic runtime asset, `se
 sensuctl asset add sensu-plugins/sensu-plugins-disk-checks:5.1.4
 {{< /code >}}
 
-You should see a response like this:
+The response will indicate that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -33,6 +33,11 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 added asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 
@@ -49,6 +54,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -59,10 +69,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][7] and register the asset using `sensuctl create --file filename.yml`.
 
-Use sensuctl to confirm that both the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+To confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  cpu-checks-plugins   //assets.bonsai.sensu.io/.../sensu-plugins-cpu-checks_4.1.0_centos_linux_amd64.tar.gz          518e7c1  
@@ -105,11 +120,16 @@ sudo service sensu-agent restart
 
 ## Validate the check
 
-Use sensuctl to confirm that Sensu is monitoring CPU usage using the `check-cpu`, returning an OK status (`0`).
+Use sensuctl to confirm that Sensu is monitoring CPU usage.
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list the `check-cpu` check, returning an OK status (`0`)
+
+{{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
  sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
@@ -123,6 +143,7 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 * [Use assets to install plugins][2]
 * [Monitor external resources with proxy checks and entities][5]
 * [Send Slack alerts with handlers][6]
+
 
 [1]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-cpu-checks
 [2]: ../../../plugins/use-assets-to-install-plugins/

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -37,6 +37,11 @@ Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP dynamic runtim
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-http:5.1.1
 added asset: sensu-plugins/sensu-plugins-http:5.1.1
 
@@ -53,6 +58,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -63,10 +73,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][17] and register the asset using `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Use sensuctl to confirm that both the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+Use sensuctl to confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  sensu-plugins-http         //assets.bonsai.sensu.io/.../sensu-plugins-http_5.1.1_centos_linux_amd64.tar.gz         31023af  
@@ -152,6 +167,11 @@ Use sensuctl to confirm that Sensu added the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should list `check-sensu-site`:
+
+{{< code shell >}}
        Name                     Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                     Assets                Hooks   Publish?   Stdin?  
 ────────────────── ────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
  check-sensu-site   check-http.rb -u https://sensu.io         60                0     0   proxy                      sensu-plugins-http,sensu-ruby-runtime             true     false
@@ -175,24 +195,31 @@ sudo service sensu-agent restart
 
 ### Validate the check
 
-Use sensuctl to confirm that Sensu created the proxy entity `sensu-site`:
+Use sensuctl to confirm that Sensu created `sensu-site`.
+It might take a few moments for Sensu to execute the check and create the proxy entity.
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the `sensu-site` proxy entity:
+
+{{< code shell >}}
       ID        Class    OS           Subscriptions                   Last Seen            
 ────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
 sensu-centos   agent   linux   proxy,entity:sensu-centos   2019-01-16 21:50:03 +0000 UTC  
 sensu-site     proxy           entity:sensu-site           N/A  
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: It might take a few moments for Sensu to execute the check and create the proxy entity.
-{{% /notice %}}
-
 Then, use sensuctl to confirm that Sensu is monitoring `sensu-site` with the `check-sensu-site` check:
 
 {{< code shell >}}
 sensuctl event info sensu-site check-sensu-site
+{{< /code >}}
+
+The response should list `check-sensu-site` status and history data for the `sensu-site` proxy entity:
+
+{{< code shell >}}
 === sensu-site - check-sensu-site
 Entity:    sensu-site
 Check:     check-sensu-site
@@ -340,6 +367,11 @@ Use sensuctl to confirm that the entities were added:
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the new `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
         ID           Class    OS           Subscriptions                   Last Seen            
 ─────────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
  github-site         proxy                                       N/A                            
@@ -431,6 +463,12 @@ Use sensuctl to confirm that Sensu created the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should include the `check-http` check:
+
+{{< code shell >}}
+sensuctl check list
        Name                      Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                   Assets                  Hooks   Publish?   Stdin?
 ───────────────── ─────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
   check-http        check-http.rb -u {{ .labels.url }}         60                0     0   proxy                     sensu-plugins-http,sensu-ruby-runtime           true       false                                     
@@ -449,6 +487,11 @@ Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io,
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list check status data for the `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
       Entity                Check          Output   Status   Silenced             Timestamp            
 ─────────────────── ───────────────────── ──────── ──────── ────────── ─────────────────────────────── 
 github-site         check-http                           0   false      2019-01-17 17:10:31 +0000 UTC  

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -66,6 +66,11 @@ Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] dynamic 
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 added asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
@@ -52,6 +52,11 @@ To add the has-contact dynamic runtime asset to Sensu, use [`sensuctl asset add`
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.2.0 -r contact-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.2.0
 added asset: sensu/sensu-go-has-contact-filter:0.2.0
 
@@ -133,6 +138,11 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 
@@ -152,14 +162,12 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run this example:
+To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+
+- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
 {{< code shell >}}
-# Edit before running:
-# 1. Add your SLACK_WEBHOOK_URL
-# 2. Make sure the Slack channels specified in the
-#    command` attributes match channels available
-#    to receive test alerts in your Slack instance.
 echo '---
 type: Handler
 api_version: core/v2
@@ -344,6 +352,7 @@ In this example, the `dev` label in the check configuration overrides the `ops` 
 
 Now that you've set up contact routing for two example teams, you can create additional filters, handlers, and labels to represent your team's contacts.
 Learn how to use Sensu to [Reduce alert fatigue][11].
+
 
 [1]: ../../../operations/deploy-sensu/install-sensu#install-the-sensu-backend
 [2]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
@@ -92,33 +92,43 @@ Use the template toolkit command to print a list of the available event attribut
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
-	.Entity{
-    	.EntityClass: "agent",
-    	.System:      .System{
-	[...]
-	.Check{
-    	.Command:           "",
-    	.Handlers:          {"keepalive"},
-    	.HighFlapThreshold: 0x0,
-	[...]
+    .Entity{
+        .EntityClass: "agent",
+        .System:      .System{
+    [...]
+    .Check{
+        .Command:           "",
+        .Handlers:          {"keepalive"},
+        .HighFlapThreshold: 0x0,
+    [...]
 {{< /code >}}
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
 sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
     .Entity:{
         .EntityClass:        "proxy",
         .System:             .System{
-	[...]
+    [...]
     .Check:{
         .Command:           "health.sh",
         .Handlers:          {"slack"},
@@ -134,6 +144,11 @@ For example, to test the output for the `{{.Check.Name}}` attribute for the even
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --template "{{.Check.Name}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 executing command with --template {{.Check.Name}}
 Template String Output: keepalive
@@ -145,6 +160,11 @@ You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate te
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 Executing command with --template Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}
 Template String Output: Server: "webserver01 Check: check-http Status: passing"
 {{< /code >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/plan-maintenance.md
@@ -55,11 +55,9 @@ Use sensuctl to verify that the silenced entry against the entity `i-424242` was
 sensuctl silenced info 'entity:i-424242:check-http'
 {{< /code >}}
 
-After the silenced entry starts to take effect, events that are silenced will be marked as such in `sensuctl events`:
+After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
-sensuctl event list
-
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
    i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
@@ -72,6 +70,7 @@ sensuctl event list
 ## Next steps
 
 Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+
 
 [1]: ../handlers/
 [2]: ../silencing/#silence-all-checks-on-a-specific-entity

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -29,6 +29,11 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
 added asset: sensu/sensu-influxdb-handler:3.1.2
 
@@ -130,10 +135,17 @@ spec:
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
 For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
 
-Update the output metric format and output metric handlers to use the check with InfluxDB:
+Update the output metric format and output metric handlers to use the check with InfluxDB:.
+
+To update the output metric format, run:
 
 {{< code shell >}}
 sensuctl check set-output-metric-format collect-metrics influxdb_line
+{{< /code >}}
+
+To update the output metric handlers, run:
+
+{{< code shell >}}
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
@@ -33,6 +33,11 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler -r email-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 no version specified, using latest: 0.6.0
 fetching bonsai asset: sensu/sensu-email-handler:0.6.0
 added asset: sensu/sensu-email-handler:0.6.0
@@ -271,6 +276,7 @@ Now that you know how to apply a handler to a check and take action on events:
 - Check out the [Reduce alert fatigue][7] guide.
 
 You can also follow our [Up and running with Sensu Go][9] interactive tutorial to set up the Sensu Go email handler and test a similar workflow with the addition of a Sensu agent for producing events using scheduled checks.
+
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
@@ -28,6 +28,11 @@ Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -50,7 +50,6 @@ sensuctl check set-hooks nginx_process  \
 
 Verify that the check hook is behaving properly against a specific event with `sensuctl`.
 It might take a few moments after you assign the check hook for the check to be scheduled on the entity and the result sent back to the Sensu backend.
-The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -63,6 +62,8 @@ sensuctl event info i-424242 nginx_process --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -113,7 +114,11 @@ This example uses sensuctl to query event info and send the response to `jq` so 
 
 {{< code shell >}}
 sensuctl event info i-424242 nginx_process --format json | jq -r '.check.hooks[0].output' 
+{{< /code >}}
 
+This example output is truncated for brevity, but it reflects the output of the `ps aux` command specified in the check hook you created:
+
+{{< code shell >}}
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.3  46164  6704 ?        Ss   Nov17   0:11 /usr/lib/systemd/systemd --switched-root --system --deserialize 20
 root         2  0.0  0.0      0     0 ?        S    Nov17   0:00 [kthreadd]
@@ -123,11 +128,11 @@ root         8  0.0  0.0      0     0 ?        S    Nov17   0:00 [rcu_bh]
 root         9  0.0  0.0      0     0 ?        S    Nov17   0:34 [rcu_sched]
 {{< /code >}}
 
-Although this output is truncated in the interest of brevity, it reflects the output of the `ps aux` command specified in the check hook you created.
 Now when you are alerted that Nginx is not running, you can review the check hook output to confirm this is true with no need to start up an SSH session to investigate.
 
 ## Next steps
 
 To learn more about data collection with check hooks, read the [hooks reference][1].
+
 
 [1]: ../hooks/

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -34,7 +34,7 @@ Use sensuctl to register the Sensu Disk Checks Plugin dynamic runtime asset, `se
 sensuctl asset add sensu-plugins/sensu-plugins-disk-checks:5.1.4
 {{< /code >}}
 
-You should see a response like this:
+The response will indicate that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -33,6 +33,11 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 added asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 
@@ -49,6 +54,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -59,10 +69,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][7] and register the asset using `sensuctl create --file filename.yml`.
 
-Use sensuctl to confirm that both the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+To confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  cpu-checks-plugins   //assets.bonsai.sensu.io/.../sensu-plugins-cpu-checks_4.1.0_centos_linux_amd64.tar.gz          518e7c1  
@@ -105,11 +120,16 @@ sudo service sensu-agent restart
 
 ## Validate the check
 
-Use sensuctl to confirm that Sensu is monitoring CPU usage using the `check-cpu`, returning an OK status (`0`).
+Use sensuctl to confirm that Sensu is monitoring CPU usage.
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list the `check-cpu` check, returning an OK status (`0`)
+
+{{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
  sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
@@ -123,6 +143,7 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 * [Use assets to install plugins][2]
 * [Monitor external resources with proxy checks and entities][5]
 * [Send Slack alerts with handlers][6]
+
 
 [1]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-cpu-checks
 [2]: ../../../plugins/use-assets-to-install-plugins/

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -37,6 +37,11 @@ Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP dynamic runtim
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-http:5.1.1
 added asset: sensu-plugins/sensu-plugins-http:5.1.1
 
@@ -53,6 +58,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -63,10 +73,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][17] and register the asset using `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Use sensuctl to confirm that both the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+Use sensuctl to confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  sensu-plugins-http         //assets.bonsai.sensu.io/.../sensu-plugins-http_5.1.1_centos_linux_amd64.tar.gz         31023af  
@@ -152,6 +167,11 @@ Use sensuctl to confirm that Sensu added the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should list `check-sensu-site`:
+
+{{< code shell >}}
        Name                     Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                     Assets                Hooks   Publish?   Stdin?  
 ────────────────── ────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
  check-sensu-site   check-http.rb -u https://sensu.io         60                0     0   proxy                      sensu-plugins-http,sensu-ruby-runtime             true     false
@@ -175,24 +195,31 @@ sudo service sensu-agent restart
 
 ### Validate the check
 
-Use sensuctl to confirm that Sensu created the proxy entity `sensu-site`:
+Use sensuctl to confirm that Sensu created `sensu-site`.
+It might take a few moments for Sensu to execute the check and create the proxy entity.
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the `sensu-site` proxy entity:
+
+{{< code shell >}}
       ID        Class    OS           Subscriptions                   Last Seen            
 ────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
 sensu-centos   agent   linux   proxy,entity:sensu-centos   2019-01-16 21:50:03 +0000 UTC  
 sensu-site     proxy           entity:sensu-site           N/A  
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: It might take a few moments for Sensu to execute the check and create the proxy entity.
-{{% /notice %}}
-
 Then, use sensuctl to confirm that Sensu is monitoring `sensu-site` with the `check-sensu-site` check:
 
 {{< code shell >}}
 sensuctl event info sensu-site check-sensu-site
+{{< /code >}}
+
+The response should list `check-sensu-site` status and history data for the `sensu-site` proxy entity:
+
+{{< code shell >}}
 === sensu-site - check-sensu-site
 Entity:    sensu-site
 Check:     check-sensu-site
@@ -340,6 +367,11 @@ Use sensuctl to confirm that the entities were added:
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the new `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
         ID           Class    OS           Subscriptions                   Last Seen            
 ─────────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
  github-site         proxy                                       N/A                            
@@ -431,6 +463,12 @@ Use sensuctl to confirm that Sensu created the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should include the `check-http` check:
+
+{{< code shell >}}
+sensuctl check list
        Name                      Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                   Assets                  Hooks   Publish?   Stdin?
 ───────────────── ─────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
   check-http        check-http.rb -u {{ .labels.url }}         60                0     0   proxy                     sensu-plugins-http,sensu-ruby-runtime           true       false                                     
@@ -449,6 +487,11 @@ Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io,
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list check status data for the `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
       Entity                Check          Output   Status   Silenced             Timestamp            
 ─────────────────── ───────────────────── ──────── ──────── ────────── ─────────────────────────────── 
 github-site         check-http                           0   false      2019-01-17 17:10:31 +0000 UTC  

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -66,6 +66,11 @@ Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] dynamic 
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 added asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
@@ -52,6 +52,11 @@ To add the has-contact dynamic runtime asset to Sensu, use [`sensuctl asset add`
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.2.0 -r contact-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.2.0
 added asset: sensu/sensu-go-has-contact-filter:0.2.0
 
@@ -133,6 +138,11 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 
@@ -152,14 +162,12 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run this example:
+To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+
+- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
 {{< code shell >}}
-# Edit before running:
-# 1. Add your SLACK_WEBHOOK_URL
-# 2. Make sure the Slack channels specified in the
-#    command` attributes match channels available
-#    to receive test alerts in your Slack instance.
 echo '---
 type: Handler
 api_version: core/v2
@@ -345,10 +353,11 @@ In this example, the `dev` label in the check configuration overrides the `ops` 
 Now that you've set up contact routing for two example teams, you can create additional filters, handlers, and labels to represent your team's contacts.
 Learn how to use Sensu to [Reduce alert fatigue][11].
 
+
 [1]: ../../../operations/deploy-sensu/install-sensu#install-the-sensu-backend
 [2]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents
 [3]: ../../../operations/deploy-sensu/install-sensu#install-sensuctl
-[4]: ../../../sensuctl/#first-time-setup-and-authentication-and-authentication
+[4]: ../../../sensuctl/#first-time-setup-and-authentication
 [5]: https://curl.haxx.se/
 [6]: https://api.slack.com/incoming-webhooks
 [7]: ../../../learn/learn-sensu-sandbox/

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handler-templates.md
@@ -92,33 +92,43 @@ Use the template toolkit command to print a list of the available event attribut
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
-	.Entity{
-    	.EntityClass: "agent",
-    	.System:      .System{
-	[...]
-	.Check{
-    	.Command:           "",
-    	.Handlers:          {"keepalive"},
-    	.HighFlapThreshold: 0x0,
-	[...]
+    .Entity{
+        .EntityClass: "agent",
+        .System:      .System{
+    [...]
+    .Check{
+        .Command:           "",
+        .Handlers:          {"keepalive"},
+        .HighFlapThreshold: 0x0,
+    [...]
 {{< /code >}}
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
 sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
     .Entity:{
         .EntityClass:        "proxy",
         .System:             .System{
-	[...]
+    [...]
     .Check:{
         .Command:           "health.sh",
         .Handlers:          {"slack"},
@@ -134,6 +144,11 @@ For example, to test the output for the `{{.Check.Name}}` attribute for the even
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --template "{{.Check.Name}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 executing command with --template {{.Check.Name}}
 Template String Output: keepalive
@@ -145,6 +160,11 @@ You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate te
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 Executing command with --template Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}
 Template String Output: Server: "webserver01 Check: check-http Status: passing"
 {{< /code >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
@@ -55,11 +55,9 @@ Use sensuctl to verify that the silenced entry against the entity `i-424242` was
 sensuctl silenced info 'entity:i-424242:check-http'
 {{< /code >}}
 
-After the silenced entry starts to take effect, events that are silenced will be marked as such in `sensuctl events`:
+After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
-sensuctl event list
-
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
    i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
@@ -72,6 +70,7 @@ sensuctl event list
 ## Next steps
 
 Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+
 
 [1]: ../handlers/
 [2]: ../silencing/#silence-all-checks-on-a-specific-entity

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -29,6 +29,11 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
 added asset: sensu/sensu-influxdb-handler:3.1.2
 
@@ -130,10 +135,17 @@ spec:
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
 For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
 
-Update the output metric format and output metric handlers to use the check with InfluxDB:
+Update the output metric format and output metric handlers to use the check with InfluxDB:.
+
+To update the output metric format, run:
 
 {{< code shell >}}
 sensuctl check set-output-metric-format collect-metrics influxdb_line
+{{< /code >}}
+
+To update the output metric handlers, run:
+
+{{< code shell >}}
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -33,6 +33,11 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler -r email-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 no version specified, using latest: 0.6.0
 fetching bonsai asset: sensu/sensu-email-handler:0.6.0
 added asset: sensu/sensu-email-handler:0.6.0
@@ -271,6 +276,7 @@ Now that you know how to apply a handler to a check and take action on events:
 - Check out the [Reduce alert fatigue][7] guide.
 
 You can also follow our [Up and running with Sensu Go][9] interactive tutorial to set up the Sensu Go email handler and test a similar workflow with the addition of a Sensu agent for producing events using scheduled checks.
+
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
@@ -28,6 +28,11 @@ Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -50,7 +50,6 @@ sensuctl check set-hooks nginx_process  \
 
 Verify that the check hook is behaving properly against a specific event with `sensuctl`.
 It might take a few moments after you assign the check hook for the check to be scheduled on the entity and the result sent back to the Sensu backend.
-The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -63,6 +62,8 @@ sensuctl event info i-424242 nginx_process --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -113,7 +114,11 @@ This example uses sensuctl to query event info and send the response to `jq` so 
 
 {{< code shell >}}
 sensuctl event info i-424242 nginx_process --format json | jq -r '.check.hooks[0].output' 
+{{< /code >}}
 
+This example output is truncated for brevity, but it reflects the output of the `ps aux` command specified in the check hook you created:
+
+{{< code shell >}}
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.3  46164  6704 ?        Ss   Nov17   0:11 /usr/lib/systemd/systemd --switched-root --system --deserialize 20
 root         2  0.0  0.0      0     0 ?        S    Nov17   0:00 [kthreadd]
@@ -123,11 +128,11 @@ root         8  0.0  0.0      0     0 ?        S    Nov17   0:00 [rcu_bh]
 root         9  0.0  0.0      0     0 ?        S    Nov17   0:34 [rcu_sched]
 {{< /code >}}
 
-Although this output is truncated in the interest of brevity, it reflects the output of the `ps aux` command specified in the check hook you created.
 Now when you are alerted that Nginx is not running, you can review the check hook output to confirm this is true with no need to start up an SSH session to investigate.
 
 ## Next steps
 
 To learn more about data collection with check hooks, read the [hooks reference][1].
+
 
 [1]: ../hooks/

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -34,7 +34,7 @@ Use sensuctl to register the Sensu Disk Checks Plugin dynamic runtime asset, `se
 sensuctl asset add sensu-plugins/sensu-plugins-disk-checks:5.1.4
 {{< /code >}}
 
-You should see a response like this:
+The response will indicate that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -33,6 +33,11 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 added asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 
@@ -49,6 +54,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -59,10 +69,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][7] and register the asset using `sensuctl create --file filename.yml`.
 
-Use sensuctl to confirm that both the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+To confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  cpu-checks-plugins   //assets.bonsai.sensu.io/.../sensu-plugins-cpu-checks_4.1.0_centos_linux_amd64.tar.gz          518e7c1  
@@ -105,11 +120,16 @@ sudo service sensu-agent restart
 
 ## Validate the check
 
-Use sensuctl to confirm that Sensu is monitoring CPU usage using the `check-cpu`, returning an OK status (`0`).
+Use sensuctl to confirm that Sensu is monitoring CPU usage.
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list the `check-cpu` check, returning an OK status (`0`)
+
+{{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
  sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
@@ -123,6 +143,7 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 * [Use assets to install plugins][2]
 * [Monitor external resources with proxy checks and entities][5]
 * [Send Slack alerts with handlers][6]
+
 
 [1]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-cpu-checks
 [2]: ../../../plugins/use-assets-to-install-plugins/

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -37,6 +37,11 @@ Use [`sensuctl asset add`][21] to register the Sensu Plugins HTTP dynamic runtim
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-http:5.1.1 -r sensu-plugins-http
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-http:5.1.1
 added asset: sensu-plugins/sensu-plugins-http:5.1.1
 
@@ -53,6 +58,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -63,10 +73,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][17] and register the asset using `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Use sensuctl to confirm that both the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+Use sensuctl to confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `sensu-plugins-http` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  sensu-plugins-http         //assets.bonsai.sensu.io/.../sensu-plugins-http_5.1.1_centos_linux_amd64.tar.gz         31023af  
@@ -152,6 +167,11 @@ Use sensuctl to confirm that Sensu added the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should list `check-sensu-site`:
+
+{{< code shell >}}
        Name                     Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                     Assets                Hooks   Publish?   Stdin?  
 ────────────────── ────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
  check-sensu-site   check-http.rb -u https://sensu.io         60                0     0   proxy                      sensu-plugins-http,sensu-ruby-runtime             true     false
@@ -175,24 +195,31 @@ sudo service sensu-agent restart
 
 ### Validate the check
 
-Use sensuctl to confirm that Sensu created the proxy entity `sensu-site`:
+Use sensuctl to confirm that Sensu created `sensu-site`.
+It might take a few moments for Sensu to execute the check and create the proxy entity.
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the `sensu-site` proxy entity:
+
+{{< code shell >}}
       ID        Class    OS           Subscriptions                   Last Seen            
 ────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
 sensu-centos   agent   linux   proxy,entity:sensu-centos   2019-01-16 21:50:03 +0000 UTC  
 sensu-site     proxy           entity:sensu-site           N/A  
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: It might take a few moments for Sensu to execute the check and create the proxy entity.
-{{% /notice %}}
-
 Then, use sensuctl to confirm that Sensu is monitoring `sensu-site` with the `check-sensu-site` check:
 
 {{< code shell >}}
 sensuctl event info sensu-site check-sensu-site
+{{< /code >}}
+
+The response should list `check-sensu-site` status and history data for the `sensu-site` proxy entity:
+
+{{< code shell >}}
 === sensu-site - check-sensu-site
 Entity:    sensu-site
 Check:     check-sensu-site
@@ -340,6 +367,11 @@ Use sensuctl to confirm that the entities were added:
 
 {{< code shell >}}
 sensuctl entity list
+{{< /code >}}
+
+The response should list the new `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
         ID           Class    OS           Subscriptions                   Last Seen            
 ─────────────────── ─────── ─────── ─────────────────────────── ─────────────────────────────── 
  github-site         proxy                                       N/A                            
@@ -431,6 +463,12 @@ Use sensuctl to confirm that Sensu created the check:
 
 {{< code shell >}}
 sensuctl check list
+{{< /code >}}
+
+The response should include the `check-http` check:
+
+{{< code shell >}}
+sensuctl check list
        Name                      Command               Interval   Cron   Timeout   TTL   Subscriptions   Handlers                   Assets                  Hooks   Publish?   Stdin?
 ───────────────── ─────────────────────────────────── ────────── ────── ───────── ───── ─────────────── ────────── ─────────────────────────────────────── ─────── ────────── ────────
   check-http        check-http.rb -u {{ .labels.url }}         60                0     0   proxy                     sensu-plugins-http,sensu-ruby-runtime           true       false                                     
@@ -449,6 +487,11 @@ Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io,
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list check status data for the `sensu-docs`, `packagecloud-site`, and `github-site` proxy entities:
+
+{{< code shell >}}
       Entity                Check          Output   Status   Silenced             Timestamp            
 ─────────────────── ───────────────────── ──────── ──────── ────────── ─────────────────────────────── 
 github-site         check-http                           0   false      2019-01-17 17:10:31 +0000 UTC  

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -66,6 +66,11 @@ Use [`sensuctl asset add`][5] to register the [fatigue check filter][8] dynamic 
 
 {{< code shell >}}
 sensuctl asset add nixwiz/sensu-go-fatigue-check-filter:0.3.2 -r fatigue-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 added asset: nixwiz/sensu-go-fatigue-check-filter:0.3.2
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -52,6 +52,11 @@ To add the has-contact dynamic runtime asset to Sensu, use [`sensuctl asset add`
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.2.0 -r contact-filter
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.2.0
 added asset: sensu/sensu-go-has-contact-filter:0.2.0
 
@@ -133,6 +138,11 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 
@@ -152,14 +162,12 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run this example:
+To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+
+- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
 {{< code shell >}}
-# Edit before running:
-# 1. Add your SLACK_WEBHOOK_URL
-# 2. Make sure the Slack channels specified in the
-#    command` attributes match channels available
-#    to receive test alerts in your Slack instance.
 echo '---
 type: Handler
 api_version: core/v2
@@ -344,6 +352,7 @@ In this example, the `dev` label in the check configuration overrides the `ops` 
 
 Now that you've set up contact routing for two example teams, you can create additional filters, handlers, and labels to represent your team's contacts.
 Learn how to use Sensu to [Reduce alert fatigue][11].
+
 
 [1]: ../../../operations/deploy-sensu/install-sensu#install-the-sensu-backend
 [2]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
@@ -92,6 +92,11 @@ Use the template toolkit command to print a list of the available event attribut
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
@@ -108,10 +113,15 @@ INFO[0000] asset includes builds, using builds instead of asset  asset=template-
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
 sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+{{< /code >}}
+
+The response lists the available attributes for the event:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,
@@ -134,6 +144,11 @@ For example, to test the output for the `{{.Check.Name}}` attribute for the even
 
 {{< code shell >}}
 cat event.json | sensuctl command exec template-toolkit-command -- --template "{{.Check.Name}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 executing command with --template {{.Check.Name}}
 Template String Output: keepalive
@@ -145,6 +160,11 @@ You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate te
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"
+{{< /code >}}
+
+The response will list the template output:
+
+{{< code shell >}}
 Executing command with --template Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}
 Template String Output: Server: "webserver01 Check: check-http Status: passing"
 {{< /code >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
@@ -55,11 +55,9 @@ Use sensuctl to verify that the silenced entry against the entity `i-424242` was
 sensuctl silenced info 'entity:i-424242:check-http'
 {{< /code >}}
 
-After the silenced entry starts to take effect, events that are silenced will be marked as such in `sensuctl events`:
+After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
-sensuctl event list
-
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
    i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
@@ -72,6 +70,7 @@ sensuctl event list
 ## Next steps
 
 Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+
 
 [1]: ../handlers/
 [2]: ../silencing/#silence-all-checks-on-a-specific-entity

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -29,6 +29,11 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
 added asset: sensu/sensu-influxdb-handler:3.1.2
 
@@ -130,10 +135,17 @@ spec:
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
 For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
 
-Update the output metric format and output metric handlers to use the check with InfluxDB:
+Update the output metric format and output metric handlers to use the check with InfluxDB:.
+
+To update the output metric format, run:
 
 {{< code shell >}}
 sensuctl check set-output-metric-format collect-metrics influxdb_line
+{{< /code >}}
+
+To update the output metric handlers, run:
+
+{{< code shell >}}
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -33,6 +33,11 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler -r email-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 no version specified, using latest: 0.6.0
 fetching bonsai asset: sensu/sensu-email-handler:0.6.0
 added asset: sensu/sensu-email-handler:0.6.0
@@ -271,6 +276,7 @@ Now that you know how to apply a handler to a check and take action on events:
 - Check out the [Reduce alert fatigue][7] guide.
 
 You can also follow our [Up and running with Sensu Go][9] interactive tutorial to set up the Sensu Go email handler and test a similar workflow with the addition of a Sensu agent for producing events using scheduled checks.
+
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -28,6 +28,11 @@ Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -50,7 +50,6 @@ sensuctl check set-hooks nginx_process  \
 
 Verify that the check hook is behaving properly against a specific event with `sensuctl`.
 It might take a few moments after you assign the check hook for the check to be scheduled on the entity and the result sent back to the Sensu backend.
-The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -63,6 +62,8 @@ sensuctl event info i-424242 nginx_process --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+The check hook command result is available in the `hooks` array, within the `check` scope:
 
 {{< language-toggle >}}
 
@@ -113,7 +114,11 @@ This example uses sensuctl to query event info and send the response to `jq` so 
 
 {{< code shell >}}
 sensuctl event info i-424242 nginx_process --format json | jq -r '.check.hooks[0].output' 
+{{< /code >}}
 
+This example output is truncated for brevity, but it reflects the output of the `ps aux` command specified in the check hook you created:
+
+{{< code shell >}}
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.3  46164  6704 ?        Ss   Nov17   0:11 /usr/lib/systemd/systemd --switched-root --system --deserialize 20
 root         2  0.0  0.0      0     0 ?        S    Nov17   0:00 [kthreadd]
@@ -123,11 +128,11 @@ root         8  0.0  0.0      0     0 ?        S    Nov17   0:00 [rcu_bh]
 root         9  0.0  0.0      0     0 ?        S    Nov17   0:34 [rcu_sched]
 {{< /code >}}
 
-Although this output is truncated in the interest of brevity, it reflects the output of the `ps aux` command specified in the check hook you created.
 Now when you are alerted that Nginx is not running, you can review the check hook output to confirm this is true with no need to start up an SSH session to investigate.
 
 ## Next steps
 
 To learn more about data collection with check hooks, read the [hooks reference][1].
+
 
 [1]: ../hooks/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -34,7 +34,7 @@ Use sensuctl to register the Sensu Disk Checks Plugin dynamic runtime asset, `se
 sensuctl asset add sensu-plugins/sensu-plugins-disk-checks:5.1.4
 {{< /code >}}
 
-You should see a response like this:
+The response will indicate that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -33,6 +33,11 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 
 {{< code shell >}}
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 added asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
 
@@ -49,6 +54,11 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
+{{< /code >}}
+
+The response will indicate that the asset was added:
+
+{{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
 added asset: sensu/sensu-ruby-runtime:0.0.10
 
@@ -59,10 +69,15 @@ resource, populate the "runtime_assets" field with ["sensu-ruby-runtime"].
 
 You can also download the dynamic runtime asset definition from [Bonsai][7] and register the asset using `sensuctl create --file filename.yml`.
 
-Use sensuctl to confirm that both the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets are ready to use:
+To confirm that both dynamic runtime assets are ready to use:
 
 {{< code shell >}}
 sensuctl asset list
+{{< /code >}}
+
+The response should list the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets:
+
+{{< code shell >}}
           Name                                                URL                                       Hash    
 ────────────────────────── ─────────────────────────────────────────────────────────────────────────── ───────── 
  cpu-checks-plugins   //assets.bonsai.sensu.io/.../sensu-plugins-cpu-checks_4.1.0_centos_linux_amd64.tar.gz          518e7c1  
@@ -105,11 +120,16 @@ sudo service sensu-agent restart
 
 ## Validate the check
 
-Use sensuctl to confirm that Sensu is monitoring CPU usage using the `check-cpu`, returning an OK status (`0`).
+Use sensuctl to confirm that Sensu is monitoring CPU usage.
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
 
 {{< code shell >}}
 sensuctl event list
+{{< /code >}}
+
+The response should list the `check-cpu` check, returning an OK status (`0`)
+
+{{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
  sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
@@ -123,6 +143,7 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 * [Use assets to install plugins][2]
 * [Monitor external resources with proxy checks and entities][5]
 * [Send Slack alerts with handlers][6]
+
 
 [1]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-cpu-checks
 [2]: ../../../plugins/use-assets-to-install-plugins/


### PR DESCRIPTION
## Description
Part 4 -- Separates commands into individual code blocks and separates commands from responses throughout the docs to clarify instructions and make it easier for readers to copy and paste our code examples.

## Motivation and Context
Monitoring as code project