### PR TITLE
Adjust the protip about sensuctl create -f in Prom metrics guide

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -268,10 +268,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
-{{% /notice %}}
-
 Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
 {{< language-toggle >}}
@@ -285,6 +281,11 @@ sensuctl create --file handler.json --file asset_influxdb.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+{{% notice protip %}}
+**PRO TIP**: `sensuctl create --file` also accepts files that contain multiple resources' definitions.
+You could save both the asset and handler definitions in a single file and use `sensuctl create --file FILE_NAME.EXT` to add them.
+{{% /notice %}}
 
 ## Collect Prometheus metrics with Sensu
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -268,10 +268,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
-{{% /notice %}}
-
 Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
 {{< language-toggle >}}
@@ -285,6 +281,11 @@ sensuctl create --file handler.json --file asset_influxdb.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+{{% notice protip %}}
+**PRO TIP**: `sensuctl create --file` also accepts files that contain multiple resources' definitions.
+You could save both the asset and handler definitions in a single file and use `sensuctl create --file FILE_NAME.EXT` to add them.
+{{% /notice %}}
 
 ## Collect Prometheus metrics with Sensu
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -268,10 +268,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
-{{% /notice %}}
-
 Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
 {{< language-toggle >}}
@@ -285,6 +281,11 @@ sensuctl create --file handler.json --file asset_influxdb.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+{{% notice protip %}}
+**PRO TIP**: `sensuctl create --file` also accepts files that contain multiple resources' definitions.
+You could save both the asset and handler definitions in a single file and use `sensuctl create --file FILE_NAME.EXT` to add them.
+{{% /notice %}}
 
 ## Collect Prometheus metrics with Sensu
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -268,10 +268,6 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: `sensuctl create -f` also accepts files that contain multiple resources' definitions.
-{{% /notice %}}
-
 Use `sensuctl` to add the handler and dynamic runtime asset to Sensu:
 
 {{< language-toggle >}}
@@ -285,6 +281,11 @@ sensuctl create --file handler.json --file asset_influxdb.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+{{% notice protip %}}
+**PRO TIP**: `sensuctl create --file` also accepts files that contain multiple resources' definitions.
+You could save both the asset and handler definitions in a single file and use `sensuctl create --file FILE_NAME.EXT` to add them.
+{{% /notice %}}
 
 ## Collect Prometheus metrics with Sensu
 


### PR DESCRIPTION
## Description
- Clarifies explanation in protip re: using a single file with multiple types of resource definitions with sensuctl create -f
- Moves protip to end of section (after the sensuctl create command)

## Motivation and Context
Noticed when working on something else