### PR TITLE
Move handler templates guide up within the Process category

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 80
+weight: 55
 version: "6.0"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 80
+weight: 55
 version: "6.1"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 80
+weight: 55
 version: "6.2"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 80
+weight: 55
 version: "6.3"
 product: "Sensu Go"
 menu:


### PR DESCRIPTION
## Description
Moves the hander templates guide up to follow the other handler guides in the Process sub-category. This matches the way we've organized content within other categories (major references followed by relevant guides; other references followed by their relevant guides)

## Motivation and Context
Noticed when working on something else