### PR TITLE
Update instructions for changing attributes for an existing agent entity

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -314,7 +314,7 @@ For complex, non-identifying metadata that you will *not* need to use in respons
 ### Proxy entity labels {#proxy-entities-managed}
 
 For entities with class `proxy`, you can create and manage labels with sensuctl.
-For example, to create a proxy entity with a `url` label using sensuctl `create`, create a file called `example.json` with an entity definition that includes `labels`:
+For example, to create a proxy entity with a `url` label using sensuctl `create`, create a file named `example.yml` or `example.json` with an entity definition that includes `labels`:
 
 {{< language-toggle >}}
 
@@ -375,11 +375,11 @@ Then run `sensuctl create` to create the entity based on the definition:
 {{< language-toggle >}}
 
 {{< code shell "YML">}}
-sensuctl create --file entity.yml
+sensuctl create --file example.yml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl create --file entity.json
+sensuctl create --file example.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -437,7 +437,7 @@ See [Monitor external resources with proxy requests and entities][17] for detail
 
 ### Agent entity labels {#agent-entities-managed}
 
-For entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
+For new entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
 For example, to add a `url` label, open `/etc/sensu/agent.yml` and add configuration for `labels`:
 
 {{< code yml >}}
@@ -450,6 +450,11 @@ Or, use `sensu-agent start` configuration flags:
 {{< code shell >}}
 sensu-agent start --labels url=sensu.docs.io
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+{{% /notice %}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -181,18 +181,17 @@ The response should list `check-sensu-site`:
 ### Add the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `proxy`.
-After you [install an agent][19], open `/etc/sensu/agent.yml` and add the `proxy` subscription so the subscription configuration looks like this:
+After you [install an agent][19], use sensuctl to add the `proxy` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - proxy
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `proxy` and press enter.
 
 ### Validate the check
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -207,18 +207,17 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ## Configure the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `system`.
-After you [install an agent][4], open `/etc/sensu/agent.yml` and add the `system` subscription so the subscription configuration looks like this:
+After you [install an agent][4], use sensuctl to add the `system` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - system
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `system` and press enter.
 
 ## Validate the check
 

--- a/content/sensu-go/6.0/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.0/web-ui/view-manage-resources.md
@@ -34,7 +34,7 @@ Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
 
 ## Manage entities
 
-Silence and delete Sensu entities in the web UI Entities page.
+Edit, silence, and delete Sensu entities in the web UI Entities page.
 
 ## Manage silences
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -437,7 +437,7 @@ See [Monitor external resources with proxy requests and entities][17] for detail
 
 ### Agent entity labels {#agent-entities-managed}
 
-For entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
+For new entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
 For example, to add a `url` label, open `/etc/sensu/agent.yml` and add configuration for `labels`:
 
 {{< code yml >}}
@@ -450,6 +450,11 @@ Or, use `sensu-agent start` configuration flags:
 {{< code shell >}}
 sensu-agent start --labels url=sensu.docs.io
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+{{% /notice %}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -181,18 +181,17 @@ The response should list `check-sensu-site`:
 ### Add the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `proxy`.
-After you [install an agent][19], open `/etc/sensu/agent.yml` and add the `proxy` subscription so the subscription configuration looks like this:
+After you [install an agent][19], use sensuctl to add the `proxy` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - proxy
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `proxy` and press enter.
 
 ### Validate the check
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -207,18 +207,17 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ## Configure the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `system`.
-After you [install an agent][4], open `/etc/sensu/agent.yml` and add the `system` subscription so the subscription configuration looks like this:
+After you [install an agent][4], use sensuctl to add the `system` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - system
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `system` and press enter.
 
 ## Validate the check
 

--- a/content/sensu-go/6.1/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.1/web-ui/view-manage-resources.md
@@ -34,7 +34,7 @@ Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
 
 ## Manage entities
 
-Silence and delete Sensu entities in the web UI Entities page.
+Edit, silence, and delete Sensu entities in the web UI Entities page.
 
 ## Manage silences
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -454,7 +454,7 @@ See [Monitor external resources with proxy requests and entities][17] for detail
 
 ### Agent entity labels {#agent-entities-managed}
 
-For entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
+For new entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
 For example, to add a `url` label, open `/etc/sensu/agent.yml` and add configuration for `labels`:
 
 {{< code yml >}}
@@ -467,6 +467,11 @@ Or, use `sensu-agent start` configuration flags:
 {{< code shell >}}
 sensu-agent start --labels url=sensu.docs.io
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+{{% /notice %}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -181,18 +181,17 @@ The response should list `check-sensu-site`:
 ### Add the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `proxy`.
-After you [install an agent][19], open `/etc/sensu/agent.yml` and add the `proxy` subscription so the subscription configuration looks like this:
+After you [install an agent][19], use sensuctl to add the `proxy` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - proxy
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `proxy` and press enter.
 
 ### Validate the check
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -207,18 +207,17 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ## Configure the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `system`.
-After you [install an agent][4], open `/etc/sensu/agent.yml` and add the `system` subscription so the subscription configuration looks like this:
+After you [install an agent][4], use sensuctl to add the `system` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - system
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `system` and press enter.
 
 ## Validate the check
 

--- a/content/sensu-go/6.2/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.2/web-ui/view-manage-resources.md
@@ -34,7 +34,7 @@ Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
 
 ## Manage entities
 
-Silence and delete Sensu entities in the web UI Entities page.
+Edit, silence, and delete Sensu entities in the web UI Entities page.
 
 ## Manage silences
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -454,7 +454,7 @@ See [Monitor external resources with proxy requests and entities][17] for detail
 
 ### Agent entity labels {#agent-entities-managed}
 
-For entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
+For new entities with class `agent`, you can define entity attributes in the `/etc/sensu/agent.yml` configuration file.
 For example, to add a `url` label, open `/etc/sensu/agent.yml` and add configuration for `labels`:
 
 {{< code yml >}}
@@ -467,6 +467,11 @@ Or, use `sensu-agent start` configuration flags:
 {{< code shell >}}
 sensu-agent start --labels url=sensu.docs.io
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+{{% /notice %}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -181,18 +181,17 @@ The response should list `check-sensu-site`:
 ### Add the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `proxy`.
-After you [install an agent][19], open `/etc/sensu/agent.yml` and add the `proxy` subscription so the subscription configuration looks like this:
+After you [install an agent][19], use sensuctl to add the `proxy` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - proxy
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `proxy` and press enter.
 
 ### Validate the check
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -207,18 +207,17 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ## Configure the subscription
 
 To run the check, you'll need a Sensu agent with the subscription `system`.
-After you [install an agent][4], open `/etc/sensu/agent.yml` and add the `system` subscription so the subscription configuration looks like this:
+After you [install an agent][4], use sensuctl to add the `system` subscription to the entity the Sensu agent is observing.
 
-{{< code yml >}}
-subscriptions:
-  - system
-{{< /code >}}
-
-Then, restart the agent:
+In the following command, replace `ENTITY_NAME` with the name of the entity on your system.
+Then, run:
 
 {{< code shell >}}
-sudo service sensu-agent restart
+sensuctl entity update ENTITY_NAME
 {{< /code >}}
+
+- For `Entity Class`, press enter.
+- For `Subscriptions`, type `system` and press enter.
 
 ## Validate the check
 

--- a/content/sensu-go/6.3/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.3/web-ui/view-manage-resources.md
@@ -34,7 +34,7 @@ Resolve, re-run, silence, and delete Sensu events in the web UI Events page.
 
 ## Manage entities
 
-Silence and delete Sensu entities in the web UI Entities page.
+Edit, silence, and delete Sensu entities in the web UI Entities page.
 
 ## Manage silences
 


### PR DESCRIPTION
## Description
Updates instructions for 6.x docs to explain how to properly update attributes for an existing agent entity (with the post-6.x default being backend-managed entities).

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3056