### PR TITLE
Add note that agents cannot create events in more than one namespace

### DIFF
--- a/content/sensu-go/5.21/api/events.md
+++ b/content/sensu-go/5.21/api/events.md
@@ -214,7 +214,9 @@ HTTP/1.1 201 Created
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event that references an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.<br>{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< code shell >}}
 {

--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -671,7 +671,11 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+
+{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 
 ## Manage events
 

--- a/content/sensu-go/5.21/reference/namespaces.md
+++ b/content/sensu-go/5.21/reference/namespaces.md
@@ -56,7 +56,7 @@ spec:
 **Use namespaces for isolation, not organization**
 
 Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
-Agents cannot belong to two namespaces or execute checks in two different namespaces.
+An agent cannot belong to two namespaces or execute checks in two different namespaces.
 To organize resources, use labels rather than multiple namespaces.
 
 ## Default namespaces

--- a/content/sensu-go/6.0/api/events.md
+++ b/content/sensu-go/6.0/api/events.md
@@ -226,7 +226,9 @@ HTTP/1.1 201 Created
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event that references an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.<br>{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< code shell >}}
 {

--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -866,7 +866,11 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+
+{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 
 ## Manage events
 

--- a/content/sensu-go/6.0/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.0/operations/control-access/namespaces.md
@@ -56,7 +56,7 @@ spec:
 **Use namespaces for isolation, not organization**
 
 Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
-Agents cannot belong to two namespaces or execute checks in two different namespaces.
+An agent cannot belong to two namespaces or execute checks in two different namespaces.
 To organize resources, use labels rather than multiple namespaces.
 
 ## Default namespaces

--- a/content/sensu-go/6.1/api/events.md
+++ b/content/sensu-go/6.1/api/events.md
@@ -228,7 +228,9 @@ HTTP/1.1 201 Created
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event that references an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.<br>{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< code shell >}}
 {

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -866,7 +866,11 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+
+{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 
 ## Manage events
 

--- a/content/sensu-go/6.1/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.1/operations/control-access/namespaces.md
@@ -56,7 +56,7 @@ spec:
 **Use namespaces for isolation, not organization**
 
 Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
-Agents cannot belong to two namespaces or execute checks in two different namespaces.
+An agent cannot belong to two namespaces or execute checks in two different namespaces.
 To organize resources, use labels rather than multiple namespaces.
 
 ## Default namespaces

--- a/content/sensu-go/6.2/api/events.md
+++ b/content/sensu-go/6.2/api/events.md
@@ -230,7 +230,9 @@ HTTP/1.1 201 Created
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event that references an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.<br>{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< code shell >}}
 {

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -873,7 +873,11 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+
+{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 
 ## Manage events
 

--- a/content/sensu-go/6.2/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.2/operations/control-access/namespaces.md
@@ -56,7 +56,7 @@ spec:
 **Use namespaces for isolation, not organization**
 
 Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
-Agents cannot belong to two namespaces or execute checks in two different namespaces.
+An agent cannot belong to two namespaces or execute checks in two different namespaces.
 To organize resources, use labels rather than multiple namespaces.
 
 ## Default namespaces

--- a/content/sensu-go/6.3/api/events.md
+++ b/content/sensu-go/6.3/api/events.md
@@ -230,7 +230,9 @@ HTTP/1.1 201 Created
 
 /events (POST) | 
 ----------------|------
-description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+description     | Creates a new Sensu event. To update an existing event, use the [`/events` PUT endpoint][11].<br><br>If you create a new event that references an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.<br>{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/events
 payload         | {{< code shell >}}
 {

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -873,7 +873,11 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 You can send events directly to the Sensu pipeline using the [events API][16].
 To create an event, send a JSON event definition to the [events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+
+{{% notice note %}}
+**NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
+{{% /notice %}}
 
 ## Manage events
 

--- a/content/sensu-go/6.3/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.3/operations/control-access/namespaces.md
@@ -56,7 +56,7 @@ spec:
 **Use namespaces for isolation, not organization**
 
 Use namespaces to enforce full isolation of different groups of resources, not to organize resources.
-Agents cannot belong to two namespaces or execute checks in two different namespaces.
+An agent cannot belong to two namespaces or execute checks in two different namespaces.
 To organize resources, use labels rather than multiple namespaces.
 
 ## Default namespaces


### PR DESCRIPTION
## Description
Adds a note in the events API POST description table and the event reference to explain that an agent cannot belong to or create events in more than one namespace. Also notes that sensu-backend-created proxy entities will be created in the same namespace.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3091