### PR TITLE
Add metrics specification section in metrics reference

### DIFF
--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -1397,7 +1397,7 @@ check:
 
 |metrics     |      |
 -------------|------
-description  | Metrics collected by the entity in Sensu metric format. See the [metric attributes][30].
+description  | Metrics collected by the entity in Sensu metric format. See the [metrics attributes][30].
 type         | Map
 required     | false
 example      | {{< language-toggle >}}
@@ -1686,7 +1686,7 @@ status: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metric attributes
+### Metrics attributes
 
 handlers     |      |
 -------------|------
@@ -1860,7 +1860,7 @@ value: 0.005
 [27]: ../filters/#filter-for-state-change-only
 [28]: ../filters/#filter-for-repeated-events
 [29]: #metadata-attributes
-[30]: #metric-attributes
+[30]: #metrics-attributes
 [31]: #use-event-data
 [32]: #history-attributes
 [33]: ../checks#spec-attributes

--- a/content/sensu-go/5.21/reference/filters.md
+++ b/content/sensu-go/5.21/reference/filters.md
@@ -1027,7 +1027,7 @@ spec:
 [20]: ../events/#history-attributes
 [21]: ../checks#check-scheduling
 [22]: ../handlers/
-[23]: ../events#metric-attributes
+[23]: ../events#metrics-attributes
 [24]: ../entities#metadata-attributes
 [25]: ../rbac/#default-roles-and-cluster-roles
 [26]: ../agent#keepalive-monitoring

--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -1400,7 +1400,7 @@ check:
 
 |metrics     |      |
 -------------|------
-description  | Metrics collected by the entity in Sensu metric format. See the [metric attributes][30].
+description  | Metrics collected by the entity in Sensu metric format. See the [metrics attributes][30].
 type         | Map
 required     | false
 example      | {{< language-toggle >}}
@@ -1705,7 +1705,7 @@ status: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metric attributes
+### Metrics attributes
 
 handlers     |      |
 -------------|------
@@ -1880,7 +1880,7 @@ value: 0.005
 [27]: ../../observe-filter/filters/#filter-for-state-change-only
 [28]: ../../observe-filter/filters/#filter-for-repeated-events
 [29]: #metadata-attributes
-[30]: #metric-attributes
+[30]: #metrics-attributes
 [31]: #use-event-data
 [32]: #history-attributes
 [33]: ../../observe-schedule/checks#spec-attributes

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/filters.md
@@ -1107,7 +1107,7 @@ spec:
 [20]: ../../observe-events/events/#history-attributes
 [21]: ../../observe-schedule/checks#check-scheduling
 [22]: ../../observe-process/handlers/
-[23]: ../../observe-events/events#metric-attributes
+[23]: ../../observe-events/events#metrics-attributes
 [24]: ../../observe-entities/entities#metadata-attributes
 [25]: ../../../operations/control-access/rbac/#default-roles-and-cluster-roles
 [26]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
@@ -472,7 +472,14 @@ sensuctl event info entity_name check_name --format json
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.
 
+## Metrics specification
 
+The check specification describes [metrics attributes in checks][19].
+
+The event specification describes [metrics attributes in events][5].
+
+
+[1]: ../checks/#output-metric-tags
 [2]: ../../observe-process/aggregate-metrics-statsd/
 [3]: ../checks/#output-metric-handlers
 [4]: #extract-metrics-from-check-output
@@ -482,13 +489,15 @@ See [Troubleshoot Sensu][24] for an example debug handler that writes events to 
 [8]: https://bonsai.sensu.io/
 [9]: #supported-output-metric-formats
 [10]: ../checks/#output-metric-format
-[11]: #process-extracted-metrics
+[11]: #process-extracted-and-tagged-metrics
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [13]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [14]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [15]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
+[17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage
+[19]: ../checks/#output-metric-format
 [20]: ../../observe-events/events/#example-status-and-metrics-event
 [22]: ../checks/#check-token-substitution
 [23]: ../../observe-process/populate-metrics-influxdb/

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -1400,7 +1400,7 @@ check:
 
 |metrics     |      |
 -------------|------
-description  | Metrics collected by the entity in Sensu metric format. See the [metric attributes][30].
+description  | Metrics collected by the entity in Sensu metric format. See the [metrics attributes][30].
 type         | Map
 required     | false
 example      | {{< language-toggle >}}
@@ -1705,7 +1705,7 @@ status: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metric attributes
+### Metrics attributes
 
 handlers     |      |
 -------------|------
@@ -1880,7 +1880,7 @@ value: 0.005
 [27]: ../../observe-filter/filters/#filter-for-state-change-only
 [28]: ../../observe-filter/filters/#filter-for-repeated-events
 [29]: #metadata-attributes
-[30]: #metric-attributes
+[30]: #metrics-attributes
 [31]: #use-event-data
 [32]: #history-attributes
 [33]: ../../observe-schedule/checks#spec-attributes

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/filters.md
@@ -1107,7 +1107,7 @@ spec:
 [20]: ../../observe-events/events/#history-attributes
 [21]: ../../observe-schedule/checks#check-scheduling
 [22]: ../../observe-process/handlers/
-[23]: ../../observe-events/events#metric-attributes
+[23]: ../../observe-events/events#metrics-attributes
 [24]: ../../observe-entities/entities#metadata-attributes
 [25]: ../../../operations/control-access/rbac/#default-roles-and-cluster-roles
 [26]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
@@ -497,6 +497,12 @@ sensuctl event info entity_name check_name --format json
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.
 
+## Metrics specification
+
+The check specification describes [metrics attributes in checks][19].
+
+The event specification describes [metrics attributes in events][5].
+
 
 [1]: ../checks/#output-metric-tags
 [2]: ../../observe-process/aggregate-metrics-statsd/
@@ -516,6 +522,7 @@ See [Troubleshoot Sensu][24] for an example debug handler that writes events to 
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage
+[19]: ../checks/#output-metric-format
 [20]: ../../observe-events/events/#example-status-and-metrics-event
 [21]: ../checks/#output_metric_tags-attributes
 [22]: ../checks/#check-token-substitution

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -1426,7 +1426,7 @@ check:
 
 |metrics     |      |
 -------------|------
-description  | Metrics collected by the entity in Sensu metric format. See the [metric attributes][30].
+description  | Metrics collected by the entity in Sensu metric format. See the [metrics attributes][30].
 type         | Map
 required     | false
 example      | {{< language-toggle >}}
@@ -1731,7 +1731,7 @@ status: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metric attributes
+### Metrics attributes
 
 handlers     |      |
 -------------|------
@@ -1906,7 +1906,7 @@ value: 0.005
 [27]: ../../observe-filter/filters/#filter-for-state-change-only
 [28]: ../../observe-filter/filters/#filter-for-repeated-events
 [29]: #metadata-attributes
-[30]: #metric-attributes
+[30]: #metrics-attributes
 [31]: #use-event-data
 [32]: #history-attributes
 [33]: ../../observe-schedule/checks#spec-attributes

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
@@ -1107,7 +1107,7 @@ spec:
 [20]: ../../observe-events/events/#history-attributes
 [21]: ../../observe-schedule/checks#check-scheduling
 [22]: ../../observe-process/handlers/
-[23]: ../../observe-events/events#metric-attributes
+[23]: ../../observe-events/events#metrics-attributes
 [24]: ../../observe-entities/entities#metadata-attributes
 [25]: ../../../operations/control-access/rbac/#default-roles-and-cluster-roles
 [26]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -497,6 +497,12 @@ sensuctl event info entity_name check_name --format json
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.
 
+## Metrics specification
+
+The check specification describes [metrics attributes in checks][19].
+
+The event specification describes [metrics attributes in events][5].
+
 
 [1]: ../checks/#output-metric-tags
 [2]: ../../observe-process/aggregate-metrics-statsd/
@@ -516,6 +522,7 @@ See [Troubleshoot Sensu][24] for an example debug handler that writes events to 
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage
+[19]: ../checks/#output-metric-format
 [20]: ../../observe-events/events/#example-status-and-metrics-event
 [21]: ../checks/#output_metric_tags-attributes
 [22]: ../checks/#check-token-substitution

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -1426,7 +1426,7 @@ check:
 
 |metrics     |      |
 -------------|------
-description  | Metrics collected by the entity in Sensu metric format. See the [metric attributes][30].
+description  | Metrics collected by the entity in Sensu metric format. See the [metrics attributes][30].
 type         | Map
 required     | false
 example      | {{< language-toggle >}}
@@ -1731,7 +1731,7 @@ status: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metric attributes
+### Metrics attributes
 
 handlers     |      |
 -------------|------
@@ -1906,7 +1906,7 @@ value: 0.005
 [27]: ../../observe-filter/filters/#filter-for-state-change-only
 [28]: ../../observe-filter/filters/#filter-for-repeated-events
 [29]: #metadata-attributes
-[30]: #metric-attributes
+[30]: #metrics-attributes
 [31]: #use-event-data
 [32]: #history-attributes
 [33]: ../../observe-schedule/checks#spec-attributes

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -1107,7 +1107,7 @@ spec:
 [20]: ../../observe-events/events/#history-attributes
 [21]: ../../observe-schedule/checks#check-scheduling
 [22]: ../../observe-process/handlers/
-[23]: ../../observe-events/events#metric-attributes
+[23]: ../../observe-events/events#metrics-attributes
 [24]: ../../observe-entities/entities#metadata-attributes
 [25]: ../../../operations/control-access/rbac/#default-roles-and-cluster-roles
 [26]: ../../observe-schedule/agent#keepalive-monitoring

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -497,6 +497,12 @@ sensuctl event info entity_name check_name --format json
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.
 
+## Metrics specification
+
+The check specification describes [metrics attributes in checks][19].
+
+The event specification describes [metrics attributes in events][5].
+
 
 [1]: ../checks/#output-metric-tags
 [2]: ../../observe-process/aggregate-metrics-statsd/
@@ -516,6 +522,7 @@ See [Troubleshoot Sensu][24] for an example debug handler that writes events to 
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage
+[19]: ../checks/#output-metric-format
 [20]: ../../observe-events/events/#example-status-and-metrics-event
 [21]: ../checks/#output_metric_tags-attributes
 [22]: ../checks/#check-token-substitution


### PR DESCRIPTION
## Description
Adds link to check and event specs in metrics reference so users can find descriptions for the metrics attributes.

## Motivation and Context
Need specs to make it a reference!
