### PR TITLE
Update docs to explain wrapped-json and add examples

### DIFF
--- a/content/sensu-go/6.0/api/_index.md
+++ b/content/sensu-go/6.0/api/_index.md
@@ -50,7 +50,7 @@ In terms of output formats, the [Sensu API][9] uses `json` output format for res
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
 
-Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 

--- a/content/sensu-go/6.0/api/_index.md
+++ b/content/sensu-go/6.0/api/_index.md
@@ -45,7 +45,12 @@ See the [RBAC reference][3] for more information about configuring Sensu users a
 ## Data format
 
 The Sensu API uses JSON-formatted requests and responses.
-In terms of [sensuctl output types][1], the Sensu API uses the `json` format, not `wrapped-json`.
+
+In terms of output formats, the [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
+
+Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 
@@ -707,3 +712,4 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [25]: ../sensuctl/
 [26]: ../web-ui/
 [27]: https://tools.ietf.org/html/rfc7519
+[28]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.0/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.0/learn/learn-sensu-sandbox.md
@@ -206,7 +206,7 @@ sensuctl asset info sensu-slack-handler --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-slack-handler --format json
+sensuctl asset info sensu-slack-handler --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -38,7 +38,7 @@ Sensu events contain:
 
 ## Example status-only event
 
-The following example shows a [status-only event][4]:
+The following example shows the complete resource definition for a [status-only event][4]:
 
 {{< language-toggle >}}
 
@@ -50,41 +50,51 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.sh -w 75 -c 90
-    duration: 1.07055808
+    command: check-cpu.rb -w 75 -c 90
+    duration: 5.058211427
     env_vars: null
-    executed: 1552594757
+    executed: 1617050501
     handlers: []
     high_flap_threshold: 0
     history:
-    - executed: 1552594757
+    - executed: 1617050261
+      status: 0
+    - executed: 1617050321
+      status: 0
+    - executed: 1617050381
+      status: 0
+    - executed: 1617050441
+      status: 0
+    - executed: 1617050501
       status: 0
     interval: 60
-    is_silenced: true
-    issued: 1552594757
-    last_ok: 1552594758
+    is_silenced: false
+    issued: 1617050501
+    last_ok: 1617050501
     low_flap_threshold: 0
     metadata:
-      name: check-cpu
+      name: check_cpu
       namespace: default
-    occurrences: 1
-    occurrences_watermark: 1
+    occurrences: 5
+    occurrences_watermark: 5
     output: |
-      CPU OK - Usage:3.96
-    silenced:
-      entity:gin:server-health
+      CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0
     output_metric_format: ""
-    output_metric_handlers: []
+    output_metric_handlers: null
     proxy_entity_name: ""
     publish: true
     round_robin: false
-    runtime_assets: []
+    runtime_assets:
+    - cpu-checks-plugins
+    - sensu-ruby-runtime
+    scheduler: memory
+    secrets: null
     state: passing
     status: 0
     stdin: false
     subdue: null
     subscriptions:
-    - linux
+    - system
     timeout: 0
     total_state_change: 0
     ttl: 0
@@ -92,7 +102,7 @@ spec:
     deregister: false
     deregistration: {}
     entity_class: agent
-    last_seen: 1552594641
+    last_seen: 1617050501
     metadata:
       name: sensu-centos
       namespace: default
@@ -106,12 +116,15 @@ spec:
     - secret_key
     - private_key
     - secret
+    sensu_agent_version: 6.0.0
     subscriptions:
     - linux
     - entity:sensu-centos
     system:
       arch: amd64
+      cloud_provider: ""
       hostname: sensu-centos
+      libc_type: glibc
       network:
         interfaces:
         - addresses:
@@ -120,22 +133,24 @@ spec:
           name: lo
         - addresses:
           - 10.0.2.15/24
-          - fe80::9688:67ca:3d78:ced9/64
-          mac: 08:00:27:11:ad:d2
-          name: enp0s3
+          - fe80::a268:dcce:3be:1c73/64
+          mac: 08:00:27:8b:c9:3f
+          name: eth0
         - addresses:
-          - 172.28.128.3/24
-          - fe80::a00:27ff:fe6b:c1e9/64
-          mac: 08:00:27:6b:c1:e9
-          name: enp0s8
+          - 172.28.128.45/24
+          - fe80::a00:27ff:feb2:dc46/64
+          mac: 08:00:27:b2:dc:46
+          name: eth1
       os: linux
       platform: centos
       platform_family: rhel
-      platform_version: 7.4.1708
+      platform_version: 7.5.1804
       processes: null
+      vm_role: guest
+      vm_system: vbox
     user: agent
-  timestamp: 1552594758
-  event_id: 3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f
+  id: 3c3e68f6-6db7-40d3-9b84-4d61817ae559
+  timestamp: 1617050507
 {{< /code >}}
 
 {{< code json >}}
@@ -148,45 +163,63 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.sh -w 75 -c 90",
-      "duration": 1.07055808,
+      "command": "check-cpu.rb -w 75 -c 90",
+      "duration": 5.058211427,
       "env_vars": null,
-      "executed": 1552594757,
+      "executed": 1617050501,
       "handlers": [],
       "high_flap_threshold": 0,
       "history": [
         {
-          "executed": 1552594757,
+          "executed": 1617050261,
+          "status": 0
+        },
+        {
+          "executed": 1617050321,
+          "status": 0
+        },
+        {
+          "executed": 1617050381,
+          "status": 0
+        },
+        {
+          "executed": 1617050441,
+          "status": 0
+        },
+        {
+          "executed": 1617050501,
           "status": 0
         }
       ],
       "interval": 60,
-      "is_silenced": true,
-      "issued": 1552594757,
-      "last_ok": 1552594758,
+      "is_silenced": false,
+      "issued": 1617050501,
+      "last_ok": 1617050501,
       "low_flap_threshold": 0,
       "metadata": {
-        "name": "check-cpu",
+        "name": "check_cpu",
         "namespace": "default"
       },
-      "occurrences": 1,
-      "occurrences_watermark": 1,
-      "output": "CPU OK - Usage:3.96\n",
-      "silenced": [
-        "entity:gin:scheck-cpu"
-      ],
+      "occurrences": 5,
+      "occurrences_watermark": 5,
+      "output": "CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
       "output_metric_format": "",
-      "output_metric_handlers": [],
+      "output_metric_handlers": null,
       "proxy_entity_name": "",
       "publish": true,
       "round_robin": false,
-      "runtime_assets": [],
+      "runtime_assets": [
+        "cpu-checks-plugins",
+        "sensu-ruby-runtime"
+      ],
+      "scheduler": "memory",
+      "secrets": null,
       "state": "passing",
       "status": 0,
       "stdin": false,
       "subdue": null,
       "subscriptions": [
-        "linux"
+        "system"
       ],
       "timeout": 0,
       "total_state_change": 0,
@@ -196,7 +229,7 @@ spec:
       "deregister": false,
       "deregistration": {},
       "entity_class": "agent",
-      "last_seen": 1552594641,
+      "last_seen": 1617050501,
       "metadata": {
         "name": "sensu-centos",
         "namespace": "default"
@@ -212,59 +245,210 @@ spec:
         "private_key",
         "secret"
       ],
+      "sensu_agent_version": "6.0.0",
       "subscriptions": [
         "linux",
         "entity:sensu-centos"
       ],
       "system": {
         "arch": "amd64",
+        "cloud_provider": "",
         "hostname": "sensu-centos",
+        "libc_type": "glibc",
         "network": {
           "interfaces": [
             {
               "addresses": [
                 "127.0.0.1/8",
-                "::1/128"
+                ":1/128"
               ],
               "name": "lo"
             },
             {
               "addresses": [
                 "10.0.2.15/24",
-                "fe80::9688:67ca:3d78:ced9/64"
+                "fe80::a268:dcce:3be:1c73/64"
               ],
-              "mac": "08:00:27:11:ad:d2",
-              "name": "enp0s3"
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
             },
             {
               "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:fe6b:c1e9/64"
+                "172.28.128.45/24",
+                "fe80::a00:27ff:feb2:dc46/64"
               ],
-              "mac": "08:00:27:6b:c1:e9",
-              "name": "enp0s8"
+              "mac": "08:00:27:b2:dc:46",
+              "name": "eth1"
             }
           ]
         },
         "os": "linux",
         "platform": "centos",
         "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "processes": null
+        "platform_version": "7.5.1804",
+        "processes": null,
+        "vm_role": "guest",
+        "vm_system": "vbox"
       },
       "user": "agent"
     },
-    "timestamp": 1552594758,
-    "event_id": "3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f"
+    "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+    "timestamp": 1617050507
   }
 }
 {{< /code >}}
 
 {{< /language-toggle >}}
 
+### Example status-only event from the Sensu API
+
+Sensu sends events to the backend in `json` format, without the outer-level `spec` wrapper or `type` and `api_version` attributes that are included in the `wrapped-json` format.
+This is the format that events are in when Sensu sends them to handlers:
+
+{{< code json >}}
+{
+  "check": {
+    "command": "check-cpu.rb -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 5.058211427,
+    "executed": 1617050501,
+    "history": [
+      {
+        "status": 0,
+        "executed": 1617050261
+      },
+      {
+        "status": 0,
+        "executed": 1617050321
+      },
+      {
+        "status": 0,
+        "executed": 1617050381
+      },
+      {
+        "status": 0,
+        "executed": 1617050441
+      },
+      {
+        "status": 0,
+        "executed": 1617050501
+      }
+    ],
+    "issued": 1617050501,
+    "output": "CheckCPU TOTAL OK: total=0.4 user=0.2 nice=0.0 system=0.2 idle=99.6 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
+    "state": "passing",
+    "status": 0,
+    "total_state_change": 0,
+    "last_ok": 1617050501,
+    "occurrences": 5,
+    "occurrences_watermark": 5,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default"
+    },
+    "secrets": null,
+    "is_silenced": false,
+    "scheduler": "memory"
+  },
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::a268:dcce:3be:1c73/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:b2:dc:46",
+            "addresses": [
+              "172.28.128.45/24",
+              "fe80::a00:27ff:feb2:dc46/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1617049781,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.0.0"
+  },
+  "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+  "metadata": {
+    "namespace": "default"
+  },
+  "timestamp": 1617050507
+}
+{{< /code >}}
+
 ## Example metrics-only event
 
-This example shows a [metrics-only event][5]:
+This example shows the complete resource definition for a [metrics-only event][5]:
 
 {{< language-toggle >}}
 
@@ -420,7 +604,7 @@ spec:
 
 ## Example status and metrics event
 
-The following example [status and metrics event][19] contains _both_ a check and metrics:
+The following example resource definition for a [status and metrics event][19] contains _both_ a check and metrics:
 
 {{< language-toggle >}}
 
@@ -696,7 +880,7 @@ To list all events:
 sensuctl event list
 {{< /code >}}
 
-To show event details in the default [output format][18]:
+To show event details in the default [output format][18] (tabular):
 
 {{< code shell >}}
 sensuctl event info entity-name check-name
@@ -710,6 +894,9 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 {{< language-toggle >}}
 {{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl event info entity-name check-name --format wrapped-json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
@@ -1868,7 +2055,7 @@ value: 0.005
 [15]: ../../../web-ui/
 [16]: ../../../api/events/
 [17]: ../../../sensuctl/
-[18]: ../../../sensuctl/create-manage-resources/#sensuctl-event
+[18]: ../../../sensuctl/#preferred-output-format
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -121,7 +121,7 @@ You will see a confirmation message:
 Updated
 {{< /code >}}
 
-To view the updated `slack` handler definition:
+To view the updated `slack` handler resource definition:
 
 {{< language-toggle >}}
 
@@ -130,7 +130,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -416,7 +416,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/route-alerts.md
@@ -552,7 +552,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/plan-maintenance.md
@@ -103,7 +103,7 @@ sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl silenced info 'entity:i-424242:check-http' --format json
+sensuctl silenced info 'entity:i-424242:check-http' --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -46,7 +46,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][13] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Run `sensuctl asset list --format yaml` or `sensuctl asset list --format json` to confirm that the dynamic runtime asset is ready to use.
+Run `sensuctl asset list --format yaml` or `sensuctl asset list --format wrapped-json` to confirm that the dynamic runtime asset is ready to use.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -82,7 +82,7 @@ sensuctl handler info influx-db --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info influx-db --format json
+sensuctl handler info influx-db --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -179,7 +179,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -80,7 +80,7 @@ To confirm that the check was added to your Sensu backend and view the check def
 sensuctl check info file_exists --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl check info file_exists --format json
+sensuctl check info file_exists --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -216,7 +216,7 @@ Make sure that your handler was added by retrieving the complete handler definit
 sensuctl handler info pagerduty --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl handler info pagerduty --format json
+sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
@@ -93,7 +93,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -173,7 +173,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -42,7 +42,7 @@ sensuctl hook info process_tree --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl hook info process_tree --format json
+sensuctl hook info process_tree --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -110,7 +110,7 @@ sensuctl event info i-424242 nginx_process --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info i-424242 nginx_process --format json
+sensuctl event info i-424242 nginx_process --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -242,7 +242,7 @@ sensuctl event info sensu-centos collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info sensu-centos collect-metrics --format json
+sensuctl event info sensu-centos collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/hooks.md
@@ -89,7 +89,7 @@ sensuctl event info entity_name check_name --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info entity_name check_name --format json
+sensuctl event info entity_name check_name --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
@@ -463,17 +463,9 @@ To confirm that your check is extracting metrics, inspect the events the check y
 **NOTE**: Replace `entity_name` and `check_name` with the names of the entity and check whose events you want to review.
 {{% /notice %}}
 
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl event info entity_name check_name --format yaml
-{{< /code >}}
-
 {{< code shell "JSON" >}}
 sensuctl event info entity_name check_name --format json
 {{< /code >}}
-
-{{< /language-toggle >}}
 
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -145,7 +145,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -329,7 +329,7 @@ sensuctl check info nginx_service --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info nginx_service --format json
+sensuctl check info nginx_service --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/operations/control-access/rbac.md
+++ b/content/sensu-go/6.0/operations/control-access/rbac.md
@@ -196,7 +196,7 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `wrapped-json` format for use with `sensuctl create`:
 
 {{< language-toggle >}}
 
@@ -205,7 +205,7 @@ sensuctl user list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl user list --format json
+sensuctl user list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.0/operations/control-access/use-apikeys.md
@@ -85,12 +85,16 @@ The response will include the new API key:
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key in YAML or JSON format:
+To get information about an API key, run:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format wrapped-json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -113,6 +117,21 @@ metadata:
 spec:
   created_at: 1570718917
   username: admin
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+{
+  "type": "APIKey",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
+  },
+  "spec": {
+    "created_at": 1570718917,
+    "username": "admin"
+  }
+}
 {{< /code >}}
 
 {{< code json >}}

--- a/content/sensu-go/6.0/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/license.md
@@ -118,7 +118,7 @@ To view license details in YAML or JSON, run:
 sensuctl license info --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl license info --format json
+sensuctl license info --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -435,9 +435,9 @@ curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/n
 {{< /code >}}
 
 You can also access your Sensu Go configuration in JSON or YAML using sensuctl.
-For example, `sensuctl check list --format json`.
+For example, `sensuctl check list --format wrapped-json`.
 Run `sensuctl help` to see available commands.
-For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][5].
+For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][22].
 
 ### Step 3: Translate plugins and register dynamic runtime assets
 
@@ -518,6 +518,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [19]: https://github.com/nixwiz/sensu-go-fatigue-check-filter/#filter-definition
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
+[22]: ../../../sensuctl/#preferred-output-format
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/

--- a/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
@@ -415,7 +415,7 @@ sensuctl asset info sensu-plugins-disk-checks --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-plugins-disk-checks --format json
+sensuctl asset info sensu-plugins-disk-checks --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.0/plugins/use-assets-to-install-plugins.md
@@ -124,7 +124,7 @@ sensuctl asset list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset list --format json
+sensuctl asset list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.0/sensuctl/_index.md
+++ b/content/sensu-go/6.0/sensuctl/_index.md
@@ -162,14 +162,26 @@ You can use this hash instead of the password when you use sensuctl to [create][
 
 ## Preferred output format
 
+## Preferred output format
+
 Sensuctl supports the following output formats:
 
-- `tabular`: A user-friendly, columnar format
-- `wrapped-json`: An accepted format for use with [`sensuctl create`][5]
-- `yaml`: An accepted format for use with [`sensuctl create`][5]
-- `json`: A format used by the [Sensu API][9]
+- `tabular`: Output is organized in user-friendly columns (default).
+- `yaml`: Output is in [YAML][20] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `wrapped-json`: Output is in [JSON][21] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `json`: Output is in [JSON][21] format. Resource definitions **do not** include an outer-level `spec` "wrapping" or the resource `type` and `api_version`.
 
-After you are logged in, you can change the output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+After you are logged in, you can change the default output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+
+### Output format significance
+
+To use [sensuctl create][5] to create a resource, you must provide the resource definition in `yaml` or `wrapped-json` format.
+These formats include the resource type, which sensuctl needs to determine what kind of resource to create.
+
+The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+
+Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 
@@ -361,3 +373,7 @@ create  delete  import  list
 [14]: ../api/auth/
 [15]: https://en.wikipedia.org/wiki/Bcrypt
 [16]: https://tools.ietf.org/html/rfc7519
+[20]: https://yaml.org/
+[21]: https://www.json.org/
+[22]: ../api/#url-format
+[23]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.0/sensuctl/_index.md
+++ b/content/sensu-go/6.0/sensuctl/_index.md
@@ -181,7 +181,7 @@ These formats include the resource type, which sensuctl needs to determine what 
 The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 
-Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -15,12 +15,16 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl dump all --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --format wrapped-json --file my-resources.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -37,6 +41,10 @@ To export only checks for only the current namespace to STDOUT in YAML or JSON f
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
@@ -49,6 +57,10 @@ To export only handlers and filters for only the current namespace to a file nam
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -66,6 +78,10 @@ For example:
 sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump all --all-namespaces --format json --file my-resources.json
 {{< /code >}}
@@ -78,6 +94,10 @@ sensuctl dump all --all-namespaces --format json --file my-resources.json
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
@@ -88,6 +108,10 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -106,6 +130,10 @@ Here's an example that uses fully qualified names:
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
@@ -118,6 +146,10 @@ Here's an example that uses short names:
 
 {{< code shell "YML" >}}
 sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -147,6 +179,12 @@ sensuctl dump all \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format wrapped-json > backup/config.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump all \
 --all-namespaces \
@@ -162,6 +200,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 --all-namespaces \
 --format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format wrapped-json > backup/rbac.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
@@ -175,6 +218,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
 --format yaml > backup/cannotrestore.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format wrapped-json > backup/cannotrestore.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
@@ -194,6 +242,11 @@ Because users require this additional configuration and API keys cannot be resto
 sensuctl dump core/v2.Entity \
 --all-namespaces \
 --format yaml > backup/inventory.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format wrapped-json > backup/inventory.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Entity \
@@ -223,6 +276,11 @@ mkdir backup
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.Hook,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
@@ -341,7 +399,7 @@ The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 sensuctl describe-type core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-{{< code shell "JSON">}}
+{{< code shell "Wrapped JSON">}}
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -17,8 +17,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 ## Create resources
 
 The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
-The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4].
-Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
+The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 See the [list of supported resource types][3] `for sensuctl create`.
 See the [reference docs][6] for information about creating resource definitions.
 
@@ -149,12 +148,12 @@ The following table describes the command-specific flags.
 `ClusterRoleBinding`  | `cluster_role_binding` | `Entity` | [`Env`][24]
 `entity` | [`EtcdReplicators`][29] | `Event` | `event`
 `EventFilter` | `event_filter` | [`GlobalConfig`][11] | `Handler` 
-`handler` | `Hook` | `hook` | `Hook`
-`hook_config` | `Mutator` | `mutator` | `Namespace`
-`namespace` | `Role` | `role` | `RoleBinding`
-`role_binding` | [`Secret`][28] | `Silenced` | `silenced`
-[`User`][8] | `user` | [`VaultProvider`][24] | [`ldap`][26]
-[`ad`][25] | [`oidc`][37] | [`TessenConfig`][27] | [`PostgresConfig`][32]
+`handler` | `Hook` | `hook` | `Mutator`
+`mutator` | `Namespace` | `namespace` | `Role`
+`role` | `RoleBinding` | `role_binding` | [`Secret`][28]
+`Silenced` | `silenced` | [`User`][8] | `user`
+[`VaultProvider`][24] | [`ldap`][26] | [`ad`][25] | [`oidc`][37]
+[`TessenConfig`][27] | [`PostgresConfig`][32]
 
 ### Create resources across namespaces
 
@@ -368,7 +367,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `json` format:
+To see the definition for a check named `check-cpu`:
 
 {{< language-toggle >}}
 
@@ -377,7 +376,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check-cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -501,7 +500,6 @@ The response will list all supported `sensuctl prune` resource types:
   authentication/v2.Provider                           authentication/v2   Provider             false
   licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
   store/v1.PostgresConfig                              store/v1            PostgresConfig       false
-  federation/v1.Cluster                                federation/v1       Cluster              false
   federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
   secrets/v1.Secret                                    secrets/v1          Secret               true
   secrets/v1.Provider                                  secrets/v1          Provider             false

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -50,7 +50,7 @@ In terms of output formats, the [Sensu API][9] uses `json` output format for res
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
 
-Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -45,7 +45,12 @@ See the [RBAC reference][3] for more information about configuring Sensu users a
 ## Data format
 
 The Sensu API uses JSON-formatted requests and responses.
-In terms of [sensuctl output types][1], the Sensu API uses the `json` format, not `wrapped-json`.
+
+In terms of output formats, the [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
+
+Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 
@@ -758,3 +763,4 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [25]: ../sensuctl/
 [26]: ../web-ui/
 [27]: https://tools.ietf.org/html/rfc7519
+[28]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.1/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.1/learn/learn-sensu-sandbox.md
@@ -206,7 +206,7 @@ sensuctl asset info sensu-slack-handler --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-slack-handler --format json
+sensuctl asset info sensu-slack-handler --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -38,7 +38,7 @@ Sensu events contain:
 
 ## Example status-only event
 
-The following example shows a [status-only event][4]:
+The following example shows the complete resource definition for a [status-only event][4]:
 
 {{< language-toggle >}}
 
@@ -50,41 +50,51 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.sh -w 75 -c 90
-    duration: 1.07055808
+    command: check-cpu.rb -w 75 -c 90
+    duration: 5.058211427
     env_vars: null
-    executed: 1552594757
+    executed: 1617050501
     handlers: []
     high_flap_threshold: 0
     history:
-    - executed: 1552594757
+    - executed: 1617050261
+      status: 0
+    - executed: 1617050321
+      status: 0
+    - executed: 1617050381
+      status: 0
+    - executed: 1617050441
+      status: 0
+    - executed: 1617050501
       status: 0
     interval: 60
-    is_silenced: true
-    issued: 1552594757
-    last_ok: 1552594758
+    is_silenced: false
+    issued: 1617050501
+    last_ok: 1617050501
     low_flap_threshold: 0
     metadata:
-      name: check-cpu
+      name: check_cpu
       namespace: default
-    occurrences: 1
-    occurrences_watermark: 1
+    occurrences: 5
+    occurrences_watermark: 5
     output: |
-      CPU OK - Usage:3.96
-    silenced:
-      entity:gin:server-health
+      CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0
     output_metric_format: ""
-    output_metric_handlers: []
+    output_metric_handlers: null
     proxy_entity_name: ""
     publish: true
     round_robin: false
-    runtime_assets: []
+    runtime_assets:
+    - cpu-checks-plugins
+    - sensu-ruby-runtime
+    scheduler: memory
+    secrets: null
     state: passing
     status: 0
     stdin: false
     subdue: null
     subscriptions:
-    - linux
+    - system
     timeout: 0
     total_state_change: 0
     ttl: 0
@@ -92,7 +102,7 @@ spec:
     deregister: false
     deregistration: {}
     entity_class: agent
-    last_seen: 1552594641
+    last_seen: 1617050501
     metadata:
       name: sensu-centos
       namespace: default
@@ -106,12 +116,15 @@ spec:
     - secret_key
     - private_key
     - secret
+    sensu_agent_version: 6.1.0
     subscriptions:
     - linux
     - entity:sensu-centos
     system:
       arch: amd64
+      cloud_provider: ""
       hostname: sensu-centos
+      libc_type: glibc
       network:
         interfaces:
         - addresses:
@@ -120,22 +133,24 @@ spec:
           name: lo
         - addresses:
           - 10.0.2.15/24
-          - fe80::9688:67ca:3d78:ced9/64
-          mac: 08:00:27:11:ad:d2
-          name: enp0s3
+          - fe80::a268:dcce:3be:1c73/64
+          mac: 08:00:27:8b:c9:3f
+          name: eth0
         - addresses:
-          - 172.28.128.3/24
-          - fe80::a00:27ff:fe6b:c1e9/64
-          mac: 08:00:27:6b:c1:e9
-          name: enp0s8
+          - 172.28.128.45/24
+          - fe80::a00:27ff:feb2:dc46/64
+          mac: 08:00:27:b2:dc:46
+          name: eth1
       os: linux
       platform: centos
       platform_family: rhel
-      platform_version: 7.4.1708
+      platform_version: 7.5.1804
       processes: null
+      vm_role: guest
+      vm_system: vbox
     user: agent
-  timestamp: 1552594758
-  event_id: 3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f
+  id: 3c3e68f6-6db7-40d3-9b84-4d61817ae559
+  timestamp: 1617050507
 {{< /code >}}
 
 {{< code json >}}
@@ -148,45 +163,63 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.sh -w 75 -c 90",
-      "duration": 1.07055808,
+      "command": "check-cpu.rb -w 75 -c 90",
+      "duration": 5.058211427,
       "env_vars": null,
-      "executed": 1552594757,
+      "executed": 1617050501,
       "handlers": [],
       "high_flap_threshold": 0,
       "history": [
         {
-          "executed": 1552594757,
+          "executed": 1617050261,
+          "status": 0
+        },
+        {
+          "executed": 1617050321,
+          "status": 0
+        },
+        {
+          "executed": 1617050381,
+          "status": 0
+        },
+        {
+          "executed": 1617050441,
+          "status": 0
+        },
+        {
+          "executed": 1617050501,
           "status": 0
         }
       ],
       "interval": 60,
-      "is_silenced": true,
-      "issued": 1552594757,
-      "last_ok": 1552594758,
+      "is_silenced": false,
+      "issued": 1617050501,
+      "last_ok": 1617050501,
       "low_flap_threshold": 0,
       "metadata": {
-        "name": "check-cpu",
+        "name": "check_cpu",
         "namespace": "default"
       },
-      "occurrences": 1,
-      "occurrences_watermark": 1,
-      "output": "CPU OK - Usage:3.96\n",
-      "silenced": [
-        "entity:gin:scheck-cpu"
-      ],
+      "occurrences": 5,
+      "occurrences_watermark": 5,
+      "output": "CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
       "output_metric_format": "",
-      "output_metric_handlers": [],
+      "output_metric_handlers": null,
       "proxy_entity_name": "",
       "publish": true,
       "round_robin": false,
-      "runtime_assets": [],
+      "runtime_assets": [
+        "cpu-checks-plugins",
+        "sensu-ruby-runtime"
+      ],
+      "scheduler": "memory",
+      "secrets": null,
       "state": "passing",
       "status": 0,
       "stdin": false,
       "subdue": null,
       "subscriptions": [
-        "linux"
+        "system"
       ],
       "timeout": 0,
       "total_state_change": 0,
@@ -196,7 +229,7 @@ spec:
       "deregister": false,
       "deregistration": {},
       "entity_class": "agent",
-      "last_seen": 1552594641,
+      "last_seen": 1617050501,
       "metadata": {
         "name": "sensu-centos",
         "namespace": "default"
@@ -212,59 +245,210 @@ spec:
         "private_key",
         "secret"
       ],
+      "sensu_agent_version": "6.1.0",
       "subscriptions": [
         "linux",
         "entity:sensu-centos"
       ],
       "system": {
         "arch": "amd64",
+        "cloud_provider": "",
         "hostname": "sensu-centos",
+        "libc_type": "glibc",
         "network": {
           "interfaces": [
             {
               "addresses": [
                 "127.0.0.1/8",
-                "::1/128"
+                ":1/128"
               ],
               "name": "lo"
             },
             {
               "addresses": [
                 "10.0.2.15/24",
-                "fe80::9688:67ca:3d78:ced9/64"
+                "fe80::a268:dcce:3be:1c73/64"
               ],
-              "mac": "08:00:27:11:ad:d2",
-              "name": "enp0s3"
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
             },
             {
               "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:fe6b:c1e9/64"
+                "172.28.128.45/24",
+                "fe80::a00:27ff:feb2:dc46/64"
               ],
-              "mac": "08:00:27:6b:c1:e9",
-              "name": "enp0s8"
+              "mac": "08:00:27:b2:dc:46",
+              "name": "eth1"
             }
           ]
         },
         "os": "linux",
         "platform": "centos",
         "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "processes": null
+        "platform_version": "7.5.1804",
+        "processes": null,
+        "vm_role": "guest",
+        "vm_system": "vbox"
       },
       "user": "agent"
     },
-    "timestamp": 1552594758,
-    "event_id": "3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f"
+    "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+    "timestamp": 1617050507
   }
 }
 {{< /code >}}
 
 {{< /language-toggle >}}
 
+### Example status-only event from the Sensu API
+
+Sensu sends events to the backend in `json` format, without the outer-level `spec` wrapper or `type` and `api_version` attributes that are included in the `wrapped-json` format.
+This is the format that events are in when Sensu sends them to handlers:
+
+{{< code json >}}
+{
+  "check": {
+    "command": "check-cpu.rb -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 5.058211427,
+    "executed": 1617050501,
+    "history": [
+      {
+        "status": 0,
+        "executed": 1617050261
+      },
+      {
+        "status": 0,
+        "executed": 1617050321
+      },
+      {
+        "status": 0,
+        "executed": 1617050381
+      },
+      {
+        "status": 0,
+        "executed": 1617050441
+      },
+      {
+        "status": 0,
+        "executed": 1617050501
+      }
+    ],
+    "issued": 1617050501,
+    "output": "CheckCPU TOTAL OK: total=0.4 user=0.2 nice=0.0 system=0.2 idle=99.6 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
+    "state": "passing",
+    "status": 0,
+    "total_state_change": 0,
+    "last_ok": 1617050501,
+    "occurrences": 5,
+    "occurrences_watermark": 5,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default"
+    },
+    "secrets": null,
+    "is_silenced": false,
+    "scheduler": "memory"
+  },
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::a268:dcce:3be:1c73/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:b2:dc:46",
+            "addresses": [
+              "172.28.128.45/24",
+              "fe80::a00:27ff:feb2:dc46/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1617049781,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.1.0"
+  },
+  "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+  "metadata": {
+    "namespace": "default"
+  },
+  "timestamp": 1617050507
+}
+{{< /code >}}
+
 ## Example metrics-only event
 
-This example shows a [metrics-only event][5]:
+This example shows the complete resource definition for a [metrics-only event][5]:
 
 {{< language-toggle >}}
 
@@ -420,7 +604,7 @@ spec:
 
 ## Example status and metrics event
 
-The following example [status and metrics event][19] contains _both_ a check and metrics:
+The following example resource definition for a [status and metrics event][19] contains _both_ a check and metrics:
 
 {{< language-toggle >}}
 
@@ -696,7 +880,7 @@ To list all events:
 sensuctl event list
 {{< /code >}}
 
-To show event details in the default [output format][18]:
+To show event details in the default [output format][18] (tabular):
 
 {{< code shell >}}
 sensuctl event info entity-name check-name
@@ -710,6 +894,9 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 {{< language-toggle >}}
 {{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl event info entity-name check-name --format wrapped-json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
@@ -1868,7 +2055,7 @@ value: 0.005
 [15]: ../../../web-ui/
 [16]: ../../../api/events/
 [17]: ../../../sensuctl/
-[18]: ../../../sensuctl/create-manage-resources/#sensuctl-event
+[18]: ../../../sensuctl/create-manage-resources/#preferred-output-format
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -121,7 +121,7 @@ You will see a confirmation message:
 Updated
 {{< /code >}}
 
-To view the updated `slack` handler definition:
+To view the updated `slack` handler resource definition:
 
 {{< language-toggle >}}
 
@@ -130,7 +130,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -418,7 +418,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
@@ -552,7 +552,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/plan-maintenance.md
@@ -103,7 +103,7 @@ sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl silenced info 'entity:i-424242:check-http' --format json
+sensuctl silenced info 'entity:i-424242:check-http' --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -46,7 +46,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][13] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Run `sensuctl asset list --format yaml` or `sensuctl asset list --format json` to confirm that the dynamic runtime asset is ready to use.
+Run `sensuctl asset list --format yaml` or `sensuctl asset list --format wrapped-json` to confirm that the dynamic runtime asset is ready to use.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -82,7 +82,7 @@ sensuctl handler info influx-db --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info influx-db --format json
+sensuctl handler info influx-db --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -179,7 +179,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -80,7 +80,7 @@ To confirm that the check was added to your Sensu backend and view the check def
 sensuctl check info file_exists --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl check info file_exists --format json
+sensuctl check info file_exists --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -216,7 +216,7 @@ Make sure that your handler was added by retrieving the complete handler definit
 sensuctl handler info pagerduty --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl handler info pagerduty --format json
+sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
@@ -93,7 +93,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -173,7 +173,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -42,7 +42,7 @@ sensuctl hook info process_tree --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl hook info process_tree --format json
+sensuctl hook info process_tree --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -110,7 +110,7 @@ sensuctl event info i-424242 nginx_process --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info i-424242 nginx_process --format json
+sensuctl event info i-424242 nginx_process --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -242,7 +242,7 @@ sensuctl event info sensu-centos collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info sensu-centos collect-metrics --format json
+sensuctl event info sensu-centos collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/hooks.md
@@ -89,7 +89,7 @@ sensuctl event info entity_name check_name --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info entity_name check_name --format json
+sensuctl event info entity_name check_name --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
@@ -488,17 +488,9 @@ To confirm that your check is extracting metrics, inspect the events the check y
 **NOTE**: Replace `entity_name` and `check_name` with the names of the entity and check whose events you want to review.
 {{% /notice %}}
 
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl event info entity_name check_name --format yaml
-{{< /code >}}
-
 {{< code shell "JSON" >}}
 sensuctl event info entity_name check_name --format json
 {{< /code >}}
-
-{{< /language-toggle >}}
 
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -145,7 +145,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -329,7 +329,7 @@ sensuctl check info nginx_service --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info nginx_service --format json
+sensuctl check info nginx_service --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/operations/control-access/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/rbac.md
@@ -196,7 +196,7 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `wrapped-json` format for use with `sensuctl create`:
 
 {{< language-toggle >}}
 
@@ -205,7 +205,7 @@ sensuctl user list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl user list --format json
+sensuctl user list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.1/operations/control-access/use-apikeys.md
@@ -85,12 +85,16 @@ The response will include the new API key:
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key in YAML or JSON format:
+To get information about an API key:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format wrapped-json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -113,6 +117,21 @@ metadata:
 spec:
   created_at: 1570718917
   username: admin
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+{
+  "type": "APIKey",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
+  },
+  "spec": {
+    "created_at": 1570718917,
+    "username": "admin"
+  }
+}
 {{< /code >}}
 
 {{< code json >}}

--- a/content/sensu-go/6.1/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/license.md
@@ -118,7 +118,7 @@ To view license details in YAML or JSON, run:
 sensuctl license info --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl license info --format json
+sensuctl license info --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -435,9 +435,9 @@ curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/n
 {{< /code >}}
 
 You can also access your Sensu Go configuration in JSON or YAML using sensuctl.
-For example, `sensuctl check list --format json`.
+For example, `sensuctl check list --format wrapped-json`.
 Run `sensuctl help` to see available commands.
-For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][5].
+For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][22].
 
 ### Step 3: Translate plugins and register dynamic runtime assets
 
@@ -517,6 +517,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [18]: https://github.com/sensu/sensu-translator/
 [19]: https://github.com/nixwiz/sensu-go-fatigue-check-filter/#filter-definition
 [20]: https://packagecloud.io/sensu/community/
+[22]: ../../../sensuctl/#preferred-output-format
 [21]: https://github.com/sensu-plugins/
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -415,7 +415,7 @@ sensuctl asset info sensu-plugins-disk-checks --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-plugins-disk-checks --format json
+sensuctl asset info sensu-plugins-disk-checks --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.1/plugins/use-assets-to-install-plugins.md
@@ -124,7 +124,7 @@ sensuctl asset list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset list --format json
+sensuctl asset list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.1/sensuctl/_index.md
+++ b/content/sensu-go/6.1/sensuctl/_index.md
@@ -162,14 +162,26 @@ You can use this hash instead of the password when you use sensuctl to [create][
 
 ## Preferred output format
 
+## Preferred output format
+
 Sensuctl supports the following output formats:
 
-- `tabular`: A user-friendly, columnar format
-- `wrapped-json`: An accepted format for use with [`sensuctl create`][5]
-- `yaml`: An accepted format for use with [`sensuctl create`][5]
-- `json`: A format used by the [Sensu API][9]
+- `tabular`: Output is organized in user-friendly columns (default).
+- `yaml`: Output is in [YAML][20] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `wrapped-json`: Output is in [JSON][21] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `json`: Output is in [JSON][21] format. Resource definitions **do not** include an outer-level `spec` "wrapping" or the resource `type` and `api_version`.
 
-After you are logged in, you can change the output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+After you are logged in, you can change the default output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+
+### Output format significance
+
+To use [sensuctl create][5] to create a resource, you must provide the resource definition in `yaml` or `wrapped-json` format.
+These formats include the resource type, which sensuctl needs to determine what kind of resource to create.
+
+The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+
+Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 
@@ -361,3 +373,7 @@ create  delete  import  list
 [14]: ../api/auth/
 [15]: https://en.wikipedia.org/wiki/Bcrypt
 [16]: https://tools.ietf.org/html/rfc7519
+[20]: https://yaml.org/
+[21]: https://www.json.org/
+[22]: ../api/#url-format
+[23]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.1/sensuctl/_index.md
+++ b/content/sensu-go/6.1/sensuctl/_index.md
@@ -181,7 +181,7 @@ These formats include the resource type, which sensuctl needs to determine what 
 The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 
-Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 

--- a/content/sensu-go/6.1/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.1/sensuctl/back-up-recover.md
@@ -15,12 +15,16 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl dump all --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --format wrapped-json --file my-resources.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -37,6 +41,10 @@ To export only checks for only the current namespace to STDOUT in YAML or JSON f
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
@@ -49,6 +57,10 @@ To export only handlers and filters for only the current namespace to a file nam
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -66,6 +78,10 @@ For example:
 sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump all --all-namespaces --format json --file my-resources.json
 {{< /code >}}
@@ -78,6 +94,10 @@ sensuctl dump all --all-namespaces --format json --file my-resources.json
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
@@ -88,6 +108,10 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -106,6 +130,10 @@ Here's an example that uses fully qualified names:
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
@@ -118,6 +146,10 @@ Here's an example that uses short names:
 
 {{< code shell "YML" >}}
 sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -147,6 +179,12 @@ sensuctl dump all \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format wrapped-json > backup/config.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump all \
 --all-namespaces \
@@ -162,6 +200,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 --all-namespaces \
 --format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format wrapped-json > backup/rbac.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
@@ -175,6 +218,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
 --format yaml > backup/cannotrestore.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format wrapped-json > backup/cannotrestore.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
@@ -194,6 +242,11 @@ Because users require this additional configuration and API keys cannot be resto
 sensuctl dump core/v2.Entity \
 --all-namespaces \
 --format yaml > backup/inventory.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format wrapped-json > backup/inventory.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Entity \
@@ -223,6 +276,11 @@ mkdir backup
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
@@ -345,7 +403,7 @@ The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 sensuctl describe-type core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-{{< code shell "JSON">}}
+{{< code shell "Wrapped JSON">}}
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -17,8 +17,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 ## Create resources
 
 The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
-The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4].
-Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
+The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 See the [list of supported resource types][3] `for sensuctl create`.
 See the [reference docs][6] for information about creating resource definitions.
 
@@ -368,7 +367,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `json` format:
+To see the definition for a check named `check-cpu`:
 
 {{< language-toggle >}}
 
@@ -377,7 +376,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check-cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -505,7 +504,6 @@ The response will list all supported `sensuctl prune` resource types:
   authentication/v2.Provider                           authentication/v2   Provider             false
   licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
   store/v1.PostgresConfig                              store/v1            PostgresConfig       false
-  federation/v1.Cluster                                federation/v1       Cluster              false
   federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
   secrets/v1.Secret                                    secrets/v1          Secret               true
   secrets/v1.Provider                                  secrets/v1          Provider             false

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -50,7 +50,7 @@ In terms of output formats, the [Sensu API][9] uses `json` output format for res
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
 
-Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -45,7 +45,11 @@ See the [RBAC reference][3] for more information about configuring Sensu users a
 ## Data format
 
 The Sensu API uses JSON-formatted requests and responses.
-In terms of [sensuctl output types][1], the Sensu API uses the `json` format, not `wrapped-json`.
+In terms of output formats, for `core`-group API responses, Sensu uses `json` format.
+For [commercial][8] APIs, Sensu uses `wrapped-json` format for API responses.
+The `wrapped-json` format includes an outer-level "wrapping" that lists the `type` and `api_version` attributes in the resource definition.
+
+Sensu sends events to the backend [in `json` format][28], without the `type` and `api_version` attributes.
 
 ## Versioning
 
@@ -758,3 +762,4 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [25]: ../sensuctl/
 [26]: ../web-ui/
 [27]: https://tools.ietf.org/html/rfc7519
+[28]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -45,11 +45,12 @@ See the [RBAC reference][3] for more information about configuring Sensu users a
 ## Data format
 
 The Sensu API uses JSON-formatted requests and responses.
-In terms of output formats, for `core`-group API responses, Sensu uses `json` format.
-For [commercial][8] APIs, Sensu uses `wrapped-json` format for API responses.
-The `wrapped-json` format includes an outer-level "wrapping" that lists the `type` and `api_version` attributes in the resource definition.
 
-Sensu sends events to the backend [in `json` format][28], without the `type` and `api_version` attributes.
+In terms of output formats, the [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
+
+Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 

--- a/content/sensu-go/6.2/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.2/learn/learn-sensu-sandbox.md
@@ -206,7 +206,7 @@ sensuctl asset info sensu-slack-handler --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-slack-handler --format json
+sensuctl asset info sensu-slack-handler --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -304,7 +304,7 @@ spec:
 
 ### Example status-only event from the Sensu API
 
-Sensu sends events to the backend in `json` format, without the outer-level `type` and `api_version` attributes that are included in the `wrapped-json` format.
+Sensu sends events to the backend in `json` format, without the outer-level `spec` wrapper or `type` and `api_version` attributes that are included in the `wrapped-json` format.
 This is the format that events are in when Sensu sends them to handlers:
 
 {{< code json >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -38,7 +38,7 @@ Sensu events contain:
 
 ## Example status-only event
 
-The following example shows a [status-only event][4]:
+The following example shows the complete resource definition for a [status-only event][4]:
 
 {{< language-toggle >}}
 
@@ -50,41 +50,51 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.sh -w 75 -c 90
-    duration: 1.07055808
+    command: check-cpu.rb -w 75 -c 90
+    duration: 5.058211427
     env_vars: null
-    executed: 1552594757
+    executed: 1617050501
     handlers: []
     high_flap_threshold: 0
     history:
-    - executed: 1552594757
+    - executed: 1617050261
+      status: 0
+    - executed: 1617050321
+      status: 0
+    - executed: 1617050381
+      status: 0
+    - executed: 1617050441
+      status: 0
+    - executed: 1617050501
       status: 0
     interval: 60
-    is_silenced: true
-    issued: 1552594757
-    last_ok: 1552594758
+    is_silenced: false
+    issued: 1617050501
+    last_ok: 1617050501
     low_flap_threshold: 0
     metadata:
-      name: check-cpu
+      name: check_cpu
       namespace: default
-    occurrences: 1
-    occurrences_watermark: 1
+    occurrences: 5
+    occurrences_watermark: 5
     output: |
-      CPU OK - Usage:3.96
-    silenced:
-      entity:gin:server-health
+      CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0
     output_metric_format: ""
-    output_metric_handlers: []
+    output_metric_handlers: null
     proxy_entity_name: ""
     publish: true
     round_robin: false
-    runtime_assets: []
+    runtime_assets:
+    - cpu-checks-plugins
+    - sensu-ruby-runtime
+    scheduler: memory
+    secrets: null
     state: passing
     status: 0
     stdin: false
     subdue: null
     subscriptions:
-    - linux
+    - system
     timeout: 0
     total_state_change: 0
     ttl: 0
@@ -92,7 +102,7 @@ spec:
     deregister: false
     deregistration: {}
     entity_class: agent
-    last_seen: 1552594641
+    last_seen: 1617050501
     metadata:
       name: sensu-centos
       namespace: default
@@ -106,12 +116,15 @@ spec:
     - secret_key
     - private_key
     - secret
+    sensu_agent_version: 6.2.6
     subscriptions:
     - linux
     - entity:sensu-centos
     system:
       arch: amd64
+      cloud_provider: ""
       hostname: sensu-centos
+      libc_type: glibc
       network:
         interfaces:
         - addresses:
@@ -120,23 +133,25 @@ spec:
           name: lo
         - addresses:
           - 10.0.2.15/24
-          - fe80::9688:67ca:3d78:ced9/64
-          mac: 08:00:27:11:ad:d2
-          name: enp0s3
+          - fe80::a268:dcce:3be:1c73/64
+          mac: 08:00:27:8b:c9:3f
+          name: eth0
         - addresses:
-          - 172.28.128.3/24
-          - fe80::a00:27ff:fe6b:c1e9/64
-          mac: 08:00:27:6b:c1:e9
-          name: enp0s8
+          - 172.28.128.45/24
+          - fe80::a00:27ff:feb2:dc46/64
+          mac: 08:00:27:b2:dc:46
+          name: eth1
       os: linux
       platform: centos
       platform_family: rhel
-      platform_version: 7.4.1708
+      platform_version: 7.5.1804
       processes: null
+      vm_role: guest
+      vm_system: vbox
     user: agent
-  timestamp: 1552594758
-  id: 3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f
-  sequence: 1
+  id: 3c3e68f6-6db7-40d3-9b84-4d61817ae559
+  sequence: 5
+  timestamp: 1617050507
 {{< /code >}}
 
 {{< code json >}}
@@ -149,45 +164,63 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.sh -w 75 -c 90",
-      "duration": 1.07055808,
+      "command": "check-cpu.rb -w 75 -c 90",
+      "duration": 5.058211427,
       "env_vars": null,
-      "executed": 1552594757,
+      "executed": 1617050501,
       "handlers": [],
       "high_flap_threshold": 0,
       "history": [
         {
-          "executed": 1552594757,
+          "executed": 1617050261,
+          "status": 0
+        },
+        {
+          "executed": 1617050321,
+          "status": 0
+        },
+        {
+          "executed": 1617050381,
+          "status": 0
+        },
+        {
+          "executed": 1617050441,
+          "status": 0
+        },
+        {
+          "executed": 1617050501,
           "status": 0
         }
       ],
       "interval": 60,
-      "is_silenced": true,
-      "issued": 1552594757,
-      "last_ok": 1552594758,
+      "is_silenced": false,
+      "issued": 1617050501,
+      "last_ok": 1617050501,
       "low_flap_threshold": 0,
       "metadata": {
-        "name": "check-cpu",
+        "name": "check_cpu",
         "namespace": "default"
       },
-      "occurrences": 1,
-      "occurrences_watermark": 1,
-      "output": "CPU OK - Usage:3.96\n",
-      "silenced": [
-        "entity:gin:scheck-cpu"
-      ],
+      "occurrences": 5,
+      "occurrences_watermark": 5,
+      "output": "CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
       "output_metric_format": "",
-      "output_metric_handlers": [],
+      "output_metric_handlers": null,
       "proxy_entity_name": "",
       "publish": true,
       "round_robin": false,
-      "runtime_assets": [],
+      "runtime_assets": [
+        "cpu-checks-plugins",
+        "sensu-ruby-runtime"
+      ],
+      "scheduler": "memory",
+      "secrets": null,
       "state": "passing",
       "status": 0,
       "stdin": false,
       "subdue": null,
       "subscriptions": [
-        "linux"
+        "system"
       ],
       "timeout": 0,
       "total_state_change": 0,
@@ -197,7 +230,7 @@ spec:
       "deregister": false,
       "deregistration": {},
       "entity_class": "agent",
-      "last_seen": 1552594641,
+      "last_seen": 1617050501,
       "metadata": {
         "name": "sensu-centos",
         "namespace": "default"
@@ -213,60 +246,212 @@ spec:
         "private_key",
         "secret"
       ],
+      "sensu_agent_version": "6.2.6",
       "subscriptions": [
         "linux",
         "entity:sensu-centos"
       ],
       "system": {
         "arch": "amd64",
+        "cloud_provider": "",
         "hostname": "sensu-centos",
+        "libc_type": "glibc",
         "network": {
           "interfaces": [
             {
               "addresses": [
                 "127.0.0.1/8",
-                "::1/128"
+                ":1/128"
               ],
               "name": "lo"
             },
             {
               "addresses": [
                 "10.0.2.15/24",
-                "fe80::9688:67ca:3d78:ced9/64"
+                "fe80::a268:dcce:3be:1c73/64"
               ],
-              "mac": "08:00:27:11:ad:d2",
-              "name": "enp0s3"
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
             },
             {
               "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:fe6b:c1e9/64"
+                "172.28.128.45/24",
+                "fe80::a00:27ff:feb2:dc46/64"
               ],
-              "mac": "08:00:27:6b:c1:e9",
-              "name": "enp0s8"
+              "mac": "08:00:27:b2:dc:46",
+              "name": "eth1"
             }
           ]
         },
         "os": "linux",
         "platform": "centos",
         "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "processes": null
+        "platform_version": "7.5.1804",
+        "processes": null,
+        "vm_role": "guest",
+        "vm_system": "vbox"
       },
       "user": "agent"
     },
-    "timestamp": 1552594758,
-    "id": "3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f",
-    "sequence": 1
+    "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+    "sequence": 5,
+    "timestamp": 1617050507
   }
 }
 {{< /code >}}
 
 {{< /language-toggle >}}
 
+### Example status-only event from the Sensu API
+
+Sensu sends events to the backend in `json` format, without the outer-level `type` and `api_version` attributes that are included in the `wrapped-json` format.
+This is the format that events are in when Sensu sends them to handlers:
+
+{{< code json >}}
+{
+  "check": {
+    "command": "check-cpu.rb -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 5.058211427,
+    "executed": 1617050501,
+    "history": [
+      {
+        "status": 0,
+        "executed": 1617050261
+      },
+      {
+        "status": 0,
+        "executed": 1617050321
+      },
+      {
+        "status": 0,
+        "executed": 1617050381
+      },
+      {
+        "status": 0,
+        "executed": 1617050441
+      },
+      {
+        "status": 0,
+        "executed": 1617050501
+      }
+    ],
+    "issued": 1617050501,
+    "output": "CheckCPU TOTAL OK: total=0.4 user=0.2 nice=0.0 system=0.2 idle=99.6 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
+    "state": "passing",
+    "status": 0,
+    "total_state_change": 0,
+    "last_ok": 1617050501,
+    "occurrences": 5,
+    "occurrences_watermark": 5,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default"
+    },
+    "secrets": null,
+    "is_silenced": false,
+    "scheduler": "memory"
+  },
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::a268:dcce:3be:1c73/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:b2:dc:46",
+            "addresses": [
+              "172.28.128.45/24",
+              "fe80::a00:27ff:feb2:dc46/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1617049781,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.2.6"
+  },
+  "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+  "metadata": {
+    "namespace": "default"
+  },
+  "sequence": 5,
+  "timestamp": 1617050507
+}
+{{< /code >}}
+
 ## Example metrics-only event
 
-This example shows a [metrics-only event][5]:
+This example shows the complete resource definition for a [metrics-only event][5]:
 
 {{< language-toggle >}}
 
@@ -424,7 +609,7 @@ spec:
 
 ## Example status and metrics event
 
-The following example [status and metrics event][19] contains _both_ a check and metrics:
+The following example resource definition for a [status and metrics event][19] contains _both_ a check and metrics:
 
 {{< language-toggle >}}
 
@@ -702,7 +887,7 @@ To list all events:
 sensuctl event list
 {{< /code >}}
 
-To show event details in the default [output format][18]:
+To show event details in the default [output format][18] (tabular):
 
 {{< code shell >}}
 sensuctl event info entity-name check-name
@@ -716,6 +901,9 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 {{< language-toggle >}}
 {{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl event info entity-name check-name --format wrapped-json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
@@ -1894,7 +2082,7 @@ value: 0.005
 [15]: ../../../web-ui/
 [16]: ../../../api/events/
 [17]: ../../../sensuctl/
-[18]: ../../../sensuctl/create-manage-resources/#sensuctl-event
+[18]: ../../../sensuctl/#preferred-output-format
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -121,7 +121,7 @@ You will see a confirmation message:
 Updated
 {{< /code >}}
 
-To view the updated `slack` handler definition:
+To view the updated `slack` handler resource definition:
 
 {{< language-toggle >}}
 
@@ -130,7 +130,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -418,7 +418,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -409,7 +409,7 @@ You will see a confirmation message:
 Updated
 {{< /code >}}
 
-To view the updated `slack` handler definition:
+To view the updated `slack` handler resource definition:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
@@ -552,7 +552,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
@@ -103,7 +103,7 @@ sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl silenced info 'entity:i-424242:check-http' --format json
+sensuctl silenced info 'entity:i-424242:check-http' --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -46,7 +46,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][13] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Run `sensuctl asset list --format yaml` or `sensuctl asset list --format json` to confirm that the dynamic runtime asset is ready to use.
+Run `sensuctl asset list --format yaml` or `sensuctl asset list --format wrapped-json` to confirm that the dynamic runtime asset is ready to use.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -82,7 +82,7 @@ sensuctl handler info influx-db --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info influx-db --format json
+sensuctl handler info influx-db --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -179,7 +179,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -80,7 +80,7 @@ To confirm that the check was added to your Sensu backend and view the check def
 sensuctl check info file_exists --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl check info file_exists --format json
+sensuctl check info file_exists --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -216,7 +216,7 @@ Make sure that your handler was added by retrieving the complete handler definit
 sensuctl handler info pagerduty --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl handler info pagerduty --format json
+sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
@@ -93,7 +93,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -173,7 +173,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -42,7 +42,7 @@ sensuctl hook info process_tree --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl hook info process_tree --format json
+sensuctl hook info process_tree --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -110,7 +110,7 @@ sensuctl event info i-424242 nginx_process --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info i-424242 nginx_process --format json
+sensuctl event info i-424242 nginx_process --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -242,7 +242,7 @@ sensuctl event info sensu-centos collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info sensu-centos collect-metrics --format json
+sensuctl event info sensu-centos collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/hooks.md
@@ -89,7 +89,7 @@ sensuctl event info entity_name check_name --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info entity_name check_name --format json
+sensuctl event info entity_name check_name --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -488,17 +488,9 @@ To confirm that your check is extracting metrics, inspect the events the check y
 **NOTE**: Replace `entity_name` and `check_name` with the names of the entity and check whose events you want to review.
 {{% /notice %}}
 
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl event info entity_name check_name --format yaml
-{{< /code >}}
-
 {{< code shell "JSON" >}}
-sensuctl event info entity_name check_name --format wrapped-json
+sensuctl event info entity_name check_name --format json
 {{< /code >}}
-
-{{< /language-toggle >}}
 
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -495,7 +495,7 @@ sensuctl event info entity_name check_name --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info entity_name check_name --format json
+sensuctl event info entity_name check_name --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -145,7 +145,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -329,7 +329,7 @@ sensuctl check info nginx_service --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info nginx_service --format json
+sensuctl check info nginx_service --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -196,7 +196,7 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `wrapped-json` format for use with `sensuctl create`:
 
 {{< language-toggle >}}
 
@@ -205,7 +205,7 @@ sensuctl user list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl user list --format json
+sensuctl user list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.2/operations/control-access/use-apikeys.md
@@ -85,12 +85,16 @@ The response will include the new API key:
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key in YAML or JSON format:
+To get information about an API key:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format wrapped-json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -113,6 +117,21 @@ metadata:
 spec:
   created_at: 1570718917
   username: admin
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+{
+  "type": "APIKey",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
+  },
+  "spec": {
+    "created_at": 1570718917,
+    "username": "admin"
+  }
+}
 {{< /code >}}
 
 {{< code json >}}

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -118,7 +118,7 @@ To view license details in YAML or JSON, run:
 sensuctl license info --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl license info --format json
+sensuctl license info --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -435,7 +435,7 @@ curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/n
 {{< /code >}}
 
 You can also access your Sensu Go configuration in JSON or YAML using sensuctl.
-For example, `sensuctl check list --format json`.
+For example, `sensuctl check list --format wrapped-json`.
 Run `sensuctl help` to see available commands.
 For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][5].
 
@@ -501,7 +501,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [2]: https://etcd.io/docs/latest/
 [3]: ../../../observability-pipeline/observe-schedule/backend/
 [4]: ../../../observability-pipeline/observe-schedule/agent/
-[5]: ../../../sensuctl/
+[5]: ../../../sensuctl/#preferred-output-format
 [6]: ../../../observability-pipeline/observe-entities/entities/
 [7]: ../../../observability-pipeline/observe-entities/monitor-external-resources/
 [8]: ../../../observability-pipeline/observe-schedule/hooks/

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -437,7 +437,7 @@ curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/n
 You can also access your Sensu Go configuration in JSON or YAML using sensuctl.
 For example, `sensuctl check list --format wrapped-json`.
 Run `sensuctl help` to see available commands.
-For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][5].
+For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][22].
 
 ### Step 3: Translate plugins and register dynamic runtime assets
 
@@ -501,7 +501,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [2]: https://etcd.io/docs/latest/
 [3]: ../../../observability-pipeline/observe-schedule/backend/
 [4]: ../../../observability-pipeline/observe-schedule/agent/
-[5]: ../../../sensuctl/#preferred-output-format
+[5]: ../../../sensuctl/
 [6]: ../../../observability-pipeline/observe-entities/entities/
 [7]: ../../../observability-pipeline/observe-entities/monitor-external-resources/
 [8]: ../../../observability-pipeline/observe-schedule/hooks/
@@ -518,6 +518,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [19]: https://github.com/nixwiz/sensu-go-fatigue-check-filter/#filter-definition
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
+[22]: ../../../sensuctl/#preferred-output-format
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -415,7 +415,7 @@ sensuctl asset info sensu-plugins-disk-checks --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-plugins-disk-checks --format json
+sensuctl asset info sensu-plugins-disk-checks --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.2/plugins/use-assets-to-install-plugins.md
@@ -124,7 +124,7 @@ sensuctl asset list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset list --format json
+sensuctl asset list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/sensuctl/_index.md
+++ b/content/sensu-go/6.2/sensuctl/_index.md
@@ -232,7 +232,7 @@ These formats include the resource type, which sensuctl needs to determine what 
 The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 
-Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 

--- a/content/sensu-go/6.2/sensuctl/_index.md
+++ b/content/sensu-go/6.2/sensuctl/_index.md
@@ -220,7 +220,7 @@ Sensuctl supports the following output formats:
 - `tabular`: Output is organized in user-friendly columns (default).
 - `yaml`: Output is in [YAML][20] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
 - `wrapped-json`: Output is in [JSON][21] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
-- `json`: Output is in [JSON][21] format. Resource definitions **do not** include an outer-level `spec` "wrapping" or the resource `type` and `api_version`. 
+- `json`: Output is in [JSON][21] format. Resource definitions **do not** include an outer-level `spec` "wrapping" or the resource `type` and `api_version`.
 
 After you are logged in, you can change the default output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
 

--- a/content/sensu-go/6.2/sensuctl/_index.md
+++ b/content/sensu-go/6.2/sensuctl/_index.md
@@ -217,12 +217,22 @@ You can use this hash instead of the password when you use sensuctl to [create][
 
 Sensuctl supports the following output formats:
 
-- `tabular`: A user-friendly columnar format (and the default output format)
-- `wrapped-json`: A format that includes an outer-level "wrapping" that lists the resource `type` and `api_version` for use with [`sensuctl create`][5]
-- `yaml`: A format that includes the `type` and `api_version` in the resource definition for use with [`sensuctl create`][5]
-- `json`: The format the [Sensu API][9] uses for all resources
+- `tabular`: Output is organized in user-friendly columns (default).
+- `yaml`: Output is in [YAML][20] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `wrapped-json`: Output is in [JSON][21] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `json`: Output is in [JSON][21] format. Resource definitions **do not** include an outer-level `spec` "wrapping" or the resource `type` and `api_version`. 
 
 After you are logged in, you can change the default output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+
+### Output format significance
+
+To use [sensuctl create][5] to create a resource, you must provide the resource definition in `yaml` or `wrapped-json` format.
+These formats include the resource type, which sensuctl needs to determine what kind of resource to create.
+
+The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+
+Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 
@@ -417,3 +427,7 @@ create  delete  import  list
 [17]: ../operations/control-access/ldap-auth
 [18]: ../operations/control-access/ad-auth
 [19]: ../commercial/
+[20]: https://yaml.org/
+[21]: https://www.json.org/
+[22]: ../api/#url-format
+[23]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.2/sensuctl/_index.md
+++ b/content/sensu-go/6.2/sensuctl/_index.md
@@ -217,12 +217,12 @@ You can use this hash instead of the password when you use sensuctl to [create][
 
 Sensuctl supports the following output formats:
 
-- `tabular`: A user-friendly, columnar format
-- `wrapped-json`: An accepted format for use with [`sensuctl create`][5]
-- `yaml`: An accepted format for use with [`sensuctl create`][5]
-- `json`: A format used by the [Sensu API][9]
+- `tabular`: A user-friendly columnar format (and the default output format)
+- `wrapped-json`: A format that includes an outer-level "wrapping" that lists the resource `type` and `api_version` for use with [`sensuctl create`][5]
+- `yaml`: A format that includes the `type` and `api_version` in the resource definition for use with [`sensuctl create`][5]
+- `json`: The format the [Sensu API][9] uses for all resources
 
-After you are logged in, you can change the output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+After you are logged in, you can change the default output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
 
 ## Non-interactive mode
 

--- a/content/sensu-go/6.2/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.2/sensuctl/back-up-recover.md
@@ -15,12 +15,16 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl dump all --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --format wrapped-json --file my-resources.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -37,6 +41,10 @@ To export only checks for only the current namespace to STDOUT in YAML or JSON f
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
@@ -49,6 +57,10 @@ To export only handlers and filters for only the current namespace to a file nam
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -66,6 +78,10 @@ For example:
 sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump all --all-namespaces --format json --file my-resources.json
 {{< /code >}}
@@ -78,6 +94,10 @@ sensuctl dump all --all-namespaces --format json --file my-resources.json
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
@@ -88,6 +108,10 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -106,6 +130,10 @@ Here's an example that uses fully qualified names:
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
@@ -118,6 +146,10 @@ Here's an example that uses short names:
 
 {{< code shell "YML" >}}
 sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -147,6 +179,12 @@ sensuctl dump all \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format wrapped-json > backup/config.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump all \
 --all-namespaces \
@@ -162,6 +200,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 --all-namespaces \
 --format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format wrapped-json > backup/rbac.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
@@ -175,6 +218,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
 --format yaml > backup/cannotrestore.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format wrapped-json > backup/cannotrestore.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
@@ -194,6 +242,11 @@ Because users require this additional configuration and API keys cannot be resto
 sensuctl dump core/v2.Entity \
 --all-namespaces \
 --format yaml > backup/inventory.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format wrapped-json > backup/inventory.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Entity \
@@ -223,6 +276,11 @@ mkdir backup
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
@@ -342,7 +400,7 @@ The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 sensuctl describe-type core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-{{< code shell "JSON">}}
+{{< code shell "Wrapped JSON">}}
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -378,7 +378,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `json` format:
+To see the definition for a check named `check-cpu`:
 
 {{< language-toggle >}}
 
@@ -387,7 +387,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check-cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -17,8 +17,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 ## Create resources
 
 The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
-The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4].
-Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
+The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 See the [list of supported resource types][3] `for sensuctl create`.
 See the [reference docs][6] for information about creating resource definitions.
 

--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -50,7 +50,7 @@ In terms of output formats, the [Sensu API][9] uses `json` output format for res
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
 
-Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 

--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -45,7 +45,12 @@ See the [RBAC reference][3] for more information about configuring Sensu users a
 ## Data format
 
 The Sensu API uses JSON-formatted requests and responses.
-In terms of [sensuctl output types][1], the Sensu API uses the `json` format, not `wrapped-json`.
+
+In terms of output formats, the [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+The `wrapped-json` format includes an outer-level `spec` "wrapping" for resource attributes and lists the resource `type` and `api_version`.
+
+Sensu sends events to the backend [in `json` format][28], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Versioning
 
@@ -758,3 +763,4 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [25]: ../sensuctl/
 [26]: ../web-ui/
 [27]: https://tools.ietf.org/html/rfc7519
+[28]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.3/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.3/learn/learn-sensu-sandbox.md
@@ -206,7 +206,7 @@ sensuctl asset info sensu-slack-handler --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-slack-handler --format json
+sensuctl asset info sensu-slack-handler --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -38,7 +38,7 @@ Sensu events contain:
 
 ## Example status-only event
 
-The following example shows a [status-only event][4]:
+The following example shows the complete resource definition for a [status-only event][4]:
 
 {{< language-toggle >}}
 
@@ -50,41 +50,51 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.sh -w 75 -c 90
-    duration: 1.07055808
+    command: check-cpu.rb -w 75 -c 90
+    duration: 5.058211427
     env_vars: null
-    executed: 1552594757
+    executed: 1617050501
     handlers: []
     high_flap_threshold: 0
     history:
-    - executed: 1552594757
+    - executed: 1617050261
+      status: 0
+    - executed: 1617050321
+      status: 0
+    - executed: 1617050381
+      status: 0
+    - executed: 1617050441
+      status: 0
+    - executed: 1617050501
       status: 0
     interval: 60
-    is_silenced: true
-    issued: 1552594757
-    last_ok: 1552594758
+    is_silenced: false
+    issued: 1617050501
+    last_ok: 1617050501
     low_flap_threshold: 0
     metadata:
-      name: check-cpu
+      name: check_cpu
       namespace: default
-    occurrences: 1
-    occurrences_watermark: 1
+    occurrences: 5
+    occurrences_watermark: 5
     output: |
-      CPU OK - Usage:3.96
-    silenced:
-      entity:gin:server-health
+      CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0
     output_metric_format: ""
-    output_metric_handlers: []
+    output_metric_handlers: null
     proxy_entity_name: ""
     publish: true
     round_robin: false
-    runtime_assets: []
+    runtime_assets:
+    - cpu-checks-plugins
+    - sensu-ruby-runtime
+    scheduler: memory
+    secrets: null
     state: passing
     status: 0
     stdin: false
     subdue: null
     subscriptions:
-    - linux
+    - system
     timeout: 0
     total_state_change: 0
     ttl: 0
@@ -92,7 +102,7 @@ spec:
     deregister: false
     deregistration: {}
     entity_class: agent
-    last_seen: 1552594641
+    last_seen: 1617050501
     metadata:
       name: sensu-centos
       namespace: default
@@ -106,12 +116,15 @@ spec:
     - secret_key
     - private_key
     - secret
+    sensu_agent_version: 6.2.6
     subscriptions:
     - linux
     - entity:sensu-centos
     system:
       arch: amd64
+      cloud_provider: ""
       hostname: sensu-centos
+      libc_type: glibc
       network:
         interfaces:
         - addresses:
@@ -120,23 +133,25 @@ spec:
           name: lo
         - addresses:
           - 10.0.2.15/24
-          - fe80::9688:67ca:3d78:ced9/64
-          mac: 08:00:27:11:ad:d2
-          name: enp0s3
+          - fe80::a268:dcce:3be:1c73/64
+          mac: 08:00:27:8b:c9:3f
+          name: eth0
         - addresses:
-          - 172.28.128.3/24
-          - fe80::a00:27ff:fe6b:c1e9/64
-          mac: 08:00:27:6b:c1:e9
-          name: enp0s8
+          - 172.28.128.45/24
+          - fe80::a00:27ff:feb2:dc46/64
+          mac: 08:00:27:b2:dc:46
+          name: eth1
       os: linux
       platform: centos
       platform_family: rhel
-      platform_version: 7.4.1708
+      platform_version: 7.5.1804
       processes: null
+      vm_role: guest
+      vm_system: vbox
     user: agent
-  timestamp: 1552594758
-  id: 3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f
-  sequence: 1
+  id: 3c3e68f6-6db7-40d3-9b84-4d61817ae559
+  sequence: 5
+  timestamp: 1617050507
 {{< /code >}}
 
 {{< code json >}}
@@ -149,45 +164,63 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.sh -w 75 -c 90",
-      "duration": 1.07055808,
+      "command": "check-cpu.rb -w 75 -c 90",
+      "duration": 5.058211427,
       "env_vars": null,
-      "executed": 1552594757,
+      "executed": 1617050501,
       "handlers": [],
       "high_flap_threshold": 0,
       "history": [
         {
-          "executed": 1552594757,
+          "executed": 1617050261,
+          "status": 0
+        },
+        {
+          "executed": 1617050321,
+          "status": 0
+        },
+        {
+          "executed": 1617050381,
+          "status": 0
+        },
+        {
+          "executed": 1617050441,
+          "status": 0
+        },
+        {
+          "executed": 1617050501,
           "status": 0
         }
       ],
       "interval": 60,
-      "is_silenced": true,
-      "issued": 1552594757,
-      "last_ok": 1552594758,
+      "is_silenced": false,
+      "issued": 1617050501,
+      "last_ok": 1617050501,
       "low_flap_threshold": 0,
       "metadata": {
-        "name": "check-cpu",
+        "name": "check_cpu",
         "namespace": "default"
       },
-      "occurrences": 1,
-      "occurrences_watermark": 1,
-      "output": "CPU OK - Usage:3.96\n",
-      "silenced": [
-        "entity:gin:scheck-cpu"
-      ],
+      "occurrences": 5,
+      "occurrences_watermark": 5,
+      "output": "CheckCPU TOTAL OK: total=0.41 user=0.2 nice=0.0 system=0.2 idle=99.59 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
       "output_metric_format": "",
-      "output_metric_handlers": [],
+      "output_metric_handlers": null,
       "proxy_entity_name": "",
       "publish": true,
       "round_robin": false,
-      "runtime_assets": [],
+      "runtime_assets": [
+        "cpu-checks-plugins",
+        "sensu-ruby-runtime"
+      ],
+      "scheduler": "memory",
+      "secrets": null,
       "state": "passing",
       "status": 0,
       "stdin": false,
       "subdue": null,
       "subscriptions": [
-        "linux"
+        "system"
       ],
       "timeout": 0,
       "total_state_change": 0,
@@ -197,7 +230,7 @@ spec:
       "deregister": false,
       "deregistration": {},
       "entity_class": "agent",
-      "last_seen": 1552594641,
+      "last_seen": 1617050501,
       "metadata": {
         "name": "sensu-centos",
         "namespace": "default"
@@ -213,60 +246,212 @@ spec:
         "private_key",
         "secret"
       ],
+      "sensu_agent_version": "6.2.6",
       "subscriptions": [
         "linux",
         "entity:sensu-centos"
       ],
       "system": {
         "arch": "amd64",
+        "cloud_provider": "",
         "hostname": "sensu-centos",
+        "libc_type": "glibc",
         "network": {
           "interfaces": [
             {
               "addresses": [
                 "127.0.0.1/8",
-                "::1/128"
+                ":1/128"
               ],
               "name": "lo"
             },
             {
               "addresses": [
                 "10.0.2.15/24",
-                "fe80::9688:67ca:3d78:ced9/64"
+                "fe80::a268:dcce:3be:1c73/64"
               ],
-              "mac": "08:00:27:11:ad:d2",
-              "name": "enp0s3"
+              "mac": "08:00:27:8b:c9:3f",
+              "name": "eth0"
             },
             {
               "addresses": [
-                "172.28.128.3/24",
-                "fe80::a00:27ff:fe6b:c1e9/64"
+                "172.28.128.45/24",
+                "fe80::a00:27ff:feb2:dc46/64"
               ],
-              "mac": "08:00:27:6b:c1:e9",
-              "name": "enp0s8"
+              "mac": "08:00:27:b2:dc:46",
+              "name": "eth1"
             }
           ]
         },
         "os": "linux",
         "platform": "centos",
         "platform_family": "rhel",
-        "platform_version": "7.4.1708",
-        "processes": null
+        "platform_version": "7.5.1804",
+        "processes": null,
+        "vm_role": "guest",
+        "vm_system": "vbox"
       },
       "user": "agent"
     },
-    "timestamp": 1552594758,
-    "id": "3a5948f3-6ffd-4ea2-a41e-334f4a72ca2f",
-    "sequence": 1
+    "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+    "sequence": 5,
+    "timestamp": 1617050507
   }
 }
 {{< /code >}}
 
 {{< /language-toggle >}}
 
+### Example status-only event from the Sensu API
+
+Sensu sends events to the backend in `json` format, without the outer-level `spec` wrapper or `type` and `api_version` attributes that are included in the `wrapped-json` format.
+This is the format that events are in when Sensu sends them to handlers:
+
+{{< code json >}}
+{
+  "check": {
+    "command": "check-cpu.rb -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "cpu-checks-plugins",
+      "sensu-ruby-runtime"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 5.058211427,
+    "executed": 1617050501,
+    "history": [
+      {
+        "status": 0,
+        "executed": 1617050261
+      },
+      {
+        "status": 0,
+        "executed": 1617050321
+      },
+      {
+        "status": 0,
+        "executed": 1617050381
+      },
+      {
+        "status": 0,
+        "executed": 1617050441
+      },
+      {
+        "status": 0,
+        "executed": 1617050501
+      }
+    ],
+    "issued": 1617050501,
+    "output": "CheckCPU TOTAL OK: total=0.4 user=0.2 nice=0.0 system=0.2 idle=99.6 iowait=0.0 irq=0.0 softirq=0.0 steal=0.0 guest=0.0 guest_nice=0.0\n",
+    "state": "passing",
+    "status": 0,
+    "total_state_change": 0,
+    "last_ok": 1617050501,
+    "occurrences": 5,
+    "occurrences_watermark": 5,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default"
+    },
+    "secrets": null,
+    "is_silenced": false,
+    "scheduler": "memory"
+  },
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::a268:dcce:3be:1c73/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:b2:dc:46",
+            "addresses": [
+              "172.28.128.45/24",
+              "fe80::a00:27ff:feb2:dc46/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1617049781,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.2.6"
+  },
+  "id": "3c3e68f6-6db7-40d3-9b84-4d61817ae559",
+  "metadata": {
+    "namespace": "default"
+  },
+  "sequence": 5,
+  "timestamp": 1617050507
+}
+{{< /code >}}
+
 ## Example metrics-only event
 
-This example shows a [metrics-only event][5]:
+This example shows the complete resource definition for a [metrics-only event][5]:
 
 {{< language-toggle >}}
 
@@ -424,7 +609,7 @@ spec:
 
 ## Example status and metrics event
 
-The following example [status and metrics event][19] contains _both_ a check and metrics:
+The following example resource definition for a [status and metrics event][19] contains _both_ a check and metrics:
 
 {{< language-toggle >}}
 
@@ -702,7 +887,7 @@ To list all events:
 sensuctl event list
 {{< /code >}}
 
-To show event details in the default [output format][18]:
+To show event details in the default [output format][18] (tabular):
 
 {{< code shell >}}
 sensuctl event info entity-name check-name
@@ -716,6 +901,9 @@ With both the `list` and `info` commands, you can specify an [output format][18]
 {{< language-toggle >}}
 {{< code shell "YML" >}}
 sensuctl event info entity-name check-name --format yaml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl event info entity-name check-name --format wrapped-json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl event info entity-name check-name --format json
@@ -1894,7 +2082,7 @@ value: 0.005
 [15]: ../../../web-ui/
 [16]: ../../../api/events/
 [17]: ../../../sensuctl/
-[18]: ../../../sensuctl/create-manage-resources/#sensuctl-event
+[18]: ../../../sensuctl/create-manage-resources/#preferred-output-format
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -121,7 +121,7 @@ You will see a confirmation message:
 Updated
 {{< /code >}}
 
-To view the updated `slack` handler definition:
+To view the updated `slack` handler resource definition:
 
 {{< language-toggle >}}
 
@@ -130,7 +130,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -418,7 +418,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -552,7 +552,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
@@ -103,7 +103,7 @@ sensuctl silenced info 'entity:i-424242:check-http' --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl silenced info 'entity:i-424242:check-http' --format json
+sensuctl silenced info 'entity:i-424242:check-http' --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -46,7 +46,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][13] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
 
-Run `sensuctl asset list --format yaml` or `sensuctl asset list --format json` to confirm that the dynamic runtime asset is ready to use.
+Run `sensuctl asset list --format yaml` or `sensuctl asset list --format wrapped-json` to confirm that the dynamic runtime asset is ready to use.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -82,7 +82,7 @@ sensuctl handler info influx-db --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info influx-db --format json
+sensuctl handler info influx-db --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -179,7 +179,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -80,7 +80,7 @@ To confirm that the check was added to your Sensu backend and view the check def
 sensuctl check info file_exists --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl check info file_exists --format json
+sensuctl check info file_exists --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -216,7 +216,7 @@ Make sure that your handler was added by retrieving the complete handler definit
 sensuctl handler info pagerduty --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl handler info pagerduty --format json
+sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -93,7 +93,7 @@ sensuctl handler info slack --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl handler info slack --format json
+sensuctl handler info slack --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -173,7 +173,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -42,7 +42,7 @@ sensuctl hook info process_tree --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl hook info process_tree --format json
+sensuctl hook info process_tree --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -110,7 +110,7 @@ sensuctl event info i-424242 nginx_process --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info i-424242 nginx_process --format json
+sensuctl event info i-424242 nginx_process --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -112,7 +112,7 @@ sensuctl check info collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info collect-metrics --format json
+sensuctl check info collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -242,7 +242,7 @@ sensuctl event info sensu-centos collect-metrics --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info sensu-centos collect-metrics --format json
+sensuctl event info sensu-centos collect-metrics --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
@@ -89,7 +89,7 @@ sensuctl event info entity_name check_name --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl event info entity_name check_name --format json
+sensuctl event info entity_name check_name --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -488,17 +488,9 @@ To confirm that your check is extracting metrics, inspect the events the check y
 **NOTE**: Replace `entity_name` and `check_name` with the names of the entity and check whose events you want to review.
 {{% /notice %}}
 
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl event info entity_name check_name --format yaml
-{{< /code >}}
-
 {{< code shell "JSON" >}}
 sensuctl event info entity_name check_name --format json
 {{< /code >}}
-
-{{< /language-toggle >}}
 
 You should expect to see errors logged by sensu-agent if it is unable to parse the check output.
 See [Troubleshoot Sensu][24] for an example debug handler that writes events to a file for inspection.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -145,7 +145,7 @@ sensuctl check info check_cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check_cpu --format json
+sensuctl check info check_cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -329,7 +329,7 @@ sensuctl check info nginx_service --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info nginx_service --format json
+sensuctl check info nginx_service --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -196,7 +196,7 @@ sensuctl user reinstate USERNAME
 
 You can use [sensuctl][2] to see a list of all users within Sensu.
 
-To return a list of users in `yaml` or `json` format for use with `sensuctl create`:
+To return a list of users in `yaml` or `wrapped-json` format for use with `sensuctl create`:
 
 {{< language-toggle >}}
 
@@ -205,7 +205,7 @@ sensuctl user list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl user list --format json
+sensuctl user list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.3/operations/control-access/use-apikeys.md
@@ -85,12 +85,16 @@ The response will include the new API key:
 Created: /api/core/v2/apikeys/7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
 {{< /code >}}
 
-To get information about an API key in YAML or JSON format:
+To get information about an API key:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped-JSON" >}}
+sensuctl api-key info 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2 --format wrapped-json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -113,6 +117,21 @@ metadata:
 spec:
   created_at: 1570718917
   username: admin
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+{
+  "type": "APIKey",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2",
+    "created_by": "admin"
+  },
+  "spec": {
+    "created_at": 1570718917,
+    "username": "admin"
+  }
+}
 {{< /code >}}
 
 {{< code json >}}

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -118,7 +118,7 @@ To view license details in YAML or JSON, run:
 sensuctl license info --format yaml
 {{< /code >}}
 {{< code shell "JSON" >}}
-sensuctl license info --format json
+sensuctl license info --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -435,9 +435,9 @@ curl -H "Authorization: Bearer $SENSU_TOKEN" http://127.0.0.1:8080/api/core/v2/n
 {{< /code >}}
 
 You can also access your Sensu Go configuration in JSON or YAML using sensuctl.
-For example, `sensuctl check list --format json`.
+For example, `sensuctl check list --format wrapped-json`.
 Run `sensuctl help` to see available commands.
-For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][5].
+For more information about sensuctl's output formats (`json`, `wrapped-json`, and `yaml`), see the [sensuctl reference][22].
 
 ### Step 3: Translate plugins and register dynamic runtime assets
 
@@ -518,6 +518,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [19]: https://github.com/nixwiz/sensu-go-fatigue-check-filter/#filter-definition
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
+[22]: ../../../sensuctl/#preferred-output-format
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -415,7 +415,7 @@ sensuctl asset info sensu-plugins-disk-checks --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset info sensu-plugins-disk-checks --format json
+sensuctl asset info sensu-plugins-disk-checks --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
@@ -124,7 +124,7 @@ sensuctl asset list --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl asset list --format json
+sensuctl asset list --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/sensuctl/_index.md
+++ b/content/sensu-go/6.3/sensuctl/_index.md
@@ -232,7 +232,7 @@ These formats include the resource type, which sensuctl needs to determine what 
 The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
 For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
 
-Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
+Sensu sends events to the backend in [`json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 

--- a/content/sensu-go/6.3/sensuctl/_index.md
+++ b/content/sensu-go/6.3/sensuctl/_index.md
@@ -217,12 +217,22 @@ You can use this hash instead of the password when you use sensuctl to [create][
 
 Sensuctl supports the following output formats:
 
-- `tabular`: A user-friendly, columnar format
-- `wrapped-json`: An accepted format for use with [`sensuctl create`][5]
-- `yaml`: An accepted format for use with [`sensuctl create`][5]
-- `json`: A format used by the [Sensu API][9]
+- `tabular`: Output is organized in user-friendly columns (default).
+- `yaml`: Output is in [YAML][20] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `wrapped-json`: Output is in [JSON][21] format. Resource definitions include an outer-level `spec` "wrapping" for resource attributes and list the resource `type` and `api_version`.
+- `json`: Output is in [JSON][21] format. Resource definitions **do not** include an outer-level `spec` "wrapping" or the resource `type` and `api_version`.
 
-After you are logged in, you can change the output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+After you are logged in, you can change the default output format with `sensuctl config set-format` or set the output format per command with the `--format` flag.
+
+### Output format significance
+
+To use [sensuctl create][5] to create a resource, you must provide the resource definition in `yaml` or `wrapped-json` format.
+These formats include the resource type, which sensuctl needs to determine what kind of resource to create.
+
+The [Sensu API][9] uses `json` output format for responses for APIs in the `core` [group][22].
+For APIs that are not in the `core` group, responses are in the `wrapped-json` output format.
+
+Sensu sends events to the backend [in `json` format][23], without the `spec` attribute wrapper or `type` and `api_version` attributes.
 
 ## Non-interactive mode
 
@@ -417,3 +427,7 @@ create  delete  import  list
 [17]: ../operations/control-access/ldap-auth
 [18]: ../operations/control-access/ad-auth
 [19]: ../commercial/
+[20]: https://yaml.org/
+[21]: https://www.json.org/
+[22]: ../api/#url-format
+[23]: ../observability-pipeline/observe-events/events/#example-status-only-event-from-the-sensu-api

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -15,12 +15,16 @@ The `sensuctl dump` command allows you to export your [resources][6] to standard
 You can export all of your resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in YAML or JSON format:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
 
 {{< language-toggle >}}
 
 {{< code shell "YML" >}}
 sensuctl dump all --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --format wrapped-json --file my-resources.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -37,6 +41,10 @@ To export only checks for only the current namespace to STDOUT in YAML or JSON f
 sensuctl dump core/v2.CheckConfig --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --format json
 {{< /code >}}
@@ -49,6 +57,10 @@ To export only handlers and filters for only the current namespace to a file nam
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -66,6 +78,10 @@ For example:
 sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump all --all-namespaces --format json --file my-resources.json
 {{< /code >}}
@@ -78,6 +94,10 @@ sensuctl dump all --all-namespaces --format json --file my-resources.json
 sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 {{< /code >}}
@@ -88,6 +108,10 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format json
 
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -106,6 +130,10 @@ Here's an example that uses fully qualified names:
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
 {{< /code >}}
 
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
@@ -118,6 +146,10 @@ Here's an example that uses short names:
 
 {{< code shell "YML" >}}
 sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< code shell "JSON" >}}
@@ -147,6 +179,12 @@ sensuctl dump all \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --format yaml > backup/config.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all \
+--all-namespaces \
+--omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--format wrapped-json > backup/config.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump all \
 --all-namespaces \
@@ -162,6 +200,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 --all-namespaces \
 --format yaml > backup/rbac.yml
 {{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
+--all-namespaces \
+--format wrapped-json > backup/rbac.json
+{{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
@@ -175,6 +218,11 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
 --format yaml > backup/cannotrestore.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.APIKey,core/v2.User \
+--all-namespaces \
+--format wrapped-json > backup/cannotrestore.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
@@ -194,6 +242,11 @@ Because users require this additional configuration and API keys cannot be resto
 sensuctl dump core/v2.Entity \
 --all-namespaces \
 --format yaml > backup/inventory.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Entity \
+--all-namespaces \
+--format wrapped-json > backup/inventory.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Entity \
@@ -223,6 +276,11 @@ mkdir backup
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
 --all-namespaces \
 --format yaml | grep -v "^\s*namespace:" > backup/pipelines.yml
+{{< /code >}}
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
+--all-namespaces \
+--format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
 {{< code shell "JSON" >}}
 sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
@@ -342,7 +400,7 @@ The default is unformatted, but you can specify either `wrapped-json` or `yaml`:
 sensuctl describe-type core/v2.CheckConfig --format yaml
 {{< /code >}}
 
-{{< code shell "JSON">}}
+{{< code shell "Wrapped JSON">}}
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -17,8 +17,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 ## Create resources
 
 The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
-The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4].
-Both JSON and YAML resource definitions wrap the contents of the resource in `spec` and identify the resource `type`.
+The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 See the [list of supported resource types][3] `for sensuctl create`.
 See the [reference docs][6] for information about creating resource definitions.
 
@@ -378,7 +377,7 @@ sensuctl check list --format wrapped-json > my-resources.json
 
 {{< /language-toggle >}}
 
-To see the definition for a check named `check-cpu` in `yaml` or `json` format:
+To see the definition for a check named `check-cpu`:
 
 {{< language-toggle >}}
 
@@ -387,7 +386,7 @@ sensuctl check info check-cpu --format yaml
 {{< /code >}}
 
 {{< code shell "JSON" >}}
-sensuctl check info check-cpu --format json
+sensuctl check info check-cpu --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}


### PR DESCRIPTION
## Description
- Improves the wrapped-json definition in sensuctl and API index pages
- Adds an example of an event in `json` format (as Sensu would send it to a handler) in the Event reference
- Corrects sensuctl commands to include an example for wrapped-json when the output will be used for sensuctl create
- Corrects sensuctl commands to produce complete resource definitions so that they use `wrapped-json` format (since that is what we're showing in the output)

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3084
