### PR TITLE
Consolidate services check commands in Prom metrics guide

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -91,14 +91,10 @@ sensuctl entity update sensu-centos
 - For `Entity Class`, press enter.
 - For `Subscriptions`, type `app_tier` and press enter.
 
-Run these commands to confirm both Sensu services are running:
+Run this command to confirm both Sensu services are running:
 
 {{< code shell >}}
-systemctl status sensu-backend
-{{< /code >}}
-
-{{< code shell >}}
-systemctl status sensu-agent
+systemctl status sensu-backend && systemctl status sensu-agent
 {{< /code >}}
 
 ### Install and configure InfluxDB

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -91,14 +91,10 @@ sensuctl entity update sensu-centos
 - For `Entity Class`, press enter.
 - For `Subscriptions`, type `app_tier` and press enter.
 
-Run these commands to confirm both Sensu services are running:
+Run this command to confirm both Sensu services are running:
 
 {{< code shell >}}
-systemctl status sensu-backend
-{{< /code >}}
-
-{{< code shell >}}
-systemctl status sensu-agent
+systemctl status sensu-backend && systemctl status sensu-agent
 {{< /code >}}
 
 ### Install and configure InfluxDB

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -91,14 +91,10 @@ sensuctl entity update sensu-centos
 - For `Entity Class`, press enter.
 - For `Subscriptions`, type `app_tier` and press enter.
 
-Run these commands to confirm both Sensu services are running:
+Run this command to confirm both Sensu services are running:
 
 {{< code shell >}}
-systemctl status sensu-backend
-{{< /code >}}
-
-{{< code shell >}}
-systemctl status sensu-agent
+systemctl status sensu-backend && systemctl status sensu-agent
 {{< /code >}}
 
 ### Install and configure InfluxDB

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -91,14 +91,10 @@ sensuctl entity update sensu-centos
 - For `Entity Class`, press enter.
 - For `Subscriptions`, type `app_tier` and press enter.
 
-Run these commands to confirm both Sensu services are running:
+Run this command to confirm both Sensu services are running:
 
 {{< code shell >}}
-systemctl status sensu-backend
-{{< /code >}}
-
-{{< code shell >}}
-systemctl status sensu-agent
+systemctl status sensu-backend && systemctl status sensu-agent
 {{< /code >}}
 
 ### Install and configure InfluxDB


### PR DESCRIPTION
## Description
Consolidates the two commands to confirm Sensu services are running into a single command in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/prometheus-metrics/#install-and-configure-sensu-go.

## Motivation and Context
Make the guide a little more streamlined
