### PR TITLE
Update GitHub links that redirect to main

### DIFF
--- a/content/sensu-go/5.21/_index.md
+++ b/content/sensu-go/5.21/_index.md
@@ -72,7 +72,7 @@ Learn about [support packages](https://sensu.io/support) and [commercial feature
 [1]: get-started/
 [2]: https://www.influxdata.com/
 [3]: https://docs.sensu.io/plugins/latest/reference/
-[4]: https://www.github.com/sensu/sensu-go/blob/master/LICENSE/
+[4]: https://www.github.com/sensu/sensu-go/blob/main/LICENSE/
 [5]: https://www.github.com/sensu/sensu-go/
 [6]: operations/deploy-sensu/install-sensu#install-sensu-agents
 [7]: guides/monitor-external-resources/

--- a/content/sensu-go/5.21/get-started.md
+++ b/content/sensu-go/5.21/get-started.md
@@ -60,7 +60,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../reference/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
+[11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
 [12]: ../learn/learn-in-15/
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare

--- a/content/sensu-go/5.21/learn/sandbox.md
+++ b/content/sensu-go/5.21/learn/sandbox.md
@@ -38,4 +38,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
 [3]: ../../learn/prometheus-metrics/
-[4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/
+[4]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
@@ -383,7 +383,7 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [4]: https://etcd.io/docs/v3.3.13/
 [5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
-[7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
+[7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
 [8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
 [9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/5.21/platforms.md
+++ b/content/sensu-go/5.21/platforms.md
@@ -370,7 +370,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [13]: https://github.com/sensu/sensu-go-chef/
 [14]: https://github.com/sensu/sensu-puppet/
 [15]: https://sensu.io/enterprise/
-[16]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
+[16]: https://www.github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md
 [17]: https://github.com/jaredledvina/sensu-go-ansible/
 [18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.4/sensu-go_5.21.4_linux_armv7.tar.gz
 [20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.21.4/sensu-go_5.21.4_linux_amd64.zip

--- a/content/sensu-go/5.21/release-notes.md
+++ b/content/sensu-go/5.21/release-notes.md
@@ -1278,9 +1278,9 @@ To get started with Sensu Go:
 [2]: https://semver.org/spec/v2.0.0.html
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
-[5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
+[5]: https://www.github.com/sensu/sensu-go/blob/main/CHANGELOG.md#500---2018-11-30
 [6]: https://sensu.io/blog/sensu-go-is-here/
-[7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
+[7]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
 [10]: /sensu-go/5.1/reference/rbac#managing-users

--- a/content/sensu-go/6.0/_index.md
+++ b/content/sensu-go/6.0/_index.md
@@ -63,7 +63,7 @@ Sensu Go is the latest version of Sensu, designed to be portable, straightforwar
 [1]: get-started/
 [2]: https://www.influxdata.com/
 [3]: plugins/
-[4]: https://www.github.com/sensu/sensu-go/blob/master/LICENSE/
+[4]: https://www.github.com/sensu/sensu-go/blob/main/LICENSE/
 [5]: https://www.github.com/sensu/sensu-go/
 [6]: operations/deploy-sensu/cluster-sensu/
 [7]: #built-in-support-for-industry-standard-tools

--- a/content/sensu-go/6.0/get-started.md
+++ b/content/sensu-go/6.0/get-started.md
@@ -64,7 +64,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
+[11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
 [12]: ../learn/learn-in-15/
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare

--- a/content/sensu-go/6.0/learn/sandbox.md
+++ b/content/sensu-go/6.0/learn/sandbox.md
@@ -29,4 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/
+[4]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -390,7 +390,7 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [4]: https://etcd.io/docs/v3.3.13/
 [5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
-[7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
+[7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
 [8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
 [9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.0/platforms.md
+++ b/content/sensu-go/6.0/platforms.md
@@ -366,7 +366,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [13]: https://github.com/sensu/sensu-go-chef/
 [14]: https://github.com/sensu/sensu-puppet/
 [15]: https://sensu.io/enterprise/
-[16]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
+[16]: https://www.github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md
 [17]: https://github.com/jaredledvina/sensu-go-ansible/
 [18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.0.0/sensu-go_6.0.0_linux_armv7.tar.gz
 [20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.0.0/sensu-go_6.0.0_linux_amd64.zip

--- a/content/sensu-go/6.0/release-notes.md
+++ b/content/sensu-go/6.0/release-notes.md
@@ -1338,9 +1338,9 @@ To get started with Sensu Go:
 [2]: https://semver.org/spec/v2.0.0.html
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
-[5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
+[5]: https://www.github.com/sensu/sensu-go/blob/main/CHANGELOG.md#500---2018-11-30
 [6]: https://sensu.io/blog/sensu-go-is-here/
-[7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
+[7]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
 [10]: /sensu-go/5.1/reference/rbac#managing-users

--- a/content/sensu-go/6.1/_index.md
+++ b/content/sensu-go/6.1/_index.md
@@ -63,7 +63,7 @@ Sensu Go is the latest version of Sensu, designed to be portable, straightforwar
 [1]: get-started/
 [2]: https://www.influxdata.com/
 [3]: plugins/
-[4]: https://www.github.com/sensu/sensu-go/blob/master/LICENSE/
+[4]: https://www.github.com/sensu/sensu-go/blob/main/LICENSE/
 [5]: https://www.github.com/sensu/sensu-go/
 [6]: operations/deploy-sensu/cluster-sensu/
 [7]: #built-in-support-for-industry-standard-tools

--- a/content/sensu-go/6.1/get-started.md
+++ b/content/sensu-go/6.1/get-started.md
@@ -64,7 +64,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
+[11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
 [12]: ../learn/learn-in-15/
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare

--- a/content/sensu-go/6.1/learn/sandbox.md
+++ b/content/sensu-go/6.1/learn/sandbox.md
@@ -29,4 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/
+[4]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -390,7 +390,7 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [4]: https://etcd.io/docs/v3.3.13/
 [5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
-[7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
+[7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
 [8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
 [9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.1/platforms.md
+++ b/content/sensu-go/6.1/platforms.md
@@ -366,7 +366,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [13]: https://github.com/sensu/sensu-go-chef/
 [14]: https://github.com/sensu/sensu-puppet/
 [15]: https://sensu.io/enterprise/
-[16]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
+[16]: https://www.github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md
 [17]: https://github.com/jaredledvina/sensu-go-ansible/
 [18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.1.4/sensu-go_6.1.4_linux_armv7.tar.gz
 [20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.1.4/sensu-go_6.1.4_linux_amd64.zip

--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -1456,9 +1456,9 @@ To get started with Sensu Go:
 [2]: https://semver.org/spec/v2.0.0.html
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
-[5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
+[5]: https://www.github.com/sensu/sensu-go/blob/main/CHANGELOG.md#500---2018-11-30
 [6]: https://sensu.io/blog/sensu-go-is-here/
-[7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
+[7]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
 [10]: /sensu-go/5.1/reference/rbac#managing-users

--- a/content/sensu-go/6.2/_index.md
+++ b/content/sensu-go/6.2/_index.md
@@ -63,7 +63,7 @@ Sensu Go is the latest version of Sensu, designed to be portable, straightforwar
 [1]: get-started/
 [2]: https://www.influxdata.com/
 [3]: plugins/
-[4]: https://www.github.com/sensu/sensu-go/blob/master/LICENSE/
+[4]: https://www.github.com/sensu/sensu-go/blob/main/LICENSE/
 [5]: https://www.github.com/sensu/sensu-go/
 [6]: operations/deploy-sensu/cluster-sensu/
 [7]: #built-in-support-for-industry-standard-tools

--- a/content/sensu-go/6.2/get-started.md
+++ b/content/sensu-go/6.2/get-started.md
@@ -64,7 +64,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
+[11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
 [12]: ../learn/learn-in-15/
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare

--- a/content/sensu-go/6.2/learn/sandbox.md
+++ b/content/sensu-go/6.2/learn/sandbox.md
@@ -29,4 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/
+[4]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -390,7 +390,7 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [4]: https://etcd.io/docs/v3.3.13/
 [5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
-[7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
+[7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
 [8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
 [9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.2/platforms.md
+++ b/content/sensu-go/6.2/platforms.md
@@ -366,7 +366,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [13]: https://github.com/sensu/sensu-go-chef/
 [14]: https://github.com/sensu/sensu-puppet/
 [15]: https://sensu.io/enterprise/
-[16]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
+[16]: https://www.github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md
 [17]: https://github.com/jaredledvina/sensu-go-ansible/
 [18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.5/sensu-go_6.2.5_linux_armv7.tar.gz
 [20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.5/sensu-go_6.2.5_linux_amd64.zip

--- a/content/sensu-go/6.2/release-notes.md
+++ b/content/sensu-go/6.2/release-notes.md
@@ -1570,9 +1570,9 @@ To get started with Sensu Go:
 [2]: https://semver.org/spec/v2.0.0.html
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
-[5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
+[5]: https://www.github.com/sensu/sensu-go/blob/main/CHANGELOG.md#500---2018-11-30
 [6]: https://sensu.io/blog/sensu-go-is-here/
-[7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
+[7]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
 [10]: /sensu-go/5.1/reference/rbac#managing-users

--- a/content/sensu-go/6.3/_index.md
+++ b/content/sensu-go/6.3/_index.md
@@ -63,7 +63,7 @@ Sensu Go is the latest version of Sensu, designed to be portable, straightforwar
 [1]: get-started/
 [2]: https://www.influxdata.com/
 [3]: plugins/
-[4]: https://www.github.com/sensu/sensu-go/blob/master/LICENSE/
+[4]: https://www.github.com/sensu/sensu-go/blob/main/LICENSE/
 [5]: https://www.github.com/sensu/sensu-go/
 [6]: operations/deploy-sensu/cluster-sensu/
 [7]: #built-in-support-for-industry-standard-tools

--- a/content/sensu-go/6.3/get-started.md
+++ b/content/sensu-go/6.3/get-started.md
@@ -64,7 +64,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [8]: https://discourse.sensu.io/
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
-[11]: https://github.com/sensu/sensu-go/blob/master/README.md#building-from-source
+[11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
 [12]: ../learn/learn-in-15/
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare

--- a/content/sensu-go/6.3/learn/sandbox.md
+++ b/content/sensu-go/6.3/learn/sandbox.md
@@ -29,4 +29,4 @@ Use the [Sensu translator][4] to translate check configurations from Sensu Core 
 
 [1]: ../learn-sensu-sandbox/
 [2]: https://github.com/sensu/sensu-k8s-quick-start
-[4]: https://github.com/sensu/sandbox/tree/master/sensu-go/lesson_plans/check-upgrade/
+[4]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/lesson_plans/check-upgrade/

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -390,7 +390,7 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [4]: https://etcd.io/docs/v3.3.13/
 [5]: https://etcd.io/docs/v3.3.13/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
-[7]: https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml
+[7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
 [8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
 [9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.3/platforms.md
+++ b/content/sensu-go/6.3/platforms.md
@@ -366,7 +366,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [13]: https://github.com/sensu/sensu-go-chef/
 [14]: https://github.com/sensu/sensu-puppet/
 [15]: https://sensu.io/enterprise/
-[16]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
+[16]: https://www.github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md
 [17]: https://github.com/jaredledvina/sensu-go-ansible/
 [18]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.5/sensu-go_6.2.5_linux_armv7.tar.gz
 [20]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.2.5/sensu-go_6.2.5_linux_amd64.zip

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -1570,9 +1570,9 @@ To get started with Sensu Go:
 [2]: https://semver.org/spec/v2.0.0.html
 [3]: /sensu-go/5.1/installation/upgrade#upgrading-sensu-backend-binaries-to-5-1-0
 [4]: /sensu-go/5.1/reference/agent/
-[5]: https://www.github.com/sensu/sensu-go/blob/master/CHANGELOG.md#500---2018-11-30
+[5]: https://www.github.com/sensu/sensu-go/blob/main/CHANGELOG.md#500---2018-11-30
 [6]: https://sensu.io/blog/sensu-go-is-here/
-[7]: https://www.github.com/sensu/sandbox/tree/master/sensu-go/core/
+[7]: https://www.github.com/sensu/sandbox/tree/main/sensu-go/core/
 [8]: /sensu-go/5.0/installation/install-sensu/
 [9]: /sensu-go/5.0/guides/monitor-server-resources/
 [10]: /sensu-go/5.1/reference/rbac#managing-users


### PR DESCRIPTION
## Description
Fixes GitHub links throughout docs that point to `master` but redirect to `main`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3067
