### PR TITLE
Update docs to encourage stronger dynamic passwords

### DIFF
--- a/content/sensu-go/6.0/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.0/operations/control-access/create-limited-service-accounts.md
@@ -44,7 +44,7 @@ A limited service account requires:
 1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
-sensuctl user create ec2-service --password='password'
+sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum | cut -d' ' -f1 | head -c 32)
 {{< /code >}}
 
    This command creates the following user definition:

--- a/content/sensu-go/6.0/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.0/operations/control-access/create-limited-service-accounts.md
@@ -41,7 +41,7 @@ A limited service account requires:
 **NOTE**: To use a service account to manage Sensu resources in more than one namespace, create a [cluster role](../rbac/#cluster-role-example) instead of a role and a [cluster role binding](../rbac/#cluster-role-binding-example) instead of a role binding.
 {{% /notice %}}
 
-1. Create a user with the username `ec2-service`:
+1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
 sensuctl user create ec2-service --password='password'

--- a/content/sensu-go/6.1/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.1/operations/control-access/create-limited-service-accounts.md
@@ -44,7 +44,7 @@ A limited service account requires:
 1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
-sensuctl user create ec2-service --password='password'
+sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum | cut -d' ' -f1 | head -c 32)
 {{< /code >}}
 
    This command creates the following user definition:

--- a/content/sensu-go/6.1/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.1/operations/control-access/create-limited-service-accounts.md
@@ -41,7 +41,7 @@ A limited service account requires:
 **NOTE**: To use a service account to manage Sensu resources in more than one namespace, create a [cluster role](../rbac/#cluster-role-example) instead of a role and a [cluster role binding](../rbac/#cluster-role-binding-example) instead of a role binding.
 {{% /notice %}}
 
-1. Create a user with the username `ec2-service`:
+1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
 sensuctl user create ec2-service --password='password'

--- a/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
@@ -44,7 +44,7 @@ A limited service account requires:
 1. Create a user with the username `ec2-service`:
 
    {{< code shell >}}
-sensuctl user create ec2-service --password='password'
+sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum | cut -d' ' -f1 | head -c 32)
 {{< /code >}}
 
    This command creates the following user definition:

--- a/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
@@ -41,7 +41,7 @@ A limited service account requires:
 **NOTE**: To use a service account to manage Sensu resources in more than one namespace, create a [cluster role](../rbac/#cluster-role-example) instead of a role and a [cluster role binding](../rbac/#cluster-role-binding-example) instead of a role binding.
 {{% /notice %}}
 
-1. Create a user with the username `ec2-service`:
+1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
 sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum | cut -d' ' -f1 | head -c 32)

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -44,7 +44,7 @@ A limited service account requires:
 1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
-sensuctl user create ec2-service --password='password'
+sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum | cut -d' ' -f1 | head -c 32)
 {{< /code >}}
 
    This command creates the following user definition:

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -41,7 +41,7 @@ A limited service account requires:
 **NOTE**: To use a service account to manage Sensu resources in more than one namespace, create a [cluster role](../rbac/#cluster-role-example) instead of a role and a [cluster role binding](../rbac/#cluster-role-binding-example) instead of a role binding.
 {{% /notice %}}
 
-1. Create a user with the username `ec2-service`:
+1. Create a user with the username `ec2-service` and a dynamically created random password:
 
    {{< code shell >}}
 sensuctl user create ec2-service --password='password'


### PR DESCRIPTION


<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Use dynamic passwords in documentation over static ones that could be copy/pasted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
The `password` of "password" sadly is still one of the most used passwords. If someone is going to copy/paste let it at least be a relatively secure and random password.

## Review Instructions
<!--- Optional -->
