### PR TITLE
Add handler troubleshooting instructions

### DIFF
--- a/content/sensu-go/5.21/guides/send-slack-alerts.md
+++ b/content/sensu-go/5.21/guides/send-slack-alerts.md
@@ -45,7 +45,7 @@ Read [the asset reference](../../reference/assets#asset-builds) for more informa
 
 ## Get a Slack webhook
 
-If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12].
 After saving, you'll see your webhook URL under Integration Settings.
 

--- a/content/sensu-go/5.21/learn/sample-app.md
+++ b/content/sensu-go/5.21/learn/sample-app.md
@@ -222,7 +222,7 @@ sensuctl create --file go/config/assets/slack-handler.yaml
 
 **2. Get your Slack webhook URL and add it to `go/config/handlers/slack.yaml`.**
 
-If you're already an admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
+If you're already an admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
 If you're not yet a Slack admin, [start here][5] to create a new workspace.
 After saving, you'll see your webhook URL under Integration Settings.
 

--- a/content/sensu-go/5.21/reference/handlers.md
+++ b/content/sensu-go/5.21/reference/handlers.md
@@ -941,6 +941,54 @@ spec:
 
 {{< /language-toggle >}}
 
+## Troubleshoot a handler
+
+If you are not receiving events via a handler even though a check is generating events as expected, follow these steps to manually execute the handler and confirm whether the handler is working properly.
+
+1. List all events:
+{{< code shell >}}
+sensuctl event list
+{{< /code >}}
+
+   Choose an event from the list to use for troubleshooting and note the event's check and entity names.
+
+2. Navigate to the `/var/cache/sensu/sensu-backend/` directory:
+{{< code shell >}}
+cd /var/cache/sensu/sensu-backend/
+{{< /code >}}
+
+3. Run `ls` to list the contents of the `/var/cache/sensu/sensu-backend/` directory.
+In the list, identify the handler's dynamic runtime asset SHA.
+
+   {{% notice note %}}
+**NOTE**: If the list includes more than one SHA, run `sensuctl asset list`.
+In the response, the Hash column contains the first seven characters for each asset build's SHA.
+Note the hash for your build of the handler asset and compare it with the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
+{{% /notice %}}
+
+4. Navigate to the `bin` directory for the handler asset SHA.
+Before you run the command below, replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
+{{< code shell >}}
+cd HANDLER_ASSET_SHA/bin
+{{< /code >}}
+
+5. Run the command to manually execute the handler.
+Before you run the command below, replace the following text:
+   - `ENTITY_NAME`: Replace with the entity name for the event you are using to troubleshoot.
+   - `CHECK_NAME`: Replace with the check name for the event you are using to troubleshoot.
+   - `HANDLER_COMMAND`: Replace with the `command` value for the handler you are troubleshooting.
+
+   {{< code shell >}}
+sensuctl event info ENTITY_NAME CHECK_NAME --format json | ./HANDLER_COMMAND
+{{< /code >}}
+
+If your handler is working properly, you will receive an alert for the event via the handler.
+The response for your manual execution command will also include a message to confirm notification was sent.
+In this case, your Sensu pipeline is not causing the problem with missing events.
+
+If you do not receive an alert for the event, the handler is not working properly.
+In this case, the manual execution response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error to help you correct the problem.
+
 
 [1]: ../checks/
 [2]: https://en.wikipedia.org/wiki/Standard_streams

--- a/content/sensu-go/6.0/learn/sample-app.md
+++ b/content/sensu-go/6.0/learn/sample-app.md
@@ -222,7 +222,7 @@ sensuctl create --file go/config/assets/slack-handler.yaml
 
 **2. Get your Slack webhook URL and add it to `go/config/handlers/slack.yaml`.**
 
-If you're already an admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
+If you're already an admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
 If you're not yet a Slack admin, [start here][5] to create a new workspace.
 After saving, you'll see your webhook URL under Integration Settings.
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handlers.md
@@ -944,6 +944,54 @@ spec:
 
 {{< /language-toggle >}}
 
+## Troubleshoot a handler
+
+If you are not receiving events via a handler even though a check is generating events as expected, follow these steps to manually execute the handler and confirm whether the handler is working properly.
+
+1. List all events:
+{{< code shell >}}
+sensuctl event list
+{{< /code >}}
+
+   Choose an event from the list to use for troubleshooting and note the event's check and entity names.
+
+2. Navigate to the `/var/cache/sensu/sensu-backend/` directory:
+{{< code shell >}}
+cd /var/cache/sensu/sensu-backend/
+{{< /code >}}
+
+3. Run `ls` to list the contents of the `/var/cache/sensu/sensu-backend/` directory.
+In the list, identify the handler's dynamic runtime asset SHA.
+
+   {{% notice note %}}
+**NOTE**: If the list includes more than one SHA, run `sensuctl asset list`.
+In the response, the Hash column contains the first seven characters for each asset build's SHA.
+Note the hash for your build of the handler asset and compare it with the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
+{{% /notice %}}
+
+4. Navigate to the `bin` directory for the handler asset SHA.
+Before you run the command below, replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
+{{< code shell >}}
+cd HANDLER_ASSET_SHA/bin
+{{< /code >}}
+
+5. Run the command to manually execute the handler.
+Before you run the command below, replace the following text:
+   - `ENTITY_NAME`: Replace with the entity name for the event you are using to troubleshoot.
+   - `CHECK_NAME`: Replace with the check name for the event you are using to troubleshoot.
+   - `HANDLER_COMMAND`: Replace with the `command` value for the handler you are troubleshooting.
+
+   {{< code shell >}}
+sensuctl event info ENTITY_NAME CHECK_NAME --format json | ./HANDLER_COMMAND
+{{< /code >}}
+
+If your handler is working properly, you will receive an alert for the event via the handler.
+The response for your manual execution command will also include a message to confirm notification was sent.
+In this case, your Sensu pipeline is not causing the problem with missing events.
+
+If you do not receive an alert for the event, the handler is not working properly.
+In this case, the manual execution response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error to help you correct the problem.
+
 
 [1]: ../../observe-schedule/checks/
 [2]: https://en.wikipedia.org/wiki/Standard_streams

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/send-slack-alerts.md
@@ -58,7 +58,7 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Get a Slack webhook
 
-If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12] and then create your webhook.
 
 After saving, you'll see your webhook URL under Integration Settings.

--- a/content/sensu-go/6.1/learn/sample-app.md
+++ b/content/sensu-go/6.1/learn/sample-app.md
@@ -222,7 +222,7 @@ sensuctl create --file go/config/assets/slack-handler.yaml
 
 **2. Get your Slack webhook URL and add it to `go/config/handlers/slack.yaml`.**
 
-If you're already an admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
+If you're already an admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
 If you're not yet a Slack admin, [start here][5] to create a new workspace.
 After saving, you'll see your webhook URL under Integration Settings.
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
@@ -944,6 +944,54 @@ spec:
 
 {{< /language-toggle >}}
 
+## Troubleshoot a handler
+
+If you are not receiving events via a handler even though a check is generating events as expected, follow these steps to manually execute the handler and confirm whether the handler is working properly.
+
+1. List all events:
+{{< code shell >}}
+sensuctl event list
+{{< /code >}}
+
+   Choose an event from the list to use for troubleshooting and note the event's check and entity names.
+
+2. Navigate to the `/var/cache/sensu/sensu-backend/` directory:
+{{< code shell >}}
+cd /var/cache/sensu/sensu-backend/
+{{< /code >}}
+
+3. Run `ls` to list the contents of the `/var/cache/sensu/sensu-backend/` directory.
+In the list, identify the handler's dynamic runtime asset SHA.
+
+   {{% notice note %}}
+**NOTE**: If the list includes more than one SHA, run `sensuctl asset list`.
+In the response, the Hash column contains the first seven characters for each asset build's SHA.
+Note the hash for your build of the handler asset and compare it with the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
+{{% /notice %}}
+
+4. Navigate to the `bin` directory for the handler asset SHA.
+Before you run the command below, replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
+{{< code shell >}}
+cd HANDLER_ASSET_SHA/bin
+{{< /code >}}
+
+5. Run the command to manually execute the handler.
+Before you run the command below, replace the following text:
+   - `ENTITY_NAME`: Replace with the entity name for the event you are using to troubleshoot.
+   - `CHECK_NAME`: Replace with the check name for the event you are using to troubleshoot.
+   - `HANDLER_COMMAND`: Replace with the `command` value for the handler you are troubleshooting.
+
+   {{< code shell >}}
+sensuctl event info ENTITY_NAME CHECK_NAME --format json | ./HANDLER_COMMAND
+{{< /code >}}
+
+If your handler is working properly, you will receive an alert for the event via the handler.
+The response for your manual execution command will also include a message to confirm notification was sent.
+In this case, your Sensu pipeline is not causing the problem with missing events.
+
+If you do not receive an alert for the event, the handler is not working properly.
+In this case, the manual execution response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error to help you correct the problem.
+
 
 [1]: ../../observe-schedule/checks/
 [2]: https://en.wikipedia.org/wiki/Standard_streams

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
@@ -58,7 +58,7 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Get a Slack webhook
 
-If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12] and then create your webhook.
 
 After saving, you'll see your webhook URL under Integration Settings.

--- a/content/sensu-go/6.2/learn/sample-app.md
+++ b/content/sensu-go/6.2/learn/sample-app.md
@@ -222,7 +222,7 @@ sensuctl create --file go/config/assets/slack-handler.yaml
 
 **2. Get your Slack webhook URL and add it to `go/config/handlers/slack.yaml`.**
 
-If you're already an admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
+If you're already an admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
 If you're not yet a Slack admin, [start here][5] to create a new workspace.
 After saving, you'll see your webhook URL under Integration Settings.
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -944,6 +944,52 @@ spec:
 
 {{< /language-toggle >}}
 
+## Troubleshoot a handler
+
+If you are not receiving events via a handler even though a check is generating events as expected, follow these steps to manually execute the handler and confirm whether the handler is working properly.
+
+1. List all events:
+{{< code shell >}}
+sensuctl event list
+{{< /code >}}
+
+   Choose an event from the list to use for troubleshooting and note the event's check and entity names.
+
+2. Navigate to the `/var/cache/sensu/sensu-backend/` directory:
+{{< code shell >}}
+cd /var/cache/sensu/sensu-backend/
+{{< /code >}}
+
+3. Run `ls` to list the contents of the `/var/cache/sensu/sensu-backend/` directory.
+In the list, identify the handler's dynamic runtime asset SHA.
+
+   {{% notice note %}}
+**NOTE**: If the list includes more than one SHA, run `sensuctl asset list`.
+In the response, the Hash column contains the first seven characters for each asset build's SHA.
+Note the SHA for your build of the handler asset and match it against the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
+{{% /notice %}}
+
+4. Navigate to the `bin` directory for the handler asset SHA.
+Replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
+{{< code shell >}}
+cd HANDLER_ASSET_SHA/bin
+{{< /code >}}
+
+5. Run the command to manually execute the handler.
+Before you run the command example below, replace the following text:
+   - `ENTITY_NAME`: Replace with the entity name for the event you are using to troubleshoot.
+   - `CHECK_NAME`: Replace with the check name for the event you are using to troubleshoot.
+   - `HANDLER_COMMAND`: Replace with the `command` value for the handler you are troubleshooting.
+
+   {{< code shell >}}
+sensuctl event info ENTITY_NAME CHECK_NAME --format json | ./HANDLER_COMMAND
+{{< /code >}}
+
+If your handler is working properly and the problem lies elsewhere, you will receive an alert for the event via the handler.
+The response for your manual execution command will also include a message to confirm notification was sent.
+
+If there is a problem with your handler, the response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error.
+
 
 [1]: ../../observe-schedule/checks/
 [2]: https://en.wikipedia.org/wiki/Standard_streams

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -966,17 +966,17 @@ In the list, identify the handler's dynamic runtime asset SHA.
    {{% notice note %}}
 **NOTE**: If the list includes more than one SHA, run `sensuctl asset list`.
 In the response, the Hash column contains the first seven characters for each asset build's SHA.
-Note the SHA for your build of the handler asset and match it against the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
+Note the hash for your build of the handler asset and compare it with the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
 {{% /notice %}}
 
 4. Navigate to the `bin` directory for the handler asset SHA.
-Replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
+Before you run the command below, replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
 {{< code shell >}}
 cd HANDLER_ASSET_SHA/bin
 {{< /code >}}
 
 5. Run the command to manually execute the handler.
-Before you run the command example below, replace the following text:
+Before you run the command below, replace the following text:
    - `ENTITY_NAME`: Replace with the entity name for the event you are using to troubleshoot.
    - `CHECK_NAME`: Replace with the check name for the event you are using to troubleshoot.
    - `HANDLER_COMMAND`: Replace with the `command` value for the handler you are troubleshooting.
@@ -985,10 +985,12 @@ Before you run the command example below, replace the following text:
 sensuctl event info ENTITY_NAME CHECK_NAME --format json | ./HANDLER_COMMAND
 {{< /code >}}
 
-If your handler is working properly and the problem lies elsewhere, you will receive an alert for the event via the handler.
+If your handler is working properly, you will receive an alert for the event via the handler.
 The response for your manual execution command will also include a message to confirm notification was sent.
+In this case, your Sensu pipeline is not causing the problem with missing events.
 
-If there is a problem with your handler, the response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error.
+If you do not receive an alert for the event, the handler is not working properly.
+In this case, the manual execution response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error to help you correct the problem.
 
 
 [1]: ../../observe-schedule/checks/

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
@@ -58,7 +58,7 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Get a Slack webhook
 
-If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12] and then create your webhook.
 
 After saving, you'll see your webhook URL under Integration Settings.

--- a/content/sensu-go/6.3/learn/sample-app.md
+++ b/content/sensu-go/6.3/learn/sample-app.md
@@ -222,7 +222,7 @@ sensuctl create --file go/config/assets/slack-handler.yaml
 
 **2. Get your Slack webhook URL and add it to `go/config/handlers/slack.yaml`.**
 
-If you're already an admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
+If you're already an admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration and save the settings.
 If you're not yet a Slack admin, [start here][5] to create a new workspace.
 After saving, you'll see your webhook URL under Integration Settings.
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -944,6 +944,54 @@ spec:
 
 {{< /language-toggle >}}
 
+## Troubleshoot a handler
+
+If you are not receiving events via a handler even though a check is generating events as expected, follow these steps to manually execute the handler and confirm whether the handler is working properly.
+
+1. List all events:
+{{< code shell >}}
+sensuctl event list
+{{< /code >}}
+
+   Choose an event from the list to use for troubleshooting and note the event's check and entity names.
+
+2. Navigate to the `/var/cache/sensu/sensu-backend/` directory:
+{{< code shell >}}
+cd /var/cache/sensu/sensu-backend/
+{{< /code >}}
+
+3. Run `ls` to list the contents of the `/var/cache/sensu/sensu-backend/` directory.
+In the list, identify the handler's dynamic runtime asset SHA.
+
+   {{% notice note %}}
+**NOTE**: If the list includes more than one SHA, run `sensuctl asset list`.
+In the response, the Hash column contains the first seven characters for each asset build's SHA.
+Note the hash for your build of the handler asset and compare it with the SHAs listed in the `/var/cache/sensu/sensu-backend/` directory to find the correct handler asset SHA.
+{{% /notice %}}
+
+4. Navigate to the `bin` directory for the handler asset SHA.
+Before you run the command below, replace `HANDLER_ASSET_SHA` with the SHA you identified in the previous step.
+{{< code shell >}}
+cd HANDLER_ASSET_SHA/bin
+{{< /code >}}
+
+5. Run the command to manually execute the handler.
+Before you run the command below, replace the following text:
+   - `ENTITY_NAME`: Replace with the entity name for the event you are using to troubleshoot.
+   - `CHECK_NAME`: Replace with the check name for the event you are using to troubleshoot.
+   - `HANDLER_COMMAND`: Replace with the `command` value for the handler you are troubleshooting.
+
+   {{< code shell >}}
+sensuctl event info ENTITY_NAME CHECK_NAME --format json | ./HANDLER_COMMAND
+{{< /code >}}
+
+If your handler is working properly, you will receive an alert for the event via the handler.
+The response for your manual execution command will also include a message to confirm notification was sent.
+In this case, your Sensu pipeline is not causing the problem with missing events.
+
+If you do not receive an alert for the event, the handler is not working properly.
+In this case, the manual execution response will include the message `Error executing HANDLER_ASSET_NAME:`, followed by a description of the specific error to help you correct the problem.
+
 
 [1]: ../../observe-schedule/checks/
 [2]: https://en.wikipedia.org/wiki/Standard_streams

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -58,7 +58,7 @@ Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Get a Slack webhook
 
-If you're already the admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
 If you're not yet a Slack admin, [create a new workspace][12] and then create your webhook.
 
 After saving, you'll see your webhook URL under Integration Settings.


### PR DESCRIPTION
## Description
Adds steps for troubleshooting a handler by executing the command manually with existing event info.

Also fixes one formatting nit in the Send Slack alerts guide.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3078
