### PR TITLE
Update and move Prometheus metrics guide from learn to observe-scehdule

### DIFF
--- a/content/sensu-go/6.0/learn/_index.md
+++ b/content/sensu-go/6.0/learn/_index.md
@@ -35,7 +35,7 @@ The live demo also gives you a chance to try commands with [sensuctl][8], the Se
 ## Sensu sandbox
 
 For further learning opportunities, download the [Sensu sandbox][4].
-Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] with Sensu.
 
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
@@ -45,6 +45,5 @@ We also have a GitHub lesson that guides you through [deploying a Sensu cluster 
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/
-[6]: prometheus-metrics/
 [7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
 [8]: ../sensuctl/

--- a/content/sensu-go/6.0/learn/sandbox.md
+++ b/content/sensu-go/6.0/learn/sandbox.md
@@ -22,14 +22,6 @@ The Learn Sensu sandbox is a CentOS 7 virtual machine pre-installed with Sensu, 
 Follow the instructions for [Getting Started with Sensu Go on Kubernetes][2] to deploy a Sensu cluster and an example application (NGINX) into Kubernetes with a Sensu agent sidecar.
 You'll also learn to use sensuctl to configure a Nagios-style monitoring check for the example application.
 
-## Collect metrics
-
-The Prometheus ecosystem's exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Follow [Collect Prometheus metrics with Sensu][3] to run Sensu and Prometheus in parallel and make use of environments where you've already deployed Prometheus.
-
-Learn to configure the Sensu Prometheus Collector check plugin to collect metrics from a Prometheus exporter or the Prometheus query API.
-Then, use Sensu to route the collected metrics to the time-series database InfluxDB and query InfluxDB to display the collected metrics with Grafana.
-
 ## Upgrade from Sensu Core 1.x to Sensu Go
 
 Use the [Sensu translator][4] to translate check configurations from Sensu Core 1.x to Sensu Go and learn how to visually inspect and adjust check token substitution and extended attributes to make sure your Core checks work properly in Sensu Go.
@@ -37,5 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[3]: ../../learn/prometheus-metrics/
 [4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
@@ -488,7 +488,7 @@ The event specification describes [metrics attributes in events][5].
 [4]: #extract-metrics-from-check-output
 [5]: ../../observe-events/events/#metrics
 [6]: #metric-check-example
-[7]: ../../../learn/prometheus-metrics/
+[7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/
 [9]: #supported-output-metric-formats
 [10]: ../checks/#output-metric-format

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -1,17 +1,24 @@
 ---
 title: "Collect Prometheus metrics with Sensu"
-version: "6.0"
+linkTitle: "Collect Prometheus Metrics"
+guide_title: "Collect Prometheus metrics with Sensu"
+type: "guide"
 description: "The Sensu Prometheus Collector is a check plugin that collects metrics from a Prometheus exporter or the Prometheus query API. This allows Sensu to route the collected metrics to a time-series database, like InfluxDB. Follow this guide to start collecting Prometheus metrics with Sensu."
+weight: 55
+version: "6.0"
 product: "Sensu Go"
 platformContent: false
+menu:
+  sensu-go-6.0:
+    parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects metrics from a [Prometheus exporter][2] or the [Prometheus query API][3].
+The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
 This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.  
+Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
 
 This guide uses CentOS 7 as the operating system with all components running on the same compute resource.
 Commands and steps may change for different distributions or if components are running on different compute resources.
@@ -75,20 +82,16 @@ vagrant   7647  3937  2 22:23 pts/0    00:00:00 ./prometheus --config.file=prome
 
 Follow the RHEL/CentOS [install instructions][4] for the Sensu backend, the Sensu agent, and sensuctl.
 
-Add an `app_tier` subscription to `/etc/sensu/agent.yml`:
+Use [sensuctl][15] to add an `app_tier` subscription to the sensu-centos entity the Sensu agent is observing:
 
 {{< code shell >}}
-subscriptions:
-  - "app_tier"
+sensuctl entity update sensu-centos
 {{< /code >}}
 
-Restart the Sensu agent to apply the configuration change:
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `app_tier` and press enter.
 
-{{< code shell >}}
-sudo systemctl restart sensu-agent
-{{< /code >}}
-
-Run these commands to ensure Sensu services are running:
+Run these commands to confirm both Sensu services are running:
 
 {{< code shell >}}
 systemctl status sensu-backend
@@ -153,7 +156,7 @@ Install Grafana:
 sudo yum install -y https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4-1.x86_64.rpm
 {{< /code >}}
 
-Change Grafana's listen port so that it does not conflict with the Sensu web UI:
+Change Grafana's listen port so that it does not conflict with the Sensu [web UI][14]:
 
 {{< code shell >}}
 sudo sed -i 's/^;http_port = 3000/http_port = 4000/' /etc/grafana/grafana.ini
@@ -189,7 +192,7 @@ sudo systemctl start grafana-server
 
 ### Create a Sensu InfluxDB handler asset
 
-Create a file named `asset_influxdb` that contains the following dynamic runtime asset definition:
+Create a file named `asset_influxdb.yml` or `asset_influxdb.json` that contains the following [dynamic runtime asset][11] definition:
 
 {{< language-toggle >}}
 
@@ -225,7 +228,7 @@ spec:
 
 ### Create a Sensu handler
 
-Create a file named `handler` that contains the following handler definition:
+Create a file named `handler.yml` or `handler.json` that contains the following [handler][12] definition:
 
 {{< language-toggle >}}
 
@@ -269,17 +272,25 @@ spec:
 **PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
 {{% /notice %}}
 
-Use `sensuctl` to add the handler and the dynamic runtime asset to Sensu:
+Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
-{{< code shell >}}
-sensuctl create --file handler --file asset_influxdb
+{{< language-toggle >}}
+
+{{< code shell "YAML" >}}
+sensuctl create --file handler.yml --file asset_influxdb.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file handler.json --file asset_influxdb.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Collect Prometheus metrics with Sensu
 
 ### Create a Sensu Prometheus Collector asset
 
-Create a file named `asset_prometheus` that contains the following handler definition:
+Create a file named `asset_prometheus.yml` or `asset_prometheus.json` that contains the following [dynamic runtime asset][11] definition:
 
 {{< language-toggle >}}
 
@@ -314,7 +325,7 @@ spec:
 
 ### Add a Sensu check to complete the pipeline
 
-Create a file named `check` that contains the following check definition:
+Create a file named `check.yml` or `check.json` that contains the following [check][13] definition:
 
 {{< language-toggle >}}
 
@@ -371,13 +382,21 @@ spec:
 
 {{< /language-toggle >}}
 
-Use `sensuctl` to add the check to Sensu:
+Use `sensuctl` to add the check and dynamic runtime asset to Sensu:
 
-{{< code shell >}}
-sensuctl create --file check --file asset_prometheus
+{{< language-toggle >}}
+
+{{< code shell "YAML" >}}
+sensuctl create --file check.yml --file asset_prometheus.yml
 {{< /code >}}
 
-Open the Sensu web UI to see the events generated by the `prometheus_metrics` check.
+{{< code shell "JSON" >}}
+sensuctl create --file check.json --file asset_prometheus.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Open the Sensu [web UI][14] to see the events generated by the `prometheus_metrics` check.
 Visit http://127.0.0.1:3000, and log in as the admin user (created during the [initialization step][8] when you installed the Sensu backend).
 
 You can also see the metric event data using sensuctl.
@@ -428,7 +447,7 @@ You should now have a working set-up with Prometheus scraping metrics.
 The Sensu Prometheus Collector runs via a Sensu check and collects metrics from the Prometheus API.
 The metrics are handled by the InfluxDB handler, sent to InfluxDB, and visualized by a Grafana dashboard.
 
-You can plug the Sensu Prometheus Collector into your Sensu ecosystem.
+You can add the Sensu Prometheus Collector to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
@@ -436,8 +455,15 @@ Prometheus has a [comprehensive list][7] of additional exporters to pull in metr
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-prometheus-collector/
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
-[4]: ../../operations/deploy-sensu/install-sensu/
+[4]: ../../../operations/deploy-sensu/install-sensu/
 [5]: https://github.com/prometheus/node_exporter/
 [6]: https://github.com/google/cadvisor/
 [7]: https://prometheus.io/docs/instrumenting/exporters/
-[8]: ../../operations/deploy-sensu/install-sensu/#3-initialize
+[8]: ../../../operations/deploy-sensu/install-sensu/#3-initialize
+[9]: ../../../operations/monitoring-as-code/
+[10]: ../metrics/
+[11]: ../../../plugins/assets/
+[12]: ../../observe-process/handlers/
+[13]: ../checks/
+[14]: ../../../web-ui/
+[15]: ../../../sensuctl/

--- a/content/sensu-go/6.1/learn/_index.md
+++ b/content/sensu-go/6.1/learn/_index.md
@@ -35,7 +35,7 @@ The live demo also gives you a chance to try commands with [sensuctl][8], the Se
 ## Sensu sandbox
 
 For further learning opportunities, download the [Sensu sandbox][4].
-Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] with Sensu.
 
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
@@ -45,6 +45,5 @@ We also have a GitHub lesson that guides you through [deploying a Sensu cluster 
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/
-[6]: prometheus-metrics/
 [7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
 [8]: ../sensuctl/

--- a/content/sensu-go/6.1/learn/sandbox.md
+++ b/content/sensu-go/6.1/learn/sandbox.md
@@ -22,14 +22,6 @@ The Learn Sensu sandbox is a CentOS 7 virtual machine pre-installed with Sensu, 
 Follow the instructions for [Getting Started with Sensu Go on Kubernetes][2] to deploy a Sensu cluster and an example application (NGINX) into Kubernetes with a Sensu agent sidecar.
 You'll also learn to use sensuctl to configure a Nagios-style monitoring check for the example application.
 
-## Collect metrics
-
-The Prometheus ecosystem's exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Follow [Collect Prometheus metrics with Sensu][3] to run Sensu and Prometheus in parallel and make use of environments where you've already deployed Prometheus.
-
-Learn to configure the Sensu Prometheus Collector check plugin to collect metrics from a Prometheus exporter or the Prometheus query API.
-Then, use Sensu to route the collected metrics to the time-series database InfluxDB and query InfluxDB to display the collected metrics with Grafana.
-
 ## Upgrade from Sensu Core 1.x to Sensu Go
 
 Use the [Sensu translator][4] to translate check configurations from Sensu Core 1.x to Sensu Go and learn how to visually inspect and adjust check token substitution and extended attributes to make sure your Core checks work properly in Sensu Go.
@@ -37,5 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[3]: ../../learn/prometheus-metrics/
 [4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
@@ -513,7 +513,7 @@ The event specification describes [metrics attributes in events][5].
 [4]: #extract-metrics-from-check-output
 [5]: ../../observe-events/events/#metrics
 [6]: #metric-check-example
-[7]: ../../../learn/prometheus-metrics/
+[7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/
 [9]: #supported-output-metric-formats
 [10]: ../checks/#output-metric-format

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -1,17 +1,24 @@
 ---
 title: "Collect Prometheus metrics with Sensu"
-version: "6.3"
+linkTitle: "Collect Prometheus Metrics"
+guide_title: "Collect Prometheus metrics with Sensu"
+type: "guide"
 description: "The Sensu Prometheus Collector is a check plugin that collects metrics from a Prometheus exporter or the Prometheus query API. This allows Sensu to route the collected metrics to a time-series database, like InfluxDB. Follow this guide to start collecting Prometheus metrics with Sensu."
+weight: 55
+version: "6.1"
 product: "Sensu Go"
 platformContent: false
+menu:
+  sensu-go-6.1:
+    parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects metrics from a [Prometheus exporter][2] or the [Prometheus query API][3].
+The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
 This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.  
+Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
 
 This guide uses CentOS 7 as the operating system with all components running on the same compute resource.
 Commands and steps may change for different distributions or if components are running on different compute resources.
@@ -75,20 +82,16 @@ vagrant   7647  3937  2 22:23 pts/0    00:00:00 ./prometheus --config.file=prome
 
 Follow the RHEL/CentOS [install instructions][4] for the Sensu backend, the Sensu agent, and sensuctl.
 
-Add an `app_tier` subscription to `/etc/sensu/agent.yml`:
+Use [sensuctl][15] to add an `app_tier` subscription to the sensu-centos entity the Sensu agent is observing:
 
 {{< code shell >}}
-subscriptions:
-  - "app_tier"
+sensuctl entity update sensu-centos
 {{< /code >}}
 
-Restart the Sensu agent to apply the configuration change:
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `app_tier` and press enter.
 
-{{< code shell >}}
-sudo systemctl restart sensu-agent
-{{< /code >}}
-
-Run these commands to ensure Sensu services are running:
+Run these commands to confirm both Sensu services are running:
 
 {{< code shell >}}
 systemctl status sensu-backend
@@ -153,7 +156,7 @@ Install Grafana:
 sudo yum install -y https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4-1.x86_64.rpm
 {{< /code >}}
 
-Change Grafana's listen port so that it does not conflict with the Sensu web UI:
+Change Grafana's listen port so that it does not conflict with the Sensu [web UI][14]:
 
 {{< code shell >}}
 sudo sed -i 's/^;http_port = 3000/http_port = 4000/' /etc/grafana/grafana.ini
@@ -189,7 +192,7 @@ sudo systemctl start grafana-server
 
 ### Create a Sensu InfluxDB handler asset
 
-Create a file named `asset_influxdb` that contains the following dynamic runtime asset definition:
+Create a file named `asset_influxdb.yml` or `asset_influxdb.json` that contains the following [dynamic runtime asset][11] definition:
 
 {{< language-toggle >}}
 
@@ -225,7 +228,7 @@ spec:
 
 ### Create a Sensu handler
 
-Create a file named `handler` that contains the following handler definition:
+Create a file named `handler.yml` or `handler.json` that contains the following [handler][12] definition:
 
 {{< language-toggle >}}
 
@@ -269,17 +272,25 @@ spec:
 **PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
 {{% /notice %}}
 
-Use `sensuctl` to add the handler and the dynamic runtime asset to Sensu:
+Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
-{{< code shell >}}
-sensuctl create --file handler --file asset_influxdb
+{{< language-toggle >}}
+
+{{< code shell "YAML" >}}
+sensuctl create --file handler.yml --file asset_influxdb.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file handler.json --file asset_influxdb.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Collect Prometheus metrics with Sensu
 
 ### Create a Sensu Prometheus Collector asset
 
-Create a file named `asset_prometheus` that contains the following handler definition:
+Create a file named `asset_prometheus.yml` or `asset_prometheus.json` that contains the following [dynamic runtime asset][11] definition:
 
 {{< language-toggle >}}
 
@@ -314,7 +325,7 @@ spec:
 
 ### Add a Sensu check to complete the pipeline
 
-Create a file named `check` that contains the following check definition:
+Create a file named `check.yml` or `check.json` that contains the following [check][13] definition:
 
 {{< language-toggle >}}
 
@@ -371,13 +382,21 @@ spec:
 
 {{< /language-toggle >}}
 
-Use `sensuctl` to add the check to Sensu:
+Use `sensuctl` to add the check and dynamic runtime asset to Sensu:
 
-{{< code shell >}}
-sensuctl create --file check --file asset_prometheus
+{{< language-toggle >}}
+
+{{< code shell "YAML" >}}
+sensuctl create --file check.yml --file asset_prometheus.yml
 {{< /code >}}
 
-Open the Sensu web UI to see the events generated by the `prometheus_metrics` check.
+{{< code shell "JSON" >}}
+sensuctl create --file check.json --file asset_prometheus.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Open the Sensu [web UI][14] to see the events generated by the `prometheus_metrics` check.
 Visit http://127.0.0.1:3000, and log in as the admin user (created during the [initialization step][8] when you installed the Sensu backend).
 
 You can also see the metric event data using sensuctl.
@@ -428,7 +447,7 @@ You should now have a working set-up with Prometheus scraping metrics.
 The Sensu Prometheus Collector runs via a Sensu check and collects metrics from the Prometheus API.
 The metrics are handled by the InfluxDB handler, sent to InfluxDB, and visualized by a Grafana dashboard.
 
-You can plug the Sensu Prometheus Collector into your Sensu ecosystem.
+You can add the Sensu Prometheus Collector to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
@@ -436,8 +455,15 @@ Prometheus has a [comprehensive list][7] of additional exporters to pull in metr
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-prometheus-collector/
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
-[4]: ../../operations/deploy-sensu/install-sensu/
+[4]: ../../../operations/deploy-sensu/install-sensu/
 [5]: https://github.com/prometheus/node_exporter/
 [6]: https://github.com/google/cadvisor/
 [7]: https://prometheus.io/docs/instrumenting/exporters/
-[8]: ../../operations/deploy-sensu/install-sensu/#3-initialize
+[8]: ../../../operations/deploy-sensu/install-sensu/#3-initialize
+[9]: ../../../operations/monitoring-as-code/
+[10]: ../metrics/
+[11]: ../../../plugins/assets/
+[12]: ../../observe-process/handlers/
+[13]: ../checks/
+[14]: ../../../web-ui/
+[15]: ../../../sensuctl/

--- a/content/sensu-go/6.2/learn/_index.md
+++ b/content/sensu-go/6.2/learn/_index.md
@@ -35,7 +35,7 @@ The live demo also gives you a chance to try commands with [sensuctl][8], the Se
 ## Sensu sandbox
 
 For further learning opportunities, download the [Sensu sandbox][4].
-Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] with Sensu.
 
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
@@ -45,6 +45,5 @@ We also have a GitHub lesson that guides you through [deploying a Sensu cluster 
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/
-[6]: prometheus-metrics/
 [7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
 [8]: ../sensuctl/

--- a/content/sensu-go/6.2/learn/sandbox.md
+++ b/content/sensu-go/6.2/learn/sandbox.md
@@ -22,14 +22,6 @@ The Learn Sensu sandbox is a CentOS 7 virtual machine pre-installed with Sensu, 
 Follow the instructions for [Getting Started with Sensu Go on Kubernetes][2] to deploy a Sensu cluster and an example application (NGINX) into Kubernetes with a Sensu agent sidecar.
 You'll also learn to use sensuctl to configure a Nagios-style monitoring check for the example application.
 
-## Collect metrics
-
-The Prometheus ecosystem's exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Follow [Collect Prometheus metrics with Sensu][3] to run Sensu and Prometheus in parallel and make use of environments where you've already deployed Prometheus.
-
-Learn to configure the Sensu Prometheus Collector check plugin to collect metrics from a Prometheus exporter or the Prometheus query API.
-Then, use Sensu to route the collected metrics to the time-series database InfluxDB and query InfluxDB to display the collected metrics with Grafana.
-
 ## Upgrade from Sensu Core 1.x to Sensu Go
 
 Use the [Sensu translator][4] to translate check configurations from Sensu Core 1.x to Sensu Go and learn how to visually inspect and adjust check token substitution and extended attributes to make sure your Core checks work properly in Sensu Go.
@@ -37,5 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[3]: ../../learn/prometheus-metrics/
 [4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -513,7 +513,7 @@ The event specification describes [metrics attributes in events][5].
 [4]: #extract-metrics-from-check-output
 [5]: ../../observe-events/events/#metrics
 [6]: #metric-check-example
-[7]: ../../../learn/prometheus-metrics/
+[7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/
 [9]: #supported-output-metric-formats
 [10]: ../checks/#output-metric-format

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -1,17 +1,24 @@
 ---
 title: "Collect Prometheus metrics with Sensu"
-version: "6.1"
+linkTitle: "Collect Prometheus Metrics"
+guide_title: "Collect Prometheus metrics with Sensu"
+type: "guide"
 description: "The Sensu Prometheus Collector is a check plugin that collects metrics from a Prometheus exporter or the Prometheus query API. This allows Sensu to route the collected metrics to a time-series database, like InfluxDB. Follow this guide to start collecting Prometheus metrics with Sensu."
+weight: 55
+version: "6.2"
 product: "Sensu Go"
 platformContent: false
+menu:
+  sensu-go-6.2:
+    parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects metrics from a [Prometheus exporter][2] or the [Prometheus query API][3].
+The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
 This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.  
+Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
 
 This guide uses CentOS 7 as the operating system with all components running on the same compute resource.
 Commands and steps may change for different distributions or if components are running on different compute resources.
@@ -75,20 +82,16 @@ vagrant   7647  3937  2 22:23 pts/0    00:00:00 ./prometheus --config.file=prome
 
 Follow the RHEL/CentOS [install instructions][4] for the Sensu backend, the Sensu agent, and sensuctl.
 
-Add an `app_tier` subscription to `/etc/sensu/agent.yml`:
+Use [sensuctl][15] to add an `app_tier` subscription to the sensu-centos entity the Sensu agent is observing:
 
 {{< code shell >}}
-subscriptions:
-  - "app_tier"
+sensuctl entity update sensu-centos
 {{< /code >}}
 
-Restart the Sensu agent to apply the configuration change:
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `app_tier` and press enter.
 
-{{< code shell >}}
-sudo systemctl restart sensu-agent
-{{< /code >}}
-
-Run these commands to ensure Sensu services are running:
+Run these commands to confirm both Sensu services are running:
 
 {{< code shell >}}
 systemctl status sensu-backend
@@ -153,7 +156,7 @@ Install Grafana:
 sudo yum install -y https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4-1.x86_64.rpm
 {{< /code >}}
 
-Change Grafana's listen port so that it does not conflict with the Sensu web UI:
+Change Grafana's listen port so that it does not conflict with the Sensu [web UI][14]:
 
 {{< code shell >}}
 sudo sed -i 's/^;http_port = 3000/http_port = 4000/' /etc/grafana/grafana.ini
@@ -189,7 +192,7 @@ sudo systemctl start grafana-server
 
 ### Create a Sensu InfluxDB handler asset
 
-Create a file named `asset_influxdb` that contains the following dynamic runtime asset definition:
+Create a file named `asset_influxdb.yml` or `asset_influxdb.json` that contains the following [dynamic runtime asset][11] definition:
 
 {{< language-toggle >}}
 
@@ -225,7 +228,7 @@ spec:
 
 ### Create a Sensu handler
 
-Create a file named `handler` that contains the following handler definition:
+Create a file named `handler.yml` or `handler.json` that contains the following [handler][12] definition:
 
 {{< language-toggle >}}
 
@@ -269,17 +272,25 @@ spec:
 **PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
 {{% /notice %}}
 
-Use `sensuctl` to add the handler and the dynamic runtime asset to Sensu:
+Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
-{{< code shell >}}
-sensuctl create --file handler --file asset_influxdb
+{{< language-toggle >}}
+
+{{< code shell "YAML" >}}
+sensuctl create --file handler.yml --file asset_influxdb.yml
 {{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file handler.json --file asset_influxdb.json
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Collect Prometheus metrics with Sensu
 
 ### Create a Sensu Prometheus Collector asset
 
-Create a file named `asset_prometheus` that contains the following handler definition:
+Create a file named `asset_prometheus.yml` or `asset_prometheus.json` that contains the following [dynamic runtime asset][11] definition:
 
 {{< language-toggle >}}
 
@@ -314,7 +325,7 @@ spec:
 
 ### Add a Sensu check to complete the pipeline
 
-Create a file named `check` that contains the following check definition:
+Create a file named `check.yml` or `check.json` that contains the following [check][13] definition:
 
 {{< language-toggle >}}
 
@@ -371,13 +382,21 @@ spec:
 
 {{< /language-toggle >}}
 
-Use `sensuctl` to add the check to Sensu:
+Use `sensuctl` to add the check and dynamic runtime asset to Sensu:
 
-{{< code shell >}}
-sensuctl create --file check --file asset_prometheus
+{{< language-toggle >}}
+
+{{< code shell "YAML" >}}
+sensuctl create --file check.yml --file asset_prometheus.yml
 {{< /code >}}
 
-Open the Sensu web UI to see the events generated by the `prometheus_metrics` check.
+{{< code shell "JSON" >}}
+sensuctl create --file check.json --file asset_prometheus.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Open the Sensu [web UI][14] to see the events generated by the `prometheus_metrics` check.
 Visit http://127.0.0.1:3000, and log in as the admin user (created during the [initialization step][8] when you installed the Sensu backend).
 
 You can also see the metric event data using sensuctl.
@@ -428,7 +447,7 @@ You should now have a working set-up with Prometheus scraping metrics.
 The Sensu Prometheus Collector runs via a Sensu check and collects metrics from the Prometheus API.
 The metrics are handled by the InfluxDB handler, sent to InfluxDB, and visualized by a Grafana dashboard.
 
-You can plug the Sensu Prometheus Collector into your Sensu ecosystem.
+You can add the Sensu Prometheus Collector to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
@@ -436,8 +455,15 @@ Prometheus has a [comprehensive list][7] of additional exporters to pull in metr
 [1]: https://bonsai.sensu.io/assets/sensu/sensu-prometheus-collector/
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
-[4]: ../../operations/deploy-sensu/install-sensu/
+[4]: ../../../operations/deploy-sensu/install-sensu/
 [5]: https://github.com/prometheus/node_exporter/
 [6]: https://github.com/google/cadvisor/
 [7]: https://prometheus.io/docs/instrumenting/exporters/
-[8]: ../../operations/deploy-sensu/install-sensu/#3-initialize
+[8]: ../../../operations/deploy-sensu/install-sensu/#3-initialize
+[9]: ../../../operations/monitoring-as-code/
+[10]: ../metrics/
+[11]: ../../../plugins/assets/
+[12]: ../../observe-process/handlers/
+[13]: ../checks/
+[14]: ../../../web-ui/
+[15]: ../../../sensuctl/

--- a/content/sensu-go/6.3/learn/_index.md
+++ b/content/sensu-go/6.3/learn/_index.md
@@ -35,7 +35,7 @@ The live demo also gives you a chance to try commands with [sensuctl][8], the Se
 ## Sensu sandbox
 
 For further learning opportunities, download the [Sensu sandbox][4].
-Follow the sandbox lessons to [build your first monitoring and observability workflow][5] and [collect Prometheus metrics][6] with a Sensu check plugin.
+Follow the sandbox lessons to [build your first monitoring and observability workflow][5] with Sensu.
 
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
@@ -45,6 +45,5 @@ We also have a GitHub lesson that guides you through [deploying a Sensu cluster 
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/
-[6]: prometheus-metrics/
 [7]: https://github.com/sensu/sensu-k8s-quick-start#getting-started-with-sensu-go-on-kubernetes
 [8]: ../sensuctl/

--- a/content/sensu-go/6.3/learn/sandbox.md
+++ b/content/sensu-go/6.3/learn/sandbox.md
@@ -22,14 +22,6 @@ The Learn Sensu sandbox is a CentOS 7 virtual machine pre-installed with Sensu, 
 Follow the instructions for [Getting Started with Sensu Go on Kubernetes][2] to deploy a Sensu cluster and an example application (NGINX) into Kubernetes with a Sensu agent sidecar.
 You'll also learn to use sensuctl to configure a Nagios-style monitoring check for the example application.
 
-## Collect metrics
-
-The Prometheus ecosystem's exporters expose metrics that Sensu can collect and route to one or more time-series databases.
-Follow [Collect Prometheus metrics with Sensu][3] to run Sensu and Prometheus in parallel and make use of environments where you've already deployed Prometheus.
-
-Learn to configure the Sensu Prometheus Collector check plugin to collect metrics from a Prometheus exporter or the Prometheus query API.
-Then, use Sensu to route the collected metrics to the time-series database InfluxDB and query InfluxDB to display the collected metrics with Grafana.
-
 ## Upgrade from Sensu Core 1.x to Sensu Go
 
 Use the [Sensu translator][4] to translate check configurations from Sensu Core 1.x to Sensu Go and learn how to visually inspect and adjust check token substitution and extended attributes to make sure your Core checks work properly in Sensu Go.
@@ -37,5 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[3]: ../../learn/prometheus-metrics/
 [4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -513,7 +513,7 @@ The event specification describes [metrics attributes in events][5].
 [4]: #extract-metrics-from-check-output
 [5]: ../../observe-events/events/#metrics
 [6]: #metric-check-example
-[7]: ../../../learn/prometheus-metrics/
+[7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/
 [9]: #supported-output-metric-formats
 [10]: ../checks/#output-metric-format

--- a/static.json
+++ b/static.json
@@ -267,6 +267,14 @@
             "url": "/sensu-go/5.21/api",
             "status": 301
         },
+        "~ ^/sensu-go/latest/learn/prometheus-metrics/?$": {
+            "url": "/sensu-go/latest/observability-pipeline/observe-schedule/prometheus-metrics",
+            "status": 301
+        },
+        "~ ^/sensu-go/6.[0-9]/?((?<=\/).*)?/learn/prometheus-metrics/?$": {
+            "url": "/sensu-go/latest/observability-pipeline/observe-schedule/prometheus-metrics",
+            "status": 301
+        },
         "~ ^/sensu-go/latest/reference/agent/?$": {
             "url": "/sensu-go/latest/observability-pipeline/observe-schedule/agent",
             "status": 301


### PR DESCRIPTION
## Description
- Updates Collect Prometheus metrics with Sensu to update the agent entity's subscriptions using sensuctl rather than by editing the agent config file.
- Moves Collect Prometheus metrics with Sensu from the Learn category to the Observability Pipeline > Schedule subcategory
- Updates static.json to redirect from Learn category location for all 6.x docs
- Propagates changes to all 6.x docs

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3025