### PR TITLE
Update css to nowrap table headers

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
@@ -117,7 +117,7 @@ In issuing certificates for cluster members, the IP address or hostname used in 
 
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (e.g. `backend-1.example.com`), and an unqualified name (e.g. `backend-1`):
 
-Unqualified name | IP address | Fully qualified domain name (FQDN) | Additional names     |
+Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |
 -----------------|------------|------------------------------------|----------------------|
 backend-1        | 10.0.0.1   | backend-1.example.com              | localhost, 127.0.0.1 |
 backend-2        | 10.0.0.2   | backend-2.example.com              | localhost, 127.0.0.1 |

--- a/content/sensu-go/5.21/platforms.md
+++ b/content/sensu-go/5.21/platforms.md
@@ -20,7 +20,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu backend
 
-| Platform and Version | `amd64` | | | |
+| Platform<br>and Version | `amd64` | | | |
 |----------------------|---------|---|---|---|
 | RHEL/CentOS 6, 7, 8 | {{< check >}} | | | |
 | Debian 8, 9, 10     | {{< check >}} | | | |
@@ -32,7 +32,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu agent
 
-| Platform and Version | `amd64` | `386` | | | | |
+| Platform<br>and Version | `amd64` | `386` | | | | |
 |----------------------|---------|-------|---|---|---|---|
 | RHEL/CentOS 6, 7, 8 | {{< check >}} | | | |
 | Debian 8, 9, 10     | {{< check >}} | | | |
@@ -46,7 +46,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensuctl command line tool
 
-| Platform and Version | `amd64` | `386` | | | | |
+| Platform<br>and Version | `amd64` | `386` | | | | |
 |----------------------|---------|-------|---|---|---|---|
 | RHEL/CentOS 6, 7, 8 | {{< check >}} | | | |
 | Debian 8, 9, 10     | {{< check >}} | | | |

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -51,7 +51,7 @@ The response will include the complete hook resource definition in the specified
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: HookConfig
 api_version: core/v2

--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -134,7 +134,7 @@ In issuing certificates for cluster members, the IP address or hostname used in 
 
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (e.g. `backend-1.example.com`), and an unqualified name (e.g. `backend-1`):
 
-Unqualified name | IP address | Fully qualified domain name (FQDN) | Additional names     |
+Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |
 -----------------|------------|------------------------------------|----------------------|
 backend-1        | 10.0.0.1   | backend-1.example.com              | localhost, 127.0.0.1 |
 backend-2        | 10.0.0.2   | backend-2.example.com              | localhost, 127.0.0.1 |

--- a/content/sensu-go/6.0/platforms.md
+++ b/content/sensu-go/6.0/platforms.md
@@ -20,13 +20,13 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, 19.10, 20.04 |
+|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -36,7 +36,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -51,7 +51,7 @@ The response will include the complete hook resource definition in the specified
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: HookConfig
 api_version: core/v2

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -134,7 +134,7 @@ In issuing certificates for cluster members, the IP address or hostname used in 
 
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (e.g. `backend-1.example.com`), and an unqualified name (e.g. `backend-1`):
 
-Unqualified name | IP address | Fully qualified domain name (FQDN) | Additional names     |
+Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |
 -----------------|------------|------------------------------------|----------------------|
 backend-1        | 10.0.0.1   | backend-1.example.com              | localhost, 127.0.0.1 |
 backend-2        | 10.0.0.2   | backend-2.example.com              | localhost, 127.0.0.1 |

--- a/content/sensu-go/6.1/platforms.md
+++ b/content/sensu-go/6.1/platforms.md
@@ -20,13 +20,13 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, 19.10, 20.04 |
+|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -36,7 +36,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -51,7 +51,7 @@ The response will include the complete hook resource definition in the specified
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: HookConfig
 api_version: core/v2

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -134,7 +134,7 @@ In issuing certificates for cluster members, the IP address or hostname used in 
 
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (e.g. `backend-1.example.com`), and an unqualified name (e.g. `backend-1`):
 
-Unqualified name | IP address | Fully qualified domain name (FQDN) | Additional names     |
+Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |
 -----------------|------------|------------------------------------|----------------------|
 backend-1        | 10.0.0.1   | backend-1.example.com              | localhost, 127.0.0.1 |
 backend-2        | 10.0.0.2   | backend-2.example.com              | localhost, 127.0.0.1 |

--- a/content/sensu-go/6.2/platforms.md
+++ b/content/sensu-go/6.2/platforms.md
@@ -20,13 +20,13 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, 19.10, 20.04 |
+|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -36,7 +36,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -51,7 +51,7 @@ The response will include the complete hook resource definition in the specified
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: HookConfig
 api_version: core/v2

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -134,7 +134,7 @@ In issuing certificates for cluster members, the IP address or hostname used in 
 
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (e.g. `backend-1.example.com`), and an unqualified name (e.g. `backend-1`):
 
-Unqualified name | IP address | Fully qualified domain name (FQDN) | Additional names     |
+Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |
 -----------------|------------|------------------------------------|----------------------|
 backend-1        | 10.0.0.1   | backend-1.example.com              | localhost, 127.0.0.1 |
 backend-2        | 10.0.0.2   | backend-2.example.com              | localhost, 127.0.0.1 |

--- a/content/sensu-go/6.3/platforms.md
+++ b/content/sensu-go/6.3/platforms.md
@@ -20,13 +20,13 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, 19.10, 20.04 |
+|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -36,7 +36,7 @@ Supported packages are available through [sensu/stable][8] on packagecloud and t
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7 and later | Windows Server 2008 R2 and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/static/stylesheets/scss/_table.scss
+++ b/static/stylesheets/scss/_table.scss
@@ -34,6 +34,8 @@ table {
     color: white;
     font-size: 1.8rem;
     font-weight: 600;
+    overflow-x: visible;
+    white-space: nowrap;
   }
 
   thead {

--- a/static/stylesheets/scss/_table.scss
+++ b/static/stylesheets/scss/_table.scss
@@ -38,6 +38,12 @@ table {
     white-space: nowrap;
   }
 
+  @media only screen and (max-width: 600px) {
+    th {
+      white-space: normal;
+    }
+  }
+
   thead {
     background-color: #2C3458;
   }


### PR DESCRIPTION
## Description
Adds `overflow-x: visible;` and `white-space: nowrap;` to `th` in _table.scss for table header rows to prevent long table header text from wrapping to fit the width of the entire first column.

Adds a wrap override for screen size smaller than 600px so that table headings are not cut off on mobile devices.

I could not fix the way the text wraps in table cells themselves.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2202

## More Information

Before:
<img width="774" alt="before" src="https://user-images.githubusercontent.com/19190208/113749646-dd4edc00-96d7-11eb-858a-e58096347002.png">

After (screen size >= 600px):
<img width="810" alt="after-desktop" src="https://user-images.githubusercontent.com/19190208/113749610-d0ca8380-96d7-11eb-8b4a-8832f71425d0.png">

After (screen size < 600px):
<img width="423" alt="after-lessthan600px" src="https://user-images.githubusercontent.com/19190208/113749674-e3dd5380-96d7-11eb-8b19-a70bd0d060b0.png">
