### PR TITLE
Add explicit info about not configuring external etcd within Sensu

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
@@ -320,6 +320,7 @@ If you do not properly configure secure etcd communication, your Sensu configura
 
 To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -789,7 +789,10 @@ dashboard-port: 4000{{< /code >}}
 
 | etcd-advertise-client-urls |      |
 --------------|------
-description   | List of this member's client URLs to advertise to the rest of the cluster.
+description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type          | List
 default       | `http://localhost:2379`
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -806,7 +809,10 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -822,7 +828,8 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br><To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
 etcd-cipher-suites:
@@ -848,7 +855,10 @@ etcd-cipher-suites:
 
 | etcd-client-cert-auth |      |
 ------------------------|------
-description             | If `true`, enable client certificate authentication. Otherwise, `false`.
+description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
@@ -861,7 +871,10 @@ etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
 ------------------------|------
-description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
+description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
@@ -878,7 +891,10 @@ etcd-client-urls:
 
 | etcd-discovery        |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
@@ -893,7 +909,10 @@ etcd-discovery:
 
 | etcd-discovery-srv    |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
@@ -908,7 +927,10 @@ etcd-discovery-srv:
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
-description                        | List of this member's peer URLs to advertise to the rest of the cluster.
+description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                               | List
 default                            | `http://127.0.0.1:2380`
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -925,7 +947,10 @@ etcd-initial-advertise-peer-urls:
 
 | etcd-initial-cluster |      |
 -----------------------|------
-description            | Initial cluster configuration for bootstrapping.
+description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `default=http://127.0.0.1:2380`
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -938,7 +963,10 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
-description                  | Initial cluster state (`new` or `existing`).
+description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
@@ -951,7 +979,10 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
@@ -964,7 +995,10 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
 -----------------|------
-description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 example          | {{< code shell >}}# Command line example
@@ -977,7 +1011,10 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 
 | etcd-listen-client-urls |      |
 --------------------------|------
-description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.
+description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                      | List
 default                   | `http://127.0.0.1:2379`
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
@@ -994,7 +1031,10 @@ etcd-listen-client-urls:
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
-description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.
+description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2380`
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
@@ -1011,7 +1051,10 @@ etcd-listen-peer-urls:
 
 | etcd-name      |      |
 -----------------|------
-description      | Human-readable name for this member.
+description      | Human-readable name for this member.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
@@ -1024,7 +1067,10 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 example               | {{< code shell >}}# Command line example
@@ -1036,7 +1082,10 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
-description                  | Enable peer client certificate authentication.
+description                  | Enable peer client certificate authentication.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
@@ -1049,7 +1098,10 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
 ---------------------|------
-description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
+description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 example              | {{< code shell >}}# Command line example
@@ -1061,7 +1113,10 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
-description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
+description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 example                     | {{< code shell >}}# Command line example
@@ -1073,7 +1128,10 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
-description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
+description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
@@ -1086,7 +1144,10 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
 -----------------|------
-description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
+description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
@@ -1193,6 +1254,9 @@ pipelined-workers: 100{{< /code >}}
 -----------------------|------
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
@@ -1208,7 +1272,10 @@ etcd-election-timeout: 1000{{< /code >}}
 | etcd-heartbeat-interval |      |
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
-**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
+**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
@@ -1223,6 +1290,9 @@ etcd-heartbeat-interval: 100{{< /code >}}
 -----------------------|------
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
@@ -1238,6 +1308,9 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 -----------------------|------
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`

--- a/content/sensu-go/5.21/reference/datastore.md
+++ b/content/sensu-go/5.21/reference/datastore.md
@@ -22,6 +22,8 @@ This embedded database allows you to get started with Sensu without deploying a 
 Sensu's default embedded etcd configuration listens for unencrypted communication on [ports][19] 2379 (client requests) and 2380 (peer communication).
 
 Sensu can be configured to disable the embedded etcd database and use one or more [external etcd nodes][8] for configuration and event storage instead.
+To stand up an external etcd cluster, follow etcd's [clustering guide][7] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
@@ -326,6 +328,7 @@ pool_size: 20
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [6]: ../../operations/deploy-sensu/deployment-architecture/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../web-ui/
 [10]: ../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -759,7 +759,10 @@ dashboard-port: 4000{{< /code >}}
 
 | etcd-advertise-client-urls |      |
 --------------|------
-description   | List of this member's client URLs to advertise to the rest of the cluster.
+description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -775,7 +778,10 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -789,7 +795,8 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
 etcd-cipher-suites:
@@ -814,7 +821,10 @@ etcd-cipher-suites:
 
 | etcd-client-cert-auth |      |
 ------------------------|------
-description             | If `true`, enable client certificate authentication. Otherwise, `false`.
+description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
@@ -825,7 +835,10 @@ etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
 ------------------------|------
-description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
+description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
@@ -841,7 +854,10 @@ etcd-client-urls:
 
 | etcd-discovery        |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
@@ -854,7 +870,10 @@ etcd-discovery:
 
 | etcd-discovery-srv    |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
@@ -867,7 +886,10 @@ etcd-discovery-srv:
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
-description                        | List of this member's peer URLs to advertise to the rest of the cluster.
+description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -883,7 +905,10 @@ etcd-initial-advertise-peer-urls:
 
 | etcd-initial-cluster |      |
 -----------------------|------
-description            | Initial cluster configuration for bootstrapping.
+description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -894,7 +919,10 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
-description                  | Initial cluster state (`new` or `existing`).
+description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
@@ -905,7 +933,10 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
@@ -916,7 +947,10 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
 -----------------|------
-description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -928,7 +962,10 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 
 | etcd-listen-client-urls |      |
 --------------------------|------
-description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.
+description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
@@ -944,7 +981,10 @@ etcd-listen-client-urls:
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
-description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.
+description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
@@ -960,7 +1000,10 @@ etcd-listen-peer-urls:
 
 | etcd-name      |      |
 -----------------|------
-description      | Human-readable name for this member.
+description      | Human-readable name for this member.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
@@ -971,7 +1014,10 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
@@ -981,7 +1027,10 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
-description                  | Enable peer client certificate authentication.
+description                  | Enable peer client certificate authentication.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
@@ -992,7 +1041,10 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
 ---------------------|------
-description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
+description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -1002,7 +1054,10 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
-description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
+description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
@@ -1012,7 +1067,10 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
-description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
+description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
@@ -1023,7 +1081,10 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
 -----------------|------
-description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
+description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
@@ -1115,6 +1176,9 @@ pipelined-workers: 100{{< /code >}}
 -----------------------|------
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
@@ -1129,7 +1193,10 @@ etcd-election-timeout: 1000{{< /code >}}
 | etcd-heartbeat-interval |      |
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
-**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
+**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
@@ -1142,6 +1209,9 @@ etcd-heartbeat-interval: 100{{< /code >}}
 -----------------------|------
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
@@ -1155,6 +1225,9 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 -----------------------|------
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`

--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -327,6 +327,7 @@ If you do not properly configure secure etcd communication, your Sensu configura
 
 To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:

--- a/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
@@ -23,6 +23,8 @@ This embedded database allows you to get started with Sensu without deploying a 
 Sensu's default embedded etcd configuration listens for unencrypted communication on [ports][19] 2379 (client requests) and 2380 (peer communication).
 
 Sensu can be configured to disable the embedded etcd database and use one or more [external etcd nodes][8] for configuration and event storage instead.
+To stand up an external etcd cluster, follow etcd's [clustering guide][7] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
@@ -327,6 +329,7 @@ pool_size: 20
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [6]: ../deployment-architecture/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -773,7 +773,10 @@ dashboard-port: 4000{{< /code >}}
 
 | etcd-advertise-client-urls |      |
 --------------|------
-description   | List of this member's client URLs to advertise to the rest of the cluster.
+description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -789,7 +792,10 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -803,7 +809,8 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
 etcd-cipher-suites:
@@ -828,7 +835,10 @@ etcd-cipher-suites:
 
 | etcd-client-cert-auth |      |
 ------------------------|------
-description             | If `true`, enable client certificate authentication. Otherwise, `false`.
+description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
@@ -839,7 +849,10 @@ etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
 ------------------------|------
-description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
+description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
@@ -855,7 +868,10 @@ etcd-client-urls:
 
 | etcd-discovery        |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
@@ -868,7 +884,10 @@ etcd-discovery:
 
 | etcd-discovery-srv    |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
@@ -881,7 +900,10 @@ etcd-discovery-srv:
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
-description                        | List of this member's peer URLs to advertise to the rest of the cluster.
+description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -897,7 +919,10 @@ etcd-initial-advertise-peer-urls:
 
 | etcd-initial-cluster |      |
 -----------------------|------
-description            | Initial cluster configuration for bootstrapping.
+description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -908,7 +933,10 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
-description                  | Initial cluster state (`new` or `existing`).
+description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
@@ -919,7 +947,10 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
@@ -930,7 +961,10 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
 -----------------|------
-description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -942,7 +976,10 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 
 | etcd-listen-client-urls |      |
 --------------------------|------
-description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.
+description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
@@ -958,7 +995,10 @@ etcd-listen-client-urls:
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
-description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.
+description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
@@ -974,7 +1014,10 @@ etcd-listen-peer-urls:
 
 | etcd-name      |      |
 -----------------|------
-description      | Human-readable name for this member.
+description      | Human-readable name for this member.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
@@ -985,7 +1028,10 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
@@ -995,7 +1041,10 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
-description                  | Enable peer client certificate authentication.
+description                  | Enable peer client certificate authentication.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
@@ -1006,7 +1055,10 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
 ---------------------|------
-description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
+description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -1016,7 +1068,10 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
-description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
+description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
@@ -1026,7 +1081,10 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
-description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
+description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
@@ -1037,7 +1095,10 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
 -----------------|------
-description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
+description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
@@ -1129,6 +1190,9 @@ pipelined-workers: 100{{< /code >}}
 -----------------------|------
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
@@ -1143,7 +1207,10 @@ etcd-election-timeout: 1000{{< /code >}}
 | etcd-heartbeat-interval |      |
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
-**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
+**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
@@ -1156,6 +1223,9 @@ etcd-heartbeat-interval: 100{{< /code >}}
 -----------------------|------
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
@@ -1169,6 +1239,9 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 -----------------------|------
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -327,6 +327,7 @@ If you do not properly configure secure etcd communication, your Sensu configura
 
 To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:

--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -23,6 +23,8 @@ This embedded database allows you to get started with Sensu without deploying a 
 Sensu's default embedded etcd configuration listens for unencrypted communication on [ports][19] 2379 (client requests) and 2380 (peer communication).
 
 Sensu can be configured to disable the embedded etcd database and use one or more [external etcd nodes][8] for configuration and event storage instead.
+To stand up an external etcd cluster, follow etcd's [clustering guide][7] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
@@ -419,6 +421,7 @@ strict: true
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [6]: ../deployment-architecture/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -773,7 +773,10 @@ dashboard-port: 4000{{< /code >}}
 
 | etcd-advertise-client-urls |      |
 --------------|------
-description   | List of this member's client URLs to advertise to the rest of the cluster.
+description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -789,7 +792,10 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -803,7 +809,7 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/). Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
 etcd-cipher-suites:
@@ -828,7 +834,10 @@ etcd-cipher-suites:
 
 | etcd-client-cert-auth |      |
 ------------------------|------
-description             | If `true`, enable client certificate authentication. Otherwise, `false`.
+description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
@@ -839,7 +848,10 @@ etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
 ------------------------|------
-description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
+description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
@@ -855,7 +867,10 @@ etcd-client-urls:
 
 | etcd-discovery        |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
@@ -868,7 +883,10 @@ etcd-discovery:
 
 | etcd-discovery-srv    |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
@@ -881,7 +899,10 @@ etcd-discovery-srv:
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
-description                        | List of this member's peer URLs to advertise to the rest of the cluster.
+description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -897,7 +918,10 @@ etcd-initial-advertise-peer-urls:
 
 | etcd-initial-cluster |      |
 -----------------------|------
-description            | Initial cluster configuration for bootstrapping.
+description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -908,7 +932,10 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
-description                  | Initial cluster state (`new` or `existing`).
+description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
@@ -919,7 +946,10 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
@@ -930,7 +960,10 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
 -----------------|------
-description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -942,7 +975,10 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 
 | etcd-listen-client-urls |      |
 --------------------------|------
-description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.
+description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
@@ -958,7 +994,10 @@ etcd-listen-client-urls:
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
-description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.
+description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
@@ -974,7 +1013,10 @@ etcd-listen-peer-urls:
 
 | etcd-name      |      |
 -----------------|------
-description      | Human-readable name for this member.
+description      | Human-readable name for this member.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
@@ -985,7 +1027,10 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
@@ -995,7 +1040,10 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
-description                  | Enable peer client certificate authentication.
+description                  | Enable peer client certificate authentication.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
@@ -1006,7 +1054,10 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
 ---------------------|------
-description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
+description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -1016,7 +1067,10 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
-description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
+description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
@@ -1026,7 +1080,10 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
-description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
+description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
@@ -1037,7 +1094,10 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
 -----------------|------
-description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
+description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
@@ -1129,6 +1189,9 @@ pipelined-workers: 100{{< /code >}}
 -----------------------|------
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
@@ -1143,7 +1206,11 @@ etcd-election-timeout: 1000{{< /code >}}
 | etcd-heartbeat-interval |      |
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
-**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
+**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
@@ -1156,6 +1223,9 @@ etcd-heartbeat-interval: 100{{< /code >}}
 -----------------------|------
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
@@ -1169,6 +1239,9 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 -----------------------|------
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -327,6 +327,7 @@ If you do not properly configure secure etcd communication, your Sensu configura
 
 To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`)
 
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -327,7 +327,7 @@ If you do not properly configure secure etcd communication, your Sensu configura
 
 To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
-Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`)
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:

--- a/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
@@ -23,6 +23,8 @@ This embedded database allows you to get started with Sensu without deploying a 
 Sensu's default embedded etcd configuration listens for unencrypted communication on [ports][19] 2379 (client requests) and 2380 (peer communication).
 
 Sensu can be configured to disable the embedded etcd database and use one or more [external etcd nodes][8] for configuration and event storage instead.
+To stand up an external etcd cluster, follow etcd's [clustering guide][7] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
@@ -443,6 +445,7 @@ enable_round_robin: true
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [5]: ../../../observability-pipeline/observe-schedule/checks/#round-robin-checks
 [6]: ../deployment-architecture/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -773,7 +773,10 @@ dashboard-port: 4000{{< /code >}}
 
 | etcd-advertise-client-urls |      |
 --------------|------
-description   | List of this member's client URLs to advertise to the rest of the cluster.
+description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type          | List
 default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -789,7 +792,10 @@ etcd-advertise-client-urls:
 
 | etcd-cert-file |      |
 -----------------|------
-description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
@@ -803,7 +809,8 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
 etcd-cipher-suites:
@@ -828,7 +835,10 @@ etcd-cipher-suites:
 
 | etcd-client-cert-auth |      |
 ------------------------|------
-description             | If `true`, enable client certificate authentication. Otherwise, `false`.
+description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | Boolean
 default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
@@ -839,7 +849,10 @@ etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
 ------------------------|------
-description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].
+description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
@@ -855,7 +868,10 @@ etcd-client-urls:
 
 | etcd-discovery        |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
@@ -868,7 +884,10 @@ etcd-discovery:
 
 | etcd-discovery-srv    |      |
 ------------------------|------
-description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.
+description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | String
 default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
@@ -881,7 +900,10 @@ etcd-discovery-srv:
 
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
-description                        | List of this member's peer URLs to advertise to the rest of the cluster.
+description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                               | List
 default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -897,7 +919,10 @@ etcd-initial-advertise-peer-urls:
 
 | etcd-initial-cluster |      |
 -----------------------|------
-description            | Initial cluster configuration for bootstrapping.
+description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -908,7 +933,10 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 
 | etcd-initial-cluster-state |      |
 -----------------------------|------
-description                  | Initial cluster state (`new` or `existing`).
+description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
@@ -919,7 +947,10 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
 -----------------------------|------
-description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.
+description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | String
 default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
@@ -930,7 +961,10 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
 -----------------|------
-description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.
+description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -942,7 +976,10 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 
 | etcd-listen-client-urls |      |
 --------------------------|------
-description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.
+description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                      | List
 default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
@@ -958,7 +995,10 @@ etcd-listen-client-urls:
 
 | etcd-listen-peer-urls |      |
 ------------------------|------
-description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.
+description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                    | List
 default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
@@ -974,7 +1014,10 @@ etcd-listen-peer-urls:
 
 | etcd-name      |      |
 -----------------|------
-description      | Human-readable name for this member.
+description      | Human-readable name for this member.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | String
 default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
@@ -985,7 +1028,10 @@ etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
 ----------------------|------
-description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
@@ -995,7 +1041,10 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
-description                  | Enable peer client certificate authentication.
+description                  | Enable peer client certificate authentication.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                         | Boolean
 default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
@@ -1006,7 +1055,10 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
 ---------------------|------
-description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.
+description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
@@ -1016,7 +1068,10 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
-description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.
+description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
@@ -1026,7 +1081,10 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
 -----------------------|------
-description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.
+description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | String
 default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
@@ -1037,7 +1095,10 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
 -----------------|------
-description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.
+description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type             | Boolean
 default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
@@ -1129,6 +1190,9 @@ pipelined-workers: 100{{< /code >}}
 -----------------------|------
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1000`
@@ -1143,7 +1207,10 @@ etcd-election-timeout: 1000{{< /code >}}
 | etcd-heartbeat-interval |      |
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
-**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}
+**WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 type                   | Integer
 default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
@@ -1156,6 +1223,9 @@ etcd-heartbeat-interval: 100{{< /code >}}
 -----------------------|------
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+{{% /notice %}}{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
 default                | `1572864`
@@ -1168,7 +1238,10 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 | etcd-quota-backend-bytes |      |
 -----------------------|------
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
-**WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
+**WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.{{% notice note %}}
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+{{% /notice %}}
 {{% /notice %}}
 type                   | Integer
 default                | `4294967296`

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -327,6 +327,7 @@ If you do not properly configure secure etcd communication, your Sensu configura
 
 To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -23,6 +23,8 @@ This embedded database allows you to get started with Sensu without deploying a 
 Sensu's default embedded etcd configuration listens for unencrypted communication on [ports][19] 2379 (client requests) and 2380 (peer communication).
 
 Sensu can be configured to disable the embedded etcd database and use one or more [external etcd nodes][8] for configuration and event storage instead.
+To stand up an external etcd cluster, follow etcd's [clustering guide][7] using the same store configuration.
+Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
@@ -443,6 +445,7 @@ enable_round_robin: true
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [5]: ../../../observability-pipeline/observe-schedule/checks/#round-robin-checks
 [6]: ../deployment-architecture/
+[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event


### PR DESCRIPTION
## Description
Adds instructions to avoid configuring etcd with Sensu backend config flags or in the Sensu backend config file (and to follow the etcd clustering guide instead) for customers who are using external etcd.

Added to existing information in:
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/datastore/#use-default-event-storage

Added notes for etcd config flags in:
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/backend/#advanced-configuration-options

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3044
