### PR TITLE
Fix incorrect asset name in confirmation message in Collect Metrics guide

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -42,7 +42,7 @@ added asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4
 
 You have successfully added the Sensu asset resource, but the asset will not get downloaded until
 it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
-resource, populate the "runtime_assets" field with ["disk-checks-plugins"].
+resource, populate the "runtime_assets" field with ["sensu-plugins/sensu-plugins-disk-checks"].
 {{< /code >}}
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][7] and register the asset with `sensuctl create --file filename.yml`.

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -42,7 +42,7 @@ added asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4
 
 You have successfully added the Sensu asset resource, but the asset will not get downloaded until
 it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
-resource, populate the "runtime_assets" field with ["disk-checks-plugins"].
+resource, populate the "runtime_assets" field with ["sensu-plugins/sensu-plugins-disk-checks"].
 {{< /code >}}
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][7] and register the asset with `sensuctl create --file filename.yml`.

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -42,7 +42,7 @@ added asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4
 
 You have successfully added the Sensu asset resource, but the asset will not get downloaded until
 it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
-resource, populate the "runtime_assets" field with ["disk-checks-plugins"].
+resource, populate the "runtime_assets" field with ["sensu-plugins/sensu-plugins-disk-checks"].
 {{< /code >}}
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][7] and register the asset with `sensuctl create --file filename.yml`.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -42,7 +42,7 @@ added asset: sensu-plugins/sensu-plugins-disk-checks:5.1.4
 
 You have successfully added the Sensu asset resource, but the asset will not get downloaded until
 it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
-resource, populate the "runtime_assets" field with ["disk-checks-plugins"].
+resource, populate the "runtime_assets" field with ["sensu-plugins/sensu-plugins-disk-checks"].
 {{< /code >}}
 
 You can also download the dynamic runtime asset definition for Debian or Alpine from [Bonsai][7] and register the asset with `sensuctl create --file filename.yml`.


### PR DESCRIPTION
## Description
The confirmation message example for adding the first runtime asset in Collect Metrics listed the wrong asset name. Replaced with `sensu-plugins/sensu-plugins-disk-checks` (the correct name).

## Motivation and Context
Noticed while working on something else