### PR TITLE
Fix typo in 'commercial'

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
@@ -118,7 +118,7 @@ Five etcd nodes allow you to tolerate the loss of two nodes, but with a greater 
 
 #### Scaled cluster performance with PostgreSQL
 
-To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commmercial feature][9].
+To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commercial feature][9].
 See the [Datastore reference][8] for details on configuring the Sensu backend to use PostgreSQL for event storage.
 
 {{< figure src="/images/clustered_architecture_postgres.png" alt="Clustered Sensu Go architecture with PostgreSQL" link="/images/clustered_architecture_postgres.png" target="_blank" >}}

--- a/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
@@ -118,7 +118,7 @@ Five etcd nodes allow you to tolerate the loss of two nodes, but with a greater 
 
 #### Scaled cluster performance with PostgreSQL
 
-To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commmercial feature][9].
+To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commercial feature][9].
 See the [Datastore reference][8] for details on configuring the Sensu backend to use PostgreSQL for event storage.
 
 {{< figure src="/images/clustered_architecture_postgres.png" alt="Clustered Sensu Go architecture with PostgreSQL" link="/images/clustered_architecture_postgres.png" target="_blank" >}}

--- a/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
@@ -118,7 +118,7 @@ Five etcd nodes allow you to tolerate the loss of two nodes, but with a greater 
 
 #### Scaled cluster performance with PostgreSQL
 
-To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commmercial feature][9].
+To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commercial feature][9].
 See the [Datastore reference][8] for details on configuring the Sensu backend to use PostgreSQL for event storage.
 
 {{< figure src="/images/clustered_architecture_postgres.png" alt="Clustered Sensu Go architecture with PostgreSQL" link="/images/clustered_architecture_postgres.png" target="_blank" >}}

--- a/content/sensu-go/6.2/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/deployment-architecture.md
@@ -118,7 +118,7 @@ Five etcd nodes allow you to tolerate the loss of two nodes, but with a greater 
 
 #### Scaled cluster performance with PostgreSQL
 
-To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commmercial feature][9].
+To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commercial feature][9].
 See the [Datastore reference][8] for details on configuring the Sensu backend to use PostgreSQL for event storage.
 
 {{< figure src="/images/clustered_architecture_postgres.png" alt="Clustered Sensu Go architecture with PostgreSQL" link="/images/clustered_architecture_postgres.png" target="_blank" >}}

--- a/content/sensu-go/6.3/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/deployment-architecture.md
@@ -118,7 +118,7 @@ Five etcd nodes allow you to tolerate the loss of two nodes, but with a greater 
 
 #### Scaled cluster performance with PostgreSQL
 
-To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commmercial feature][9].
+To achieve the high rate of event processing that many enterprises require, Sensu supports PostgreSQL event storage as a [commercial feature][9].
 See the [Datastore reference][8] for details on configuring the Sensu backend to use PostgreSQL for event storage.
 
 {{< figure src="/images/clustered_architecture_postgres.png" alt="Clustered Sensu Go architecture with PostgreSQL" link="/images/clustered_architecture_postgres.png" target="_blank" >}}


### PR DESCRIPTION
## Description
Fixes a typo in "commmercial"

## Motivation and Context
Noticed earlier today