### PR TITLE
Add link to check dependencies asset in migrate guide

### DIFF
--- a/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
@@ -277,7 +277,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
 `aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
 `hooks` | See the [translate hooks][73] section.
-`dependencies`| Check dependencies are not available in Sensu Go.
+`dependencies`| Use the [Core Dependencies Filter][22] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using **token substitution** in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
@@ -481,6 +481,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [19]: https://github.com/nixwiz/sensu-go-fatigue-check-filter/#filter-definition
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
+[22]: https://bonsai.sensu.io/assets/sensu/sensu-dependencies-filter
 [24]: ../../../reference/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -281,7 +281,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
 `aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
 `hooks` | See the [translate hooks][73] section.
-`dependencies`| Check dependencies are not available in Sensu Go.
+`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using **token substitution** in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
@@ -519,6 +519,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [22]: ../../../sensuctl/#preferred-output-format
+[23]: https://bonsai.sensu.io/assets/sensu/sensu-dependencies-filter
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -281,7 +281,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
 `aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
 `hooks` | See the [translate hooks][73] section.
-`dependencies`| Check dependencies are not available in Sensu Go.
+`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using **token substitution** in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
@@ -518,6 +518,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [19]: https://github.com/nixwiz/sensu-go-fatigue-check-filter/#filter-definition
 [20]: https://packagecloud.io/sensu/community/
 [22]: ../../../sensuctl/#preferred-output-format
+[23]: https://bonsai.sensu.io/assets/sensu/sensu-dependencies-filter
 [21]: https://github.com/sensu-plugins/
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -281,7 +281,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
 `aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
 `hooks` | See the [translate hooks][73] section.
-`dependencies`| Check dependencies are not available in Sensu Go.
+`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using **token substitution** in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
@@ -519,6 +519,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [22]: ../../../sensuctl/#preferred-output-format
+[23]: https://bonsai.sensu.io/assets/sensu/sensu-dependencies-filter
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -281,7 +281,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
 `aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
 `hooks` | See the [translate hooks][73] section.
-`dependencies`| Check dependencies are not available in Sensu Go.
+`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using **token substitution** in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
@@ -519,6 +519,7 @@ You may also want to re-install the `sensu-install` tool using the [`sensu-plugi
 [20]: https://packagecloud.io/sensu/community/
 [21]: https://github.com/sensu-plugins/
 [22]: ../../../sensuctl/#preferred-output-format
+[23]: https://bonsai.sensu.io/assets/sensu/sensu-dependencies-filter
 [24]: ../../../observability-pipeline/observe-entities/entities#metadata-attributes
 [25]: https://sensu.io/blog/check-configuration-upgrades-with-the-sensu-go-sandbox/
 [26]: https://sensu.io/blog/self-service-monitoring-checks-in-sensu-go/


### PR DESCRIPTION
## Description
Adds link to [Core Dependencies Filter](https://bonsai.sensu.io/assets/sensu/sensu-dependencies-filter) asset in Migrate guide.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2752

See also https://sensu.slack.com/archives/CCBBAAZQW/p1617398855113200