### PR TITLE
Add note about using node IP instead of localhost when securing cluster

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
@@ -50,6 +50,10 @@ To properly secure etcd communication, replace the default parameter values in y
  - A certificate and key for the `etcd-peer-cert-file` and `etcd-peer-key-file` to secure cluster communication
  - Non-default values for `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-advertise-client-urls`
 
+    {{% notice note %}}
+**NOTE**: If you are securing a [cluster](../cluster-sensu), use your backend node IP address instead of `localhost` in the non-default values for `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-advertise-client-urls`.
+{{% /notice %}}
+
 In addition, set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate.
 Because etcd does not require authentication by default, you must set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -56,6 +56,10 @@ etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 
+    {{% notice note %}}
+**NOTE**: If you are securing a [cluster](../cluster-sensu), use your backend node IP address instead of `localhost` in the non-default values for `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-advertise-client-urls`.
+{{% /notice %}}
+
 5. Set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate:
 {{< code yml >}}
 etcd-client-cert-auth: "true"

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -56,6 +56,10 @@ etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 
+    {{% notice note %}}
+**NOTE**: If you are securing a [cluster](../cluster-sensu), use your backend node IP address instead of `localhost` in the non-default values for `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-advertise-client-urls`.
+{{% /notice %}}
+
 5. Set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate:
 {{< code yml >}}
 etcd-client-cert-auth: "true"

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -56,6 +56,10 @@ etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 
+    {{% notice note %}}
+**NOTE**: If you are securing a [cluster](../cluster-sensu), use your backend node IP address instead of `localhost` in the non-default values for `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-advertise-client-urls`.
+{{% /notice %}}
+
 5. Set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate:
 {{< code yml >}}
 etcd-client-cert-auth: "true"

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -56,6 +56,10 @@ etcd-listen-peer-urls: "https://localhost:2380"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 
+    {{% notice note %}}
+**NOTE**: If you are securing a [cluster](../cluster-sensu), use your backend node IP address instead of `localhost` in the non-default values for `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-advertise-client-urls`.
+{{% /notice %}}
+
 5. Set `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` to `true` to ensure that etcd only allows connections from clients and peers that present a valid, trusted certificate:
 {{< code yml >}}
 etcd-client-cert-auth: "true"


### PR DESCRIPTION
## Description
Adds a note in step 4 of https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/#secure-etcd-peer-communication to explain that users should replace the example `localhost` with the backend node IP address if they are securing a cluster.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3125