### PR TITLE
Update redirect for ready-only to use an alias

### DIFF
--- a/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
@@ -8,6 +8,8 @@ weight: 60
 version: "6.2"
 product: "Sensu Go"
 platformContent: false
+aliases:
+  - ../../../guides/create-a-ready-only-user/
 menu: 
   sensu-go-6.2:
     parent: control-access

--- a/static.json
+++ b/static.json
@@ -43,10 +43,6 @@
             "url": "/sensu-enterprise-dashboard/latest/$1",
             "status": 301
         },
-        "~ ^/sensu-go/latest/guides/create-a-ready-only-user/?$": {
-            "url": "/sensu-go/latest/operations/control-access/create-read-only-user",
-            "status": 301
-        },
         "~ ^/sensu-go/6.2/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 302


### PR DESCRIPTION
## Description
Add alias for /sensu-go/latest/guides/create-a-ready-only-user/ in /sensu-go/latest/operations/control-access/create-read-only-user for 6.2 doc to test using alias for redirect rather than static.json.

## Motivation and Context
Updating docs wiki, which instructs to use an alias for redirects when possible (before resorting to static.json)