### PR TITLE
Fix broken link to sensu.io/downloads

### DIFF
--- a/content/sensu-go/5.21/platforms.md
+++ b/content/sensu-go/5.21/platforms.md
@@ -363,7 +363,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/sensu-license/
 [8]: https://packagecloud.io/sensu/stable/
-[9]: https://sensu.io/downloads/
+[9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/
 [11]: https://hub.docker.com/r/sensu/sensu-rhel/
 [12]: https://github.com/sensu/grafana-sensu-go-datasource/

--- a/content/sensu-go/6.0/platforms.md
+++ b/content/sensu-go/6.0/platforms.md
@@ -359,7 +359,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/sensu-license/
 [8]: https://packagecloud.io/sensu/stable/
-[9]: https://sensu.io/downloads/
+[9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/
 [11]: https://hub.docker.com/r/sensu/sensu-rhel/
 [12]: https://github.com/sensu/grafana-sensu-go-datasource/

--- a/content/sensu-go/6.1/platforms.md
+++ b/content/sensu-go/6.1/platforms.md
@@ -359,7 +359,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/sensu-license/
 [8]: https://packagecloud.io/sensu/stable/
-[9]: https://sensu.io/downloads/
+[9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/
 [11]: https://hub.docker.com/r/sensu/sensu-rhel/
 [12]: https://github.com/sensu/grafana-sensu-go-datasource/

--- a/content/sensu-go/6.2/platforms.md
+++ b/content/sensu-go/6.2/platforms.md
@@ -359,7 +359,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/sensu-license/
 [8]: https://packagecloud.io/sensu/stable/
-[9]: https://sensu.io/downloads/
+[9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/
 [11]: https://hub.docker.com/r/sensu/sensu-rhel/
 [12]: https://github.com/sensu/grafana-sensu-go-datasource/

--- a/content/sensu-go/6.3/platforms.md
+++ b/content/sensu-go/6.3/platforms.md
@@ -359,7 +359,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/sensu-license/
 [8]: https://packagecloud.io/sensu/stable/
-[9]: https://sensu.io/downloads/
+[9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/
 [11]: https://hub.docker.com/r/sensu/sensu-rhel/
 [12]: https://github.com/sensu/grafana-sensu-go-datasource/


### PR DESCRIPTION
## Description
Fixes link to https://sensu.io/downloads (remove trailing slash) on platforms page

## Motivation and Context
https://sensu.slack.com/archives/C3MHLUP46/p1615334409064800