### PR TITLE
5.21.4: Corrects description of SIGHUP effects in event log rotation

### DIFF
--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -1358,6 +1358,10 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
+{{% notice note %}}
+**NOTE**: Event logs do not include log messages produced by sensu-backend service.
+To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../operations/monitor-sensu/log-sensu-systemd/).
+{{% /notice %}}
 
 | event-log-buffer-size |      |
 -----------------------|------
@@ -1387,11 +1391,10 @@ sensu-backend start --event-log-file /var/log/sensu/events.log
 # /etc/sensu/backend.yml example
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 
-
 ### Log rotation
 
 To manually rotate event logs, first rename (move) the current log file.
-Then, send the _SIGHUP_ signal to the sensu-backend process so it creates a new log file and starts logging to it.
+Then, send the *SIGHUP* signal to the sensu-backend process so it creates a new log file and starts logging to it.
 Most Linux distributions include `logrotate` to automatically rotate log files as a standard utility, configured to run once per day by default.
 
 Because event log files can grow quickly for larger Sensu installations, we recommend using `logrotate` to automatically rotate log files more frequently.
@@ -1417,11 +1420,10 @@ In this example, the `postrotate` script will reload the backend after log rotat
 Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
 
-In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to restart.
-
 {{% notice note %}}
-**NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../operations/monitor-sensu/log-sensu-systemd/).
+**NOTE**: In Sensu 5.21.0 through 5.21.3, `systemctl reload` sends a *SIGHUP* signal to the sensu-backend process.
+The *SIGHUP* signal causes the `backend` component to restart.<br><br>
+[Upgrade to Sensu 5.21.4 or later](../../operations/maintain-sensu/upgrade/) to avoid this issue.
 {{% /notice %}}
 
 #### Log rotation for sysvinit

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -1418,7 +1418,7 @@ Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
 
 In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to reload instead of restarting the process.
+The _SIGHUP_ signal causes the `backend` component to restart.
 
 {{% notice note %}}
 **NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../operations/monitor-sensu/log-sensu-systemd/).

--- a/content/sensu-go/5.21/release-notes.md
+++ b/content/sensu-go/5.21/release-notes.md
@@ -249,7 +249,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
 - Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
-- Adds support for reloading the backend via SIGHUP.
+- Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -1326,7 +1326,7 @@ Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
 
 In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to reload instead of restarting the process.
+The _SIGHUP_ signal causes the `backend` component to restart.
 
 {{% notice note %}}
 **NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -1273,6 +1273,11 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
+{{% notice note %}}
+**NOTE**: Event logs do not include log messages produced by sensu-backend service.
+To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
+{{% /notice %}}
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
@@ -1299,7 +1304,7 @@ event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 ### Log rotation
 
 To manually rotate event logs, first rename (move) the current log file.
-Then, send the _SIGHUP_ signal to the sensu-backend process so it creates a new log file and starts logging to it.
+Then, send the *SIGHUP* signal to the sensu-backend process so it creates a new log file and starts logging to it.
 Most Linux distributions include `logrotate` to automatically rotate log files as a standard utility, configured to run once per day by default.
 
 Because event log files can grow quickly for larger Sensu installations, we recommend using `logrotate` to automatically rotate log files more frequently.
@@ -1324,13 +1329,6 @@ In this example, the `postrotate` script will reload the backend after log rotat
 
 Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
-
-In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to restart.
-
-{{% notice note %}}
-**NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
-{{% /notice %}}
 
 #### Log rotation for sysvinit
 

--- a/content/sensu-go/6.0/release-notes.md
+++ b/content/sensu-go/6.0/release-notes.md
@@ -309,7 +309,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
 - Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
-- Adds support for reloading the backend via SIGHUP.
+- Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -1340,7 +1340,7 @@ Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
 
 In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to reload instead of restarting the process.
+The _SIGHUP_ signal causes the `backend` component to restart.
 
 {{% notice note %}}
 **NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -1287,6 +1287,11 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
+{{% notice note %}}
+**NOTE**: Event logs do not include log messages produced by sensu-backend service.
+To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
+{{% /notice %}}
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
@@ -1313,7 +1318,7 @@ event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 ### Log rotation
 
 To manually rotate event logs, first rename (move) the current log file.
-Then, send the _SIGHUP_ signal to the sensu-backend process so it creates a new log file and starts logging to it.
+Then, send the *SIGHUP* signal to the sensu-backend process so it creates a new log file and starts logging to it.
 Most Linux distributions include `logrotate` to automatically rotate log files as a standard utility, configured to run once per day by default.
 
 Because event log files can grow quickly for larger Sensu installations, we recommend using `logrotate` to automatically rotate log files more frequently.
@@ -1338,13 +1343,6 @@ In this example, the `postrotate` script will reload the backend after log rotat
 
 Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
-
-In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to restart.
-
-{{% notice note %}}
-**NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
-{{% /notice %}}
 
 #### Log rotation for sysvinit
 

--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -427,7 +427,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
 - Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
-- Adds support for reloading the backend via SIGHUP.
+- Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -1340,7 +1340,7 @@ Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
 
 In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to reload instead of restarting the process.
+The _SIGHUP_ signal causes the `backend` component to restart.
 
 {{% notice note %}}
 **NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -1287,6 +1287,11 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
+{{% notice note %}}
+**NOTE**: Event logs do not include log messages produced by sensu-backend service.
+To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
+{{% /notice %}}
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
@@ -1313,7 +1318,7 @@ event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 ### Log rotation
 
 To manually rotate event logs, first rename (move) the current log file.
-Then, send the _SIGHUP_ signal to the sensu-backend process so it creates a new log file and starts logging to it.
+Then, send the *SIGHUP* signal to the sensu-backend process so it creates a new log file and starts logging to it.
 Most Linux distributions include `logrotate` to automatically rotate log files as a standard utility, configured to run once per day by default.
 
 Because event log files can grow quickly for larger Sensu installations, we recommend using `logrotate` to automatically rotate log files more frequently.
@@ -1338,13 +1343,6 @@ In this example, the `postrotate` script will reload the backend after log rotat
 
 Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
-
-In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to restart.
-
-{{% notice note %}}
-**NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
-{{% /notice %}}
 
 #### Log rotation for sysvinit
 

--- a/content/sensu-go/6.2/release-notes.md
+++ b/content/sensu-go/6.2/release-notes.md
@@ -541,7 +541,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
 - Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
-- Adds support for reloading the backend via SIGHUP.
+- Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1340,7 +1340,7 @@ Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
 
 In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to reload instead of restarting the process.
+The _SIGHUP_ signal causes the `backend` component to restart.
 
 {{% notice note %}}
 **NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1287,6 +1287,11 @@ If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
 The event logging functionality provides better performance and reliability than event handlers.
 
+{{% notice note %}}
+**NOTE**: Event logs do not include log messages produced by sensu-backend service.
+To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
+{{% /notice %}}
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
@@ -1313,7 +1318,7 @@ event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 ### Log rotation
 
 To manually rotate event logs, first rename (move) the current log file.
-Then, send the _SIGHUP_ signal to the sensu-backend process so it creates a new log file and starts logging to it.
+Then, send the *SIGHUP* signal to the sensu-backend process so it creates a new log file and starts logging to it.
 Most Linux distributions include `logrotate` to automatically rotate log files as a standard utility, configured to run once per day by default.
 
 Because event log files can grow quickly for larger Sensu installations, we recommend using `logrotate` to automatically rotate log files more frequently.
@@ -1338,13 +1343,6 @@ In this example, the `postrotate` script will reload the backend after log rotat
 
 Without the `postrotate` script, the backend will not reload.
 This will cause sensu-backend (and sensu-agent, if translated for the Sensu agent) to no longer write to the log file, even if logrotate recreates the log file.
-
-In this script, `systemctl reload` sends a _SIGHUP_ signal to the sensu-backend process.
-The _SIGHUP_ signal causes the `backend` component to restart.
-
-{{% notice note %}}
-**NOTE**: Event logs do not include log messages produced by sensu-backend service. To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
-{{% /notice %}}
 
 #### Log rotation for sysvinit
 

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -541,7 +541,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
 - Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
-- Adds support for reloading the backend via SIGHUP.
+- Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
 


### PR DESCRIPTION
## Description
Changes "reload" to "restart" in descriptions of SIGHUP function w/r/t the backend in release notes. Corrects the description of SIGHUP function in the 5.21 docs to reflect the change for 5.21.4.

## Motivation and Context
https://sensu.slack.com/archives/C0FM2KPM5/p1614895404027600