### PR TITLE
Update 404 page text to replace site directory with Sensu docs home page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,7 +4,7 @@
     <img alt="Sensu Go Lizy mascot image" title="404 Page Not Found" src="/images/idle-lizy.png">
     <h1>404</h1>
     <h2>Page Not Found</h2>
-    <p id="instructions">Try searching the docs below, or visit the <a href="/">site directory</a>.<p>
+    <p id="instructions">Try searching the docs below, or visit the <a href="/sensu-go/latest/">Sensu Go docs homepage</a>.<p>
 
     <div class="full-width-search">
       <input id="search" type="text" />
@@ -24,11 +24,11 @@
     // Add notice about new 6.x pages that aren't present in 5.x
     // TODO: Remove after all 5.x content is archived
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/sensu-go/latest/">Sensu Go docs homepage</a>.`
     }
 
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "plugins") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">site directory</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/sensu-go/latest/">Sensu Go docs homepage</a>.`
     }
 
     // Scope the search results to a product/version (dirty)

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,7 +4,7 @@
     <img alt="Sensu Go Lizy mascot image" title="404 Page Not Found" src="/images/idle-lizy.png">
     <h1>404</h1>
     <h2>Page Not Found</h2>
-    <p id="instructions">Try searching the docs below, or visit the <a href="/sensu-go/latest/">Sensu Go docs homepage</a>.<p>
+    <p id="instructions">Try searching the docs below, or visit the <a href="/">Sensu docs homepage</a>.<p>
 
     <div class="full-width-search">
       <input id="search" type="text" />
@@ -24,11 +24,11 @@
     // Add notice about new 6.x pages that aren't present in 5.x
     // TODO: Remove after all 5.x content is archived
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/sensu-go/latest/">Sensu Go docs homepage</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">Sensu docs homepage</a>.`
     }
 
     if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "plugins") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/sensu-go/latest/">Sensu Go docs homepage</a>.`
+      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">Sensu docs homepage</a>.`
     }
 
     // Scope the search results to a product/version (dirty)


### PR DESCRIPTION
## Description
- On 404 page, replaces "site directory" text with "Sensu docs home page"

## Motivation and Context
Noticed when working on something else