### PR TITLE
Add resource definitions to clarify sensuctl commands - Part 2

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
@@ -67,13 +67,27 @@ sensuctl handler create influx-db \
 --runtime-assets influxdb-handler
 {{< /code >}}
 
-You should see a confirmation message from sensuctl:
+You should see a confirmation message:
 
 {{< code shell >}}
 Created
 {{< /code >}}
 
-You can also create the handler definition in your monitoring-as-code repository:
+To see the complete resource definition for the handler resource you just created with sensuctl, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl handler info influx-db --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl handler info influx-db --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The `influx-db` handler resource definition will be similar to this example:
 
 {{< language-toggle >}}
 
@@ -130,12 +144,13 @@ spec:
 
 {{< /language-toggle >}}
 
-## Assign the handler to an event
+You can share, reuse, and maintain this handler just like you would code: [save it to a file][6] and start building a [monitoring as code repository][7].
+
+## Assign the InfluxDB handler to a check
 
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
-For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
-
-Update the output metric format and output metric handlers to use the check with InfluxDB:.
+For example, if you followed [Collect service metrics with Sensu checks][10], you created the check named `collect-metrics`.
+You can update the check's output metric format and output metric handlers to extract the metrics with your `influx-db` handler.
 
 To update the output metric format, run:
 
@@ -149,29 +164,123 @@ To update the output metric handlers, run:
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 
-You can also assign the handler to the [Sensu StatsD listener][3] at agent startup to pass all StatsD metrics into InfluxDB:
+You should see a confirmation message:
+
+{{< code shell >}}
+Updated
+{{< /code >}}
+
+To see the updated check resource definition, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info collect-metrics --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info collect-metrics --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The updated `collect-metrics` check definition will be similar to this example:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: collect-metrics
+  namespace: default
+spec:
+  check_hooks: null
+  command: metrics-disk-usage.rb
+  env_vars: null
+  handlers: []
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: influxdb_line
+  output_metric_handlers: influx-db
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - sensu-plugins/sensu-plugins-disk-checks
+  - sensu/sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - linux
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "collect-metrics",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "metrics-disk-usage.rb",
+    "env_vars": null,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "influxdb_line",
+    "output_metric_handlers": "influx-db",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "sensu-plugins/sensu-plugins-disk-checks",
+      "sensu/sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "linux"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign the InfluxDB handler to the Sensu StatsD listener
+
+To assign your `influx-db` handler to the [Sensu StatsD listener][3] at agent startup and pass all StatsD metrics into InfluxDB:
 
 {{< code shell >}}
 sensu-agent start --statsd-event-handlers influx-db
 {{< /code >}}
 
-## Validate the handler
+## Validate the InfluxDB handler
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled you should start to see metrics populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
 See [Troubleshoot Sensu][8] for log locations by platform.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`,
-followed by a second log entry with the message `"msg":"pipelined executed event pipe
+Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.
 
 ## Next steps
 
-Now that you know how to apply a handler to metrics and take action on events, here are a few other recommended resources:
-
-* [Handlers reference][9]
-* [Aggregate metrics with the Sensu StatsD listener][3]
-* [Collect metrics with Sensu checks][10]
+Now that you know how to apply a handler to metrics and take action on events, read the [handlers reference][9] to learn more about using Sensu handlers.
 
 
 [1]: ../../observe-events/events/
@@ -179,6 +288,8 @@ Now that you know how to apply a handler to metrics and take action on events, h
 [3]: ../aggregate-metrics-statsd/
 [4]: https://github.com/sensu/sensu-influxdb-handler#installation
 [5]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[6]: ../../../operations/monitoring-as-code/#build-as-you-go
+[7]: ../../../operations/monitoring-as-code/
 [8]: ../../../operations/maintain-sensu/troubleshoot/
 [9]: ../handlers/
 [10]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -127,8 +127,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -162,9 +160,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format wrapped-json
+sensuctl check info collect-metrics --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -127,6 +127,8 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
+  labels:
+    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -160,6 +162,9 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
+    "labels": {
+      "sensu.io/managed_by": "sensuctl"
+    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -35,7 +35,7 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
@@ -56,7 +56,7 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
@@ -101,6 +101,108 @@ sensuctl check create check-cpu \
 --subscriptions system \
 --runtime-assets cpu-checks-plugins,sensu-ruby-runtime
 {{< /code >}}
+
+You should see a confirmation message:
+
+{{< code shell >}}
+Created
+{{< /code >}}
+
+To view the complete resource definition for `check-cpu`, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check-cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check-cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: check-cpu
+  namespace: default
+spec:
+  check_hooks: null
+  command: check-cpu.rb -w 75 -c 90
+  env_vars: null
+  handlers:
+  - slack
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "check-cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+If you want to share, reuse, and maintain this check just like you would code, you can [save it to a file][11] and start building a [monitoring as code repository][12].
 
 ## Configure the subscription
 
@@ -155,3 +257,5 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [8]: ../agent/#restart-the-service
 [9]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [10]: #create-a-check
+[11]: ../../../operations/monitoring-as-code/#build-as-you-go
+[12]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
@@ -67,13 +67,27 @@ sensuctl handler create influx-db \
 --runtime-assets influxdb-handler
 {{< /code >}}
 
-You should see a confirmation message from sensuctl:
+You should see a confirmation message:
 
 {{< code shell >}}
 Created
 {{< /code >}}
 
-You can also create the handler definition in your monitoring-as-code repository:
+To see the complete resource definition for the handler resource you just created with sensuctl, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl handler info influx-db --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl handler info influx-db --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The `influx-db` handler resource definition will be similar to this example:
 
 {{< language-toggle >}}
 
@@ -130,12 +144,13 @@ spec:
 
 {{< /language-toggle >}}
 
-## Assign the handler to an event
+You can share, reuse, and maintain this handler just like you would code: [save it to a file][6] and start building a [monitoring as code repository][7].
+
+## Assign the InfluxDB handler to a check
 
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
-For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
-
-Update the output metric format and output metric handlers to use the check with InfluxDB:.
+For example, if you followed [Collect service metrics with Sensu checks][10], you created the check named `collect-metrics`.
+You can update the check's output metric format and output metric handlers to extract the metrics with your `influx-db` handler.
 
 To update the output metric format, run:
 
@@ -149,29 +164,123 @@ To update the output metric handlers, run:
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 
-You can also assign the handler to the [Sensu StatsD listener][3] at agent startup to pass all StatsD metrics into InfluxDB:
+You should see a confirmation message:
+
+{{< code shell >}}
+Updated
+{{< /code >}}
+
+To see the updated check resource definition, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info collect-metrics --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info collect-metrics --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The updated `collect-metrics` check definition will be similar to this example:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: collect-metrics
+  namespace: default
+spec:
+  check_hooks: null
+  command: metrics-disk-usage.rb
+  env_vars: null
+  handlers: []
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: influxdb_line
+  output_metric_handlers: influx-db
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - sensu-plugins/sensu-plugins-disk-checks
+  - sensu/sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - linux
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "collect-metrics",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "metrics-disk-usage.rb",
+    "env_vars": null,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "influxdb_line",
+    "output_metric_handlers": "influx-db",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "sensu-plugins/sensu-plugins-disk-checks",
+      "sensu/sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "linux"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign the InfluxDB handler to the Sensu StatsD listener
+
+To assign your `influx-db` handler to the [Sensu StatsD listener][3] at agent startup and pass all StatsD metrics into InfluxDB:
 
 {{< code shell >}}
 sensu-agent start --statsd-event-handlers influx-db
 {{< /code >}}
 
-## Validate the handler
+## Validate the InfluxDB handler
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled you should start to see metrics populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
 See [Troubleshoot Sensu][8] for log locations by platform.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`,
-followed by a second log entry with the message `"msg":"pipelined executed event pipe
+Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.
 
 ## Next steps
 
-Now that you know how to apply a handler to metrics and take action on events, here are a few other recommended resources:
-
-* [Handlers reference][9]
-* [Aggregate metrics with the Sensu StatsD listener][3]
-* [Collect metrics with Sensu checks][10]
+Now that you know how to apply a handler to metrics and take action on events, read the [handlers reference][9] to learn more about using Sensu handlers.
 
 
 [1]: ../../observe-events/events/
@@ -179,6 +288,8 @@ Now that you know how to apply a handler to metrics and take action on events, h
 [3]: ../aggregate-metrics-statsd/
 [4]: https://github.com/sensu/sensu-influxdb-handler#installation
 [5]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[6]: ../../../operations/monitoring-as-code/#build-as-you-go
+[7]: ../../../operations/monitoring-as-code/
 [8]: ../../../operations/maintain-sensu/troubleshoot/
 [9]: ../handlers/
 [10]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -127,8 +127,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -162,9 +160,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format wrapped-json
+sensuctl check info collect-metrics --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -127,6 +127,8 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
+  labels:
+    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -160,6 +162,9 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
+    "labels": {
+      "sensu.io/managed_by": "sensuctl"
+    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -35,7 +35,7 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
@@ -56,7 +56,7 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
@@ -101,6 +101,108 @@ sensuctl check create check-cpu \
 --subscriptions system \
 --runtime-assets cpu-checks-plugins,sensu-ruby-runtime
 {{< /code >}}
+
+You should see a confirmation message:
+
+{{< code shell >}}
+Created
+{{< /code >}}
+
+To view the complete resource definition for `check-cpu`, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check-cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check-cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: check-cpu
+  namespace: default
+spec:
+  check_hooks: null
+  command: check-cpu.rb -w 75 -c 90
+  env_vars: null
+  handlers:
+  - slack
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "check-cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+If you want to share, reuse, and maintain this check just like you would code, you can [save it to a file][11] and start building a [monitoring as code repository][12].
 
 ## Configure the subscription
 
@@ -155,3 +257,5 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [8]: ../agent/#restart-the-service
 [9]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [10]: #create-a-check
+[11]: ../../../operations/monitoring-as-code/#build-as-you-go
+[12]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
@@ -67,13 +67,27 @@ sensuctl handler create influx-db \
 --runtime-assets influxdb-handler
 {{< /code >}}
 
-You should see a confirmation message from sensuctl:
+You should see a confirmation message:
 
 {{< code shell >}}
 Created
 {{< /code >}}
 
-You can also create the handler definition in your monitoring-as-code repository:
+To see the complete resource definition for the handler resource you just created with sensuctl, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl handler info influx-db --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl handler info influx-db --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The `influx-db` handler resource definition will be similar to this example:
 
 {{< language-toggle >}}
 
@@ -130,12 +144,13 @@ spec:
 
 {{< /language-toggle >}}
 
-## Assign the handler to an event
+You can share, reuse, and maintain this handler just like you would code: [save it to a file][6] and start building a [monitoring as code repository][7].
+
+## Assign the InfluxDB handler to a check
 
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
-For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
-
-Update the output metric format and output metric handlers to use the check with InfluxDB:.
+For example, if you followed [Collect service metrics with Sensu checks][10], you created the check named `collect-metrics`.
+You can update the check's output metric format and output metric handlers to extract the metrics with your `influx-db` handler.
 
 To update the output metric format, run:
 
@@ -149,29 +164,123 @@ To update the output metric handlers, run:
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 
-You can also assign the handler to the [Sensu StatsD listener][3] at agent startup to pass all StatsD metrics into InfluxDB:
+You should see a confirmation message:
+
+{{< code shell >}}
+Updated
+{{< /code >}}
+
+To see the updated check resource definition, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info collect-metrics --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info collect-metrics --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The updated `collect-metrics` check definition will be similar to this example:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: collect-metrics
+  namespace: default
+spec:
+  check_hooks: null
+  command: metrics-disk-usage.rb
+  env_vars: null
+  handlers: []
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: influxdb_line
+  output_metric_handlers: influx-db
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - sensu-plugins/sensu-plugins-disk-checks
+  - sensu/sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - linux
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "collect-metrics",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "metrics-disk-usage.rb",
+    "env_vars": null,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "influxdb_line",
+    "output_metric_handlers": "influx-db",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "sensu-plugins/sensu-plugins-disk-checks",
+      "sensu/sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "linux"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign the InfluxDB handler to the Sensu StatsD listener
+
+To assign your `influx-db` handler to the [Sensu StatsD listener][3] at agent startup and pass all StatsD metrics into InfluxDB:
 
 {{< code shell >}}
 sensu-agent start --statsd-event-handlers influx-db
 {{< /code >}}
 
-## Validate the handler
+## Validate the InfluxDB handler
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled you should start to see metrics populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
 See [Troubleshoot Sensu][8] for log locations by platform.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`,
-followed by a second log entry with the message `"msg":"pipelined executed event pipe
+Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.
 
 ## Next steps
 
-Now that you know how to apply a handler to metrics and take action on events, here are a few other recommended resources:
-
-* [Handlers reference][9]
-* [Aggregate metrics with the Sensu StatsD listener][3]
-* [Collect metrics with Sensu checks][10]
+Now that you know how to apply a handler to metrics and take action on events, read the [handlers reference][9] to learn more about using Sensu handlers.
 
 
 [1]: ../../observe-events/events/
@@ -179,6 +288,8 @@ Now that you know how to apply a handler to metrics and take action on events, h
 [3]: ../aggregate-metrics-statsd/
 [4]: https://github.com/sensu/sensu-influxdb-handler#installation
 [5]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[6]: ../../../operations/monitoring-as-code/#build-as-you-go
+[7]: ../../../operations/monitoring-as-code/
 [8]: ../../../operations/maintain-sensu/troubleshoot/
 [9]: ../handlers/
 [10]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -127,8 +127,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -162,9 +160,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format wrapped-json
+sensuctl check info collect-metrics --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -127,6 +127,8 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
+  labels:
+    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -160,6 +162,9 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
+    "labels": {
+      "sensu.io/managed_by": "sensuctl"
+    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -35,7 +35,7 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
@@ -56,7 +56,7 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
@@ -101,6 +101,108 @@ sensuctl check create check-cpu \
 --subscriptions system \
 --runtime-assets cpu-checks-plugins,sensu-ruby-runtime
 {{< /code >}}
+
+You should see a confirmation message:
+
+{{< code shell >}}
+Created
+{{< /code >}}
+
+To view the complete resource definition for `check-cpu`, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check-cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check-cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: check-cpu
+  namespace: default
+spec:
+  check_hooks: null
+  command: check-cpu.rb -w 75 -c 90
+  env_vars: null
+  handlers:
+  - slack
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "check-cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+If you want to share, reuse, and maintain this check just like you would code, you can [save it to a file][11] and start building a [monitoring as code repository][12].
 
 ## Configure the subscription
 
@@ -155,3 +257,5 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [8]: ../agent/#restart-the-service
 [9]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [10]: #create-a-check
+[11]: ../../../operations/monitoring-as-code/#build-as-you-go
+[12]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynam
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.2 -r influxdb-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.2
@@ -67,13 +67,27 @@ sensuctl handler create influx-db \
 --runtime-assets influxdb-handler
 {{< /code >}}
 
-You should see a confirmation message from sensuctl:
+You should see a confirmation message:
 
 {{< code shell >}}
 Created
 {{< /code >}}
 
-You can also create the handler definition in your monitoring-as-code repository:
+To see the complete resource definition for the handler resource you just created with sensuctl, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl handler info influx-db --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl handler info influx-db --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The `influx-db` handler resource definition will be similar to this example:
 
 {{< language-toggle >}}
 
@@ -130,12 +144,13 @@ spec:
 
 {{< /language-toggle >}}
 
-## Assign the handler to an event
+You can share, reuse, and maintain this handler just like you would code: [save it to a file][6] and start building a [monitoring as code repository][7].
+
+## Assign the InfluxDB handler to a check
 
 With the `influx-db` handler created, you can assign it to a check for check output metric extraction. 
-For example, suppose you followed [Collect service metrics with Sensu checks][10] to create the check named `collect-metrics`.
-
-Update the output metric format and output metric handlers to use the check with InfluxDB:.
+For example, if you followed [Collect service metrics with Sensu checks][10], you created the check named `collect-metrics`.
+You can update the check's output metric format and output metric handlers to extract the metrics with your `influx-db` handler.
 
 To update the output metric format, run:
 
@@ -149,29 +164,123 @@ To update the output metric handlers, run:
 sensuctl check set-output-metric-handlers collect-metrics influx-db
 {{< /code >}}
 
-You can also assign the handler to the [Sensu StatsD listener][3] at agent startup to pass all StatsD metrics into InfluxDB:
+You should see a confirmation message:
+
+{{< code shell >}}
+Updated
+{{< /code >}}
+
+To see the updated check resource definition, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info collect-metrics --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info collect-metrics --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The updated `collect-metrics` check definition will be similar to this example:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: collect-metrics
+  namespace: default
+spec:
+  check_hooks: null
+  command: metrics-disk-usage.rb
+  env_vars: null
+  handlers: []
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: influxdb_line
+  output_metric_handlers: influx-db
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - sensu-plugins/sensu-plugins-disk-checks
+  - sensu/sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - linux
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "collect-metrics",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "metrics-disk-usage.rb",
+    "env_vars": null,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "influxdb_line",
+    "output_metric_handlers": "influx-db",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "sensu-plugins/sensu-plugins-disk-checks",
+      "sensu/sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "linux"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign the InfluxDB handler to the Sensu StatsD listener
+
+To assign your `influx-db` handler to the [Sensu StatsD listener][3] at agent startup and pass all StatsD metrics into InfluxDB:
 
 {{< code shell >}}
 sensu-agent start --statsd-event-handlers influx-db
 {{< /code >}}
 
-## Validate the handler
+## Validate the InfluxDB handler
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled you should start to see metrics populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
 See [Troubleshoot Sensu][8] for log locations by platform.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`,
-followed by a second log entry with the message `"msg":"pipelined executed event pipe
+Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.
 
 ## Next steps
 
-Now that you know how to apply a handler to metrics and take action on events, here are a few other recommended resources:
-
-* [Handlers reference][9]
-* [Aggregate metrics with the Sensu StatsD listener][3]
-* [Collect metrics with Sensu checks][10]
+Now that you know how to apply a handler to metrics and take action on events, read the [handlers reference][9] to learn more about using Sensu handlers.
 
 
 [1]: ../../observe-events/events/
@@ -179,6 +288,8 @@ Now that you know how to apply a handler to metrics and take action on events, h
 [3]: ../aggregate-metrics-statsd/
 [4]: https://github.com/sensu/sensu-influxdb-handler#installation
 [5]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[6]: ../../../operations/monitoring-as-code/#build-as-you-go
+[7]: ../../../operations/monitoring-as-code/
 [8]: ../../../operations/maintain-sensu/troubleshoot/
 [9]: ../handlers/
 [10]: ../../observe-schedule/collect-metrics-with-checks/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -127,8 +127,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -162,9 +160,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format wrapped-json
+sensuctl check info collect-metrics --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -127,6 +127,8 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
+  labels:
+    sensu.io/managed_by: sensuctl
   name: collect-metrics
   namespace: default
 spec:
@@ -160,6 +162,9 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
+    "labels": {
+      "sensu.io/managed_by": "sensuctl"
+    },
     "name": "collect-metrics",
     "namespace": "default"
   },

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -35,7 +35,7 @@ Use [`sensuctl asset add`][9] to register the Sensu CPU Checks dynamic runtime a
 sensuctl asset add sensu-plugins/sensu-plugins-cpu-checks:4.1.0 -r cpu-checks-plugins
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu-plugins/sensu-plugins-cpu-checks:4.1.0
@@ -56,7 +56,7 @@ Then, use the following sensuctl example to register the Sensu Ruby Runtime dyna
 sensuctl asset add sensu/sensu-ruby-runtime:0.0.10 -r sensu-ruby-runtime
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-ruby-runtime:0.0.10
@@ -101,6 +101,108 @@ sensuctl check create check-cpu \
 --subscriptions system \
 --runtime-assets cpu-checks-plugins,sensu-ruby-runtime
 {{< /code >}}
+
+You should see a confirmation message:
+
+{{< code shell >}}
+Created
+{{< /code >}}
+
+To view the complete resource definition for `check-cpu`, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check-cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check-cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: check-cpu
+  namespace: default
+spec:
+  check_hooks: null
+  command: check-cpu.rb -w 75 -c 90
+  env_vars: null
+  handlers:
+  - slack
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 0
+  ttl: 0
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "check-cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+If you want to share, reuse, and maintain this check just like you would code, you can [save it to a file][11] and start building a [monitoring as code repository][12].
 
 ## Configure the subscription
 
@@ -155,3 +257,5 @@ Now that you know how to run a check to monitor CPU usage, read these resources 
 [8]: ../agent/#restart-the-service
 [9]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [10]: #create-a-check
+[11]: ../../../operations/monitoring-as-code/#build-as-you-go
+[12]: ../../../operations/monitoring-as-code/


### PR DESCRIPTION
## Description
Adds resource definitions throughout docs as needed to illustrate the resources being created and updated with sensuctl commands. Part 2

## Motivation and Context
Many of our docs (especially guides) rely on sensuctl commands to create and update resources. These commands are tidy, but they do not show users what the resources they are creating and updating look like.