### PR TITLE
Add resource definitions to clarify sensuctl commands - Part 3

### DIFF
--- a/content/sensu-go/5.21/guides/email-handler.md
+++ b/content/sensu-go/5.21/guides/email-handler.md
@@ -257,7 +257,7 @@ You should receive another email because the event status changed to `0` (OK).
 
 Now that you know how to apply a handler to a check and take action on events:
 
-- Reuse this email handler with the `check-cpu` check from our [Monitor server resources][2] guide.
+- Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
@@ -91,9 +91,11 @@ You'll use these functions to create event filters that represent the three acti
 | `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
 | `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
 
-To add these filters to Sensu, use `sensuctl create`:
+Use sensuctl to create the three event filters:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -129,7 +131,77 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl filter list --format yaml` to confirm that the filters are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_ops"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "sensu-go-has-contact-filter_any_noarch"
+    ],
+    "expressions": [
+      "has_contact(event, \"ops\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_dev"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "has_contact(event, \"dev\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_fallback"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "no_contacts(event)"
+    ]
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can also save these event filter resource definitions to a file named `filters.yml` or `filters.json` in your Sensu installation.
+When you're ready to manage your observability configurations the same way you do any other code, your `filters.yml` or `filters.json` file can become a part of your [monitoring as code][15] repository.
+
+Use sensuctl to confirm that the event filters were added:
+
+{{< code shell >}}
+sensuctl filter list
+{{< /code >}}
+
+The response should list the new `contact_ops`, `contact_dev`, and `contact_fallback` event filters:
+
+{{< code shell >}}
+        Name         Action           Expressions          
+ ────────────────── ──────── ───────────────────────────── 
+  contact_dev        allow    (has_contact(event, "dev"))  
+  contact_fallback   allow    (no_contacts(event))         
+  contact_ops        allow    (has_contact(event, "ops"))  
+{{< /code >}}
 
 ### 3. Create a handler for each contact
 
@@ -140,7 +212,7 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
@@ -153,7 +225,7 @@ resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the dynamic runtime asset: `sensu-slack-handler`.
 
-In each handler definition, specify:
+In each handler definition, you will specify:
 
 - A unique name: `slack_ops`, `slack_dev`, or `slack_fallback`
 - A customized command with the contact's preferred Slack channel
@@ -162,12 +234,16 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
 - Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
-{{< code shell >}}
+After you update the code to use your preferred Slack channels and webhook URL, run:
+
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -218,15 +294,102 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl handler list --format yaml` to confirm that the handlers are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_ops"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-ops\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_ops"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_dev"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-dev\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_dev"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_fallback"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-all\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_fallback"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Just like the event filters, you can save these handlers to a YAML or JSON file to create a handlers configuration file if you're implementing [monitoring as code][15].
+
+Use sensuctl to confirm that the handlers were added:
+
+{{< code shell >}}
+sensuctl handler list
+{{< /code >}}
+
+The response should list the new `slack_ops`, `slack_dev`, and `slack_fallback` handlers:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                        Execute                                                Environment Variables                                    Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ─────────────────────────────────────────────────── ────────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler
+{{< /code >}}
 
 ### 4. Create a handler set
 
-To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name.
+To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name, `slack`:
 
-Use `sensuctl` to create a `slack` handler set:
+{{< language-toggle >}}
 
-{{< code shell >}}
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -241,9 +404,41 @@ spec:
   type: set' | sensuctl create
 {{< /code >}}
 
-You should see updated output of `sensuctl handler list` that includes the `slack` handler set.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "slack_ops",
+      "slack_dev",
+      "slack_fallback"
+    ],
+    "type": "set"
+  }
+}' | sensuctl create
+{{< /code >}}
 
-Congratulations! Your Sensu contact routing is set up.
+{{< /language-toggle >}}
+
+Run `sensuctl handler list` again.
+The updated output should include the `slack` handler set:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                       Execute                                                Environment Variables                                  Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ────────────────────────────────────────────────── ──────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack            set          0                                                         CALL: slack_ops,slack_dev,slack_fallback                                                                                                         
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+{{< /code >}}
+
+Congratulations!
+Your Sensu contact routing is set up.
 Next, test your contact filters to make sure they work.
 
 ## Test contact routing
@@ -301,34 +496,153 @@ Resolve the events by sending the same API requests with `status` set to `0`.
 ## Manage contact labels in checks and entities
 
 To assign an alert to a contact, add a `contacts` label to the check or entity.
+The `contacts` labels should be `ops` and `dev`.
+You'll also need to update the check to use your `slack` handler.
 
-### Checks
+For example, you can update the `check_cpu` check created in [Monitor server resources][9] to include the `ops` and `dev` contacts and the `slack` handler.
 
-This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
+Use sensuctl to open the check in a text editor:
+
+{{< code shell >}}
+sensuctl edit check check_cpu
+{{< /code >}}
+
+Edit the check metadata to add the following labels:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+labels:
+  contacts: ops, dev
+{{< /code >}}
+
+{{< code json >}}
+{
+  "labels": {
+    "contacts": "ops, dev"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Save and close the updated check definition.
+A response will confirm the check was updated.
+For example:
+
+{{< code shell >}}
+Updated /api/core/v2/namespaces/default/checks/check_cpu
+{{< /code >}}
+
+Next, run this sensuctl command to add the `slack` handler:
+
+{{< code shell >}}
+sensuctl check set-handlers check_cpu slack
+{{< /code >}}
+
+Again, you will see an `Updated` confirmation message.
+
+To view the updated resource definition for `check_cpu` and confirm that it includes the `contacts` labels and `slack` handler, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check_cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check_cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the updated `check_cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
 
 {{< code yml >}}
 ---
 type: CheckConfig
 api_version: core/v2
 metadata:
-  name: check_cpu
+  created_by: admin
   labels:
     contacts: ops, dev
+  name: check_cpu
+  namespace: default
 spec:
+  check_hooks: null
   command: check-cpu.rb -w 75 -c 90
+  env_vars: null
   handlers:
   - slack
-  interval: 10
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
   publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
   subscriptions:
   - system
-  runtime-assets:
-  - sensu-plugins-cpu-checks
-  - sensu-ruby-runtime
+  timeout: 0
+  ttl: 0
 {{< /code >}}
 
-When the `check_cpu` check generates an incident, Sensu filters the event according to the `contact_ops` and `contact_dev` filters, resulting in an alert sent to #alert-ops and #alert-dev.
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "labels": {
+      "contacts": "ops, dev"
+    },
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Now when the `check_cpu` check generates an incident, Sensu will filter the event according to the `contact_ops` and `contact_dev` event filters and send alerts to #alert-ops and #alert-dev accordingly.
 
 <a href="/images/contact-routing2.png"><img src="/images/contact-routing2.png" alt="Diagram that shows an event generated with a check label for the dev and ops teams, matched to the dev team and ops team handlers using contact filters, and routed to the Slack channels for dev and ops"></a>
 <!-- Diagram source: https://www.lucidchart.com/documents/edit/3cbd2ad3-92ed-48cc-bbaa-a97f53dae1ba -->
@@ -368,3 +682,4 @@ Learn how to use Sensu to [Reduce alert fatigue][11].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [13]: ../../observe-schedule/agent/#create-observability-events-using-the-agent-api
 [14]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[15]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
@@ -35,7 +35,7 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 sensuctl asset add sensu/sensu-email-handler -r email-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 no version specified, using latest: 0.6.0
@@ -85,7 +85,9 @@ Here's an overview of how the `state_change_only` filter will work:
 
 To create the event filter, run:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -93,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only
+  name: state_change_only2
   namespace: default
 spec:
   action: allow
@@ -103,14 +105,54 @@ spec:
 EOF
 {{< /code >}}
 
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "annotations": null,
+    "labels": null,
+    "name": "state_change_only",
+    "namespace": "default"
+  },
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": [
+
+    ]
+  }
+}
+EOF
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Create the email handler definition
 
 After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
-In the handler definition's `command` value, you'll need to change a few things.
+In the handler definition's `command` value, you'll need to change a few things:
 
-Copy this text into a text editor:
+- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
+- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
+- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
+- `USERNAME`: Replace with your SMTP username, typically your email address.
+- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
 
-{{< code shell >}}
+{{% notice note %}}
+**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
+If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
+If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
+{{% /notice %}}
+
+With your updates, create the handler using sensuctl:
+
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -132,19 +174,33 @@ spec:
 EOF
 {{< /code >}}
 
-Then, replace the following text:
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "api_version": "core/v2",
+  "type": "Handler",
+  "metadata": {
+    "namespace": "default",
+    "name": "email"
+  },
+  "spec": {
+    "type": "pipe",
+    "command": "sensu-email-handler -f YOUR-SENDER@example.com -t YOUR-RECIPIENT@example.com -s YOUR-SMTP-SERVER.example.com -u USERNAME -p PASSWORD",
+    "timeout": 10,
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "state_change_only"
+    ],
+    "runtime_assets": [
+      "email-handler"
+    ]
+  }
+}
+EOF
+{{< /code >}}
 
-- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
-- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
-- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
-- `USERNAME`: Replace with your SMTP username, typically your email address.
-- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
-
-{{% notice note %}}
-**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
-If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
-If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
-{{% /notice %}}
+{{< /language-toggle >}}
 
 You probably noticed that the handler definition includes two other filters besides `state_change_only`: [`is_incident`][10] and [`not_silenced`][11].
 These two filters are included in every Sensu backend installation, so you don't have to create them.
@@ -272,6 +328,7 @@ You should receive another email because the event status changed to `0` (OK).
 Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
+- Learn how to use the event filter and handler resources you created to start developing a [monitoring as code][15] repository.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 
@@ -285,13 +342,14 @@ You can also follow our [Up and running with Sensu Go][9] interactive tutorial t
 [5]: ../../observe-filter/filters/
 [6]: ../handlers/
 [7]: ../../observe-filter/reduce-alert-fatigue/
-[8]: ../../../plugins/assets
+[8]: ../../../plugins/assets/
 [9]: ../../../learn/up-and-running/
 [10]: ../../observe-filter/filters/#built-in-filter-is_incident
 [11]: ../../observe-filter/filters/#built-in-filter-not_silenced
 [12]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [13]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [14]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler#templates
+[15]: ../../../operations/monitoring-as-code/
 [16]: ../../observe-filter/filters/
 [17]: #create-an-ad-hoc-event
 [18]: #create-the-email-handler-definition

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
@@ -271,7 +271,7 @@ You should receive another email because the event status changed to `0` (OK).
 
 Now that you know how to apply a handler to a check and take action on events:
 
-- Reuse this email handler with the `check-cpu` check from our [Monitor server resources][2] guide.
+- Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
@@ -16,7 +16,7 @@ menu:
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 You can use handlers to send an email alert, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
-This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check-cpu`.
+This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add it.
 
 ## Register the dynamic runtime asset
@@ -156,24 +156,24 @@ You can share and reuse this handler like code &mdash; [save it to a file][15] a
 ## Assign the handler to a check
 
 With the `slack` handler created, you can assign it to a check.
-To continue this example, use the `check-cpu` check created in [Monitor server resources][2].
+To continue this example, use the `check_cpu` check created in [Monitor server resources][2].
 
-Assign your `slack` handler to the `check-cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
+Assign your `slack` handler to the `check_cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
 
 {{< code shell >}}
-sensuctl check set-handlers check-cpu slack
+sensuctl check set-handlers check_cpu slack
 {{< /code >}}
 
-To view the updated `check-cpu` resource definition, run:
+To view the updated `check_cpu` resource definition, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML">}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -188,7 +188,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -222,7 +222,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -18,7 +18,7 @@ Sensu checks use the same specification as **Nagios**, so you can use Nagios che
 
 You can use checks to monitor server resources, services, and application health (for example, to check whether Nginx is running) and collect and analyze metrics (for example, to learn how much disk space you have left).
 
-This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check-cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
+This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check_cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
 To use this guide, you'll need to install a Sensu backend and have at least one Sensu agent running on Linux.
 
 ## Register dynamic runtime assets
@@ -91,11 +91,11 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check
 
-Now that the dynamic runtime assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}
-sensuctl check create check-cpu \
+sensuctl check create check_cpu \
 --command 'check-cpu.rb -w 75 -c 90' \
 --interval 60 \
 --subscriptions system \
@@ -108,21 +108,21 @@ You should see a confirmation message:
 Created
 {{< /code >}}
 
-To view the complete resource definition for `check-cpu`, run:
+To view the complete resource definition for `check_cpu`, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -132,7 +132,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -166,7 +166,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -229,12 +229,12 @@ It might take a few moments after you create the check for the check to be sched
 sensuctl event list
 {{< /code >}}
 
-The response should list the `check-cpu` check, returning an OK status (`0`)
+The response should list the `check_cpu` check, returning an OK status (`0`)
 
 {{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
- sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
+ sensu-centos   check_cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
 {{< /code >}}
 
 ## Next steps

--- a/content/sensu-go/6.0/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.0/operations/monitoring-as-code/_index.md
@@ -77,21 +77,21 @@ You must add a [`password_hash`](../../sensuctl/#generate-a-password-hash) or `p
 
 To build as you go, use sensuctl commands to retrieve your Sensu resource definitions as you create them and copy the definitions into your configuration files.
 
-For example, if you follow [Monitor server resources][8] and create a check named `check-cpu`, you can retrieve that check definition in YAML or JSON format:
+For example, if you follow [Monitor server resources][8] and create a check named `check_cpu`, you can retrieve that check definition in YAML or JSON format:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -101,7 +101,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -135,7 +135,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -174,7 +174,7 @@ spec:
 You can copy these resource definitions and paste them into manually created configuration files located anywhere on your system.
 
 Alternatively, you can view resource definitions and copy them into a new or existing configuration file with a single sensuctl command.
-To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check-cpu`).
+To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check_cpu`).
 
 - Copy the resource defintion to a new file (or overwrite an existing file with the same name):
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
@@ -91,9 +91,11 @@ You'll use these functions to create event filters that represent the three acti
 | `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
 | `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
 
-To add these filters to Sensu, use `sensuctl create`:
+Use sensuctl to create the three event filters:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -129,7 +131,77 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl filter list --format yaml` to confirm that the filters are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_ops"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "sensu-go-has-contact-filter_any_noarch"
+    ],
+    "expressions": [
+      "has_contact(event, \"ops\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_dev"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "has_contact(event, \"dev\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_fallback"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "no_contacts(event)"
+    ]
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can also save these event filter resource definitions to a file named `filters.yml` or `filters.json` in your Sensu installation.
+When you're ready to manage your observability configurations the same way you do any other code, your `filters.yml` or `filters.json` file can become a part of your [monitoring as code][15] repository.
+
+Use sensuctl to confirm that the event filters were added:
+
+{{< code shell >}}
+sensuctl filter list
+{{< /code >}}
+
+The response should list the new `contact_ops`, `contact_dev`, and `contact_fallback` event filters:
+
+{{< code shell >}}
+        Name         Action           Expressions          
+ ────────────────── ──────── ───────────────────────────── 
+  contact_dev        allow    (has_contact(event, "dev"))  
+  contact_fallback   allow    (no_contacts(event))         
+  contact_ops        allow    (has_contact(event, "ops"))  
+{{< /code >}}
 
 ### 3. Create a handler for each contact
 
@@ -140,7 +212,7 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
@@ -153,7 +225,7 @@ resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the dynamic runtime asset: `sensu-slack-handler`.
 
-In each handler definition, specify:
+In each handler definition, you will specify:
 
 - A unique name: `slack_ops`, `slack_dev`, or `slack_fallback`
 - A customized command with the contact's preferred Slack channel
@@ -162,12 +234,16 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
 - Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
-{{< code shell >}}
+After you update the code to use your preferred Slack channels and webhook URL, run:
+
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -218,15 +294,102 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl handler list --format yaml` to confirm that the handlers are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_ops"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-ops\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_ops"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_dev"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-dev\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_dev"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_fallback"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-all\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_fallback"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Just like the event filters, you can save these handlers to a YAML or JSON file to create a handlers configuration file if you're implementing [monitoring as code][15].
+
+Use sensuctl to confirm that the handlers were added:
+
+{{< code shell >}}
+sensuctl handler list
+{{< /code >}}
+
+The response should list the new `slack_ops`, `slack_dev`, and `slack_fallback` handlers:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                        Execute                                                Environment Variables                                    Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ─────────────────────────────────────────────────── ────────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler
+{{< /code >}}
 
 ### 4. Create a handler set
 
-To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name.
+To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name, `slack`:
 
-Use `sensuctl` to create a `slack` handler set:
+{{< language-toggle >}}
 
-{{< code shell >}}
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -241,9 +404,41 @@ spec:
   type: set' | sensuctl create
 {{< /code >}}
 
-You should see updated output of `sensuctl handler list` that includes the `slack` handler set.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "slack_ops",
+      "slack_dev",
+      "slack_fallback"
+    ],
+    "type": "set"
+  }
+}' | sensuctl create
+{{< /code >}}
 
-Congratulations! Your Sensu contact routing is set up.
+{{< /language-toggle >}}
+
+Run `sensuctl handler list` again.
+The updated output should include the `slack` handler set:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                       Execute                                                Environment Variables                                  Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ────────────────────────────────────────────────── ──────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack            set          0                                                         CALL: slack_ops,slack_dev,slack_fallback                                                                                                         
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+{{< /code >}}
+
+Congratulations!
+Your Sensu contact routing is set up.
 Next, test your contact filters to make sure they work.
 
 ## Test contact routing
@@ -301,34 +496,153 @@ Resolve the events by sending the same API requests with `status` set to `0`.
 ## Manage contact labels in checks and entities
 
 To assign an alert to a contact, add a `contacts` label to the check or entity.
+The `contacts` labels should be `ops` and `dev`.
+You'll also need to update the check to use your `slack` handler.
 
-### Checks
+For example, you can update the `check_cpu` check created in [Monitor server resources][9] to include the `ops` and `dev` contacts and the `slack` handler.
 
-This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
+Use sensuctl to open the check in a text editor:
+
+{{< code shell >}}
+sensuctl edit check check_cpu
+{{< /code >}}
+
+Edit the check metadata to add the following labels:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+labels:
+  contacts: ops, dev
+{{< /code >}}
+
+{{< code json >}}
+{
+  "labels": {
+    "contacts": "ops, dev"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Save and close the updated check definition.
+A response will confirm the check was updated.
+For example:
+
+{{< code shell >}}
+Updated /api/core/v2/namespaces/default/checks/check_cpu
+{{< /code >}}
+
+Next, run this sensuctl command to add the `slack` handler:
+
+{{< code shell >}}
+sensuctl check set-handlers check_cpu slack
+{{< /code >}}
+
+Again, you will see an `Updated` confirmation message.
+
+To view the updated resource definition for `check_cpu` and confirm that it includes the `contacts` labels and `slack` handler, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check_cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check_cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the updated `check_cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
 
 {{< code yml >}}
 ---
 type: CheckConfig
 api_version: core/v2
 metadata:
-  name: check_cpu
+  created_by: admin
   labels:
     contacts: ops, dev
+  name: check_cpu
+  namespace: default
 spec:
+  check_hooks: null
   command: check-cpu.rb -w 75 -c 90
+  env_vars: null
   handlers:
   - slack
-  interval: 10
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
   publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
   subscriptions:
   - system
-  runtime-assets:
-  - sensu-plugins-cpu-checks
-  - sensu-ruby-runtime
+  timeout: 0
+  ttl: 0
 {{< /code >}}
 
-When the `check_cpu` check generates an incident, Sensu filters the event according to the `contact_ops` and `contact_dev` filters, resulting in an alert sent to #alert-ops and #alert-dev.
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "labels": {
+      "contacts": "ops, dev"
+    },
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Now when the `check_cpu` check generates an incident, Sensu will filter the event according to the `contact_ops` and `contact_dev` event filters and send alerts to #alert-ops and #alert-dev accordingly.
 
 <a href="/images/contact-routing2.png"><img src="/images/contact-routing2.png" alt="Diagram that shows an event generated with a check label for the dev and ops teams, matched to the dev team and ops team handlers using contact filters, and routed to the Slack channels for dev and ops"></a>
 <!-- Diagram source: https://www.lucidchart.com/documents/edit/3cbd2ad3-92ed-48cc-bbaa-a97f53dae1ba -->
@@ -368,3 +682,4 @@ Learn how to use Sensu to [Reduce alert fatigue][11].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [13]: ../../observe-schedule/agent/#create-observability-events-using-the-agent-api
 [14]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[15]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
@@ -35,7 +35,7 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 sensuctl asset add sensu/sensu-email-handler -r email-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 no version specified, using latest: 0.6.0
@@ -85,7 +85,9 @@ Here's an overview of how the `state_change_only` filter will work:
 
 To create the event filter, run:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -93,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only
+  name: state_change_only2
   namespace: default
 spec:
   action: allow
@@ -103,14 +105,54 @@ spec:
 EOF
 {{< /code >}}
 
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "annotations": null,
+    "labels": null,
+    "name": "state_change_only",
+    "namespace": "default"
+  },
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": [
+
+    ]
+  }
+}
+EOF
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Create the email handler definition
 
 After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
-In the handler definition's `command` value, you'll need to change a few things.
+In the handler definition's `command` value, you'll need to change a few things:
 
-Copy this text into a text editor:
+- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
+- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
+- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
+- `USERNAME`: Replace with your SMTP username, typically your email address.
+- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
 
-{{< code shell >}}
+{{% notice note %}}
+**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
+If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
+If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
+{{% /notice %}}
+
+With your updates, create the handler using sensuctl:
+
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -132,19 +174,33 @@ spec:
 EOF
 {{< /code >}}
 
-Then, replace the following text:
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "api_version": "core/v2",
+  "type": "Handler",
+  "metadata": {
+    "namespace": "default",
+    "name": "email"
+  },
+  "spec": {
+    "type": "pipe",
+    "command": "sensu-email-handler -f YOUR-SENDER@example.com -t YOUR-RECIPIENT@example.com -s YOUR-SMTP-SERVER.example.com -u USERNAME -p PASSWORD",
+    "timeout": 10,
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "state_change_only"
+    ],
+    "runtime_assets": [
+      "email-handler"
+    ]
+  }
+}
+EOF
+{{< /code >}}
 
-- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
-- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
-- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
-- `USERNAME`: Replace with your SMTP username, typically your email address.
-- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
-
-{{% notice note %}}
-**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
-If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
-If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
-{{% /notice %}}
+{{< /language-toggle >}}
 
 You probably noticed that the handler definition includes two other filters besides `state_change_only`: [`is_incident`][10] and [`not_silenced`][11].
 These two filters are included in every Sensu backend installation, so you don't have to create them.
@@ -272,6 +328,7 @@ You should receive another email because the event status changed to `0` (OK).
 Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
+- Learn how to use the event filter and handler resources you created to start developing a [monitoring as code][15] repository.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 
@@ -292,6 +349,7 @@ You can also follow our [Up and running with Sensu Go][9] interactive tutorial t
 [12]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [13]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [14]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler#templates
+[15]: ../../../operations/monitoring-as-code/
 [16]: ../../observe-filter/filters/
 [17]: #create-an-ad-hoc-event
 [18]: #create-the-email-handler-definition

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
@@ -271,7 +271,7 @@ You should receive another email because the event status changed to `0` (OK).
 
 Now that you know how to apply a handler to a check and take action on events:
 
-- Reuse this email handler with the `check-cpu` check from our [Monitor server resources][2] guide.
+- Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
@@ -16,7 +16,7 @@ menu:
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 You can use handlers to send an email alert, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
-This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check-cpu`.
+This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add it.
 
 ## Register the dynamic runtime asset
@@ -156,24 +156,24 @@ You can share and reuse this handler like code &mdash; [save it to a file][15] a
 ## Assign the handler to a check
 
 With the `slack` handler created, you can assign it to a check.
-To continue this example, use the `check-cpu` check created in [Monitor server resources][2].
+To continue this example, use the `check_cpu` check created in [Monitor server resources][2].
 
-Assign your `slack` handler to the `check-cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
+Assign your `slack` handler to the `check_cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
 
 {{< code shell >}}
-sensuctl check set-handlers check-cpu slack
+sensuctl check set-handlers check_cpu slack
 {{< /code >}}
 
-To view the updated `check-cpu` resource definition, run:
+To view the updated `check_cpu` resource definition, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML">}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -188,7 +188,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -222,7 +222,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -18,7 +18,7 @@ Sensu checks use the same specification as **Nagios**, so you can use Nagios che
 
 You can use checks to monitor server resources, services, and application health (for example, to check whether Nginx is running) and collect and analyze metrics (for example, to learn how much disk space you have left).
 
-This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check-cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
+This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check_cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
 To use this guide, you'll need to install a Sensu backend and have at least one Sensu agent running on Linux.
 
 ## Register dynamic runtime assets
@@ -91,11 +91,11 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check
 
-Now that the dynamic runtime assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}
-sensuctl check create check-cpu \
+sensuctl check create check_cpu \
 --command 'check-cpu.rb -w 75 -c 90' \
 --interval 60 \
 --subscriptions system \
@@ -108,21 +108,21 @@ You should see a confirmation message:
 Created
 {{< /code >}}
 
-To view the complete resource definition for `check-cpu`, run:
+To view the complete resource definition for `check_cpu`, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -132,7 +132,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -166,7 +166,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -229,12 +229,12 @@ It might take a few moments after you create the check for the check to be sched
 sensuctl event list
 {{< /code >}}
 
-The response should list the `check-cpu` check, returning an OK status (`0`)
+The response should list the `check_cpu` check, returning an OK status (`0`)
 
 {{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
- sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
+ sensu-centos   check_cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
 {{< /code >}}
 
 ## Next steps

--- a/content/sensu-go/6.1/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.1/operations/monitoring-as-code/_index.md
@@ -77,21 +77,21 @@ You must add a [`password_hash`](../../sensuctl/#generate-a-password-hash) or `p
 
 To build as you go, use sensuctl commands to retrieve your Sensu resource definitions as you create them and copy the definitions into your configuration files.
 
-For example, if you follow [Monitor server resources][8] and create a check named `check-cpu`, you can retrieve that check definition in YAML or JSON format:
+For example, if you follow [Monitor server resources][8] and create a check named `check_cpu`, you can retrieve that check definition in YAML or JSON format:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -101,7 +101,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -135,7 +135,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -174,7 +174,7 @@ spec:
 You can copy these resource definitions and paste them into manually created configuration files located anywhere on your system.
 
 Alternatively, you can view resource definitions and copy them into a new or existing configuration file with a single sensuctl command.
-To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check-cpu`).
+To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check_cpu`).
 
 - Copy the resource defintion to a new file (or overwrite an existing file with the same name):
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
@@ -91,9 +91,11 @@ You'll use these functions to create event filters that represent the three acti
 | `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
 | `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
 
-To add these filters to Sensu, use `sensuctl create`:
+Use sensuctl to create the three event filters:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -129,7 +131,77 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl filter list --format yaml` to confirm that the filters are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_ops"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "sensu-go-has-contact-filter_any_noarch"
+    ],
+    "expressions": [
+      "has_contact(event, \"ops\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_dev"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "has_contact(event, \"dev\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_fallback"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "no_contacts(event)"
+    ]
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can also save these event filter resource definitions to a file named `filters.yml` or `filters.json` in your Sensu installation.
+When you're ready to manage your observability configurations the same way you do any other code, your `filters.yml` or `filters.json` file can become a part of your [monitoring as code][15] repository.
+
+Use sensuctl to confirm that the event filters were added:
+
+{{< code shell >}}
+sensuctl filter list
+{{< /code >}}
+
+The response should list the new `contact_ops`, `contact_dev`, and `contact_fallback` event filters:
+
+{{< code shell >}}
+        Name         Action           Expressions          
+ ────────────────── ──────── ───────────────────────────── 
+  contact_dev        allow    (has_contact(event, "dev"))  
+  contact_fallback   allow    (no_contacts(event))         
+  contact_ops        allow    (has_contact(event, "ops"))  
+{{< /code >}}
 
 ### 3. Create a handler for each contact
 
@@ -140,7 +212,7 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
@@ -153,7 +225,7 @@ resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the dynamic runtime asset: `sensu-slack-handler`.
 
-In each handler definition, specify:
+In each handler definition, you will specify:
 
 - A unique name: `slack_ops`, `slack_dev`, or `slack_fallback`
 - A customized command with the contact's preferred Slack channel
@@ -162,12 +234,16 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
 - Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
-{{< code shell >}}
+After you update the code to use your preferred Slack channels and webhook URL, run:
+
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -218,15 +294,102 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl handler list --format yaml` to confirm that the handlers are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_ops"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-ops\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_ops"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_dev"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-dev\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_dev"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_fallback"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-all\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_fallback"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Just like the event filters, you can save these handlers to a YAML or JSON file to create a handlers configuration file if you're implementing [monitoring as code][15].
+
+Use sensuctl to confirm that the handlers were added:
+
+{{< code shell >}}
+sensuctl handler list
+{{< /code >}}
+
+The response should list the new `slack_ops`, `slack_dev`, and `slack_fallback` handlers:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                        Execute                                                Environment Variables                                    Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ─────────────────────────────────────────────────── ────────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler
+{{< /code >}}
 
 ### 4. Create a handler set
 
-To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name.
+To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name, `slack`:
 
-Use `sensuctl` to create a `slack` handler set:
+{{< language-toggle >}}
 
-{{< code shell >}}
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -241,9 +404,41 @@ spec:
   type: set' | sensuctl create
 {{< /code >}}
 
-You should see updated output of `sensuctl handler list` that includes the `slack` handler set.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "slack_ops",
+      "slack_dev",
+      "slack_fallback"
+    ],
+    "type": "set"
+  }
+}' | sensuctl create
+{{< /code >}}
 
-Congratulations! Your Sensu contact routing is set up.
+{{< /language-toggle >}}
+
+Run `sensuctl handler list` again.
+The updated output should include the `slack` handler set:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                       Execute                                                Environment Variables                                  Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ────────────────────────────────────────────────── ──────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack            set          0                                                         CALL: slack_ops,slack_dev,slack_fallback                                                                                                         
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+{{< /code >}}
+
+Congratulations!
+Your Sensu contact routing is set up.
 Next, test your contact filters to make sure they work.
 
 ## Test contact routing
@@ -301,34 +496,153 @@ Resolve the events by sending the same API requests with `status` set to `0`.
 ## Manage contact labels in checks and entities
 
 To assign an alert to a contact, add a `contacts` label to the check or entity.
+The `contacts` labels should be `ops` and `dev`.
+You'll also need to update the check to use your `slack` handler.
 
-### Checks
+For example, you can update the `check_cpu` check created in [Monitor server resources][9] to include the `ops` and `dev` contacts and the `slack` handler.
 
-This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
+Use sensuctl to open the check in a text editor:
+
+{{< code shell >}}
+sensuctl edit check check_cpu
+{{< /code >}}
+
+Edit the check metadata to add the following labels:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+labels:
+  contacts: ops, dev
+{{< /code >}}
+
+{{< code json >}}
+{
+  "labels": {
+    "contacts": "ops, dev"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Save and close the updated check definition.
+A response will confirm the check was updated.
+For example:
+
+{{< code shell >}}
+Updated /api/core/v2/namespaces/default/checks/check_cpu
+{{< /code >}}
+
+Next, run this sensuctl command to add the `slack` handler:
+
+{{< code shell >}}
+sensuctl check set-handlers check_cpu slack
+{{< /code >}}
+
+Again, you will see an `Updated` confirmation message.
+
+To view the updated resource definition for `check_cpu` and confirm that it includes the `contacts` labels and `slack` handler, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check_cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check_cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the updated `check_cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
 
 {{< code yml >}}
 ---
 type: CheckConfig
 api_version: core/v2
 metadata:
-  name: check_cpu
+  created_by: admin
   labels:
     contacts: ops, dev
+  name: check_cpu
+  namespace: default
 spec:
+  check_hooks: null
   command: check-cpu.rb -w 75 -c 90
+  env_vars: null
   handlers:
   - slack
-  interval: 10
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
   publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
   subscriptions:
   - system
-  runtime-assets:
-  - sensu-plugins-cpu-checks
-  - sensu-ruby-runtime
+  timeout: 0
+  ttl: 0
 {{< /code >}}
 
-When the `check_cpu` check generates an incident, Sensu filters the event according to the `contact_ops` and `contact_dev` filters, resulting in an alert sent to #alert-ops and #alert-dev.
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "labels": {
+      "contacts": "ops, dev"
+    },
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Now when the `check_cpu` check generates an incident, Sensu will filter the event according to the `contact_ops` and `contact_dev` event filters and send alerts to #alert-ops and #alert-dev accordingly.
 
 <a href="/images/contact-routing2.png"><img src="/images/contact-routing2.png" alt="Diagram that shows an event generated with a check label for the dev and ops teams, matched to the dev team and ops team handlers using contact filters, and routed to the Slack channels for dev and ops"></a>
 <!-- Diagram source: https://www.lucidchart.com/documents/edit/3cbd2ad3-92ed-48cc-bbaa-a97f53dae1ba -->
@@ -368,3 +682,4 @@ Learn how to use Sensu to [Reduce alert fatigue][11].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [13]: ../../observe-schedule/agent/#create-observability-events-using-the-agent-api
 [14]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[15]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -35,7 +35,7 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 sensuctl asset add sensu/sensu-email-handler -r email-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 no version specified, using latest: 0.6.0
@@ -85,7 +85,9 @@ Here's an overview of how the `state_change_only` filter will work:
 
 To create the event filter, run:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -93,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only
+  name: state_change_only2
   namespace: default
 spec:
   action: allow
@@ -103,14 +105,54 @@ spec:
 EOF
 {{< /code >}}
 
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "annotations": null,
+    "labels": null,
+    "name": "state_change_only",
+    "namespace": "default"
+  },
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": [
+
+    ]
+  }
+}
+EOF
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Create the email handler definition
 
 After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
-In the handler definition's `command` value, you'll need to change a few things.
+In the handler definition's `command` value, you'll need to change a few things:
 
-Copy this text into a text editor:
+- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
+- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
+- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
+- `USERNAME`: Replace with your SMTP username, typically your email address.
+- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
 
-{{< code shell >}}
+{{% notice note %}}
+**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
+If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
+If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
+{{% /notice %}}
+
+With your updates, create the handler using sensuctl:
+
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -132,19 +174,33 @@ spec:
 EOF
 {{< /code >}}
 
-Then, replace the following text:
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "api_version": "core/v2",
+  "type": "Handler",
+  "metadata": {
+    "namespace": "default",
+    "name": "email"
+  },
+  "spec": {
+    "type": "pipe",
+    "command": "sensu-email-handler -f YOUR-SENDER@example.com -t YOUR-RECIPIENT@example.com -s YOUR-SMTP-SERVER.example.com -u USERNAME -p PASSWORD",
+    "timeout": 10,
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "state_change_only"
+    ],
+    "runtime_assets": [
+      "email-handler"
+    ]
+  }
+}
+EOF
+{{< /code >}}
 
-- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
-- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
-- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
-- `USERNAME`: Replace with your SMTP username, typically your email address.
-- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
-
-{{% notice note %}}
-**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
-If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
-If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
-{{% /notice %}}
+{{< /language-toggle >}}
 
 You probably noticed that the handler definition includes two other filters besides `state_change_only`: [`is_incident`][10] and [`not_silenced`][11].
 These two filters are included in every Sensu backend installation, so you don't have to create them.
@@ -272,6 +328,7 @@ You should receive another email because the event status changed to `0` (OK).
 Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
+- Learn how to use the event filter and handler resources you created to start developing a [monitoring as code][15] repository.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 
@@ -292,6 +349,7 @@ You can also follow our [Up and running with Sensu Go][9] interactive tutorial t
 [12]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [13]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [14]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler#templates
+[15]: ../../../operations/monitoring-as-code/
 [16]: ../../observe-filter/filters/
 [17]: #create-an-ad-hoc-event
 [18]: #create-the-email-handler-definition

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -271,7 +271,7 @@ You should receive another email because the event status changed to `0` (OK).
 
 Now that you know how to apply a handler to a check and take action on events:
 
-- Reuse this email handler with the `check-cpu` check from our [Monitor server resources][2] guide.
+- Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
@@ -16,7 +16,7 @@ menu:
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 You can use handlers to send an email alert, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
-This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check-cpu`.
+This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add it.
 
 ## Register the dynamic runtime asset
@@ -156,24 +156,24 @@ You can share and reuse this handler like code &mdash; [save it to a file][15] a
 ## Assign the handler to a check
 
 With the `slack` handler created, you can assign it to a check.
-To continue this example, use the `check-cpu` check created in [Monitor server resources][2].
+To continue this example, use the `check_cpu` check created in [Monitor server resources][2].
 
-Assign your `slack` handler to the `check-cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
+Assign your `slack` handler to the `check_cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
 
 {{< code shell >}}
-sensuctl check set-handlers check-cpu slack
+sensuctl check set-handlers check_cpu slack
 {{< /code >}}
 
-To view the updated `check-cpu` resource definition, run:
+To view the updated `check_cpu` resource definition, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML">}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -188,7 +188,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -222,7 +222,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -18,7 +18,7 @@ Sensu checks use the same specification as **Nagios**, so you can use Nagios che
 
 You can use checks to monitor server resources, services, and application health (for example, to check whether Nginx is running) and collect and analyze metrics (for example, to learn how much disk space you have left).
 
-This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check-cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
+This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check_cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
 To use this guide, you'll need to install a Sensu backend and have at least one Sensu agent running on Linux.
 
 ## Register dynamic runtime assets
@@ -91,11 +91,11 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check
 
-Now that the dynamic runtime assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}
-sensuctl check create check-cpu \
+sensuctl check create check_cpu \
 --command 'check-cpu.rb -w 75 -c 90' \
 --interval 60 \
 --subscriptions system \
@@ -108,21 +108,21 @@ You should see a confirmation message:
 Created
 {{< /code >}}
 
-To view the complete resource definition for `check-cpu`, run:
+To view the complete resource definition for `check_cpu`, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -132,7 +132,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -166,7 +166,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -229,12 +229,12 @@ It might take a few moments after you create the check for the check to be sched
 sensuctl event list
 {{< /code >}}
 
-The response should list the `check-cpu` check, returning an OK status (`0`)
+The response should list the `check_cpu` check, returning an OK status (`0`)
 
 {{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
- sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
+ sensu-centos   check_cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
 {{< /code >}}
 
 ## Next steps

--- a/content/sensu-go/6.2/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.2/operations/monitoring-as-code/_index.md
@@ -77,21 +77,21 @@ You must add a [`password_hash`](../../sensuctl/#generate-a-password-hash) or `p
 
 To build as you go, use sensuctl commands to retrieve your Sensu resource definitions as you create them and copy the definitions into your configuration files.
 
-For example, if you follow [Monitor server resources][8] and create a check named `check-cpu`, you can retrieve that check definition in YAML or JSON format:
+For example, if you follow [Monitor server resources][8] and create a check named `check_cpu`, you can retrieve that check definition in YAML or JSON format:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -101,7 +101,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -135,7 +135,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -174,7 +174,7 @@ spec:
 You can copy these resource definitions and paste them into manually created configuration files located anywhere on your system.
 
 Alternatively, you can view resource definitions and copy them into a new or existing configuration file with a single sensuctl command.
-To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check-cpu`).
+To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check_cpu`).
 
 - Copy the resource defintion to a new file (or overwrite an existing file with the same name):
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -91,9 +91,11 @@ You'll use these functions to create event filters that represent the three acti
 | `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
 | `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
 
-To add these filters to Sensu, use `sensuctl create`:
+Use sensuctl to create the three event filters:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -129,7 +131,77 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl filter list --format yaml` to confirm that the filters are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_ops"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "sensu-go-has-contact-filter_any_noarch"
+    ],
+    "expressions": [
+      "has_contact(event, \"ops\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_dev"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "has_contact(event, \"dev\")"
+    ]
+  }
+}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "contact_fallback"
+  },
+  "spec": {
+    "action": "allow",
+    "runtime_assets": [
+      "contact-filter"
+    ],
+    "expressions": [
+      "no_contacts(event)"
+    ]
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can also save these event filter resource definitions to a file named `filters.yml` or `filters.json` in your Sensu installation.
+When you're ready to manage your observability configurations the same way you do any other code, your `filters.yml` or `filters.json` file can become a part of your [monitoring as code][15] repository.
+
+Use sensuctl to confirm that the event filters were added:
+
+{{< code shell >}}
+sensuctl filter list
+{{< /code >}}
+
+The response should list the new `contact_ops`, `contact_dev`, and `contact_fallback` event filters:
+
+{{< code shell >}}
+        Name         Action           Expressions          
+ ────────────────── ──────── ───────────────────────────── 
+  contact_dev        allow    (has_contact(event, "dev"))  
+  contact_fallback   allow    (no_contacts(event))         
+  contact_ops        allow    (has_contact(event, "ops"))  
+{{< /code >}}
 
 ### 3. Create a handler for each contact
 
@@ -140,7 +212,7 @@ If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sens
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
@@ -153,7 +225,7 @@ resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the dynamic runtime asset: `sensu-slack-handler`.
 
-In each handler definition, specify:
+In each handler definition, you will specify:
 
 - A unique name: `slack_ops`, `slack_dev`, or `slack_fallback`
 - A customized command with the contact's preferred Slack channel
@@ -162,12 +234,16 @@ In each handler definition, specify:
 - An environment variable that contains your Slack webhook URL
 - The `sensu-slack-handler` dynamic runtime asset
 
-To create the `slack_ops`, `slack_dev`, and `slack_fallback` handlers, edit and run the following example:
+Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Add replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace #alert-ops, #alert-dev, and #alert-all with the names of the channels you want to use to receive alerts in your Slack instance.
 - Replace SLACK_WEBHOOK_URL with your Slack webhook URL.
 
-{{< code shell >}}
+After you update the code to use your preferred Slack channels and webhook URL, run:
+
+{{< language-toggle >}}
+
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -218,15 +294,102 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-Run `sensuctl handler list --format yaml` to confirm that the handlers are ready to use.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_ops"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-ops\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_ops"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_dev"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-dev\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_dev"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack_fallback"
+  },
+  "spec": {
+    "command": "sensu-slack-handler --channel \"#alert-all\"",
+    "env_vars": [
+      "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
+    ],
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "contact_fallback"
+    ],
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "type": "pipe"
+  }
+}' | sensuctl create
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Just like the event filters, you can save these handlers to a YAML or JSON file to create a handlers configuration file if you're implementing [monitoring as code][15].
+
+Use sensuctl to confirm that the handlers were added:
+
+{{< code shell >}}
+sensuctl handler list
+{{< /code >}}
+
+The response should list the new `slack_ops`, `slack_dev`, and `slack_fallback` handlers:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                        Execute                                                Environment Variables                                    Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ─────────────────────────────────────────────────── ────────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler
+{{< /code >}}
 
 ### 4. Create a handler set
 
-To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name.
+To centralize contact management and simplify configuration, create a handler set that combines your contact-specific handlers under a single handler name, `slack`:
 
-Use `sensuctl` to create a `slack` handler set:
+{{< language-toggle >}}
 
-{{< code shell >}}
+{{< code text "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -241,9 +404,41 @@ spec:
   type: set' | sensuctl create
 {{< /code >}}
 
-You should see updated output of `sensuctl handler list` that includes the `slack` handler set.
+{{< code text "JSON" >}}
+echo '{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "slack",
+    "namespace": "default"
+  },
+  "spec": {
+    "handlers": [
+      "slack_ops",
+      "slack_dev",
+      "slack_fallback"
+    ],
+    "type": "set"
+  }
+}' | sensuctl create
+{{< /code >}}
 
-Congratulations! Your Sensu contact routing is set up.
+{{< /language-toggle >}}
+
+Run `sensuctl handler list` again.
+The updated output should include the `slack` handler set:
+
+{{< code shell >}}
+       Name        Type   Timeout                    Filters                    Mutator                       Execute                                                Environment Variables                                  Assets         
+ ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ────────────────────────────────────────────────── ──────────────────────────────────────────────────────────────────────── ───────────────────── 
+  slack            set          0                                                         CALL: slack_ops,slack_dev,slack_fallback                                                                                                         
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+{{< /code >}}
+
+Congratulations!
+Your Sensu contact routing is set up.
 Next, test your contact filters to make sure they work.
 
 ## Test contact routing
@@ -301,34 +496,153 @@ Resolve the events by sending the same API requests with `status` set to `0`.
 ## Manage contact labels in checks and entities
 
 To assign an alert to a contact, add a `contacts` label to the check or entity.
+The `contacts` labels should be `ops` and `dev`.
+You'll also need to update the check to use your `slack` handler.
 
-### Checks
+For example, you can update the `check_cpu` check created in [Monitor server resources][9] to include the `ops` and `dev` contacts and the `slack` handler.
 
-This check definition includes two contacts (`ops` and `dev`) and the handler `slack`.
-To add the runtime assets and set up the `check_cpu` check, see [Monitor server resources][9].
+Use sensuctl to open the check in a text editor:
+
+{{< code shell >}}
+sensuctl edit check check_cpu
+{{< /code >}}
+
+Edit the check metadata to add the following labels:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+labels:
+  contacts: ops, dev
+{{< /code >}}
+
+{{< code json >}}
+{
+  "labels": {
+    "contacts": "ops, dev"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Save and close the updated check definition.
+A response will confirm the check was updated.
+For example:
+
+{{< code shell >}}
+Updated /api/core/v2/namespaces/default/checks/check_cpu
+{{< /code >}}
+
+Next, run this sensuctl command to add the `slack` handler:
+
+{{< code shell >}}
+sensuctl check set-handlers check_cpu slack
+{{< /code >}}
+
+Again, you will see an `Updated` confirmation message.
+
+To view the updated resource definition for `check_cpu` and confirm that it includes the `contacts` labels and `slack` handler, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl check info check_cpu --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl check info check_cpu --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The sensuctl response will include the updated `check_cpu` resource definition in the specified format:
+
+{{< language-toggle >}}
 
 {{< code yml >}}
 ---
 type: CheckConfig
 api_version: core/v2
 metadata:
-  name: check_cpu
+  created_by: admin
   labels:
     contacts: ops, dev
+  name: check_cpu
+  namespace: default
 spec:
+  check_hooks: null
   command: check-cpu.rb -w 75 -c 90
+  env_vars: null
   handlers:
   - slack
-  interval: 10
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: ""
+  output_metric_handlers: null
+  proxy_entity_name: ""
   publish: true
+  round_robin: false
+  runtime_assets:
+  - cpu-checks-plugins
+  - sensu-ruby-runtime
+  secrets: null
+  stdin: false
+  subdue: null
   subscriptions:
   - system
-  runtime-assets:
-  - sensu-plugins-cpu-checks
-  - sensu-ruby-runtime
+  timeout: 0
+  ttl: 0
 {{< /code >}}
 
-When the `check_cpu` check generates an incident, Sensu filters the event according to the `contact_ops` and `contact_dev` filters, resulting in an alert sent to #alert-ops and #alert-dev.
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "labels": {
+      "contacts": "ops, dev"
+    },
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "check_hooks": null,
+    "command": "check-cpu.rb -w 75 -c 90",
+    "env_vars": null,
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "secrets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Now when the `check_cpu` check generates an incident, Sensu will filter the event according to the `contact_ops` and `contact_dev` event filters and send alerts to #alert-ops and #alert-dev accordingly.
 
 <a href="/images/contact-routing2.png"><img src="/images/contact-routing2.png" alt="Diagram that shows an event generated with a check label for the dev and ops teams, matched to the dev team and ops team handlers using contact filters, and routed to the Slack channels for dev and ops"></a>
 <!-- Diagram source: https://www.lucidchart.com/documents/edit/3cbd2ad3-92ed-48cc-bbaa-a97f53dae1ba -->
@@ -368,3 +682,4 @@ Learn how to use Sensu to [Reduce alert fatigue][11].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [13]: ../../observe-schedule/agent/#create-observability-events-using-the-agent-api
 [14]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
+[15]: ../../../operations/monitoring-as-code/

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -35,7 +35,7 @@ Use the following sensuctl example to register the [Sensu Go Email Handler][3] d
 sensuctl asset add sensu/sensu-email-handler -r email-handler
 {{< /code >}}
 
-The response will indicate that the asset was added:
+The response will confirm that the asset was added:
 
 {{< code shell >}}
 no version specified, using latest: 0.6.0
@@ -85,7 +85,9 @@ Here's an overview of how the `state_change_only` filter will work:
 
 To create the event filter, run:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -93,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only
+  name: state_change_only2
   namespace: default
 spec:
   action: allow
@@ -103,14 +105,54 @@ spec:
 EOF
 {{< /code >}}
 
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "annotations": null,
+    "labels": null,
+    "name": "state_change_only",
+    "namespace": "default"
+  },
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": [
+
+    ]
+  }
+}
+EOF
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Create the email handler definition
 
 After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
-In the handler definition's `command` value, you'll need to change a few things.
+In the handler definition's `command` value, you'll need to change a few things:
 
-Copy this text into a text editor:
+- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
+- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
+- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
+- `USERNAME`: Replace with your SMTP username, typically your email address.
+- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
 
-{{< code shell >}}
+{{% notice note %}}
+**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
+If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
+If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
+{{% /notice %}}
+
+With your updates, create the handler using sensuctl:
+
+{{< language-toggle >}}
+
+{{< code text "YML">}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -132,19 +174,33 @@ spec:
 EOF
 {{< /code >}}
 
-Then, replace the following text:
+{{< code text "JSON" >}}
+cat << EOF | sensuctl create
+{
+  "api_version": "core/v2",
+  "type": "Handler",
+  "metadata": {
+    "namespace": "default",
+    "name": "email"
+  },
+  "spec": {
+    "type": "pipe",
+    "command": "sensu-email-handler -f YOUR-SENDER@example.com -t YOUR-RECIPIENT@example.com -s YOUR-SMTP-SERVER.example.com -u USERNAME -p PASSWORD",
+    "timeout": 10,
+    "filters": [
+      "is_incident",
+      "not_silenced",
+      "state_change_only"
+    ],
+    "runtime_assets": [
+      "email-handler"
+    ]
+  }
+}
+EOF
+{{< /code >}}
 
-- `YOUR-SENDER@example.com`: Replace with the email address you want to use to send email alerts.
-- `YOUR-RECIPIENT@example.com`: Replace with the email address you want to receive email alerts.
-- `YOUR-SMTP-SERVER.example.com`: Replace with the hostname of your SMTP server.
-- `USERNAME`: Replace with your SMTP username, typically your email address.
-- `PASSWORD`: Replace with your SMTP password, typically the same as your email password.
-
-{{% notice note %}}
-**NOTE**: To use Gmail or G Suite as your SMTP server, follow Google's instructions to [send email via SMTP](https://support.google.com/a/answer/176600?hl=en).
-If you have enabled 2-step verification on your Google account, use an [app password](https://support.google.com/accounts/answer/185833?hl=en) instead of your login password.
-If you have not enabled 2-step verification, you may need to adjust your [app access settings](https://support.google.com/accounts/answer/6010255) to follow the example in this guide.
-{{% /notice %}}
+{{< /language-toggle >}}
 
 You probably noticed that the handler definition includes two other filters besides `state_change_only`: [`is_incident`][10] and [`not_silenced`][11].
 These two filters are included in every Sensu backend installation, so you don't have to create them.
@@ -272,6 +328,7 @@ You should receive another email because the event status changed to `0` (OK).
 Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
+- Learn how to use the event filter and handler resources you created to start developing a [monitoring as code][15] repository.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 
@@ -292,6 +349,7 @@ You can also follow our [Up and running with Sensu Go][9] interactive tutorial t
 [12]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [13]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [14]: https://bonsai.sensu.io/assets/sensu/sensu-email-handler#templates
+[15]: ../../../operations/monitoring-as-code/
 [16]: ../../observe-filter/filters/
 [17]: #create-an-ad-hoc-event
 [18]: #create-the-email-handler-definition

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -271,7 +271,7 @@ You should receive another email because the event status changed to `0` (OK).
 
 Now that you know how to apply a handler to a check and take action on events:
 
-- Reuse this email handler with the `check-cpu` check from our [Monitor server resources][2] guide.
+- Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Read the [handlers reference][6] for in-depth handler documentation.
 - Check out the [Reduce alert fatigue][7] guide.
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -16,7 +16,7 @@ menu:
 Sensu event handlers are actions the Sensu backend executes on [events][1].
 You can use handlers to send an email alert, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
-This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check-cpu`.
+This guide will help you send alerts to Slack in the channel `monitoring` by configuring a handler named `slack` to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add it.
 
 ## Register the dynamic runtime asset
@@ -156,24 +156,24 @@ You can share and reuse this handler like code &mdash; [save it to a file][15] a
 ## Assign the handler to a check
 
 With the `slack` handler created, you can assign it to a check.
-To continue this example, use the `check-cpu` check created in [Monitor server resources][2].
+To continue this example, use the `check_cpu` check created in [Monitor server resources][2].
 
-Assign your `slack` handler to the `check-cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
+Assign your `slack` handler to the `check_cpu` check to receive Slack alerts when the CPU usage of your systems reaches the specific thresholds set in the check command:
 
 {{< code shell >}}
-sensuctl check set-handlers check-cpu slack
+sensuctl check set-handlers check_cpu slack
 {{< /code >}}
 
-To view the updated `check-cpu` resource definition, run:
+To view the updated `check_cpu` resource definition, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML">}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -188,7 +188,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -222,7 +222,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -18,7 +18,7 @@ Sensu checks use the same specification as **Nagios**, so you can use Nagios che
 
 You can use checks to monitor server resources, services, and application health (for example, to check whether Nginx is running) and collect and analyze metrics (for example, to learn how much disk space you have left).
 
-This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check-cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
+This guide will help you monitor server resources (specifically, CPU usage) by configuring a check named `check_cpu` with a subscription named `system` to target all entities that are subscribed to the `system` subscription.
 To use this guide, you'll need to install a Sensu backend and have at least one Sensu agent running on Linux.
 
 ## Register dynamic runtime assets
@@ -91,11 +91,11 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check
 
-Now that the dynamic runtime assets are registered, create a check named `check-cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu.rb -w 75 -c 90` with the `cpu-checks-plugins` and `sensu-ruby-runtime` dynamic runtime assets at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}
-sensuctl check create check-cpu \
+sensuctl check create check_cpu \
 --command 'check-cpu.rb -w 75 -c 90' \
 --interval 60 \
 --subscriptions system \
@@ -108,21 +108,21 @@ You should see a confirmation message:
 Created
 {{< /code >}}
 
-To view the complete resource definition for `check-cpu`, run:
+To view the complete resource definition for `check_cpu`, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check_cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -132,7 +132,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -166,7 +166,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -229,12 +229,12 @@ It might take a few moments after you create the check for the check to be sched
 sensuctl event list
 {{< /code >}}
 
-The response should list the `check-cpu` check, returning an OK status (`0`)
+The response should list the `check_cpu` check, returning an OK status (`0`)
 
 {{< code shell >}}
     Entity        Check                                                                    Output                                                                   Status   Silenced             Timestamp            
 ────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
- sensu-centos   check-cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
+ sensu-centos   check_cpu   CheckCPU TOTAL OK: total=0.2 user=0.0 nice=0.0 system=0.2 idle=99.8 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0        0   false      2019-04-23 16:42:28 +0000 UTC  
 {{< /code >}}
 
 ## Next steps

--- a/content/sensu-go/6.3/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.3/operations/monitoring-as-code/_index.md
@@ -77,21 +77,21 @@ You must add a [`password_hash`](../../sensuctl/#generate-a-password-hash) or `p
 
 To build as you go, use sensuctl commands to retrieve your Sensu resource definitions as you create them and copy the definitions into your configuration files.
 
-For example, if you follow [Monitor server resources][8] and create a check named `check-cpu`, you can retrieve that check definition in YAML or JSON format:
+For example, if you follow [Monitor server resources][8] and create a check named `check_cpu`, you can retrieve that check definition in YAML or JSON format:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
-sensuctl check info check-cpu --format yaml
+sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
 
-The sensuctl response will include the complete `check-cpu` resource definition in the specified format:
+The sensuctl response will include the complete `check_cpu` resource definition in the specified format:
 
 {{< language-toggle >}}
 
@@ -101,7 +101,7 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   created_by: admin
-  name: check-cpu
+  name: check_cpu
   namespace: default
 spec:
   check_hooks: null
@@ -135,7 +135,7 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "created_by": "admin",
-    "name": "check-cpu",
+    "name": "check_cpu",
     "namespace": "default"
   },
   "spec": {
@@ -174,7 +174,7 @@ spec:
 You can copy these resource definitions and paste them into manually created configuration files located anywhere on your system.
 
 Alternatively, you can view resource definitions and copy them into a new or existing configuration file with a single sensuctl command.
-To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check-cpu`).
+To use the following examples, replace `RESOURCE` with the resource type (like `check`) and replace `RESOURCE_NAME` with the name of the resource (like `check_cpu`).
 
 - Copy the resource defintion to a new file (or overwrite an existing file with the same name):
 


### PR DESCRIPTION
## Description
Adds resource definitions throughout docs as needed to illustrate the resources being created and updated with sensuctl commands. Part 3

## Motivation and Context
Many of our docs (especially guides) rely on sensuctl commands to create and update resources. These commands are tidy, but they do not show users what the resources they are creating and updating look like.