### PR TITLE
Fix typo on troubleshooting page: crrent

### DIFF
--- a/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
@@ -570,7 +570,7 @@ To restore an etcd cluster with a database size that exceeds 2 GB:
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
 {{< /code >}}
 
-2. Compact to revision and substitute the crrent revision for `$rev`:
+2. Compact to revision and substitute the current revision for `$rev`:
 {{< code shell >}}
 etcdctl compact $rev
 {{< /code >}}

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -570,7 +570,7 @@ To restore an etcd cluster with a database size that exceeds 2 GB:
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
 {{< /code >}}
 
-2. Compact to revision and substitute the crrent revision for `$rev`:
+2. Compact to revision and substitute the current revision for `$rev`:
 {{< code shell >}}
 etcdctl compact $rev
 {{< /code >}}

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -570,7 +570,7 @@ To restore an etcd cluster with a database size that exceeds 2 GB:
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
 {{< /code >}}
 
-2. Compact to revision and substitute the crrent revision for `$rev`:
+2. Compact to revision and substitute the current revision for `$rev`:
 {{< code shell >}}
 etcdctl compact $rev
 {{< /code >}}

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -570,7 +570,7 @@ To restore an etcd cluster with a database size that exceeds 2 GB:
 etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9].*'
 {{< /code >}}
 
-2. Compact to revision and substitute the crrent revision for `$rev`:
+2. Compact to revision and substitute the current revision for `$rev`:
 {{< code shell >}}
 etcdctl compact $rev
 {{< /code >}}


### PR DESCRIPTION
## Description
Fix typo: `crrent` should be `current`

## Motivation and Context
Noticed while working on something else
