### PR TITLE
Fix output_metric_handlers array formatting

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -205,7 +205,8 @@ spec:
   interval: 60
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: influx-db
+  output_metric_handlers:
+  - influx-db
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -239,7 +240,9 @@ spec:
     "interval": 60,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "influx-db",
+    "output_metric_handlers": [
+      "influx-db"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
@@ -51,7 +51,8 @@ spec:
   interval: 30
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: sensu-influxdb-handler
+  output_metric_handlers:
+  - sensu-influxdb-handler
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -85,7 +86,9 @@ spec:
     "interval": 30,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "sensu-influxdb-handler",
+    "output_metric_handlers": [
+      "sensu-influxdb-handler"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -205,7 +205,8 @@ spec:
   interval: 60
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: influx-db
+  output_metric_handlers:
+  - influx-db
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -239,7 +240,9 @@ spec:
     "interval": 60,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "influx-db",
+    "output_metric_handlers": [
+      "influx-db"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
@@ -51,7 +51,8 @@ spec:
   interval: 30
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: sensu-influxdb-handler
+  output_metric_handlers:
+  - sensu-influxdb-handler
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -85,7 +86,9 @@ spec:
     "interval": 30,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "sensu-influxdb-handler",
+    "output_metric_handlers": [
+      "sensu-influxdb-handler"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -205,7 +205,8 @@ spec:
   interval: 60
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: influx-db
+  output_metric_handlers:
+  - influx-db
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -239,7 +240,9 @@ spec:
     "interval": 60,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "influx-db",
+    "output_metric_handlers": [
+      "influx-db"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -51,7 +51,8 @@ spec:
   interval: 30
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: sensu-influxdb-handler
+  output_metric_handlers:
+  - sensu-influxdb-handler
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -85,7 +86,9 @@ spec:
     "interval": 30,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "sensu-influxdb-handler",
+    "output_metric_handlers": [
+      "sensu-influxdb-handler"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -205,7 +205,8 @@ spec:
   interval: 60
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: influx-db
+  output_metric_handlers:
+  - influx-db
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -239,7 +240,9 @@ spec:
     "interval": 60,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "influx-db",
+    "output_metric_handlers": [
+      "influx-db"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -51,7 +51,8 @@ spec:
   interval: 30
   low_flap_threshold: 0
   output_metric_format: influxdb_line
-  output_metric_handlers: sensu-influxdb-handler
+  output_metric_handlers:
+  - sensu-influxdb-handler
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -85,7 +86,9 @@ spec:
     "interval": 30,
     "low_flap_threshold": 0,
     "output_metric_format": "influxdb_line",
-    "output_metric_handlers": "sensu-influxdb-handler",
+    "output_metric_handlers": [
+      "sensu-influxdb-handler"
+    ],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,


### PR DESCRIPTION
## Description
Corrects formatting in metrics examples so that values are listed in an array.

## Motivation and Context
https://sensu.slack.com/archives/C3MHLUP46/p1615925467002500