### PR TITLE
Add example for reusing cluster roles across namespaces in RBAC ref

### DIFF
--- a/content/sensu-go/6.0/web-ui/filter.md
+++ b/content/sensu-go/6.0/web-ui/filter.md
@@ -225,4 +225,4 @@ To delete a saved search:
 [10]: #examples
 [11]: ../../operations/control-access/rbac/#namespaced-resource-types
 [12]: ../../operations/control-access/rbac/#roles-and-cluster-roles
-[13]: ../../operations/control-access/rbac/#example-workflows
+[13]: ../../operations/control-access/rbac/#create-a-role-and-role-binding

--- a/content/sensu-go/6.1/operations/control-access/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/_index.md
@@ -157,7 +157,6 @@ Users do *not* need to provide the username prefix for the authentication provid
 [30]: ldap-auth/#ldap-specification
 [31]: ad-auth/#ad-configuration-examples
 [32]: ad-auth/#ad-specification
-[33]: rbac/#example-workflows
 [36]: ../../sensuctl/#first-time-setup-and-authentication
 [37]: ad-auth/
 [38]: ../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -237,4 +237,4 @@ You can sort all resources by name, but events and silences have additional sort
 [9]: #search-operators
 [11]: ../../operations/control-access/rbac/#namespaced-resource-types
 [12]: ../../operations/control-access/rbac/#roles-and-cluster-roles
-[13]: ../../operations/control-access/rbac/#example-workflows
+[13]: ../../operations/control-access/rbac/#create-a-role-and-role-binding

--- a/content/sensu-go/6.2/web-ui/search.md
+++ b/content/sensu-go/6.2/web-ui/search.md
@@ -237,4 +237,4 @@ You can sort all resources by name, but events and silences have additional sort
 [9]: #search-operators
 [11]: ../../operations/control-access/rbac/#namespaced-resource-types
 [12]: ../../operations/control-access/rbac/#roles-and-cluster-roles
-[13]: ../../operations/control-access/rbac/#example-workflows
+[13]: ../../operations/control-access/rbac/#create-a-role-and-role-binding

--- a/content/sensu-go/6.3/web-ui/search.md
+++ b/content/sensu-go/6.3/web-ui/search.md
@@ -237,4 +237,4 @@ You can sort all resources by name, but events and silences have additional sort
 [9]: #search-operators
 [11]: ../../operations/control-access/rbac/#namespaced-resource-types
 [12]: ../../operations/control-access/rbac/#roles-and-cluster-roles
-[13]: ../../operations/control-access/rbac/#example-workflows
+[13]: ../../operations/control-access/rbac/#create-a-role-and-role-binding


### PR DESCRIPTION
## Description
Adds a scenario description and example workflow for reusing cluster roles across namespaces at the end of the RBAC reference.

Also updates links throughout to remove example-workflows heading that I removed because I changed the H3 example titles to H2 so they'll be listed in the right-margin page TOC.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3012
