### PR TITLE
Fix some format and consistency issues in handler templates doc

### DIFF
--- a/content/sensu-go/5.21/guides/handler-templates.md
+++ b/content/sensu-go/5.21/guides/handler-templates.md
@@ -31,7 +31,7 @@ The playbook for managing this alert is available at https://example.com/observa
 Handler templates use dot notation syntax to access event attributes, with the event attribute wrapped in double curly braces.
 The initial dot indicates `event`.
 
-For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `.Check.Occurrences}}`.
+For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `{{.Check.Occurrences}}`.
 
 Use HTML to format the text and spacing in your templates.
 All text outside double curly braces is copied directly into the template output, with HTML formatting applied.
@@ -83,7 +83,28 @@ The [Sensu template toolkit command][8] is a sensuctl command plugin you can use
 
 The template toolkit command uses event data you supply via STDIN in JSON format.
 
-Visit the [template toolkit command Bonsai page][8] to install the plugin.
+Add the Sensu template toolkit command asset to Sensu:
+
+{{< code shell >}}
+sensuctl asset add sensu/template-toolkit-command:0.4.0 -r template-toolkit-command
+{{< /code >}}
+
+This example uses the `-r` (rename) flag to specify a shorter name for the asset: `template-toolkit-command`.
+
+You can also download the latest asset definition from [Bonsai][8].
+
+Run `sensuctl asset list` to confirm that the asset is ready to use:
+
+{{< code shell >}}
+            Name                                                         URL                                                Hash    
+ ────────────────────────── ───────────────────────────────────────────────────────────────────────────────────────────── ───────── 
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_windows_amd64.tar.gz              019ccf3  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_darwin_amd64.tar.gz               b771813  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_armv7.tar.gz                4e7ad65  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_arm64.tar.gz                02eca1f  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_386.tar.gz                  56ed603  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_amd64.tar.gz                7dbd2c6  
+{{< /code >}}
 
 ### Print available event attributes
 
@@ -110,7 +131,7 @@ In this example, the response lists the available event attributes `.Timestamp`,
 You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
-sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit-command -- --dump-names
 INFO[0000] asset includes builds, using builds instead of asset  asset=template-toolkit-command component=asset-manager entity=sensuctl
 .Event{
     .Timestamp: 1580310179,

--- a/content/sensu-go/5.21/guides/handler-templates.md
+++ b/content/sensu-go/5.21/guides/handler-templates.md
@@ -128,7 +128,7 @@ INFO[0000] asset includes builds, using builds instead of asset  asset=template-
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info <entity_name> <check_name>` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
 sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit-command -- --dump-names
@@ -161,7 +161,7 @@ Template String Output: keepalive
 
 In this example, the command validates that for the `event.json` event, the handler template will replace `{{.Check.Name}}` with `keepalive` in template output.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info <entity_name> <check_name>` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"

--- a/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-process/handler-templates.md
@@ -32,7 +32,7 @@ The playbook for managing this alert is available at https://example.com/observa
 Handler templates use dot notation syntax to access event attributes, with the event attribute wrapped in double curly braces.
 The initial dot indicates `event`.
 
-For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `.Check.Occurrences}}`.
+For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `{{.Check.Occurrences}}`.
 
 Use HTML to format the text and spacing in your templates.
 All text outside double curly braces is copied directly into the template output, with HTML formatting applied.
@@ -84,7 +84,28 @@ The [Sensu template toolkit command][8] is a sensuctl command plugin you can use
 
 The template toolkit command uses event data you supply via STDIN in JSON format.
 
-Visit the [template toolkit command Bonsai page][8] to install the plugin.
+Add the Sensu template toolkit command asset to Sensu:
+
+{{< code shell >}}
+sensuctl asset add sensu/template-toolkit-command:0.4.0 -r template-toolkit-command
+{{< /code >}}
+
+This example uses the `-r` (rename) flag to specify a shorter name for the asset: `template-toolkit-command`.
+
+You can also download the latest asset definition from [Bonsai][8].
+
+Run `sensuctl asset list` to confirm that the asset is ready to use:
+
+{{< code shell >}}
+            Name                                                         URL                                                Hash    
+ ────────────────────────── ───────────────────────────────────────────────────────────────────────────────────────────── ───────── 
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_windows_amd64.tar.gz              019ccf3  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_darwin_amd64.tar.gz               b771813  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_armv7.tar.gz                4e7ad65  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_arm64.tar.gz                02eca1f  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_386.tar.gz                  56ed603  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_amd64.tar.gz                7dbd2c6  
+{{< /code >}}
 
 ### Print available event attributes
 
@@ -113,10 +134,10 @@ INFO[0000] asset includes builds, using builds instead of asset  asset=template-
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
+You can also use `sensuctl event info <entity_name> <check_name>` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
-sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit-command -- --dump-names
 {{< /code >}}
 
 The response lists the available attributes for the event:
@@ -156,7 +177,7 @@ Template String Output: keepalive
 
 In this example, the command validates that for the `event.json` event, the handler template will replace `{{.Check.Name}}` with `keepalive` in template output.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info <entity_name> <check_name>` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handler-templates.md
@@ -32,7 +32,7 @@ The playbook for managing this alert is available at https://example.com/observa
 Handler templates use dot notation syntax to access event attributes, with the event attribute wrapped in double curly braces.
 The initial dot indicates `event`.
 
-For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `.Check.Occurrences}}`.
+For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `{{.Check.Occurrences}}`.
 
 Use HTML to format the text and spacing in your templates.
 All text outside double curly braces is copied directly into the template output, with HTML formatting applied.
@@ -84,7 +84,28 @@ The [Sensu template toolkit command][8] is a sensuctl command plugin you can use
 
 The template toolkit command uses event data you supply via STDIN in JSON format.
 
-Visit the [template toolkit command Bonsai page][8] to install the plugin.
+Add the Sensu template toolkit command asset to Sensu:
+
+{{< code shell >}}
+sensuctl asset add sensu/template-toolkit-command:0.4.0 -r template-toolkit-command
+{{< /code >}}
+
+This example uses the `-r` (rename) flag to specify a shorter name for the asset: `template-toolkit-command`.
+
+You can also download the latest asset definition from [Bonsai][8].
+
+Run `sensuctl asset list` to confirm that the asset is ready to use:
+
+{{< code shell >}}
+            Name                                                         URL                                                Hash    
+ ────────────────────────── ───────────────────────────────────────────────────────────────────────────────────────────── ───────── 
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_windows_amd64.tar.gz              019ccf3  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_darwin_amd64.tar.gz               b771813  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_armv7.tar.gz                4e7ad65  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_arm64.tar.gz                02eca1f  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_386.tar.gz                  56ed603  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_amd64.tar.gz                7dbd2c6  
+{{< /code >}}
 
 ### Print available event attributes
 
@@ -113,10 +134,10 @@ INFO[0000] asset includes builds, using builds instead of asset  asset=template-
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
+You can also use `sensuctl event info <entity_name> <check_name>` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
-sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit-command -- --dump-names
 {{< /code >}}
 
 The response lists the available attributes for the event:
@@ -156,7 +177,7 @@ Template String Output: keepalive
 
 In this example, the command validates that for the `event.json` event, the handler template will replace `{{.Check.Name}}` with `keepalive` in template output.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info <entity_name> <check_name>` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handler-templates.md
@@ -32,7 +32,7 @@ The playbook for managing this alert is available at https://example.com/observa
 Handler templates use dot notation syntax to access event attributes, with the event attribute wrapped in double curly braces.
 The initial dot indicates `event`.
 
-For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `.Check.Occurrences}}`.
+For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `{{.Check.Occurrences}}`.
 
 Use HTML to format the text and spacing in your templates.
 All text outside double curly braces is copied directly into the template output, with HTML formatting applied.
@@ -84,7 +84,28 @@ The [Sensu template toolkit command][8] is a sensuctl command plugin you can use
 
 The template toolkit command uses event data you supply via STDIN in JSON format.
 
-Visit the [template toolkit command Bonsai page][8] to install the plugin.
+Add the Sensu template toolkit command asset to Sensu:
+
+{{< code shell >}}
+sensuctl asset add sensu/template-toolkit-command:0.4.0 -r template-toolkit-command
+{{< /code >}}
+
+This example uses the `-r` (rename) flag to specify a shorter name for the asset: `template-toolkit-command`.
+
+You can also download the latest asset definition from [Bonsai][8].
+
+Run `sensuctl asset list` to confirm that the asset is ready to use:
+
+{{< code shell >}}
+            Name                                                         URL                                                Hash    
+ ────────────────────────── ───────────────────────────────────────────────────────────────────────────────────────────── ───────── 
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_windows_amd64.tar.gz              019ccf3  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_darwin_amd64.tar.gz               b771813  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_armv7.tar.gz                4e7ad65  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_arm64.tar.gz                02eca1f  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_386.tar.gz                  56ed603  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_amd64.tar.gz                7dbd2c6  
+{{< /code >}}
 
 ### Print available event attributes
 
@@ -113,10 +134,10 @@ INFO[0000] asset includes builds, using builds instead of asset  asset=template-
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
+You can also use `sensuctl event info <entity_name> <check_name>` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
-sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
+sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit-command -- --dump-names
 {{< /code >}}
 
 The response lists the available attributes for the event:
@@ -156,7 +177,7 @@ Template String Output: keepalive
 
 In this example, the command validates that for the `event.json` event, the handler template will replace `{{.Check.Name}}` with `keepalive` in template output.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info <entity_name> <check_name>` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
@@ -32,7 +32,7 @@ The playbook for managing this alert is available at https://example.com/observa
 Handler templates use dot notation syntax to access event attributes, with the event attribute wrapped in double curly braces.
 The initial dot indicates `event`.
 
-For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `.Check.Occurrences}}`.
+For example, in a handler template, a reference to the event attribute `.Check.occurrences` becomes `{{.Check.Occurrences}}`.
 
 Use HTML to format the text and spacing in your templates.
 All text outside double curly braces is copied directly into the template output, with HTML formatting applied.
@@ -84,7 +84,28 @@ The [Sensu template toolkit command][8] is a sensuctl command plugin you can use
 
 The template toolkit command uses event data you supply via STDIN in JSON format.
 
-Visit the [template toolkit command Bonsai page][8] to install the plugin.
+Add the Sensu template toolkit command asset to Sensu:
+
+{{< code shell >}}
+sensuctl asset add sensu/template-toolkit-command:0.4.0 -r template-toolkit-command
+{{< /code >}}
+
+This example uses the `-r` (rename) flag to specify a shorter name for the asset: `template-toolkit-command`.
+
+You can also download the latest asset definition from [Bonsai][8].
+
+Run `sensuctl asset list` to confirm that the asset is ready to use:
+
+{{< code shell >}}
+            Name                                                         URL                                                Hash    
+ ────────────────────────── ───────────────────────────────────────────────────────────────────────────────────────────── ───────── 
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_windows_amd64.tar.gz              019ccf3  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_darwin_amd64.tar.gz               b771813  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_armv7.tar.gz                4e7ad65  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_arm64.tar.gz                02eca1f  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_386.tar.gz                  56ed603  
+  template-toolkit-command   //assets.bonsai.sensu.io/.../template-toolkit-command_0.4.0_linux_amd64.tar.gz                7dbd2c6  
+{{< /code >}}
 
 ### Print available event attributes
 
@@ -113,7 +134,7 @@ INFO[0000] asset includes builds, using builds instead of asset  asset=template-
 
 In this example, the response lists the available event attributes `.Timestamp`, `.Entity.EntityClass`, `.Entity.System`, `.Check.Command`, `.Check.Handlers`, and `.Check.HighFlapThreshold`.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
+You can also use `sensuctl event info <entity_name> <check_name>` to print the correct notation and pattern: template output for a specific event (in this example, an event for entity `server01` and check `server-health`):
 
 {{< code shell >}}
 sensuctl event info server01 server-health --format json | sensuctl command exec template-toolkit -- --dump-names
@@ -156,7 +177,7 @@ Template String Output: keepalive
 
 In this example, the command validates that for the `event.json` event, the handler template will replace `{{.Check.Name}}` with `keepalive` in template output.
 
-You can also use `sensuctl event info [ENTITY_NAME] [CHECK_NAME]` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
+You can also use `sensuctl event info <entity_name> <check_name>` to validate template output for a specific event (in this example, an event for entity `webserver01` and check `check-http`):
 
 {{< code shell >}}
 sensuctl event info webserver01 check-http --format json | sensuctl command exec template-toolkit-command -- --template "Server: {{.Entity.Name}} Check: {{.Check.Name}} Status: {{.Check.State}}"


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/:
- Adds commands for adding the template toolkit command asset
- Corrects a missing open-double-bracket
- Updates all sensuctl command references to template-toolkit-command so they are consistent

## Motivation and Context
Noticed during chat in #reliability today