### PR TITLE
Update filter name in send email alerts guide

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-email-alerts.md
@@ -95,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only2
+  name: state_change_only
   namespace: default
 spec:
   action: allow

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
@@ -95,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only2
+  name: state_change_only
   namespace: default
 spec:
   action: allow

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -95,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only2
+  name: state_change_only
   namespace: default
 spec:
   action: allow

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -95,7 +95,7 @@ api_version: core/v2
 metadata:
   annotations: null
   labels: null
-  name: state_change_only2
+  name: state_change_only
   namespace: default
 spec:
   action: allow


### PR DESCRIPTION
## Description
Fixes the name of the EventFilter in the send email alerts guide to match the filter name used in the handler definition.

## Motivation and Context
Noticed while working on something else