### PR TITLE
Add resource definitions to clarify sensuctl commands - Part 4

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/plan-maintenance.md
@@ -8,7 +8,7 @@ weight: 70
 version: "6.0"
 product: "Sensu Go"
 platformContent: False
-lastTested: 2018-12-04
+lastTested: 2021-03-11
 menu: 
   sensu-go-6.0:
     parent: observe-process
@@ -40,10 +40,56 @@ Your username will be added automatically as the **creator** of the silenced ent
 sensuctl silenced create \
 --subscription 'entity:i-424242' \
 --check 'check-http' \
---begin '2018-03-16 01:00:00 -04:00' \
+--begin '2021-03-14 01:00:00 -04:00' \
 --expire 3600 \
 --reason 'Server upgrade'
 {{< /code >}}
+
+This command creates the following silenced resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: Silenced
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: entity:i-424242:check-http
+  namespace: default
+spec:
+  begin: 1615698000
+  check: check-http
+  creator: admin
+  expire: 3600
+  expire_at: 1615701600
+  expire_on_resolve: false
+  reason: Server upgrade
+  subscription: entity:i-424242
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "entity:i-424242:check-http",
+    "namespace": "default"
+  },
+  "spec": {
+    "begin": 1615698000,
+    "check": "check-http",
+    "creator": "admin",
+    "expire": 3600,
+    "expire_at": 1615701600,
+    "expire_on_resolve": false,
+    "reason": "Server upgrade",
+    "subscription": "entity:i-424242"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 See the [sensuctl documentation][8] for the supported time formats for the `begin` flag.
 
@@ -51,16 +97,27 @@ See the [sensuctl documentation][8] for the supported time formats for the `begi
 
 Use sensuctl to verify that the silenced entry against the entity `i-424242` was created properly:
 
-{{< code shell >}}
-sensuctl silenced info 'entity:i-424242:check-http'
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will list the silenced resource definition.
+
 
 After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
-   i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
+   i-424242      check-http                    0          true     2021-03-14 13:22:16 -0400 EDT
 {{< /code >}}
 
 {{% notice warning %}}
@@ -69,7 +126,7 @@ After the silenced entry starts to take effect, events that are silenced will be
 
 ## Next steps
 
-Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+Read the [silencing reference][7] for in-depth documentation about silenced entries.
 
 
 [1]: ../handlers/

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -34,6 +34,59 @@ sensuctl hook create process_tree  \
 --timeout 10
 {{< /code >}}
 
+To confirm that the hook was added, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl hook info process_tree --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl hook info process_tree --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include the complete hook resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yaml >}}
+---
+type: HookConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: process_tree
+  namespace: default
+spec:
+  command: ps aux
+  runtime_assets: null
+  stdin: false
+  timeout: 10
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "process_tree",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "ps aux",
+    "runtime_assets": null,
+    "stdin": false,
+    "timeout": 10
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Assign the hook to a check
 
 Now that you've created the `process_tree` hook, you can assign it to a check.

--- a/content/sensu-go/6.0/operations/control-access/_index.md
+++ b/content/sensu-go/6.0/operations/control-access/_index.md
@@ -53,13 +53,23 @@ In addition to built-in authentication, Sensu includes commercial support for au
 * Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
 * OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
 
+Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
+
 **2. Apply the configuration with sensuctl**
 
-Log in to sensuctl as the [default admin user][3] and apply the configuration to Sensu:
+Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
 
-{{< code shell >}}
-sensuctl create --file filename.json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file authconfig.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file authconfig.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to verify that your provider configuration was applied successfully:
 

--- a/content/sensu-go/6.0/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.0/operations/control-access/create-read-only-user.md
@@ -31,20 +31,128 @@ In this section, you'll create a user and assign them read-only access to resour
 sensuctl user create alice --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: alice
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "alice",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< code shell >}}
 sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
+
+   This command creates the following role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: read-only
+  namespace: default
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< code shell >}}
 sensuctl role-binding create ops-read-only --role=read-only --group=ops
 {{< /code >}}
 
-You can also use role bindings to tie roles directly to users using the `--user` flag.
+   This command creates the following role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-read-only
+  namespace: default
+spec:
+  role_ref:
+    name: read-only
+    type: Role
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "read-only",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to all resources within the default namespace.
-You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+To manage your RBAC configuration, use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands.
 
 ## Create a cluster-wide event-reader user
 
@@ -56,15 +164,119 @@ Because you want this role to have cluster-wide permissions, you'll need to crea
 sensuctl user create bob --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: bob
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "bob",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /code >}}
 
+   This command creates the following cluster role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< code shell >}}
 sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /code >}}
+
+   This command creates the following cluster role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-event-reader
+spec:
+  role_ref:
+    name: global-event-reader
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-event-reader"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "global-event-reader",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to events across all namespaces.
 
@@ -72,5 +284,10 @@ All users in the `ops` group now have read-only access to events across all name
 
 Now that you know how to create a user, a role, and a role binding to assign a role to a user, check out the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
+Read about [monitoring as code][3] with Sensu and learn how to [use SensuFlow][4] to synchronize your monitoring and observability code with your Sensu deployments.
+
+
 [1]: ../rbac/
 [2]: ../rbac#default-users
+[3]: ../../monitoring-as-code/
+[4]: https://sensu.io/blog/monitoring-as-code-with-sensu-flow

--- a/content/sensu-go/6.0/operations/control-access/rbac.md
+++ b/content/sensu-go/6.0/operations/control-access/rbac.md
@@ -84,8 +84,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### User example
 
-The following example shows a user resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a user resource definition:
 
 {{< language-toggle >}}
 
@@ -117,6 +116,22 @@ spec:
     "groups": ["ops", "dev"]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this user with [`sensuctl create`][31], first save the definition to a file like `users.yml` or `users.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file users.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file users.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -181,11 +196,19 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl user list --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl user list --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create users
 
@@ -380,8 +403,7 @@ To create and manage cluster roles, [configure sensuctl][26] as the [default `ad
 
 ### Role example
 
-The following example shows a role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role resource definition:
 
 {{< language-toggle >}}
 
@@ -440,10 +462,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role with [`sensuctl create`][31], first save the definition to a file like `roles.yml` or `roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file roles.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role example
 
-The following example shows a cluster role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role resource definition:
 
 {{< language-toggle >}}
 
@@ -505,6 +542,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role with [`sensuctl create`][31], first save the definition to a file like `cluster_roles.yml` or `cluster_roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file cluster_roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file cluster_roles.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -572,12 +625,115 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
+This command creates the following role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin
+  namespace: production
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin",
+    "namespace": "production"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 After you create a role, [create a role binding][23] (or [cluster role binding][23]) to assign the role to users and groups.
 For example, to assign the `prod-admin` role created above to the `oncall` group, create this role binding:
 
 {{< code shell >}}
 sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin-oncall
+  namespace: production
+spec:
+  role_ref:
+    name: prod-admin
+    type: Role
+  subjects:
+  - name: oncall
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin-oncall",
+    "namespace": "production"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "prod-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "oncall",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create cluster-wide roles
 
@@ -587,6 +743,54 @@ For example, the following command creates a global event reader role that can r
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb='get,list' --resource='events'
 {{< /code >}}
+
+This command creates the following cluster-wide role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete roles and cluster roles
 
@@ -746,11 +950,9 @@ Make sure to include the groups prefix and username prefix for the authenticatio
 Without an assigned role or cluster role, users can sign in to the web UI but can't access any Sensu resources.
 With the correct roles and bindings configured, users can log in to [sensuctl][2] and the [web UI][1] using their single-sign-on username and password (no prefixes required).
 
-
 ### Role binding example
 
-The following example shows a role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -795,10 +997,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role binding with [`sensuctl create`][31], first save the definition to a file like `rolebindings.yml` or `rolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file rolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file rolebindings.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role binding example
 
-The following example shows a cluster role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -837,6 +1054,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role binding with [`sensuctl create`][31], first save the definition to a file like `clusterrolebindings.yml` or `clusterrolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file clusterrolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file clusterrolebindings.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -891,20 +1124,177 @@ sensuctl cluster-role-binding list
 You can use [sensuctl][2] to see a create a role binding that assigns a role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: Role
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a role binding that assigns a cluster role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a cluster role binding:
 
 {{< code shell >}}
-sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete role bindings and cluster role bindings
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -511,11 +511,22 @@ Sensu Inc. offers support packages for Sensu Go and [commercial features][20] de
 All commercial features are [free for your first 100 entities][29].
 To learn more about Sensu Go commercial licenses for more than 100 entities, [contact the Sensu sales team][11].
 
-If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file, then add your license using sensuctl.
+If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file.
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 
-{{< code shell >}}
+Use sensuctl to activate your license:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use sensuctl to view your license details at any time.
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/scale-event-storage.md
@@ -140,11 +140,19 @@ spec:
 
 {{< /language-toggle >}}
 
-This configuration is written to disk as `my-postgres.yml`, and you can install it using `sensuctl`:
+Save this configuration as `my-postgres.yml` or `my-postgres.json` and install it with `sensuctl`:
 
-{{< code shell >}}
-sensuctl create -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 The Sensu backend is now configured to use Postgres for event storage!
 
@@ -220,11 +228,19 @@ select sensu_entity from events where sensu_check = 'keepalive';
 ## Revert to the built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource.
-In this example, my-postgres.yml contains the same configuration you used to configure the Enterprise event store earlier in this guide:
+In this example, `my-postgres.yml` or `my-postgres.json` contain the same configuration you used to configure the Enterprise event store earlier in this guide:
 
-{{< code shell >}}
-sensuctl delete -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl delete --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl delete --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To verify that the change was effective, look for messages similar to these in the [sensu-backend log][4]:
 
@@ -274,11 +290,15 @@ Make a copy of the current `pg_hba.conf`:
 sudo cp /var/lib/pgsql/data/pg_hba.conf /var/tmp/pg_hba.conf.bak
 {{< /code >}}
 
-Next, give the repl user permissions to replicate from the standby host.
-In the following command, replace `STANDBY_IP` with the IP address of your standby host:
+In the following command, replace the `STANDBY_IP` value with the IP address of your standby host and then run the command:
 
 {{< code shell >}}
 export STANDBY_IP=192.168.52.10
+{{< /code >}}
+
+Next, give the repl user permissions to replicate from the standby host:
+
+{{< code shell >}}
 echo "host replication repl ${STANDYB_IP}/32 md5" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
 {{< /code >}}
 
@@ -332,10 +352,16 @@ sudo systemctl restart postgresql
 The standby host must be bootstrapped using the `pg_basebackup` command.
 This process will copy all configuration files from the primary as well as databases.
 
-If the standby host has ever run Postgres, you must empty the data directory:
+If the standby host has ever run Postgres, you must empty the data directory.
+First, stop Postgres:
 
 {{< code shell >}}
 sudo systemctl stop postgresql
+{{< /code >}}
+
+Empty the data directory:
+
+{{< code shell >}}
 sudo mv /var/lib/pgsql/data /var/lib/pgsql/data.bak
 {{< /code >}}
 
@@ -345,17 +371,28 @@ Make the standby data directory:
 sudo install -d -o postgres -g postgres -m 0700 /var/lib/pgsql/data
 {{< /code >}}
 
-And then bootstrap the standby data directory:
+Then bootstrap the standby data directory.
+In the following command, replace PRIMARY_IP with the IP address of your primary host and then run the command:
 
 {{< code shell >}}
 export PRIMARY_IP=192.168.52.11
+{{< /code >}}
+
+Then bootstrap the standby data directory:
+
+{{< code shell >}}
 sudo -u postgres pg_basebackup -h $PRIMARY_IP -D /var/lib/pgsql/data -P -U repl -R --xlog-method=stream
 {{< /code >}}
 
-Postgres will prompt for your password and then list database copy progress.
+Postgres will prompt for your password:
 
 {{< code postgresql >}}
 Password: 
+{{< /code >}}
+
+After you enter your password, Postgres will list database copy progress:
+
+{{< code postgresql >}}
 30318/30318 kB (100%), 1/1 tablespace
 {{< /code >}}
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/use-federation.md
@@ -147,14 +147,77 @@ Second, create a `federation-viewer` user:
 sensuctl user create federation-viewer --interactive
 {{< /code >}}
 
-When prompted, enter a password for the `federation-viewer` user.
-When prompted for groups, press enter. Note the `federation-viewer` password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+When prompted for username and groups, press enter.
+When prompted for password, enter a password for the `federation-viewer` user.
+Note the password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+
+This creates the following user:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+username: federation-viewer
+disabled: false
+{{< /code >}}
+
+{{< code json >}}
+{
+  "username": "federation-viewer",
+  "disabled": false
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Next, grant the `federation-viewer` user read-only access through a cluster role binding for the built-in `view` cluster role:
 
 {{< code shell >}}
 sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=view --user=federation-viewer
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: federation-viewer-readonly
+spec:
+  role_ref:
+    name: view
+    type: ClusterRole
+  subjects:
+  - name: federation-viewer
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "federation-viewer-readonly"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "view",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "federation-viewer",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 In step 4, you'll configure etcd replicators to copy the cluster role bindings and other RBAC policies you created in the `gateway` cluster to the `alpha` and `beta` clusters.
 
@@ -258,13 +321,13 @@ Write these EtcdReplicator definitions written to disk and use `sensuctl create 
 For a consistent experience, repeat the `ClusterRoleBinding` example in this guide for `Role`, `RoleBinding` and `ClusterRole` resource types.
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
-To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters and run the following command for each:
 
 {{< code shell >}}
 sensuctl cluster-role-binding info federation-viewer-readonly
 {{< /code >}}
 
-You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
+The `federation-viewer-readonly` binding you created in step 3 should be listed in the output from each cluster:
 
 {{< code shell >}}
 === federation-viewer-readonly
@@ -366,6 +429,7 @@ If you haven't changed the permissions of the default `admin` user, that user sh
 ## Next steps
 
 Learn more about configuring RBAC policies in our [RBAC reference documentation][10].
+
 
 [1]: ../../../api/federation/
 [2]: ../etcdreplicators/

--- a/content/sensu-go/6.0/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/license.md
@@ -20,13 +20,22 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
-With the license file downloaded, you can activate your license with sensuctl or the [license API][4].
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
 To activate your license with sensuctl:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to view your license details at any time:
 

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -207,7 +207,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -296,7 +296,7 @@ Sensu Core checks could be configured as `type: metric`, which told Sensu to alw
 This allowed Sensu Core to process output metrics via a handler even when the check status was not in an alerting state.
 
 Sensu Go treats output metrics as first-class objects, so you can process check status as well as output metrics via different event pipelines.
-See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes.
+See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes and use `output_metric_tags` to enrich extracted metrics output.
 
 <a name="translate-proxy-requests-entities"></a>
 
@@ -345,19 +345,42 @@ Sensu Core hourly filter:
 
 Sensu Go hourly filter:
 
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: EventFilter
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: hourly
+  namespace: default
+spec:
+  action: allow
+  expressions:
+  - event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0
+  runtime_assets: null
+{{< /code >}}
+
 {{< code json >}}
 {
+  "type": "EventFilter",
+  "api_version": "core/v2",
   "metadata": {
+    "created_by": "admin",
     "name": "hourly",
     "namespace": "default"
   },
-  "action": "allow",
-  "expressions": [
-    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-  ],
-  "runtime_assets": null
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+    ],
+    "runtime_assets": null
+  }
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 #### 4. Translate handlers
 

--- a/content/sensu-go/6.0/sensuctl/_index.md
+++ b/content/sensu-go/6.0/sensuctl/_index.md
@@ -53,19 +53,32 @@ For information about configuring the Sensu backend URL, see the [backend refere
 During configuration, sensuctl creates configuration files that contain information for connecting to your Sensu Go deployment.
 You can find these files at `$HOME/.config/sensu/sensuctl/profile` and `$HOME/.config/sensu/sensuctl/cluster`.
 
-For example:
+Use the `cat` command to view the contents of these files.
+For example, to view your sensuctl profile configuration, run:
 
 {{< code shell >}}
 cat .config/sensu/sensuctl/profile
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "format": "tabular",
-  "namespace": "demo",
+  "namespace": "default",
   "username": "admin"
 }
 {{< /code >}}
 
+To view your sensuctl cluster configuration, run:
+
 {{< code shell >}}
 cat .config/sensu/sensuctl/cluster 
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "api-url": "http://localhost:8080",
   "trusted-ca-file": "",

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -15,52 +15,116 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yaml` in `yaml` format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
 
-{{< code shell >}}
-sensuctl dump all --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --format yaml --file my-resources.yml
 {{< /code >}}
 
-To export only checks for only the current namespace to STDOUT in `yaml` format:
+{{< code shell "JSON" >}}
+sensuctl dump all --format json --file my-resources.json
+{{< /code >}}
 
-{{< code shell >}}
+{{< /language-toggle >}}
+
+To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters.yaml` in `yaml` format:
-
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
 For example:
 
-{{< code shell >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
-{{< code shell >}}
+{{< code shell "JSON" >}}
+sensuctl dump all --all-namespaces --format json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
 
 Here's an example that uses fully qualified names:
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Here's an example that uses short names:
 
-{{< code shell >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
 This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
@@ -71,51 +135,73 @@ You should create a backup before you [upgrade][4] to a new version of Sensu.
 Here's the step-by-step process:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Create a backup of the entire cluster, except entities, events, and [role-based access control (RBAC)][2] resources, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yaml
+--format yaml > backup/config.yml
 {{< /code >}}
-   
+{{< code shell "JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format json > backup/config.json
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Export your [RBAC][2] resources, except API keys and users, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yaml
+--format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format json > backup/rbac.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 4. Export your API keys and users resources for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yaml
+--format yaml > backup/cannotrestore.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format json > backup/cannotrestore.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
 Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
-     
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yaml
+--format yaml > backup/inventory.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format json > backup/inventory.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: If you do not export your entities, proxy check requests will not be scheduled for the excluded proxy entities.
 {{% /notice %}}
 
@@ -127,18 +213,23 @@ This backup allows you to [replicate resources across namespaces][5] without man
 To create a backup of your resources that you can replicate in new namespaces:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Back up your pipeline resources for all namespaces, stripping namespaces so that your resources are portable for reuse in any namespace.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
---format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
+--format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format json | grep -v "^\s*namespace:" > backup/pipelines.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 ## Restore resources from backup
 
@@ -152,9 +243,17 @@ sensuctl create -r -f backup/
 
 To restore a subset of your exported resources (in this example, your RBAC resources), run:
 
-{{< code shell >}}
-sensuctl create -f backup/rbac.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create -f backup/rbac.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create -f backup/rbac.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -368,7 +368,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `wrapped-json` format:
+To see the definition for a check named `check-cpu` in `yaml` or `json` format:
 
 {{< language-toggle >}}
 
@@ -377,7 +377,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check-cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -487,20 +487,21 @@ In addition, pruning requires [cluster-level privileges][35], even when all reso
 
 ##### Supported resource types
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
-
-{{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
-{{% /notice %}}
+To retrieve the supported `sensuctl prune` resource types, run:
 
 {{< code shell >}}
 sensuctl describe-type all
+{{< /code >}}
 
+The response will list all supported `sensuctl prune` resource types:
+
+{{< code shell >}}
       Fully Qualified Name           Short Name           API Version             Type          Namespaced  
  ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
   authentication/v2.Provider                           authentication/v2   Provider             false
   licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
   store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.Cluster                                federation/v1       Cluster              false
   federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
   secrets/v1.Secret                                    secrets/v1          Secret               true
   secrets/v1.Provider                                  secrets/v1          Provider             false
@@ -518,12 +519,16 @@ sensuctl describe-type all
   core/v2.Event                  events                core/v2             Event                true
   core/v2.EventFilter            filters               core/v2             EventFilter          true
   core/v2.Handler                handlers              core/v2             Handler              true
-  core/v2.Hook                   hooks                 core/v2             Hook                 true
+  core/v2.HookConfig             hooks                 core/v2             HookConfig           true
   core/v2.Mutator                mutators              core/v2             Mutator              true
   core/v2.Role                   roles                 core/v2             Role                 true
   core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
   core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
 
 ##### sensuctl prune flags
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/plan-maintenance.md
@@ -8,7 +8,7 @@ weight: 70
 version: "6.1"
 product: "Sensu Go"
 platformContent: False
-lastTested: 2018-12-04
+lastTested: 2021-03-11
 menu: 
   sensu-go-6.1:
     parent: observe-process
@@ -40,10 +40,56 @@ Your username will be added automatically as the **creator** of the silenced ent
 sensuctl silenced create \
 --subscription 'entity:i-424242' \
 --check 'check-http' \
---begin '2018-03-16 01:00:00 -04:00' \
+--begin '2021-03-14 01:00:00 -04:00' \
 --expire 3600 \
 --reason 'Server upgrade'
 {{< /code >}}
+
+This command creates the following silenced resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: Silenced
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: entity:i-424242:check-http
+  namespace: default
+spec:
+  begin: 1615698000
+  check: check-http
+  creator: admin
+  expire: 3600
+  expire_at: 1615701600
+  expire_on_resolve: false
+  reason: Server upgrade
+  subscription: entity:i-424242
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "entity:i-424242:check-http",
+    "namespace": "default"
+  },
+  "spec": {
+    "begin": 1615698000,
+    "check": "check-http",
+    "creator": "admin",
+    "expire": 3600,
+    "expire_at": 1615701600,
+    "expire_on_resolve": false,
+    "reason": "Server upgrade",
+    "subscription": "entity:i-424242"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 See the [sensuctl documentation][8] for the supported time formats for the `begin` flag.
 
@@ -51,16 +97,27 @@ See the [sensuctl documentation][8] for the supported time formats for the `begi
 
 Use sensuctl to verify that the silenced entry against the entity `i-424242` was created properly:
 
-{{< code shell >}}
-sensuctl silenced info 'entity:i-424242:check-http'
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will list the silenced resource definition.
+
 
 After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
-   i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
+   i-424242      check-http                    0          true     2021-03-14 13:22:16 -0400 EDT
 {{< /code >}}
 
 {{% notice warning %}}
@@ -69,7 +126,7 @@ After the silenced entry starts to take effect, events that are silenced will be
 
 ## Next steps
 
-Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+Read the [silencing reference][7] for in-depth documentation about silenced entries.
 
 
 [1]: ../handlers/

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -34,6 +34,59 @@ sensuctl hook create process_tree  \
 --timeout 10
 {{< /code >}}
 
+To confirm that the hook was added, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl hook info process_tree --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl hook info process_tree --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include the complete hook resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yaml >}}
+---
+type: HookConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: process_tree
+  namespace: default
+spec:
+  command: ps aux
+  runtime_assets: null
+  stdin: false
+  timeout: 10
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "process_tree",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "ps aux",
+    "runtime_assets": null,
+    "stdin": false,
+    "timeout": 10
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Assign the hook to a check
 
 Now that you've created the `process_tree` hook, you can assign it to a check.

--- a/content/sensu-go/6.1/operations/control-access/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/_index.md
@@ -53,13 +53,23 @@ In addition to built-in authentication, Sensu includes commercial support for au
 * Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
 * OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
 
+Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
+
 **2. Apply the configuration with sensuctl**
 
-Log in to sensuctl as the [default admin user][3] and apply the configuration to Sensu:
+Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
 
-{{< code shell >}}
-sensuctl create --file filename.json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file authconfig.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file authconfig.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to verify that your provider configuration was applied successfully:
 

--- a/content/sensu-go/6.1/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.1/operations/control-access/create-read-only-user.md
@@ -31,20 +31,128 @@ In this section, you'll create a user and assign them read-only access to resour
 sensuctl user create alice --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: alice
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "alice",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< code shell >}}
 sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
+
+   This command creates the following role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: read-only
+  namespace: default
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< code shell >}}
 sensuctl role-binding create ops-read-only --role=read-only --group=ops
 {{< /code >}}
 
-You can also use role bindings to tie roles directly to users using the `--user` flag.
+   This command creates the following role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-read-only
+  namespace: default
+spec:
+  role_ref:
+    name: read-only
+    type: Role
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "read-only",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to all resources within the default namespace.
-You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+To manage your RBAC configuration, use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands.
 
 ## Create a cluster-wide event-reader user
 
@@ -56,15 +164,119 @@ Because you want this role to have cluster-wide permissions, you'll need to crea
 sensuctl user create bob --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: bob
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "bob",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /code >}}
 
+   This command creates the following cluster role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< code shell >}}
 sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /code >}}
+
+   This command creates the following cluster role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-event-reader
+spec:
+  role_ref:
+    name: global-event-reader
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-event-reader"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "global-event-reader",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to events across all namespaces.
 
@@ -72,5 +284,10 @@ All users in the `ops` group now have read-only access to events across all name
 
 Now that you know how to create a user, a role, and a role binding to assign a role to a user, check out the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
+Read about [monitoring as code][3] with Sensu and learn how to [use SensuFlow][4] to synchronize your monitoring and observability code with your Sensu deployments.
+
+
 [1]: ../rbac/
 [2]: ../rbac#default-users
+[3]: ../../monitoring-as-code/
+[4]: https://sensu.io/blog/monitoring-as-code-with-sensu-flow

--- a/content/sensu-go/6.1/operations/control-access/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/rbac.md
@@ -84,8 +84,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### User example
 
-The following example shows a user resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a user resource definition:
 
 {{< language-toggle >}}
 
@@ -117,6 +116,22 @@ spec:
     "groups": ["ops", "dev"]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this user with [`sensuctl create`][31], first save the definition to a file like `users.yml` or `users.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file users.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file users.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -181,11 +196,19 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl user list --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl user list --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create users
 
@@ -380,8 +403,7 @@ To create and manage cluster roles, [configure sensuctl][26] as the [default `ad
 
 ### Role example
 
-The following example shows a role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role resource definition:
 
 {{< language-toggle >}}
 
@@ -440,10 +462,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role with [`sensuctl create`][31], first save the definition to a file like `roles.yml` or `roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file roles.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role example
 
-The following example shows a cluster role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role resource definition:
 
 {{< language-toggle >}}
 
@@ -505,6 +542,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role with [`sensuctl create`][31], first save the definition to a file like `cluster_roles.yml` or `cluster_roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file cluster_roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file cluster_roles.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -572,12 +625,115 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
+This command creates the following role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin
+  namespace: production
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin",
+    "namespace": "production"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 After you create a role, [create a role binding][23] (or [cluster role binding][23]) to assign the role to users and groups.
 For example, to assign the `prod-admin` role created above to the `oncall` group, create this role binding:
 
 {{< code shell >}}
 sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin-oncall
+  namespace: production
+spec:
+  role_ref:
+    name: prod-admin
+    type: Role
+  subjects:
+  - name: oncall
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin-oncall",
+    "namespace": "production"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "prod-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "oncall",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create cluster-wide roles
 
@@ -587,6 +743,54 @@ For example, the following command creates a global event reader role that can r
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb='get,list' --resource='events'
 {{< /code >}}
+
+This command creates the following cluster-wide role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete roles and cluster roles
 
@@ -746,11 +950,9 @@ Make sure to include the groups prefix and username prefix for the authenticatio
 Without an assigned role or cluster role, users can sign in to the web UI but can't access any Sensu resources.
 With the correct roles and bindings configured, users can log in to [sensuctl][2] and the [web UI][1] using their single-sign-on username and password (no prefixes required).
 
-
 ### Role binding example
 
-The following example shows a role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -795,10 +997,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role binding with [`sensuctl create`][31], first save the definition to a file like `rolebindings.yml` or `rolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file rolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file rolebindings.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role binding example
 
-The following example shows a cluster role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -837,6 +1054,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role binding with [`sensuctl create`][31], first save the definition to a file like `clusterrolebindings.yml` or `clusterrolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file clusterrolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file clusterrolebindings.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -891,20 +1124,177 @@ sensuctl cluster-role-binding list
 You can use [sensuctl][2] to see a create a role binding that assigns a role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: Role
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a role binding that assigns a cluster role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a cluster role binding:
 
 {{< code shell >}}
-sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete role bindings and cluster role bindings
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -511,11 +511,22 @@ Sensu Inc. offers support packages for Sensu Go and [commercial features][20] de
 All commercial features are [free for your first 100 entities][29].
 To learn more about Sensu Go commercial licenses for more than 100 entities, [contact the Sensu sales team][11].
 
-If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file, then add your license using sensuctl.
+If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file.
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 
-{{< code shell >}}
+Use sensuctl to activate your license:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use sensuctl to view your license details at any time.
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/scale-event-storage.md
@@ -140,11 +140,19 @@ spec:
 
 {{< /language-toggle >}}
 
-This configuration is written to disk as `my-postgres.yml`, and you can install it using `sensuctl`:
+Save this configuration as `my-postgres.yml` or `my-postgres.json` and install it with `sensuctl`:
 
-{{< code shell >}}
-sensuctl create -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 The Sensu backend is now configured to use Postgres for event storage!
 
@@ -220,11 +228,19 @@ select sensu_entity from events where sensu_check = 'keepalive';
 ## Revert to the built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource.
-In this example, my-postgres.yml contains the same configuration you used to configure the Enterprise event store earlier in this guide:
+In this example, `my-postgres.yml` or `my-postgres.json` contain the same configuration you used to configure the Enterprise event store earlier in this guide:
 
-{{< code shell >}}
-sensuctl delete -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl delete --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl delete --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To verify that the change was effective, look for messages similar to these in the [sensu-backend log][4]:
 
@@ -274,11 +290,15 @@ Make a copy of the current `pg_hba.conf`:
 sudo cp /var/lib/pgsql/data/pg_hba.conf /var/tmp/pg_hba.conf.bak
 {{< /code >}}
 
-Next, give the repl user permissions to replicate from the standby host.
-In the following command, replace `STANDBY_IP` with the IP address of your standby host:
+In the following command, replace the `STANDBY_IP` value with the IP address of your standby host and then run the command:
 
 {{< code shell >}}
 export STANDBY_IP=192.168.52.10
+{{< /code >}}
+
+Next, give the repl user permissions to replicate from the standby host:
+
+{{< code shell >}}
 echo "host replication repl ${STANDYB_IP}/32 md5" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
 {{< /code >}}
 
@@ -332,10 +352,16 @@ sudo systemctl restart postgresql
 The standby host must be bootstrapped using the `pg_basebackup` command.
 This process will copy all configuration files from the primary as well as databases.
 
-If the standby host has ever run Postgres, you must empty the data directory:
+If the standby host has ever run Postgres, you must empty the data directory.
+First, stop Postgres:
 
 {{< code shell >}}
 sudo systemctl stop postgresql
+{{< /code >}}
+
+Empty the data directory:
+
+{{< code shell >}}
 sudo mv /var/lib/pgsql/data /var/lib/pgsql/data.bak
 {{< /code >}}
 
@@ -345,17 +371,28 @@ Make the standby data directory:
 sudo install -d -o postgres -g postgres -m 0700 /var/lib/pgsql/data
 {{< /code >}}
 
-And then bootstrap the standby data directory:
+Then bootstrap the standby data directory.
+In the following command, replace PRIMARY_IP with the IP address of your primary host and then run the command:
 
 {{< code shell >}}
 export PRIMARY_IP=192.168.52.11
+{{< /code >}}
+
+Then bootstrap the standby data directory:
+
+{{< code shell >}}
 sudo -u postgres pg_basebackup -h $PRIMARY_IP -D /var/lib/pgsql/data -P -U repl -R --xlog-method=stream
 {{< /code >}}
 
-Postgres will prompt for your password and then list database copy progress.
+Postgres will prompt for your password:
 
 {{< code postgresql >}}
 Password: 
+{{< /code >}}
+
+After you enter your password, Postgres will list database copy progress:
+
+{{< code postgresql >}}
 30318/30318 kB (100%), 1/1 tablespace
 {{< /code >}}
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
@@ -147,14 +147,77 @@ Second, create a `federation-viewer` user:
 sensuctl user create federation-viewer --interactive
 {{< /code >}}
 
-When prompted, enter a password for the `federation-viewer` user.
-When prompted for groups, press enter. Note the `federation-viewer` password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+When prompted for username and groups, press enter.
+When prompted for password, enter a password for the `federation-viewer` user.
+Note the password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+
+This creates the following user:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+username: federation-viewer
+disabled: false
+{{< /code >}}
+
+{{< code json >}}
+{
+  "username": "federation-viewer",
+  "disabled": false
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Next, grant the `federation-viewer` user read-only access through a cluster role binding for the built-in `view` cluster role:
 
 {{< code shell >}}
 sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=view --user=federation-viewer
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: federation-viewer-readonly
+spec:
+  role_ref:
+    name: view
+    type: ClusterRole
+  subjects:
+  - name: federation-viewer
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "federation-viewer-readonly"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "view",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "federation-viewer",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 In step 4, you'll configure etcd replicators to copy the cluster role bindings and other RBAC policies you created in the `gateway` cluster to the `alpha` and `beta` clusters.
 
@@ -258,13 +321,13 @@ Write these EtcdReplicator definitions written to disk and use `sensuctl create 
 For a consistent experience, repeat the `ClusterRoleBinding` example in this guide for `Role`, `RoleBinding` and `ClusterRole` resource types.
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
-To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters and run the following command for each:
 
 {{< code shell >}}
 sensuctl cluster-role-binding info federation-viewer-readonly
 {{< /code >}}
 
-You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
+The `federation-viewer-readonly` binding you created in step 3 should be listed in the output from each cluster:
 
 {{< code shell >}}
 === federation-viewer-readonly
@@ -366,6 +429,7 @@ If you haven't changed the permissions of the default `admin` user, that user sh
 ## Next steps
 
 Learn more about configuring RBAC policies in our [RBAC reference documentation][10].
+
 
 [1]: ../../../api/federation/
 [2]: ../etcdreplicators/

--- a/content/sensu-go/6.1/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/license.md
@@ -20,13 +20,22 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
-With the license file downloaded, you can activate your license with sensuctl or the [license API][4].
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
 To activate your license with sensuctl:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to view your license details at any time:
 

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -207,7 +207,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -345,19 +345,42 @@ Sensu Core hourly filter:
 
 Sensu Go hourly filter:
 
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: EventFilter
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: hourly
+  namespace: default
+spec:
+  action: allow
+  expressions:
+  - event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0
+  runtime_assets: null
+{{< /code >}}
+
 {{< code json >}}
 {
+  "type": "EventFilter",
+  "api_version": "core/v2",
   "metadata": {
+    "created_by": "admin",
     "name": "hourly",
     "namespace": "default"
   },
-  "action": "allow",
-  "expressions": [
-    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-  ],
-  "runtime_assets": null
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+    ],
+    "runtime_assets": null
+  }
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 #### 4. Translate handlers
 

--- a/content/sensu-go/6.1/sensuctl/_index.md
+++ b/content/sensu-go/6.1/sensuctl/_index.md
@@ -53,19 +53,32 @@ For information about configuring the Sensu backend URL, see the [backend refere
 During configuration, sensuctl creates configuration files that contain information for connecting to your Sensu Go deployment.
 You can find these files at `$HOME/.config/sensu/sensuctl/profile` and `$HOME/.config/sensu/sensuctl/cluster`.
 
-For example:
+Use the `cat` command to view the contents of these files.
+For example, to view your sensuctl profile configuration, run:
 
 {{< code shell >}}
 cat .config/sensu/sensuctl/profile
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "format": "tabular",
-  "namespace": "demo",
+  "namespace": "default",
   "username": "admin"
 }
 {{< /code >}}
 
+To view your sensuctl cluster configuration, run:
+
 {{< code shell >}}
 cat .config/sensu/sensuctl/cluster 
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "api-url": "http://localhost:8080",
   "trusted-ca-file": "",

--- a/content/sensu-go/6.1/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.1/sensuctl/back-up-recover.md
@@ -15,52 +15,116 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yaml` in `yaml` format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
 
-{{< code shell >}}
-sensuctl dump all --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --format yaml --file my-resources.yml
 {{< /code >}}
 
-To export only checks for only the current namespace to STDOUT in `yaml` format:
+{{< code shell "JSON" >}}
+sensuctl dump all --format json --file my-resources.json
+{{< /code >}}
 
-{{< code shell >}}
+{{< /language-toggle >}}
+
+To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters.yaml` in `yaml` format:
-
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
 For example:
 
-{{< code shell >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
-{{< code shell >}}
+{{< code shell "JSON" >}}
+sensuctl dump all --all-namespaces --format json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
 
 Here's an example that uses fully qualified names:
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Here's an example that uses short names:
 
-{{< code shell >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
 This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
@@ -71,51 +135,73 @@ You should create a backup before you [upgrade][4] to a new version of Sensu.
 Here's the step-by-step process:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Create a backup of the entire cluster, except entities, events, and [role-based access control (RBAC)][2] resources, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yaml
+--format yaml > backup/config.yml
 {{< /code >}}
-   
+{{< code shell "JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format json > backup/config.json
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Export your [RBAC][2] resources, except API keys and users, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yaml
+--format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format json > backup/rbac.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 4. Export your API keys and users resources for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yaml
+--format yaml > backup/cannotrestore.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format json > backup/cannotrestore.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
 Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
-     
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yaml
+--format yaml > backup/inventory.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format json > backup/inventory.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: If you do not export your entities, proxy check requests will not be scheduled for the excluded proxy entities.
 {{% /notice %}}
 
@@ -127,18 +213,23 @@ This backup allows you to [replicate resources across namespaces][5] without man
 To create a backup of your resources that you can replicate in new namespaces:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Back up your pipeline resources for all namespaces, stripping namespaces so that your resources are portable for reuse in any namespace.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
---format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
+--format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format json | grep -v "^\s*namespace:" > backup/pipelines.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 ## Restore resources from backup
 
@@ -152,9 +243,17 @@ sensuctl create -r -f backup/
 
 To restore a subset of your exported resources (in this example, your RBAC resources), run:
 
-{{< code shell >}}
-sensuctl create -f backup/rbac.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create -f backup/rbac.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create -f backup/rbac.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -368,7 +368,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `wrapped-json` format:
+To see the definition for a check named `check-cpu` in `yaml` or `json` format:
 
 {{< language-toggle >}}
 
@@ -377,7 +377,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check-cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -487,20 +487,25 @@ In addition, pruning requires [cluster-level privileges][35], even when all reso
 
 ##### Supported resource types
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
-
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: In Sensu 6.1.0, `sensuctl prune` does not work with hooks.
 {{% /notice %}}
+
+To retrieve the supported `sensuctl prune` resource types, run:
 
 {{< code shell >}}
 sensuctl describe-type all
+{{< /code >}}
 
+The response will list all supported `sensuctl prune` resource types:
+
+{{< code shell >}}
       Fully Qualified Name           Short Name           API Version             Type          Namespaced  
  ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
   authentication/v2.Provider                           authentication/v2   Provider             false
   licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
   store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.Cluster                                federation/v1       Cluster              false
   federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
   secrets/v1.Secret                                    secrets/v1          Secret               true
   secrets/v1.Provider                                  secrets/v1          Provider             false
@@ -526,7 +531,7 @@ sensuctl describe-type all
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In Sensu 6.1.0, `sensuctl prune` does not work with hooks.
+**NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
 ##### sensuctl prune flags

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
@@ -8,7 +8,7 @@ weight: 70
 version: "6.2"
 product: "Sensu Go"
 platformContent: False
-lastTested: 2018-12-04
+lastTested: 2021-03-11
 menu: 
   sensu-go-6.2:
     parent: observe-process
@@ -40,10 +40,56 @@ Your username will be added automatically as the **creator** of the silenced ent
 sensuctl silenced create \
 --subscription 'entity:i-424242' \
 --check 'check-http' \
---begin '2018-03-16 01:00:00 -04:00' \
+--begin '2021-03-14 01:00:00 -04:00' \
 --expire 3600 \
 --reason 'Server upgrade'
 {{< /code >}}
+
+This command creates the following silenced resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: Silenced
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: entity:i-424242:check-http
+  namespace: default
+spec:
+  begin: 1615698000
+  check: check-http
+  creator: admin
+  expire: 3600
+  expire_at: 1615701600
+  expire_on_resolve: false
+  reason: Server upgrade
+  subscription: entity:i-424242
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "entity:i-424242:check-http",
+    "namespace": "default"
+  },
+  "spec": {
+    "begin": 1615698000,
+    "check": "check-http",
+    "creator": "admin",
+    "expire": 3600,
+    "expire_at": 1615701600,
+    "expire_on_resolve": false,
+    "reason": "Server upgrade",
+    "subscription": "entity:i-424242"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 See the [sensuctl documentation][8] for the supported time formats for the `begin` flag.
 
@@ -51,16 +97,27 @@ See the [sensuctl documentation][8] for the supported time formats for the `begi
 
 Use sensuctl to verify that the silenced entry against the entity `i-424242` was created properly:
 
-{{< code shell >}}
-sensuctl silenced info 'entity:i-424242:check-http'
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will list the silenced resource definition.
+
 
 After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
-   i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
+   i-424242      check-http                    0          true     2021-03-14 13:22:16 -0400 EDT
 {{< /code >}}
 
 {{% notice warning %}}
@@ -69,7 +126,7 @@ After the silenced entry starts to take effect, events that are silenced will be
 
 ## Next steps
 
-Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+Read the [silencing reference][7] for in-depth documentation about silenced entries.
 
 
 [1]: ../handlers/

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -34,6 +34,59 @@ sensuctl hook create process_tree  \
 --timeout 10
 {{< /code >}}
 
+To confirm that the hook was added, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl hook info process_tree --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl hook info process_tree --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include the complete hook resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yaml >}}
+---
+type: HookConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: process_tree
+  namespace: default
+spec:
+  command: ps aux
+  runtime_assets: null
+  stdin: false
+  timeout: 10
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "process_tree",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "ps aux",
+    "runtime_assets": null,
+    "stdin": false,
+    "timeout": 10
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Assign the hook to a check
 
 Now that you've created the `process_tree` hook, you can assign it to a check.

--- a/content/sensu-go/6.2/operations/control-access/_index.md
+++ b/content/sensu-go/6.2/operations/control-access/_index.md
@@ -53,13 +53,23 @@ In addition to built-in authentication, Sensu includes commercial support for au
 * Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
 * OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
 
+Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
+
 **2. Apply the configuration with sensuctl**
 
-Log in to sensuctl as the [default admin user][3] and apply the configuration to Sensu:
+Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
 
-{{< code shell >}}
-sensuctl create --file filename.json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file authconfig.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file authconfig.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to verify that your provider configuration was applied successfully:
 

--- a/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
@@ -31,20 +31,128 @@ In this section, you'll create a user and assign them read-only access to resour
 sensuctl user create alice --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: alice
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "alice",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< code shell >}}
 sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
+
+   This command creates the following role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: read-only
+  namespace: default
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< code shell >}}
 sensuctl role-binding create ops-read-only --role=read-only --group=ops
 {{< /code >}}
 
-You can also use role bindings to tie roles directly to users using the `--user` flag.
+   This command creates the following role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-read-only
+  namespace: default
+spec:
+  role_ref:
+    name: read-only
+    type: Role
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "read-only",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to all resources within the default namespace.
-You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+To manage your RBAC configuration, use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands.
 
 ## Create a cluster-wide event-reader user
 
@@ -56,15 +164,119 @@ Because you want this role to have cluster-wide permissions, you'll need to crea
 sensuctl user create bob --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: bob
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "bob",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /code >}}
 
+   This command creates the following cluster role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< code shell >}}
 sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /code >}}
+
+   This command creates the following cluster role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-event-reader
+spec:
+  role_ref:
+    name: global-event-reader
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-event-reader"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "global-event-reader",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to events across all namespaces.
 
@@ -72,5 +284,10 @@ All users in the `ops` group now have read-only access to events across all name
 
 Now that you know how to create a user, a role, and a role binding to assign a role to a user, check out the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
+Read about [monitoring as code][3] with Sensu and learn how to [use SensuFlow][4] to synchronize your monitoring and observability code with your Sensu deployments.
+
+
 [1]: ../rbac/
 [2]: ../rbac#default-users
+[3]: ../../monitoring-as-code/
+[4]: https://sensu.io/blog/monitoring-as-code-with-sensu-flow

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -84,8 +84,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### User example
 
-The following example shows a user resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a user resource definition:
 
 {{< language-toggle >}}
 
@@ -117,6 +116,22 @@ spec:
     "groups": ["ops", "dev"]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this user with [`sensuctl create`][31], first save the definition to a file like `users.yml` or `users.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file users.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file users.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -181,11 +196,19 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl user list --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl user list --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create users
 
@@ -380,8 +403,7 @@ To create and manage cluster roles, [configure sensuctl][26] as the [default `ad
 
 ### Role example
 
-The following example shows a role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role resource definition:
 
 {{< language-toggle >}}
 
@@ -440,10 +462,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role with [`sensuctl create`][31], first save the definition to a file like `roles.yml` or `roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file roles.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role example
 
-The following example shows a cluster role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role resource definition:
 
 {{< language-toggle >}}
 
@@ -505,6 +542,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role with [`sensuctl create`][31], first save the definition to a file like `cluster_roles.yml` or `cluster_roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file cluster_roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file cluster_roles.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -572,12 +625,115 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
+This command creates the following role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin
+  namespace: production
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin",
+    "namespace": "production"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 After you create a role, [create a role binding][23] (or [cluster role binding][23]) to assign the role to users and groups.
 For example, to assign the `prod-admin` role created above to the `oncall` group, create this role binding:
 
 {{< code shell >}}
 sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin-oncall
+  namespace: production
+spec:
+  role_ref:
+    name: prod-admin
+    type: Role
+  subjects:
+  - name: oncall
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin-oncall",
+    "namespace": "production"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "prod-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "oncall",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create cluster-wide roles
 
@@ -587,6 +743,54 @@ For example, the following command creates a global event reader role that can r
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb='get,list' --resource='events'
 {{< /code >}}
+
+This command creates the following cluster-wide role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete roles and cluster roles
 
@@ -746,11 +950,9 @@ Make sure to include the groups prefix and username prefix for the authenticatio
 Without an assigned role or cluster role, users can sign in to the web UI but can't access any Sensu resources.
 With the correct roles and bindings configured, users can log in to [sensuctl][2] and the [web UI][1] using their single-sign-on username and password (no prefixes required).
 
-
 ### Role binding example
 
-The following example shows a role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -795,10 +997,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role binding with [`sensuctl create`][31], first save the definition to a file like `rolebindings.yml` or `rolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file rolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file rolebindings.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role binding example
 
-The following example shows a cluster role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -837,6 +1054,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role binding with [`sensuctl create`][31], first save the definition to a file like `clusterrolebindings.yml` or `clusterrolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file clusterrolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file clusterrolebindings.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -891,20 +1124,177 @@ sensuctl cluster-role-binding list
 You can use [sensuctl][2] to see a create a role binding that assigns a role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: Role
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a role binding that assigns a cluster role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a cluster role binding:
 
 {{< code shell >}}
-sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete role bindings and cluster role bindings
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
@@ -511,11 +511,22 @@ Sensu Inc. offers support packages for Sensu Go and [commercial features][20] de
 All commercial features are [free for your first 100 entities][29].
 To learn more about Sensu Go commercial licenses for more than 100 entities, [contact the Sensu sales team][11].
 
-If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file, then add your license using sensuctl.
+If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file.
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 
-{{< code shell >}}
+Use sensuctl to activate your license:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use sensuctl to view your license details at any time.
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/scale-event-storage.md
@@ -140,11 +140,19 @@ spec:
 
 {{< /language-toggle >}}
 
-This configuration is written to disk as `my-postgres.yml`, and you can install it using `sensuctl`:
+Save this configuration as `my-postgres.yml` or `my-postgres.json` and install it with `sensuctl`:
 
-{{< code shell >}}
-sensuctl create -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 The Sensu backend is now configured to use Postgres for event storage!
 
@@ -220,11 +228,19 @@ select sensu_entity from events where sensu_check = 'keepalive';
 ## Revert to the built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource.
-In this example, my-postgres.yml contains the same configuration you used to configure the Enterprise event store earlier in this guide:
+In this example, `my-postgres.yml` or `my-postgres.json` contain the same configuration you used to configure the Enterprise event store earlier in this guide:
 
-{{< code shell >}}
-sensuctl delete -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl delete --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl delete --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To verify that the change was effective, look for messages similar to these in the [sensu-backend log][4]:
 
@@ -274,11 +290,15 @@ Make a copy of the current `pg_hba.conf`:
 sudo cp /var/lib/pgsql/data/pg_hba.conf /var/tmp/pg_hba.conf.bak
 {{< /code >}}
 
-Next, give the repl user permissions to replicate from the standby host.
-In the following command, replace `STANDBY_IP` with the IP address of your standby host:
+In the following command, replace the `STANDBY_IP` value with the IP address of your standby host and then run the command:
 
 {{< code shell >}}
 export STANDBY_IP=192.168.52.10
+{{< /code >}}
+
+Next, give the repl user permissions to replicate from the standby host:
+
+{{< code shell >}}
 echo "host replication repl ${STANDYB_IP}/32 md5" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
 {{< /code >}}
 
@@ -332,10 +352,16 @@ sudo systemctl restart postgresql
 The standby host must be bootstrapped using the `pg_basebackup` command.
 This process will copy all configuration files from the primary as well as databases.
 
-If the standby host has ever run Postgres, you must empty the data directory:
+If the standby host has ever run Postgres, you must empty the data directory.
+First, stop Postgres:
 
 {{< code shell >}}
 sudo systemctl stop postgresql
+{{< /code >}}
+
+Empty the data directory:
+
+{{< code shell >}}
 sudo mv /var/lib/pgsql/data /var/lib/pgsql/data.bak
 {{< /code >}}
 
@@ -345,17 +371,28 @@ Make the standby data directory:
 sudo install -d -o postgres -g postgres -m 0700 /var/lib/pgsql/data
 {{< /code >}}
 
-And then bootstrap the standby data directory:
+Then bootstrap the standby data directory.
+In the following command, replace PRIMARY_IP with the IP address of your primary host and then run the command:
 
 {{< code shell >}}
 export PRIMARY_IP=192.168.52.11
+{{< /code >}}
+
+Then bootstrap the standby data directory:
+
+{{< code shell >}}
 sudo -u postgres pg_basebackup -h $PRIMARY_IP -D /var/lib/pgsql/data -P -U repl -R --xlog-method=stream
 {{< /code >}}
 
-Postgres will prompt for your password and then list database copy progress.
+Postgres will prompt for your password:
 
 {{< code postgresql >}}
 Password: 
+{{< /code >}}
+
+After you enter your password, Postgres will list database copy progress:
+
+{{< code postgresql >}}
 30318/30318 kB (100%), 1/1 tablespace
 {{< /code >}}
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -147,14 +147,77 @@ Second, create a `federation-viewer` user:
 sensuctl user create federation-viewer --interactive
 {{< /code >}}
 
-When prompted, enter a password for the `federation-viewer` user.
-When prompted for groups, press enter. Note the `federation-viewer` password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+When prompted for username and groups, press enter.
+When prompted for password, enter a password for the `federation-viewer` user.
+Note the password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+
+This creates the following user:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+username: federation-viewer
+disabled: false
+{{< /code >}}
+
+{{< code json >}}
+{
+  "username": "federation-viewer",
+  "disabled": false
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Next, grant the `federation-viewer` user read-only access through a cluster role binding for the built-in `view` cluster role:
 
 {{< code shell >}}
 sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=view --user=federation-viewer
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: federation-viewer-readonly
+spec:
+  role_ref:
+    name: view
+    type: ClusterRole
+  subjects:
+  - name: federation-viewer
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "federation-viewer-readonly"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "view",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "federation-viewer",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 In step 4, you'll configure etcd replicators to copy the cluster role bindings and other RBAC policies you created in the `gateway` cluster to the `alpha` and `beta` clusters.
 
@@ -258,13 +321,13 @@ Write these EtcdReplicator definitions written to disk and use `sensuctl create 
 For a consistent experience, repeat the `ClusterRoleBinding` example in this guide for `Role`, `RoleBinding` and `ClusterRole` resource types.
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
-To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters and run the following command for each:
 
 {{< code shell >}}
 sensuctl cluster-role-binding info federation-viewer-readonly
 {{< /code >}}
 
-You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
+The `federation-viewer-readonly` binding you created in step 3 should be listed in the output from each cluster:
 
 {{< code shell >}}
 === federation-viewer-readonly
@@ -366,6 +429,7 @@ If you haven't changed the permissions of the default `admin` user, that user sh
 ## Next steps
 
 Learn more about configuring RBAC policies in our [RBAC reference documentation][10].
+
 
 [1]: ../../../api/federation/
 [2]: ../etcdreplicators/

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -20,13 +20,22 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
-With the license file downloaded, you can activate your license with sensuctl or the [license API][4].
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
 To activate your license with sensuctl:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to view your license details at any time:
 

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -207,7 +207,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -345,19 +345,42 @@ Sensu Core hourly filter:
 
 Sensu Go hourly filter:
 
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: EventFilter
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: hourly
+  namespace: default
+spec:
+  action: allow
+  expressions:
+  - event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0
+  runtime_assets: null
+{{< /code >}}
+
 {{< code json >}}
 {
+  "type": "EventFilter",
+  "api_version": "core/v2",
   "metadata": {
+    "created_by": "admin",
     "name": "hourly",
     "namespace": "default"
   },
-  "action": "allow",
-  "expressions": [
-    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-  ],
-  "runtime_assets": null
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+    ],
+    "runtime_assets": null
+  }
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 #### 4. Translate handlers
 

--- a/content/sensu-go/6.2/sensuctl/_index.md
+++ b/content/sensu-go/6.2/sensuctl/_index.md
@@ -109,19 +109,32 @@ The following table lists the command-specific flags.
 During configuration, sensuctl creates configuration files that contain information for connecting to your Sensu Go deployment.
 You can find these files at `$HOME/.config/sensu/sensuctl/profile` and `$HOME/.config/sensu/sensuctl/cluster`.
 
-For example:
+Use the `cat` command to view the contents of these files.
+For example, to view your sensuctl profile configuration, run:
 
 {{< code shell >}}
 cat .config/sensu/sensuctl/profile
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "format": "tabular",
-  "namespace": "demo",
+  "namespace": "default",
   "username": "admin"
 }
 {{< /code >}}
 
+To view your sensuctl cluster configuration, run:
+
 {{< code shell >}}
 cat .config/sensu/sensuctl/cluster 
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "api-url": "http://localhost:8080",
   "trusted-ca-file": "",

--- a/content/sensu-go/6.2/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.2/sensuctl/back-up-recover.md
@@ -15,52 +15,116 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yaml` in `yaml` format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
 
-{{< code shell >}}
-sensuctl dump all --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --format yaml --file my-resources.yml
 {{< /code >}}
 
-To export only checks for only the current namespace to STDOUT in `yaml` format:
+{{< code shell "JSON" >}}
+sensuctl dump all --format json --file my-resources.json
+{{< /code >}}
 
-{{< code shell >}}
+{{< /language-toggle >}}
+
+To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters.yaml` in `yaml` format:
-
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
 For example:
 
-{{< code shell >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
-{{< code shell >}}
+{{< code shell "JSON" >}}
+sensuctl dump all --all-namespaces --format json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
 
 Here's an example that uses fully qualified names:
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Here's an example that uses short names:
 
-{{< code shell >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
 This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
@@ -71,51 +135,73 @@ You should create a backup before you [upgrade][4] to a new version of Sensu.
 Here's the step-by-step process:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Create a backup of the entire cluster, except entities, events, and [role-based access control (RBAC)][2] resources, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yaml
+--format yaml > backup/config.yml
 {{< /code >}}
-   
+{{< code shell "JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format json > backup/config.json
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Export your [RBAC][2] resources, except API keys and users, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yaml
+--format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format json > backup/rbac.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 4. Export your API keys and users resources for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yaml
+--format yaml > backup/cannotrestore.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format json > backup/cannotrestore.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
 Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
-     
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yaml
+--format yaml > backup/inventory.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format json > backup/inventory.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: If you do not export your entities, proxy check requests will not be scheduled for the excluded proxy entities.
 {{% /notice %}}
 
@@ -127,18 +213,23 @@ This backup allows you to [replicate resources across namespaces][5] without man
 To create a backup of your resources that you can replicate in new namespaces:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Back up your pipeline resources for all namespaces, stripping namespaces so that your resources are portable for reuse in any namespace.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
---format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
+--format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format json | grep -v "^\s*namespace:" > backup/pipelines.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 ## Restore resources from backup
 
@@ -152,9 +243,17 @@ sensuctl create -r -f backup/
 
 To restore a subset of your exported resources (in this example, your RBAC resources), run:
 
-{{< code shell >}}
-sensuctl create -f backup/rbac.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create -f backup/rbac.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create -f backup/rbac.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -378,7 +378,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `wrapped-json` format:
+To see the definition for a check named `check-cpu` in `yaml` or `json` format:
 
 {{< language-toggle >}}
 
@@ -387,7 +387,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check-cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -497,15 +497,15 @@ In addition, pruning requires [cluster-level privileges][35], even when all reso
 
 ##### Supported resource types
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
-
-{{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
-{{% /notice %}}
+To retrieve the supported `sensuctl prune` resource types, run:
 
 {{< code shell >}}
 sensuctl describe-type all
+{{< /code >}}
 
+The response will list all supported `sensuctl prune` resource types:
+
+{{< code shell >}}
       Fully Qualified Name           Short Name           API Version             Type          Namespaced  
  ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
   authentication/v2.Provider                           authentication/v2   Provider             false
@@ -535,6 +535,10 @@ sensuctl describe-type all
   core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
   core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
 
 ##### sensuctl prune flags
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
@@ -8,7 +8,7 @@ weight: 70
 version: "6.3"
 product: "Sensu Go"
 platformContent: False
-lastTested: 2018-12-04
+lastTested: 2021-03-11
 menu: 
   sensu-go-6.3:
     parent: observe-process
@@ -40,10 +40,56 @@ Your username will be added automatically as the **creator** of the silenced ent
 sensuctl silenced create \
 --subscription 'entity:i-424242' \
 --check 'check-http' \
---begin '2018-03-16 01:00:00 -04:00' \
+--begin '2021-03-14 01:00:00 -04:00' \
 --expire 3600 \
 --reason 'Server upgrade'
 {{< /code >}}
+
+This command creates the following silenced resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: Silenced
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: entity:i-424242:check-http
+  namespace: default
+spec:
+  begin: 1615698000
+  check: check-http
+  creator: admin
+  expire: 3600
+  expire_at: 1615701600
+  expire_on_resolve: false
+  reason: Server upgrade
+  subscription: entity:i-424242
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Silenced",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "entity:i-424242:check-http",
+    "namespace": "default"
+  },
+  "spec": {
+    "begin": 1615698000,
+    "check": "check-http",
+    "creator": "admin",
+    "expire": 3600,
+    "expire_at": 1615701600,
+    "expire_on_resolve": false,
+    "reason": "Server upgrade",
+    "subscription": "entity:i-424242"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 See the [sensuctl documentation][8] for the supported time formats for the `begin` flag.
 
@@ -51,16 +97,27 @@ See the [sensuctl documentation][8] for the supported time formats for the `begi
 
 Use sensuctl to verify that the silenced entry against the entity `i-424242` was created properly:
 
-{{< code shell >}}
-sensuctl silenced info 'entity:i-424242:check-http'
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl silenced info 'entity:i-424242:check-http' --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will list the silenced resource definition.
+
 
 After the silenced entry starts to take effect, events that are silenced will be marked as such in the response:
 
 {{< code shell >}}
    Entity         Check        Output       Status     Silenced          Timestamp
 ──────────────   ─────────    ─────────   ──────────── ────────── ───────────────────────────────
-   i-424242      check-http                    0          true     2018-03-16 13:22:16 -0400 EDT
+   i-424242      check-http                    0          true     2021-03-14 13:22:16 -0400 EDT
 {{< /code >}}
 
 {{% notice warning %}}
@@ -69,7 +126,7 @@ After the silenced entry starts to take effect, events that are silenced will be
 
 ## Next steps
 
-Next, read the [silencing reference][7] for in-depth documentation about silenced entries.
+Read the [silencing reference][7] for in-depth documentation about silenced entries.
 
 
 [1]: ../handlers/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -34,6 +34,59 @@ sensuctl hook create process_tree  \
 --timeout 10
 {{< /code >}}
 
+To confirm that the hook was added, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl hook info process_tree --format yaml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl hook info process_tree --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+The response will include the complete hook resource definition in the specified format:
+
+{{< language-toggle >}}
+
+{{< code yaml >}}
+---
+type: HookConfig
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: process_tree
+  namespace: default
+spec:
+  command: ps aux
+  runtime_assets: null
+  stdin: false
+  timeout: 10
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "HookConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "process_tree",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "ps aux",
+    "runtime_assets": null,
+    "stdin": false,
+    "timeout": 10
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ## Assign the hook to a check
 
 Now that you've created the `process_tree` hook, you can assign it to a check.

--- a/content/sensu-go/6.3/operations/control-access/_index.md
+++ b/content/sensu-go/6.3/operations/control-access/_index.md
@@ -53,13 +53,23 @@ In addition to built-in authentication, Sensu includes commercial support for au
 * Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
 * OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
 
+Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
+
 **2. Apply the configuration with sensuctl**
 
-Log in to sensuctl as the [default admin user][3] and apply the configuration to Sensu:
+Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
 
-{{< code shell >}}
-sensuctl create --file filename.json
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file authconfig.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file authconfig.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to verify that your provider configuration was applied successfully:
 

--- a/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
@@ -31,20 +31,128 @@ In this section, you'll create a user and assign them read-only access to resour
 sensuctl user create alice --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: alice
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "alice",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `read-only` role with `get` and `list` permissions for all resources (`*`) within the `default` namespace:
 {{< code shell >}}
 sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
+
+   This command creates the following role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: read-only
+  namespace: default
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 3. Create an `ops-read-only` role binding to assign the `read-only` role to the `ops` group:
 {{< code shell >}}
 sensuctl role-binding create ops-read-only --role=read-only --group=ops
 {{< /code >}}
 
-You can also use role bindings to tie roles directly to users using the `--user` flag.
+   This command creates the following role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-read-only
+  namespace: default
+spec:
+  role_ref:
+    name: read-only
+    type: Role
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-read-only",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "read-only",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to all resources within the default namespace.
-You can use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands to manage your RBAC configuration.
+You can also use role bindings to tie roles directly to users using the `--user` flag.
+
+To manage your RBAC configuration, use the `sensuctl user`, `sensuctl role`, and `sensuctl role-binding` commands.
 
 ## Create a cluster-wide event-reader user
 
@@ -56,15 +164,119 @@ Because you want this role to have cluster-wide permissions, you'll need to crea
 sensuctl user create bob --password='password' --groups=ops
 {{< /code >}}
 
+   This command creates the following user:
+   {{< language-toggle >}}
+{{< code yml >}}
+username: bob
+groups:
+- ops
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "username": "bob",
+  "groups": [
+    "ops"
+  ],
+  "disabled": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 2. Create a `global-event-reader` cluster role with `get` and `list` permissions for `events` across all namespaces:
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb=get,list --resource=events
 {{< /code >}}
 
+   This command creates the following cluster role resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Create an `ops-event-reader` cluster role binding to assign the `global-event-reader` role to the `ops` group:
 {{< code shell >}}
 sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-event-reader --group=ops
 {{< /code >}}
+
+   This command creates the following cluster role binding resource definition:
+   {{< language-toggle >}}
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: ops-event-reader
+spec:
+  role_ref:
+    name: global-event-reader
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "ops-event-reader"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "global-event-reader",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 All users in the `ops` group now have read-only access to events across all namespaces.
 
@@ -72,5 +284,10 @@ All users in the `ops` group now have read-only access to events across all name
 
 Now that you know how to create a user, a role, and a role binding to assign a role to a user, check out the [RBAC reference][1] for in-depth documentation on role-based access control, examples, and information about cluster-wide permissions.
 
+Read about [monitoring as code][3] with Sensu and learn how to [use SensuFlow][4] to synchronize your monitoring and observability code with your Sensu deployments.
+
+
 [1]: ../rbac/
 [2]: ../rbac#default-users
+[3]: ../../monitoring-as-code/
+[4]: https://sensu.io/blog/monitoring-as-code-with-sensu-flow

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -84,8 +84,7 @@ Use your Sensu username and password to [configure sensuctl][26] or log in to th
 
 ### User example
 
-The following example shows a user resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a user resource definition:
 
 {{< language-toggle >}}
 
@@ -117,6 +116,22 @@ spec:
     "groups": ["ops", "dev"]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this user with [`sensuctl create`][31], first save the definition to a file like `users.yml` or `users.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file users.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file users.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -181,11 +196,19 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl user list --format yaml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl user list --format json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create users
 
@@ -380,8 +403,7 @@ To create and manage cluster roles, [configure sensuctl][26] as the [default `ad
 
 ### Role example
 
-The following example shows a role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role resource definition:
 
 {{< language-toggle >}}
 
@@ -440,10 +462,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role with [`sensuctl create`][31], first save the definition to a file like `roles.yml` or `roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file roles.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role example
 
-The following example shows a cluster role resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role resource definition:
 
 {{< language-toggle >}}
 
@@ -505,6 +542,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role with [`sensuctl create`][31], first save the definition to a file like `cluster_roles.yml` or `cluster_roles.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file cluster_roles.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file cluster_roles.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -572,12 +625,115 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
+This command creates the following role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Role
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin
+  namespace: production
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Role",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin",
+    "namespace": "production"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "*"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 After you create a role, [create a role binding][23] (or [cluster role binding][23]) to assign the role to users and groups.
 For example, to assign the `prod-admin` role created above to the `oncall` group, create this role binding:
 
 {{< code shell >}}
 sensuctl role-binding create prod-admin-oncall --role=prod-admin --group=oncall
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: prod-admin-oncall
+  namespace: production
+spec:
+  role_ref:
+    name: prod-admin
+    type: Role
+  subjects:
+  - name: oncall
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "prod-admin-oncall",
+    "namespace": "production"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "prod-admin",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "oncall",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Create cluster-wide roles
 
@@ -587,6 +743,54 @@ For example, the following command creates a global event reader role that can r
 {{< code shell >}}
 sensuctl cluster-role create global-event-reader --verb='get,list' --resource='events'
 {{< /code >}}
+
+This command creates the following cluster-wide role resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: global-event-reader
+spec:
+  rules:
+  - resource_names: null
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "global-event-reader"
+  },
+  "spec": {
+    "rules": [
+      {
+        "resource_names": null,
+        "resources": [
+          "events"
+        ],
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete roles and cluster roles
 
@@ -746,11 +950,9 @@ Make sure to include the groups prefix and username prefix for the authenticatio
 Without an assigned role or cluster role, users can sign in to the web UI but can't access any Sensu resources.
 With the correct roles and bindings configured, users can log in to [sensuctl][2] and the [web UI][1] using their single-sign-on username and password (no prefixes required).
 
-
 ### Role binding example
 
-The following example shows a role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -795,10 +997,25 @@ spec:
 
 {{< /language-toggle >}}
 
+To create this role binding with [`sensuctl create`][31], first save the definition to a file like `rolebindings.yml` or `rolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file rolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file rolebindings.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 ### Cluster role binding example
 
-The following example shows a cluster role binding resource definition.
-You can use this example with [`sensuctl create`][31].
+The following example shows a cluster role binding resource definition:
 
 {{< language-toggle >}}
 
@@ -837,6 +1054,22 @@ spec:
     ]
   }
 }
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To create this cluster role binding with [`sensuctl create`][31], first save the definition to a file like `clusterrolebindings.yml` or `clusterrolebindings.json`.
+
+Then, run:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file clusterrolebindings.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file clusterrolebindings.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -891,20 +1124,177 @@ sensuctl cluster-role-binding list
 You can use [sensuctl][2] to see a create a role binding that assigns a role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: Role
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "Role"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a role binding that assigns a cluster role:
 
 {{< code shell >}}
-sensuctl role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: RoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+  namespace: default
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "RoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME",
+    "namespace": "default"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To create a cluster role binding:
 
 {{< code shell >}}
-sensuctl cluster-role-binding create [NAME] --cluster-role=NAME [--user=username] [--group=groupname]
+sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: NAME
+spec:
+  role_ref:
+    name: NAME
+    type: ClusterRole
+  subjects:
+  - name: groupname
+    type: Group
+  - name: username
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "NAME"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "NAME",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "groupname",
+        "type": "Group"
+      },
+      {
+        "name": "username",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Delete role bindings and cluster role bindings
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
@@ -511,11 +511,22 @@ Sensu Inc. offers support packages for Sensu Go and [commercial features][20] de
 All commercial features are [free for your first 100 entities][29].
 To learn more about Sensu Go commercial licenses for more than 100 entities, [contact the Sensu sales team][11].
 
-If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file, then add your license using sensuctl.
+If you already have a Sensu commercial license, [log in to your Sensu account][34] and download your license file.
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 
-{{< code shell >}}
+Use sensuctl to activate your license:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use sensuctl to view your license details at any time.
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/scale-event-storage.md
@@ -140,11 +140,19 @@ spec:
 
 {{< /language-toggle >}}
 
-This configuration is written to disk as `my-postgres.yml`, and you can install it using `sensuctl`:
+Save this configuration as `my-postgres.yml` or `my-postgres.json` and install it with `sensuctl`:
 
-{{< code shell >}}
-sensuctl create -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 The Sensu backend is now configured to use Postgres for event storage!
 
@@ -220,11 +228,19 @@ select sensu_entity from events where sensu_check = 'keepalive';
 ## Revert to the built-in datastore
 
 If you want to revert to the default etcd event store, delete the PostgresConfig resource.
-In this example, my-postgres.yml contains the same configuration you used to configure the Enterprise event store earlier in this guide:
+In this example, `my-postgres.yml` or `my-postgres.json` contain the same configuration you used to configure the Enterprise event store earlier in this guide:
 
-{{< code shell >}}
-sensuctl delete -f my-postgres.yml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl delete --file my-postgres.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl delete --file my-postgres.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To verify that the change was effective, look for messages similar to these in the [sensu-backend log][4]:
 
@@ -274,11 +290,15 @@ Make a copy of the current `pg_hba.conf`:
 sudo cp /var/lib/pgsql/data/pg_hba.conf /var/tmp/pg_hba.conf.bak
 {{< /code >}}
 
-Next, give the repl user permissions to replicate from the standby host.
-In the following command, replace `STANDBY_IP` with the IP address of your standby host:
+In the following command, replace the `STANDBY_IP` value with the IP address of your standby host and then run the command:
 
 {{< code shell >}}
 export STANDBY_IP=192.168.52.10
+{{< /code >}}
+
+Next, give the repl user permissions to replicate from the standby host:
+
+{{< code shell >}}
 echo "host replication repl ${STANDYB_IP}/32 md5" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
 {{< /code >}}
 
@@ -332,10 +352,16 @@ sudo systemctl restart postgresql
 The standby host must be bootstrapped using the `pg_basebackup` command.
 This process will copy all configuration files from the primary as well as databases.
 
-If the standby host has ever run Postgres, you must empty the data directory:
+If the standby host has ever run Postgres, you must empty the data directory.
+First, stop Postgres:
 
 {{< code shell >}}
 sudo systemctl stop postgresql
+{{< /code >}}
+
+Empty the data directory:
+
+{{< code shell >}}
 sudo mv /var/lib/pgsql/data /var/lib/pgsql/data.bak
 {{< /code >}}
 
@@ -345,17 +371,28 @@ Make the standby data directory:
 sudo install -d -o postgres -g postgres -m 0700 /var/lib/pgsql/data
 {{< /code >}}
 
-And then bootstrap the standby data directory:
+Then bootstrap the standby data directory.
+In the following command, replace PRIMARY_IP with the IP address of your primary host and then run the command:
 
 {{< code shell >}}
 export PRIMARY_IP=192.168.52.11
+{{< /code >}}
+
+Then bootstrap the standby data directory:
+
+{{< code shell >}}
 sudo -u postgres pg_basebackup -h $PRIMARY_IP -D /var/lib/pgsql/data -P -U repl -R --xlog-method=stream
 {{< /code >}}
 
-Postgres will prompt for your password and then list database copy progress.
+Postgres will prompt for your password:
 
 {{< code postgresql >}}
 Password: 
+{{< /code >}}
+
+After you enter your password, Postgres will list database copy progress:
+
+{{< code postgresql >}}
 30318/30318 kB (100%), 1/1 tablespace
 {{< /code >}}
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -147,14 +147,77 @@ Second, create a `federation-viewer` user:
 sensuctl user create federation-viewer --interactive
 {{< /code >}}
 
-When prompted, enter a password for the `federation-viewer` user.
-When prompted for groups, press enter. Note the `federation-viewer` password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+When prompted for username and groups, press enter.
+When prompted for password, enter a password for the `federation-viewer` user.
+Note the password you entered &mdash; you'll use it to log in to the web UI after you configure RBAC policy replication and registered clusters into your federation.
+
+This creates the following user:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+username: federation-viewer
+disabled: false
+{{< /code >}}
+
+{{< code json >}}
+{
+  "username": "federation-viewer",
+  "disabled": false
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Next, grant the `federation-viewer` user read-only access through a cluster role binding for the built-in `view` cluster role:
 
 {{< code shell >}}
 sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=view --user=federation-viewer
 {{< /code >}}
+
+This command creates the following cluster role binding resource definition:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: federation-viewer-readonly
+spec:
+  role_ref:
+    name: view
+    type: ClusterRole
+  subjects:
+  - name: federation-viewer
+    type: User
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "federation-viewer-readonly"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "view",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "federation-viewer",
+        "type": "User"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 In step 4, you'll configure etcd replicators to copy the cluster role bindings and other RBAC policies you created in the `gateway` cluster to the `alpha` and `beta` clusters.
 
@@ -258,13 +321,13 @@ Write these EtcdReplicator definitions written to disk and use `sensuctl create 
 For a consistent experience, repeat the `ClusterRoleBinding` example in this guide for `Role`, `RoleBinding` and `ClusterRole` resource types.
 The [etcd replicators reference][2] includes [examples][9] you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 
-To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters, issuing the `sensuctl cluster-role-binding list` command for each.
+To verify that the EtcdReplicator resource is working as expected, reconfigure `sensuctl` to communicate with the `alpha` and then `beta` clusters and run the following command for each:
 
 {{< code shell >}}
 sensuctl cluster-role-binding info federation-viewer-readonly
 {{< /code >}}
 
-You should see the `federation-viewer-readonly` binding created in step 3 listed in the output from each cluster:
+The `federation-viewer-readonly` binding you created in step 3 should be listed in the output from each cluster:
 
 {{< code shell >}}
 === federation-viewer-readonly
@@ -366,6 +429,7 @@ If you haven't changed the permissions of the default `admin` user, that user sh
 ## Next steps
 
 Learn more about configuring RBAC policies in our [RBAC reference documentation][10].
+
 
 [1]: ../../../api/federation/
 [2]: ../etcdreplicators/

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -20,13 +20,22 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 
 <img alt="Screenshot of Sensu account license download" src="/images/go-license-download.png" width="350px">
 
-With the license file downloaded, you can activate your license with sensuctl or the [license API][4].
+Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
 To activate your license with sensuctl:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file sensu_license.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
 sensuctl create --file sensu_license.json
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 Use sensuctl to view your license details at any time:
 

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -207,7 +207,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 See the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (/etc/sensu/agent.yml).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -345,19 +345,42 @@ Sensu Core hourly filter:
 
 Sensu Go hourly filter:
 
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: EventFilter
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: hourly
+  namespace: default
+spec:
+  action: allow
+  expressions:
+  - event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0
+  runtime_assets: null
+{{< /code >}}
+
 {{< code json >}}
 {
+  "type": "EventFilter",
+  "api_version": "core/v2",
   "metadata": {
+    "created_by": "admin",
     "name": "hourly",
     "namespace": "default"
   },
-  "action": "allow",
-  "expressions": [
-    "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
-  ],
-  "runtime_assets": null
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0"
+    ],
+    "runtime_assets": null
+  }
 }
 {{< /code >}}
+
+{{< /language-toggle >}}
 
 #### 4. Translate handlers
 

--- a/content/sensu-go/6.3/sensuctl/_index.md
+++ b/content/sensu-go/6.3/sensuctl/_index.md
@@ -109,19 +109,32 @@ The following table lists the command-specific flags.
 During configuration, sensuctl creates configuration files that contain information for connecting to your Sensu Go deployment.
 You can find these files at `$HOME/.config/sensu/sensuctl/profile` and `$HOME/.config/sensu/sensuctl/cluster`.
 
-For example:
+Use the `cat` command to view the contents of these files.
+For example, to view your sensuctl profile configuration, run:
 
 {{< code shell >}}
 cat .config/sensu/sensuctl/profile
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "format": "tabular",
-  "namespace": "demo",
+  "namespace": "default",
   "username": "admin"
 }
 {{< /code >}}
 
+To view your sensuctl cluster configuration, run:
+
 {{< code shell >}}
 cat .config/sensu/sensuctl/cluster 
+{{< /code >}}
+
+The response should be similar to this example:
+
+{{< code shell >}}
 {
   "api-url": "http://localhost:8080",
   "trusted-ca-file": "",

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -15,52 +15,116 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yaml` in `yaml` format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
 
-{{< code shell >}}
-sensuctl dump all --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --format yaml --file my-resources.yml
 {{< /code >}}
 
-To export only checks for only the current namespace to STDOUT in `yaml` format:
+{{< code shell "JSON" >}}
+sensuctl dump all --format json --file my-resources.json
+{{< /code >}}
 
-{{< code shell >}}
+{{< /language-toggle >}}
+
+To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters.yaml` in `yaml` format:
-
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
 For example:
 
-{{< code shell >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
-{{< code shell >}}
+{{< code shell "JSON" >}}
+sensuctl dump all --all-namespaces --format json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yaml
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
 
 Here's an example that uses fully qualified names:
 
-{{< code shell >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 Here's an example that uses short names:
 
-{{< code shell >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
 This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
@@ -71,51 +135,73 @@ You should create a backup before you [upgrade][4] to a new version of Sensu.
 Here's the step-by-step process:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Create a backup of the entire cluster, except entities, events, and [role-based access control (RBAC)][2] resources, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yaml
+--format yaml > backup/config.yml
 {{< /code >}}
-   
+{{< code shell "JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format json > backup/config.json
+{{< /code >}}
+{{< /language-toggle >}}
+
 3. Export your [RBAC][2] resources, except API keys and users, for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yaml
+--format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format json > backup/rbac.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 4. Export your API keys and users resources for all namespaces.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yaml
+--format yaml > backup/cannotrestore.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format json > backup/cannotrestore.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
 Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
-     
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yaml
+--format yaml > backup/inventory.yml
 {{< /code >}}
-
-   {{% notice note %}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format json > backup/inventory.json
+{{< /code >}}
+{{< /language-toggle >}}
+{{% notice note %}}
 **NOTE**: If you do not export your entities, proxy check requests will not be scheduled for the excluded proxy entities.
 {{% /notice %}}
 
@@ -127,18 +213,23 @@ This backup allows you to [replicate resources across namespaces][5] without man
 To create a backup of your resources that you can replicate in new namespaces:
 
 1. Create a backup folder.
-
-   {{< code shell >}}
+{{< code shell >}}
 mkdir backup
 {{< /code >}}
    
 2. Back up your pipeline resources for all namespaces, stripping namespaces so that your resources are portable for reuse in any namespace.
-   
-   {{< code shell >}}
+{{< language-toggle >}}
+{{< code shell "YML" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
---format yaml | grep -v "^\s*namespace:" > backup/pipelines.yaml
+--format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
 {{< /code >}}
+{{< code shell "JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format json | grep -v "^\s*namespace:" > backup/pipelines.json
+{{< /code >}}
+{{< /language-toggle >}}
 
 ## Restore resources from backup
 
@@ -152,9 +243,17 @@ sensuctl create -r -f backup/
 
 To restore a subset of your exported resources (in this example, your RBAC resources), run:
 
-{{< code shell >}}
-sensuctl create -f backup/rbac.yaml
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create -f backup/rbac.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create -f backup/rbac.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 {{% notice note %}}
 **NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -378,7 +378,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `wrapped-json` format:
+To see the definition for a check named `check-cpu` in `yaml` or `json` format:
 
 {{< language-toggle >}}
 
@@ -387,7 +387,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format wrapped-json
+sensuctl check info check-cpu --format json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -497,15 +497,15 @@ In addition, pruning requires [cluster-level privileges][35], even when all reso
 
 ##### Supported resource types
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl prune` resource types.
-
-{{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
-{{% /notice %}}
+To retrieve the supported `sensuctl prune` resource types, run:
 
 {{< code shell >}}
 sensuctl describe-type all
+{{< /code >}}
 
+The response will list all supported `sensuctl prune` resource types:
+
+{{< code shell >}}
       Fully Qualified Name           Short Name           API Version             Type          Namespaced  
  ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
   authentication/v2.Provider                           authentication/v2   Provider             false
@@ -535,6 +535,10 @@ sensuctl describe-type all
   core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
   core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Short names are only supported for `core/v2` resources.
+{{% /notice %}}
 
 ##### sensuctl prune flags
 


### PR DESCRIPTION
## Description
Adds resource definitions throughout docs as needed to illustrate the resources being created and updated with sensuctl commands. Part 4

## Motivation and Context
Many of our docs (especially guides) rely on sensuctl commands to create and update resources. These commands are tidy, but they do not show users what the resources they are creating and updating look like.