### PR TITLE
Add note re: default unix values of 0 in events created with events API

### DIFF
--- a/content/sensu-go/5.21/reference/entities.md
+++ b/content/sensu-go/5.21/reference/entities.md
@@ -723,7 +723,8 @@ sensu_agent_version: 1.0.0
 
 last_seen    | 
 -------------|------ 
-description  | Timestamp the entity was last seen. In seconds since the Unix epoch. 
+description  | Timestamp the entity was last seen. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: In the entity attributes for events created with the [events API](../../api/events/), the `last_seen` value is `0`.
+{{% /notice %}}
 required     | false 
 type         | Integer 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -1466,7 +1466,8 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1511,7 +1512,8 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.
+description  | Time that the check request was issued. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../api/events/), the `issued` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1527,7 +1529,8 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../api/events/), the `last_ok` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1660,7 +1663,8 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -944,7 +944,8 @@ sensu_agent_version: 1.0.0
 
 last_seen    | 
 -------------|------ 
-description  | Timestamp the entity was last seen. In seconds since the Unix epoch. 
+description  | Timestamp the entity was last seen. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: In the entity attributes for events created with the [events API](../../../api/events/), the `last_seen` value is `0`.
+{{% /notice %}}
 required     | false 
 type         | Integer 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -1656,7 +1656,8 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1701,7 +1702,8 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.
+description  | Time that the check request was issued. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `issued` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1717,7 +1719,8 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `last_ok` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1866,7 +1869,8 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -944,7 +944,8 @@ sensu_agent_version: 1.0.0
 
 last_seen    | 
 -------------|------ 
-description  | Timestamp the entity was last seen. In seconds since the Unix epoch. 
+description  | Timestamp the entity was last seen. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: In the entity attributes for events created with the [events API](../../../api/events/), the `last_seen` value is `0`.
+{{% /notice %}}
 required     | false 
 type         | Integer 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -1656,7 +1656,8 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1701,7 +1702,8 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.
+description  | Time that the check request was issued. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `issued` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1717,7 +1719,8 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `last_ok` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1866,7 +1869,8 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -961,7 +961,8 @@ sensu_agent_version: 1.0.0
 
 last_seen    | 
 -------------|------ 
-description  | Timestamp the entity was last seen. In seconds since the Unix epoch. 
+description  | Timestamp the entity was last seen. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: In the entity attributes for events created with the [events API](../../../api/events/), the `last_seen` value is `0`.
+{{% /notice %}}
 required     | false 
 type         | Integer 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -1683,7 +1683,8 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1728,7 +1729,8 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.
+description  | Time that the check request was issued. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `issued` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1744,7 +1746,8 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `last_ok` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1893,7 +1896,8 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -961,7 +961,8 @@ sensu_agent_version: 1.0.0
 
 last_seen    | 
 -------------|------ 
-description  | Timestamp the entity was last seen. In seconds since the Unix epoch. 
+description  | Timestamp the entity was last seen. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: In the entity attributes for events created with the [events API](../../../api/events/), the `last_seen` value is `0`.
+{{% /notice %}}
 required     | false 
 type         | Integer 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -1683,7 +1683,8 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1728,7 +1729,8 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.
+description  | Time that the check request was issued. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `issued` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1744,7 +1746,8 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `last_ok` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1893,7 +1896,8 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.{{% notice note %}}**NOTE**: For events created with the [events API](../../../api/events/), the `executed` value is `0`.
+{{% /notice %}}
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}


### PR DESCRIPTION
## Description
In events and entities references, document fields with default `0` values for events created with the events API:
- Events:
    - `executed`
    - `issued`
    - `last_ok`
    - `history`.`executed`
- Entities:
    - `last_seen`

## Motivation and Context
https://sensu.slack.com/archives/C7UNLR0F3/p1618340845047200
