### PR TITLE
Fix link to monitor external resources in events index page

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/_index.md
@@ -315,7 +315,7 @@ Sensu's [events API][15] provides HTTP access to create, retrieve, update, and d
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
-[1]: ../observe-schedule/monitor-server-resources/
+[1]: ../observe-entities/monitor-external-resources/
 [2]: https://bonsai.sensu.io
 [3]: #status-only-events
 [4]: ../observe-schedule/hooks/

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/_index.md
@@ -315,7 +315,7 @@ Sensu's [events API][15] provides HTTP access to create, retrieve, update, and d
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
-[1]: ../observe-schedule/monitor-server-resources/
+[1]: ../observe-entities/monitor-external-resources/
 [2]: https://bonsai.sensu.io
 [3]: #status-only-events
 [4]: ../observe-schedule/hooks/

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/_index.md
@@ -315,7 +315,7 @@ Sensu's [events API][15] provides HTTP access to create, retrieve, update, and d
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
-[1]: ../observe-schedule/monitor-server-resources/
+[1]: ../observe-entities/monitor-external-resources/
 [2]: https://bonsai.sensu.io
 [3]: #status-only-events
 [4]: ../observe-schedule/hooks/

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
@@ -315,7 +315,7 @@ Sensu's [events API][15] provides HTTP access to create, retrieve, update, and d
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
-[1]: ../observe-schedule/monitor-server-resources/
+[1]: ../observe-entities/monitor-external-resources/
 [2]: https://bonsai.sensu.io
 [3]: #status-only-events
 [4]: ../observe-schedule/hooks/


### PR DESCRIPTION
## Description
In the events index page, fixes a link to Monitor external resources (the link incorrectly pointed to Monitor server resources)

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3048