### PR TITLE
Replace <a name > with <a id > throughout docs

### DIFF
--- a/content/sensu-go/5.21/api/events.md
+++ b/content/sensu-go/5.21/api/events.md
@@ -903,6 +903,6 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 [6]: ../../reference/entities#entities-specification
 [7]: ../../reference/checks#check-specification
 [8]: ../../reference/events/
-[9]: ../../reference/events#metrics
+[9]: ../../reference/events#metrics-attribute
 [10]: ../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/5.21/operations/control-access/ad-auth.md
+++ b/content/sensu-go/5.21/operations/control-access/ad-auth.md
@@ -398,7 +398,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-groups-prefix"></a>
+<a id="ad-groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -416,7 +416,7 @@ groups_prefix: ad
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-username-prefix"></a>
+<a id="ad-username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/5.21/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/5.21/operations/control-access/ldap-auth.md
@@ -335,7 +335,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="groups-prefix"></a>
+<a id="groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -353,7 +353,7 @@ groups_prefix: ldap
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="username-prefix"></a>
+<a id="username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
@@ -90,7 +90,7 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
-<a name="copy-ca-pem"></a>
+<a id="copy-ca-pem"></a>
 
 You should now have a directory at `/etc/sensu/tls` that contains the following files:
 
@@ -144,7 +144,7 @@ export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-backend-pem"></a>
+<a id="copy-backend-pem"></a>
 
 You should now have a set of files for each backend:
 
@@ -188,7 +188,7 @@ export NAME=agent
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="" -profile=agent - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-agent-pem"></a>
+<a id="copy-agent-pem"></a>
 
 You should now have a set of files for use by Sensu agents:
 

--- a/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/migrate.md
@@ -287,7 +287,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
 {{% /notice %}}
 
-<a name="translate-metric-checks"></a>
+<a id="translate-metric-checks"></a>
 
 **Translate metric checks**
 
@@ -298,14 +298,14 @@ This allowed Sensu Core to process output metrics via a handler even when the ch
 Sensu Go treats output metrics as first-class objects, so you can process check status as well as output metrics via different event pipelines.
 See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes.
 
-<a name="translate-proxy-requests-entities"></a>
+<a id="translate-proxy-requests-entities"></a>
 
 **Translate proxy requests and proxy entities**
 
 See the [guide to monitoring external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
 See the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
-<a name="translate-hooks"></a>
+<a id="translate-hooks"></a>
 
 **Translate hooks**
 

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -889,7 +889,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 ### General configuration flags
 
-<a name="allow-list"></a>
+<a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
@@ -948,7 +948,7 @@ sensu-agent start --assets-rate-limit 1.39
 # /etc/sensu/agent.yml example
 assets-rate-limit: 1.39{{< /code >}}
 
-<a name="backend-handshake-timeout"></a>
+<a id="backend-handshake-timeout"></a>
 
 | backend-handshake-timeout |      |
 ----------------------------|------
@@ -962,7 +962,7 @@ sensu-agent start --backend-handshake-timeout 20
 # /etc/sensu/agent.yml example
 backend-handshake-timeout: 20{{< /code >}}
 
-<a name="backend-heartbeat-interval"></a>
+<a id="backend-heartbeat-interval"></a>
 
 | backend-heartbeat-interval |      |
 -----------------------------|------
@@ -976,7 +976,7 @@ sensu-agent start --backend-heartbeat-interval 45
 # /etc/sensu/agent.yml example
 backend-heartbeat-interval: 45{{< /code >}}
 
-<a name="backend-heartbeat-timeout"></a>
+<a id="backend-heartbeat-timeout"></a>
 
 | backend-heartbeat-timeout |      |
 ----------------------------|------
@@ -1010,7 +1010,7 @@ backend-url:
   {{< /code >}}
 
 
-<a name="cache-dir"></a>
+<a id="cache-dir"></a>
 
 | cache-dir   |      |
 --------------|------
@@ -1036,7 +1036,7 @@ sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
 
-<a name="disable-assets"></a>
+<a id="disable-assets"></a>
 
 | disable-assets |      |
 --------------|------
@@ -1050,7 +1050,7 @@ sensu-agent start --disable-assets
 # /etc/sensu/agent.yml example
 disable-assets: true{{< /code >}}
 
-<a name="discover-processes"></a>
+<a id="discover-processes"></a>
 
 | discover-processes |      |
 --------------|------
@@ -1087,7 +1087,7 @@ labels:
   proxy_type: "website"
 {{< /code >}}
 
-<a name="name"></a>
+<a id="name-attribute"></a>
 
 | name        |      |
 --------------|------
@@ -1101,7 +1101,7 @@ sensu-agent start --name agent-01
 # /etc/sensu/agent.yml example
 name: "agent-01" {{< /code >}}
 
-<a name="log-level"></a>
+<a id="log-level"></a>
 
 | log-level   |      |
 --------------|------
@@ -1115,7 +1115,7 @@ sensu-agent start --log-level debug
 # /etc/sensu/agent.yml example
 log-level: "debug"{{< /code >}}
 
-<a name="subscriptions-flag"></a>
+<a id="subscriptions-flag"></a>
 
 | subscriptions |      |
 ----------------|------
@@ -1227,7 +1227,7 @@ sensu-agent start --deregistration-handler deregister
 # /etc/sensu/agent.yml example
 deregistration-handler: "deregister"{{< /code >}}
 
-<a name="detect-cloud-provider-flag"></a>
+<a id="detect-cloud-provider-flag"></a>
 
 
 | detect-cloud-provider  |      |
@@ -1247,7 +1247,7 @@ detect-cloud-provider: "false"{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../reference/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../reference/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1258,7 +1258,7 @@ sensu-agent start --keepalive-critical-timeout 300
 # /etc/sensu/agent.yml example
 keepalive-critical-timeout: 300{{< /code >}}
 
-<a name="keepalive-handlers-flag"></a>
+<a id="keepalive-handlers-flag"></a>
 
 | keepalive-handlers |      |
 --------------------|------
@@ -1288,7 +1288,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../reference/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../reference/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`
@@ -1417,7 +1417,7 @@ sensu-agent start --insecure-skip-tls-verify
 # /etc/sensu/agent.yml example
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------
@@ -1808,7 +1808,7 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [35]: ../backend#datastore-and-cluster-configuration-flags
 [36]: ../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags
-[38]: #name
+[38]: #name-attribute
 [39]: ../rbac/
 [40]: ../../guides/send-slack-alerts/
 [41]: ../handlers/#send-registration-events

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -909,7 +909,7 @@ sha512: 4f926bf4328...
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="filters"></a>
+<a id="filters-attribute"></a>
 
 filters      | 
 -------------|------ 
@@ -1221,5 +1221,5 @@ You must remove the archive and downloaded files from the asset cache manually.
 [39]: ../../web-ui/filter#filter-with-label-selectors
 [40]: ../../reference/agent/#configuration-via-flags
 [41]: ../../reference/backend/#configuration-via-flags
-[42]: #filters
+[42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -459,7 +459,7 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
-<a name="debug-attribute"></a>
+<a id="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
@@ -643,7 +643,7 @@ sensu-backend start --insecure-skip-tls-verify
 insecure-skip-tls-verify: true{{< /code >}}
 
 
-<a name="jwt-attributes"></a>
+<a id="jwt-attributes"></a>
 
 | jwt-private-key-file |      |
 -------------|------
@@ -688,7 +688,7 @@ sensu-backend start --key-file /path/to/ssl/key.pem
 # /etc/sensu/backend.yml example
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------
@@ -825,7 +825,7 @@ sensu-backend start --etcd-cert-file ./client.pem
 etcd-cert-file: "./client.pem"{{< /code >}}
 
 
-<a name="etcd-cipher-suites"></a>
+<a id="etcd-cipher-suites"></a>
 
 | etcd-cipher-suites    |      |
 ------------------------|------
@@ -1009,7 +1009,7 @@ sensu-backend start --etcd-key-file ./client-key.pem
 # /etc/sensu/backend.yml example
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
-<a name="etcd-listen-client-urls"></a>
+<a id="etcd-listen-client-urls"></a>
 
 | etcd-listen-client-urls |      |
 --------------------------|------
@@ -1269,7 +1269,7 @@ sensu-backend start --etcd-election-timeout 1000
 # /etc/sensu/backend.yml example
 etcd-election-timeout: 1000{{< /code >}}
 
-<a name="etcd-heartbeat-interval"></a>
+<a id="etcd-heartbeat-interval"></a>
 
 | etcd-heartbeat-interval |      |
 -----------------------|------

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -766,7 +766,7 @@ subscriptions:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="handlers-array"></a>
+<a id="handlers-array"></a>
 
 |handlers    |      |
 -------------|------
@@ -856,7 +856,7 @@ timeout: 30
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ttl-attribute"></a>
+<a id="ttl-attribute"></a>
 
 |ttl         |      |
 -------------|------
@@ -893,7 +893,7 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="flap-thresholds"></a>
+<a id="flap-thresholds"></a>
 
 |low_flap_threshold ||
 -------------|------
@@ -946,7 +946,7 @@ runtime_assets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-hooks-attribute"></a>
+<a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
 -------------|------
@@ -985,7 +985,7 @@ check_hooks:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-entity-name-attribute"></a>
+<a id="proxy-entity-name-attribute"></a>
 
 |proxy_entity_name|   |
 -------------|------
@@ -1004,7 +1004,7 @@ proxy_entity_name: switch-dc-01
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-requests-top-level"></a>
+<a id="proxy-requests-top-level"></a>
 
 |proxy_requests|    |
 -------------|------
@@ -1114,7 +1114,7 @@ output_metric_handlers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-attribute"></a>
+<a id="round-robin-attribute"></a>
 
 |round_robin |      |
 -------------|------
@@ -1520,7 +1520,7 @@ The asset reference includes an [example check definition that uses the asset pa
 [47]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
-[50]: ../../reference/events/#metrics
+[50]: ../../reference/events/#metrics-attribute
 [51]: https://github.com/sensu/sensu-influxdb-handler
 [52]: #round-robin-checks
 [53]: https://regex101.com/r/zo9mQU/2

--- a/content/sensu-go/5.21/reference/entities.md
+++ b/content/sensu-go/5.21/reference/entities.md
@@ -525,7 +525,7 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="annotations"></a>
+<a id="annotations-attribute"></a>
 
 | annotations |     |
 -------------|------
@@ -1558,7 +1558,7 @@ spec:
 [17]: ../../guides/monitor-external-resources/
 [18]: ../checks/#round-robin-checks
 [19]: #proxy-entities-managed
-[20]: #annotations
+[20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../rbac/
 [23]: ../../web-ui/filter#filter-with-label-selectors

--- a/content/sensu-go/5.21/reference/etcdreplicators.md
+++ b/content/sensu-go/5.21/reference/etcdreplicators.md
@@ -511,7 +511,7 @@ resource: Role
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="namespace-attribute"></a>
+<a id="namespace-attribute"></a>
 
 namespace    |      |
 -------------|-------

--- a/content/sensu-go/5.21/reference/events.md
+++ b/content/sensu-go/5.21/reference/events.md
@@ -1289,7 +1289,7 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="checks"></a>
+<a id="checks-attribute"></a>
 
 |check       |      |
 -------------|------
@@ -1397,7 +1397,7 @@ check:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="metrics"></a>
+<a id="metrics-attribute"></a>
 
 |metrics     |      |
 -------------|------
@@ -1860,7 +1860,7 @@ value: 0.005
 [18]: ../../sensuctl/create-manage-resources/#sensuctl-event
 [20]: ../checks#check-specification
 [21]: #check-attributes
-[22]: #metrics
+[22]: #metrics-attribute
 [23]: ../../guides/reduce-alert-fatigue/
 [24]: ../filters/
 [25]: ../checks/#check-result-specification

--- a/content/sensu-go/5.21/reference/namespaces.md
+++ b/content/sensu-go/5.21/reference/namespaces.md
@@ -263,4 +263,3 @@ name: production
 [9]: ../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [10]: ../../sensuctl/create-manage-resources/#create-resources
 [11]: #spec-attributes
-[12]: ../agent/#labels

--- a/content/sensu-go/5.21/reference/rbac.md
+++ b/content/sensu-go/5.21/reference/rbac.md
@@ -236,12 +236,12 @@ username: alice
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password"></a>
+<a id="password-attribute"></a>
 
 password     | 
 -------------|------ 
 description  | User's password. Passwords must have at least eight characters.{{% notice note %}}
-**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash-attribute) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required     | true
 type         | String
@@ -294,12 +294,12 @@ disabled: false
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password-hash"></a>
+<a id="password-hash-attribute"></a>
 
 password_hash | 
 --------------|------ 
 description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords. {{% notice note %}}
-**NOTE**: You only need to set either the [`password`](#password) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the [`password`](#password-attribute) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required      | false
 type          | String

--- a/content/sensu-go/5.21/reference/secrets-providers.md
+++ b/content/sensu-go/5.21/reference/secrets-providers.md
@@ -386,7 +386,7 @@ timeout: 20s
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="tls-vault"></a>
+<a id="tls-vault"></a>
 
 tls          | 
 -------------|------ 
@@ -445,7 +445,7 @@ version: v1
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="rate-limiter-attributes"></a>
+<a id="rate-limiter-attributes"></a>
 
 #### Rate limiter attributes
 

--- a/content/sensu-go/5.21/reference/webconfig.md
+++ b/content/sensu-go/5.21/reference/webconfig.md
@@ -221,7 +221,7 @@ created_by: admin
 
 ### Spec attributes
 
-<a name="show-local-cluster"></a>
+<a id="show-local-cluster"></a>
 
 always_show_local_cluster | 
 -------------|------ 

--- a/content/sensu-go/5.21/web-ui/_index.md
+++ b/content/sensu-go/5.21/web-ui/_index.md
@@ -10,7 +10,7 @@ menu:
     identifier: web-ui
 ---
 
-<a name="federated-webui"></a>
+<a id="federated-webui"></a>
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 

--- a/content/sensu-go/6.0/api/events.md
+++ b/content/sensu-go/6.0/api/events.md
@@ -955,6 +955,6 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 [6]: ../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../observability-pipeline/observe-schedule/checks#check-specification
 [8]: ../../observability-pipeline/observe-events/events/#events-specification
-[9]: ../../observability-pipeline/observe-events/events#metrics
+[9]: ../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -745,7 +745,7 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="annotations"></a>
+<a id="annotations-attribute"></a>
 
 | annotations |     |
 -------------|------
@@ -1596,7 +1596,7 @@ cpu_percent: 0.12639
 [17]: ../../observe-entities/monitor-external-resources/
 [18]: ../../observe-schedule/checks/#round-robin-checks
 [19]: #proxy-entities-managed
-[20]: #annotations
+[20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../../../operations/control-access/rbac/
 [23]: ../../../web-ui/filter#filter-with-label-selectors

--- a/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-events/events.md
@@ -1477,7 +1477,7 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="checks"></a>
+<a id="checks-attribute"></a>
 
 |check       |      |
 -------------|------
@@ -1587,7 +1587,7 @@ check:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="metrics"></a>
+<a id="metrics-attribute"></a>
 
 |metrics     |      |
 -------------|------
@@ -2067,7 +2067,7 @@ value: 0.005
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes
-[22]: #metrics
+[22]: #metrics-attribute
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -921,7 +921,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
-<a name="allow-list"></a>
+<a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
@@ -974,7 +974,7 @@ sensu-agent start --assets-rate-limit 1.39{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
-<a name="backend-handshake-timeout"></a>
+<a id="backend-handshake-timeout"></a>
 
 | backend-handshake-timeout |      |
 ----------------------------|------
@@ -987,7 +987,7 @@ sensu-agent start --backend-handshake-timeout 20{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
-<a name="backend-heartbeat-interval"></a>
+<a id="backend-heartbeat-interval"></a>
 
 | backend-heartbeat-interval |      |
 -----------------------------|------
@@ -1000,7 +1000,7 @@ sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
-<a name="backend-heartbeat-timeout"></a>
+<a id="backend-heartbeat-timeout"></a>
 
 | backend-heartbeat-timeout |      |
 ----------------------------|------
@@ -1031,7 +1031,7 @@ backend-url:
   - "ws://0.0.0.0:8082"
 {{< /code >}}
 
-<a name="cache-dir"></a>
+<a id="cache-dir"></a>
 
 | cache-dir   |      |
 --------------|------
@@ -1044,7 +1044,7 @@ sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
-<a name="config-file"></a>
+<a id="config-file"></a>
 
 | config-file |      |
 --------------|------
@@ -1057,7 +1057,7 @@ sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
 
-<a name="disable-assets"></a>
+<a id="disable-assets"></a>
 
 | disable-assets |      |
 --------------|------
@@ -1070,7 +1070,7 @@ sensu-agent start --disable-assets{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
-<a name="discover-processes"></a>
+<a id="discover-processes"></a>
 
 | discover-processes |      |
 --------------|------
@@ -1106,7 +1106,7 @@ labels:
   proxy_type: website
 {{< /code >}}
 
-<a name="name"></a>
+<a id="name-attribute"></a>
 
 | name        |      |
 --------------|------
@@ -1119,7 +1119,7 @@ sensu-agent start --name agent-01{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
-<a name="log-level"></a>
+<a id="log-level"></a>
 
 | log-level   |      |
 --------------|------
@@ -1132,7 +1132,7 @@ sensu-agent start --log-level debug{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
-<a name="subscriptions-flag"></a>
+<a id="subscriptions-flag"></a>
 
 | subscriptions |      |
 ----------------|------
@@ -1231,7 +1231,7 @@ sensu-agent start --deregistration-handler deregister{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
-<a name="detect-cloud-provider-flag"></a>
+<a id="detect-cloud-provider-flag"></a>
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1248,7 +1248,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1258,7 +1258,7 @@ sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
-<a name="keepalive-handlers-flag"></a>
+<a id="keepalive-handlers-flag"></a>
 
 | keepalive-handlers |      |
 --------------------|------
@@ -1287,7 +1287,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`
@@ -1398,7 +1398,7 @@ sensu-agent start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -469,7 +469,7 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
-<a name="debug-attribute"></a>
+<a id="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
@@ -629,7 +629,7 @@ sensu-backend start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="jwt-attributes"></a>
+<a id="jwt-attributes"></a>
 
 | jwt-private-key-file |      |
 -------------|------
@@ -669,7 +669,7 @@ sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------
@@ -795,7 +795,7 @@ sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
 
-<a name="etcd-cipher-suites"></a>
+<a id="etcd-cipher-suites"></a>
 
 | etcd-cipher-suites    |      |
 ------------------------|------
@@ -963,7 +963,7 @@ sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
-<a name="etcd-listen-client-urls"></a>
+<a id="etcd-listen-client-urls"></a>
 
 | etcd-listen-client-urls |      |
 --------------------------|------
@@ -1193,7 +1193,7 @@ sensu-backend start --etcd-election-timeout 1000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
-<a name="etcd-heartbeat-interval"></a>
+<a id="etcd-heartbeat-interval"></a>
 
 | etcd-heartbeat-interval |      |
 -----------------------|------

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
@@ -732,7 +732,7 @@ command: /etc/sensu/plugins/check-chef-client.go
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-subscriptions"></a>
+<a id="check-subscriptions"></a>
 
 |subscriptions|     |
 -------------|------
@@ -753,7 +753,7 @@ subscriptions:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="handlers-array"></a>
+<a id="handlers-array"></a>
 
 |handlers    |      |
 -------------|------
@@ -810,7 +810,7 @@ cron: 0 0 * * *
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="publish-attribute"></a>
+<a id="publish-attribute"></a>
 
 |publish     |      |
 -------------|------
@@ -845,7 +845,7 @@ timeout: 30
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ttl-attribute"></a>
+<a id="ttl-attribute"></a>
 
 |ttl         |      |
 -------------|------
@@ -882,7 +882,7 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="flap-thresholds"></a>
+<a id="flap-thresholds"></a>
 
 |low_flap_threshold ||
 -------------|------
@@ -935,7 +935,7 @@ runtime_assets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-hooks-attribute"></a>
+<a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
 -------------|------
@@ -974,7 +974,7 @@ check_hooks:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-entity-name-attribute"></a>
+<a id="proxy-entity-name-attribute"></a>
 
 |proxy_entity_name|   |
 -------------|------
@@ -993,7 +993,7 @@ proxy_entity_name: switch-dc-01
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-requests-top-level"></a>
+<a id="proxy-requests-top-level"></a>
 
 |proxy_requests|    |
 -------------|------
@@ -1065,7 +1065,7 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-format"></a>
+<a id="output-metric-format"></a>
 
 |output_metric_format    |      |
 -------------|------
@@ -1086,7 +1086,7 @@ output_metric_format:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-handlers"></a>
+<a id="output-metric-handlers"></a>
 
 |output_metric_handlers    |      |
 -------------|------
@@ -1107,7 +1107,7 @@ output_metric_handlers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-attribute"></a>
+<a id="round-robin-attribute"></a>
 
 |round_robin |      |
 -------------|------
@@ -1515,7 +1515,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [47]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
-[50]: ../../observe-events/events/#metrics
+[50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [52]: #round-robin-checks
 [53]: https://regex101.com/r/zo9mQU/2

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/metrics.md
@@ -481,7 +481,7 @@ The event specification describes [metrics attributes in events][5].
 [2]: ../../observe-process/aggregate-metrics-statsd/
 [3]: ../checks/#output-metric-handlers
 [4]: #extract-metrics-from-check-output
-[5]: ../../observe-events/events/#metrics
+[5]: ../../observe-events/events/#metrics-attribute
 [6]: #metric-check-example
 [7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/subscriptions.md
@@ -167,7 +167,7 @@ Two of the six Windows servers *should* execute the SQL Server metrics check, so
 
 [1]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [2]: ../agent/#subscriptions-flag
-[10]: ../agent/#name
+[10]: ../agent/#name-attribute
 [11]: ../checks/#ad-hoc-scheduling
 [12]: ../checks/#publish-attribute
 [13]: ../checks/#check-scheduling

--- a/content/sensu-go/6.0/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/ad-auth.md
@@ -398,7 +398,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-groups-prefix"></a>
+<a id="ad-groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -416,7 +416,7 @@ groups_prefix: ad
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-username-prefix"></a>
+<a id="ad-username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.0/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/ldap-auth.md
@@ -335,7 +335,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="groups-prefix"></a>
+<a id="groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -353,7 +353,7 @@ groups_prefix: ldap
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="username-prefix"></a>
+<a id="username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.0/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.0/operations/control-access/namespaces.md
@@ -263,4 +263,3 @@ name: production
 [9]: ../../deploy-sensu/install-sensu/#install-sensuctl
 [10]: ../../../sensuctl/create-manage-resources/#create-resources
 [11]: #spec-attributes
-[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.0/operations/control-access/rbac.md
+++ b/content/sensu-go/6.0/operations/control-access/rbac.md
@@ -259,12 +259,12 @@ username: alice
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password"></a>
+<a id="password-attribute"></a>
 
 password     | 
 -------------|------ 
 description  | User's password. Passwords must have at least eight characters.{{% notice note %}}
-**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash-attribute) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required     | true
 type         | String
@@ -317,12 +317,12 @@ disabled: false
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password-hash"></a>
+<a id="password-hash-attribute"></a>
 
 password_hash | 
 --------------|------ 
 description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords. {{% notice note %}}
-**NOTE**: You only need to set either the [`password`](#password) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the [`password`](#password-attribute) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required      | false
 type          | String

--- a/content/sensu-go/6.0/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/etcdreplicators.md
@@ -510,7 +510,7 @@ resource: Role
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="namespace-attribute"></a>
+<a id="namespace-attribute"></a>
 
 namespace    |      |
 -------------|-------

--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -107,7 +107,7 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
-<a name="copy-ca-pem"></a>
+<a id="copy-ca-pem"></a>
 
 You should now have a directory at `/etc/sensu/tls` that contains the following files:
 
@@ -172,7 +172,7 @@ export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-backend-pem"></a>
+<a id="copy-backend-pem"></a>
 
 You should now have a set of files for each backend:
 
@@ -219,7 +219,7 @@ export NAME=agent
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="" -profile=agent - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-agent-pem"></a>
+<a id="copy-agent-pem"></a>
 
 You should now have a set of files for use by Sensu agents:
 

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -291,7 +291,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
 {{% /notice %}}
 
-<a name="translate-metric-checks"></a>
+<a id="translate-metric-checks"></a>
 
 **Translate metric checks**
 
@@ -302,14 +302,14 @@ This allowed Sensu Core to process output metrics via a handler even when the ch
 Sensu Go treats output metrics as first-class objects, so you can process check status as well as output metrics via different event pipelines.
 See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes and use `output_metric_tags` to enrich extracted metrics output.
 
-<a name="translate-proxy-requests-entities"></a>
+<a id="translate-proxy-requests-entities"></a>
 
 **Translate proxy requests and proxy entities**
 
 See the [guide to monitoring external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
 See the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
-<a name="translate-hooks"></a>
+<a id="translate-hooks"></a>
 
 **Translate hooks**
 

--- a/content/sensu-go/6.0/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.0/operations/manage-secrets/secrets-providers.md
@@ -386,7 +386,7 @@ timeout: 20s
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="tls-vault"></a>
+<a id="tls-vault"></a>
 
 tls          | 
 -------------|------ 
@@ -445,7 +445,7 @@ version: v1
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="rate-limiter-attributes"></a>
+<a id="rate-limiter-attributes"></a>
 
 #### Rate limiter attributes
 

--- a/content/sensu-go/6.0/plugins/assets.md
+++ b/content/sensu-go/6.0/plugins/assets.md
@@ -939,7 +939,7 @@ sha512: 4f926bf4328...
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="filters"></a>
+<a id="filters-attribute"></a>
 
 filters      | 
 -------------|------ 
@@ -1252,7 +1252,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [39]: ../../web-ui/search#search-for-labels
 [40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[42]: #filters
+[42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1

--- a/content/sensu-go/6.0/web-ui/_index.md
+++ b/content/sensu-go/6.0/web-ui/_index.md
@@ -10,7 +10,7 @@ menu:
     identifier: web-ui
 ---
 
-<a name="federated-webui"></a>
+<a id="federated-webui"></a>
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 

--- a/content/sensu-go/6.0/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.0/web-ui/webconfig-reference.md
@@ -221,7 +221,7 @@ created_by: admin
 
 ### Spec attributes
 
-<a name="show-local-cluster"></a>
+<a id="show-local-cluster"></a>
 
 always_show_local_cluster | 
 -------------|------ 

--- a/content/sensu-go/6.1/api/events.md
+++ b/content/sensu-go/6.1/api/events.md
@@ -959,6 +959,6 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 [6]: ../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../observability-pipeline/observe-schedule/checks#check-specification
 [8]: ../../observability-pipeline/observe-events/events/#events-specification
-[9]: ../../observability-pipeline/observe-events/events#metrics
+[9]: ../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -745,7 +745,7 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="annotations"></a>
+<a id="annotations-attribute"></a>
 
 | annotations |     |
 -------------|------
@@ -1596,7 +1596,7 @@ cpu_percent: 0.12639
 [17]: ../../observe-entities/monitor-external-resources/
 [18]: ../../observe-schedule/checks/#round-robin-checks
 [19]: #proxy-entities-managed
-[20]: #annotations
+[20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../../../operations/control-access/rbac/
 [23]: ../../../web-ui/search#search-for-labels

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -1477,7 +1477,7 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="checks"></a>
+<a id="checks-attribute"></a>
 
 |check       |      |
 -------------|------
@@ -1587,7 +1587,7 @@ check:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="metrics"></a>
+<a id="metrics-attribute"></a>
 
 |metrics     |      |
 -------------|------
@@ -2067,7 +2067,7 @@ value: 0.005
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes
-[22]: #metrics
+[22]: #metrics-attribute
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -921,7 +921,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
-<a name="allow-list"></a>
+<a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
@@ -974,7 +974,7 @@ sensu-agent start --assets-rate-limit 1.39{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
-<a name="backend-handshake-timeout"></a>
+<a id="backend-handshake-timeout"></a>
 
 | backend-handshake-timeout |      |
 ----------------------------|------
@@ -987,7 +987,7 @@ sensu-agent start --backend-handshake-timeout 20{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
-<a name="backend-heartbeat-interval"></a>
+<a id="backend-heartbeat-interval"></a>
 
 | backend-heartbeat-interval |      |
 -----------------------------|------
@@ -1000,7 +1000,7 @@ sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
-<a name="backend-heartbeat-timeout"></a>
+<a id="backend-heartbeat-timeout"></a>
 
 | backend-heartbeat-timeout |      |
 ----------------------------|------
@@ -1031,7 +1031,7 @@ backend-url:
   - "ws://0.0.0.0:8082"
 {{< /code >}}
 
-<a name="cache-dir"></a>
+<a id="cache-dir"></a>
 
 | cache-dir   |      |
 --------------|------
@@ -1044,7 +1044,7 @@ sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
-<a name="config-file"></a>
+<a id="config-file"></a>
 
 | config-file |      |
 --------------|------
@@ -1057,7 +1057,7 @@ sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
 
-<a name="disable-assets"></a>
+<a id="disable-assets"></a>
 
 | disable-assets |      |
 --------------|------
@@ -1070,7 +1070,7 @@ sensu-agent start --disable-assets{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
-<a name="discover-processes"></a>
+<a id="discover-processes"></a>
 
 | discover-processes |      |
 --------------|------
@@ -1106,7 +1106,7 @@ labels:
   proxy_type: website
 {{< /code >}}
 
-<a name="name"></a>
+<a id="name-attribute"></a>
 
 | name        |      |
 --------------|------
@@ -1119,7 +1119,7 @@ sensu-agent start --name agent-01{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
-<a name="log-level"></a>
+<a id="log-level"></a>
 
 | log-level   |      |
 --------------|------
@@ -1132,7 +1132,7 @@ sensu-agent start --log-level debug{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
-<a name="subscriptions-flag"></a>
+<a id="subscriptions-flag"></a>
 
 | subscriptions |      |
 ----------------|------
@@ -1231,7 +1231,7 @@ sensu-agent start --deregistration-handler deregister{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
-<a name="detect-cloud-provider-flag"></a>
+<a id="detect-cloud-provider-flag"></a>
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1248,7 +1248,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1258,7 +1258,7 @@ sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
-<a name="keepalive-handlers-flag"></a>
+<a id="keepalive-handlers-flag"></a>
 
 | keepalive-handlers |      |
 --------------------|------
@@ -1287,7 +1287,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`
@@ -1398,7 +1398,7 @@ sensu-agent start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -415,7 +415,7 @@ sensu-backend start --api-listen-address [::]:8080{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
-<a name="api-request-limit"></a>
+<a id="api-request-limit"></a>
 
 | api-request-limit |      |
 -------------|------
@@ -483,7 +483,7 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
-<a name="debug-attribute"></a>
+<a id="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
@@ -643,7 +643,7 @@ sensu-backend start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="jwt-attributes"></a>
+<a id="jwt-attributes"></a>
 
 | jwt-private-key-file |      |
 -------------|------
@@ -683,7 +683,7 @@ sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------
@@ -809,7 +809,7 @@ sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
 
-<a name="etcd-cipher-suites"></a>
+<a id="etcd-cipher-suites"></a>
 
 | etcd-cipher-suites    |      |
 ------------------------|------
@@ -977,7 +977,7 @@ sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
-<a name="etcd-listen-client-urls"></a>
+<a id="etcd-listen-client-urls"></a>
 
 | etcd-listen-client-urls |      |
 --------------------------|------
@@ -1207,7 +1207,7 @@ sensu-backend start --etcd-election-timeout 1000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
-<a name="etcd-heartbeat-interval"></a>
+<a id="etcd-heartbeat-interval"></a>
 
 | etcd-heartbeat-interval |      |
 -----------------------|------

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
@@ -734,7 +734,7 @@ command: /etc/sensu/plugins/check-chef-client.go
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-subscriptions"></a>
+<a id="check-subscriptions"></a>
 
 |subscriptions|     |
 -------------|------
@@ -755,7 +755,7 @@ subscriptions:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="handlers-array"></a>
+<a id="handlers-array"></a>
 
 |handlers    |      |
 -------------|------
@@ -812,7 +812,7 @@ cron: 0 0 * * *
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="publish-attribute"></a>
+<a id="publish-attribute"></a>
 
 |publish     |      |
 -------------|------
@@ -847,7 +847,7 @@ timeout: 30
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ttl-attribute"></a>
+<a id="ttl-attribute"></a>
 
 |ttl         |      |
 -------------|------
@@ -884,7 +884,7 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="flap-thresholds"></a>
+<a id="flap-thresholds"></a>
 
 |low_flap_threshold ||
 -------------|------
@@ -937,7 +937,7 @@ runtime_assets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-hooks-attribute"></a>
+<a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
 -------------|------
@@ -976,7 +976,7 @@ check_hooks:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-entity-name-attribute"></a>
+<a id="proxy-entity-name-attribute"></a>
 
 |proxy_entity_name|   |
 -------------|------
@@ -995,7 +995,7 @@ proxy_entity_name: switch-dc-01
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-requests-top-level"></a>
+<a id="proxy-requests-top-level"></a>
 
 |proxy_requests|    |
 -------------|------
@@ -1067,7 +1067,7 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-format"></a>
+<a id="output-metric-format"></a>
 
 |output_metric_format    |      |
 -------------|------
@@ -1088,7 +1088,7 @@ output_metric_format:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-handlers"></a>
+<a id="output-metric-handlers"></a>
 
 |output_metric_handlers    |      |
 -------------|------
@@ -1109,7 +1109,7 @@ output_metric_handlers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-tags"></a>
+<a id="output-metric-tags"></a>
 
 |output_metric_tags    |      |
 -------------|------
@@ -1146,7 +1146,7 @@ output_metric_tags:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-attribute"></a>
+<a id="round-robin-attribute"></a>
 
 |round_robin |      |
 -------------|------
@@ -1612,7 +1612,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [47]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
-[50]: ../../observe-events/events/#metrics
+[50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [52]: #round-robin-checks
 [53]: https://regex101.com/r/zo9mQU/2

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
@@ -506,7 +506,7 @@ The event specification describes [metrics attributes in events][5].
 [2]: ../../observe-process/aggregate-metrics-statsd/
 [3]: ../checks/#output-metric-handlers
 [4]: #extract-metrics-from-check-output
-[5]: ../../observe-events/events/#metrics
+[5]: ../../observe-events/events/#metrics-attribute
 [6]: #metric-check-example
 [7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/subscriptions.md
@@ -167,7 +167,7 @@ Two of the six Windows servers *should* execute the SQL Server metrics check, so
 
 [1]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [2]: ../agent/#subscriptions-flag
-[10]: ../agent/#name
+[10]: ../agent/#name-attribute
 [11]: ../checks/#ad-hoc-scheduling
 [12]: ../checks/#publish-attribute
 [13]: ../checks/#check-scheduling

--- a/content/sensu-go/6.1/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ad-auth.md
@@ -398,7 +398,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-groups-prefix"></a>
+<a id="ad-groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -416,7 +416,7 @@ groups_prefix: ad
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-username-prefix"></a>
+<a id="ad-username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.1/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ldap-auth.md
@@ -335,7 +335,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="groups-prefix"></a>
+<a id="groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -353,7 +353,7 @@ groups_prefix: ldap
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="username-prefix"></a>
+<a id="username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.1/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.1/operations/control-access/namespaces.md
@@ -263,4 +263,3 @@ name: production
 [9]: ../../deploy-sensu/install-sensu/#install-sensuctl
 [10]: ../../../sensuctl/create-manage-resources/#create-resources
 [11]: #spec-attributes
-[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.1/operations/control-access/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/rbac.md
@@ -259,12 +259,12 @@ username: alice
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password"></a>
+<a id="password-attribute"></a>
 
 password     | 
 -------------|------ 
 description  | User's password. Passwords must have at least eight characters.{{% notice note %}}
-**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash-attribute) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required     | true
 type         | String
@@ -317,12 +317,12 @@ disabled: false
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password-hash"></a>
+<a id="password-hash-attribute"></a>
 
 password_hash | 
 --------------|------ 
 description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords. {{% notice note %}}
-**NOTE**: You only need to set either the [`password`](#password) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the [`password`](#password-attribute) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required      | false
 type          | String

--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -432,7 +432,7 @@ pool_size: 20
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="strict"></a>
+<a id="strict-attribute"></a>
 
 strict       |      |
 -------------|------

--- a/content/sensu-go/6.1/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/etcdreplicators.md
@@ -510,7 +510,7 @@ resource: Role
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="namespace-attribute"></a>
+<a id="namespace-attribute"></a>
 
 namespace    |      |
 -------------|-------

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -107,7 +107,7 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
-<a name="copy-ca-pem"></a>
+<a id="copy-ca-pem"></a>
 
 You should now have a directory at `/etc/sensu/tls` that contains the following files:
 
@@ -172,7 +172,7 @@ export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-backend-pem"></a>
+<a id="copy-backend-pem"></a>
 
 You should now have a set of files for each backend:
 
@@ -219,7 +219,7 @@ export NAME=agent
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="" -profile=agent - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-agent-pem"></a>
+<a id="copy-agent-pem"></a>
 
 You should now have a set of files for use by Sensu agents:
 

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -291,7 +291,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
 {{% /notice %}}
 
-<a name="translate-metric-checks"></a>
+<a id="translate-metric-checks"></a>
 
 **Translate metric checks**
 
@@ -302,14 +302,14 @@ This allowed Sensu Core to process output metrics via a handler even when the ch
 Sensu Go treats output metrics as first-class objects, so you can process check status as well as output metrics via different event pipelines.
 See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes and use `output_metric_tags` to enrich extracted metrics output.
 
-<a name="translate-proxy-requests-entities"></a>
+<a id="translate-proxy-requests-entities"></a>
 
 **Translate proxy requests and proxy entities**
 
 See the [guide to monitoring external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
 See the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
-<a name="translate-hooks"></a>
+<a id="translate-hooks"></a>
 
 **Translate hooks**
 

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
@@ -386,7 +386,7 @@ timeout: 20s
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="tls-vault"></a>
+<a id="tls-vault"></a>
 
 tls          | 
 -------------|------ 
@@ -445,7 +445,7 @@ version: v1
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="rate-limiter-attributes"></a>
+<a id="rate-limiter-attributes"></a>
 
 #### Rate limiter attributes
 

--- a/content/sensu-go/6.1/plugins/assets.md
+++ b/content/sensu-go/6.1/plugins/assets.md
@@ -939,7 +939,7 @@ sha512: 4f926bf4328...
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="filters"></a>
+<a id="filters-attribute"></a>
 
 filters      | 
 -------------|------ 
@@ -1252,7 +1252,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [39]: ../../web-ui/search#search-for-labels
 [40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[42]: #filters
+[42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1

--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -1640,7 +1640,7 @@ To get started with Sensu Go:
 [176]: /sensu-go/6.1/api/authproviders/#authproviders-get-specification
 [177]: /sensu-go/6.1/api/secrets/#providers-get-specification
 [178]: /sensu-go/6.1/web-ui/search/
-[179]: /sensu-go/6.1/operations/deploy-sensu/datastore/#strict
+[179]: /sensu-go/6.1/operations/deploy-sensu/datastore/#strict-attribute
 [180]: /sensu-go/6.1/operations/control-access/oidc-auth/#oidc-spec-attributes
 [181]: /sensu-go/6.1/operations/deploy-sensu/datastore/#spec-attributes
 [182]: /sensu-go/6.1/observability-pipeline/observe-schedule/checks#output-metric-tags

--- a/content/sensu-go/6.1/web-ui/_index.md
+++ b/content/sensu-go/6.1/web-ui/_index.md
@@ -10,7 +10,7 @@ menu:
     identifier: web-ui
 ---
 
-<a name="federated-webui"></a>
+<a id="federated-webui"></a>
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 

--- a/content/sensu-go/6.1/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.1/web-ui/webconfig-reference.md
@@ -225,7 +225,7 @@ created_by: admin
 
 ### Spec attributes
 
-<a name="show-local-cluster"></a>
+<a id="show-local-cluster"></a>
 
 always_show_local_cluster | 
 -------------|------ 

--- a/content/sensu-go/6.2/api/events.md
+++ b/content/sensu-go/6.2/api/events.md
@@ -966,6 +966,6 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 [6]: ../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../observability-pipeline/observe-schedule/checks#check-specification
 [8]: ../../observability-pipeline/observe-events/events/#events-specification
-[9]: ../../observability-pipeline/observe-events/events#metrics
+[9]: ../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -762,7 +762,7 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="annotations"></a>
+<a id="annotations-attribute"></a>
 
 | annotations |     |
 -------------|------
@@ -1614,7 +1614,7 @@ cpu_percent: 0.12639
 [17]: ../../observe-entities/monitor-external-resources/
 [18]: ../../observe-schedule/checks/#round-robin-checks
 [19]: #proxy-entities-managed
-[20]: #annotations
+[20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../../../operations/control-access/rbac/
 [23]: ../../../web-ui/search#search-for-labels

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -1380,7 +1380,7 @@ id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="sequence-attribute"></a>
+<a id="sequence-attribute"></a>
 
 sequence     |      |
 -------------|------
@@ -1504,7 +1504,7 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="checks"></a>
+<a id="checks-attribute"></a>
 
 |check       |      |
 -------------|------
@@ -1614,7 +1614,7 @@ check:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="metrics"></a>
+<a id="metrics-attribute"></a>
 
 |metrics     |      |
 -------------|------
@@ -2094,7 +2094,7 @@ value: 0.005
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes
-[22]: #metrics
+[22]: #metrics-attribute
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -926,7 +926,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
-<a name="agent-managed-entity"></a>
+<a id="agent-managed-entity"></a>
 
 | agent-managed-entity |      |
 -------------|------
@@ -943,7 +943,7 @@ sensu-agent start --agent-managed-entity{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
 
-<a name="allow-list"></a>
+<a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
@@ -996,7 +996,7 @@ sensu-agent start --assets-rate-limit 1.39{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
-<a name="backend-handshake-timeout"></a>
+<a id="backend-handshake-timeout"></a>
 
 | backend-handshake-timeout |      |
 ----------------------------|------
@@ -1009,7 +1009,7 @@ sensu-agent start --backend-handshake-timeout 20{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
-<a name="backend-heartbeat-interval"></a>
+<a id="backend-heartbeat-interval"></a>
 
 | backend-heartbeat-interval |      |
 -----------------------------|------
@@ -1022,7 +1022,7 @@ sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
-<a name="backend-heartbeat-timeout"></a>
+<a id="backend-heartbeat-timeout"></a>
 
 | backend-heartbeat-timeout |      |
 ----------------------------|------
@@ -1053,7 +1053,7 @@ backend-url:
   - "ws://0.0.0.0:8082"
 {{< /code >}}
 
-<a name="cache-dir"></a>
+<a id="cache-dir"></a>
 
 | cache-dir   |      |
 --------------|------
@@ -1066,7 +1066,7 @@ sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
-<a name="config-file"></a>
+<a id="config-file"></a>
 
 | config-file |      |
 --------------|------
@@ -1079,7 +1079,7 @@ sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
 
-<a name="disable-assets"></a>
+<a id="disable-assets"></a>
 
 | disable-assets |      |
 --------------|------
@@ -1092,7 +1092,7 @@ sensu-agent start --disable-assets{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
-<a name="discover-processes"></a>
+<a id="discover-processes"></a>
 
 | discover-processes |      |
 --------------|------
@@ -1109,8 +1109,6 @@ command line example   | {{< code shell >}}
 sensu-agent start --discover-processes{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 discover-processes: true{{< /code >}}
-
-<a name="labels"></a>
 
 | labels     |      |
 -------------|------
@@ -1130,7 +1128,7 @@ labels:
   proxy_type: website
 {{< /code >}}
 
-<a name="name"></a>
+<a id="name-attribute"></a>
 
 | name        |      |
 --------------|------
@@ -1143,7 +1141,7 @@ sensu-agent start --name agent-01{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
-<a name="log-level"></a>
+<a id="log-level"></a>
 
 | log-level   |      |
 --------------|------
@@ -1156,7 +1154,7 @@ sensu-agent start --log-level debug{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
-<a name="subscriptions-flag"></a>
+<a id="subscriptions-flag"></a>
 
 | subscriptions |      |
 ----------------|------
@@ -1255,7 +1253,7 @@ sensu-agent start --deregistration-handler deregister{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
-<a name="detect-cloud-provider-flag"></a>
+<a id="detect-cloud-provider-flag"></a>
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1272,7 +1270,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1282,7 +1280,7 @@ sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
-<a name="keepalive-handlers-flag"></a>
+<a id="keepalive-handlers-flag"></a>
 
 | keepalive-handlers |      |
 --------------------|------
@@ -1311,7 +1309,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`
@@ -1422,7 +1420,7 @@ sensu-agent start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -415,7 +415,7 @@ sensu-backend start --api-listen-address [::]:8080{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
-<a name="api-request-limit"></a>
+<a id="api-request-limit"></a>
 
 | api-request-limit |      |
 -------------|------
@@ -483,7 +483,7 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
-<a name="debug-attribute"></a>
+<a id="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
@@ -643,7 +643,7 @@ sensu-backend start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="jwt-attributes"></a>
+<a id="jwt-attributes"></a>
 
 | jwt-private-key-file |      |
 -------------|------
@@ -683,7 +683,7 @@ sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------
@@ -809,7 +809,7 @@ sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
 
-<a name="etcd-cipher-suites"></a>
+<a id="etcd-cipher-suites"></a>
 
 | etcd-cipher-suites    |      |
 ------------------------|------
@@ -976,7 +976,7 @@ sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
-<a name="etcd-listen-client-urls"></a>
+<a id="etcd-listen-client-urls"></a>
 
 | etcd-listen-client-urls |      |
 --------------------------|------
@@ -1206,7 +1206,7 @@ sensu-backend start --etcd-election-timeout 1000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
-<a name="etcd-heartbeat-interval"></a>
+<a id="etcd-heartbeat-interval"></a>
 
 | etcd-heartbeat-interval |      |
 -----------------------|------

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
@@ -742,7 +742,7 @@ command: /etc/sensu/plugins/check-chef-client.go
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-subscriptions"></a>
+<a id="check-subscriptions"></a>
 
 |subscriptions|     |
 -------------|------
@@ -763,7 +763,7 @@ subscriptions:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="handlers-array"></a>
+<a id="handlers-array"></a>
 
 |handlers    |      |
 -------------|------
@@ -820,7 +820,7 @@ cron: 0 0 * * *
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="publish-attribute"></a>
+<a id="publish-attribute"></a>
 
 |publish     |      |
 -------------|------
@@ -855,7 +855,7 @@ timeout: 30
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ttl-attribute"></a>
+<a id="ttl-attribute"></a>
 
 |ttl         |      |
 -------------|------
@@ -892,7 +892,7 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="flap-thresholds"></a>
+<a id="flap-thresholds"></a>
 
 |low_flap_threshold ||
 -------------|------
@@ -945,7 +945,7 @@ runtime_assets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-hooks-attribute"></a>
+<a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
 -------------|------
@@ -984,7 +984,7 @@ check_hooks:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-entity-name-attribute"></a>
+<a id="proxy-entity-name-attribute"></a>
 
 |proxy_entity_name|   |
 -------------|------
@@ -1003,7 +1003,7 @@ proxy_entity_name: switch-dc-01
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-requests-top-level"></a>
+<a id="proxy-requests-top-level"></a>
 
 |proxy_requests|    |
 -------------|------
@@ -1075,7 +1075,7 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="scheduler-attribute"></a>
+<a id="scheduler-attribute"></a>
 
 |scheduler  |     |
 ------------|-----
@@ -1093,7 +1093,7 @@ scheduler: postgres
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-format"></a>
+<a id="output-metric-format"></a>
 
 |output_metric_format    |      |
 -------------|------
@@ -1114,7 +1114,7 @@ output_metric_format:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-handlers"></a>
+<a id="output-metric-handlers"></a>
 
 |output_metric_handlers    |      |
 -------------|------
@@ -1135,7 +1135,7 @@ output_metric_handlers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-tags"></a>
+<a id="output-metric-tags"></a>
 
 |output_metric_tags    |      |
 -------------|------
@@ -1172,7 +1172,7 @@ output_metric_tags:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-attribute"></a>
+<a id="round-robin-attribute"></a>
 
 |round_robin |      |
 -------------|------
@@ -1638,7 +1638,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [47]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
-[50]: ../../observe-events/events/#metrics
+[50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [52]: #round-robin-checks
 [53]: https://regex101.com/r/zo9mQU/2

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -506,7 +506,7 @@ The event specification describes [metrics attributes in events][5].
 [2]: ../../observe-process/aggregate-metrics-statsd/
 [3]: ../checks/#output-metric-handlers
 [4]: #extract-metrics-from-check-output
-[5]: ../../observe-events/events/#metrics
+[5]: ../../observe-events/events/#metrics-attribute
 [6]: #metric-check-example
 [7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/subscriptions.md
@@ -167,7 +167,7 @@ Two of the six Windows servers *should* execute the SQL Server metrics check, so
 
 [1]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [2]: ../agent/#subscriptions-flag
-[10]: ../agent/#name
+[10]: ../agent/#name-attribute
 [11]: ../checks/#ad-hoc-scheduling
 [12]: ../checks/#publish-attribute
 [13]: ../checks/#check-scheduling

--- a/content/sensu-go/6.2/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ad-auth.md
@@ -398,7 +398,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-groups-prefix"></a>
+<a id="ad-groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -416,7 +416,7 @@ groups_prefix: ad
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-username-prefix"></a>
+<a id="ad-username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.2/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ldap-auth.md
@@ -386,7 +386,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="groups-prefix"></a>
+<a id="groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -404,7 +404,7 @@ groups_prefix: ldap
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="username-prefix"></a>
+<a id="username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.2/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.2/operations/control-access/namespaces.md
@@ -263,4 +263,3 @@ name: production
 [9]: ../../deploy-sensu/install-sensu/#install-sensuctl
 [10]: ../../../sensuctl/create-manage-resources/#create-resources
 [11]: #spec-attributes
-[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -259,12 +259,12 @@ username: alice
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password"></a>
+<a id="password-attribute"></a>
 
 password     | 
 -------------|------ 
 description  | User's password. Passwords must have at least eight characters.{{% notice note %}}
-**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash-attribute) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required     | true
 type         | String
@@ -317,12 +317,12 @@ disabled: false
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password-hash"></a>
+<a id="password-hash-attribute"></a>
 
 password_hash | 
 --------------|------ 
 description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords. {{% notice note %}}
-**NOTE**: You only need to set either the [`password`](#password) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the [`password`](#password-attribute) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required      | false
 type          | String

--- a/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
@@ -436,7 +436,7 @@ pool_size: 20
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="strict"></a>
+<a id="strict-attribute"></a>
 
 strict       |      |
 -------------|------
@@ -455,7 +455,7 @@ strict: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-postgresql"></a>
+<a id="round-robin-postgresql"></a>
 
 enable_round_robin |      |
 -------------|------

--- a/content/sensu-go/6.2/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/etcdreplicators.md
@@ -510,7 +510,7 @@ resource: Role
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="namespace-attribute"></a>
+<a id="namespace-attribute"></a>
 
 namespace    |      |
 -------------|-------

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -107,7 +107,7 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
-<a name="copy-ca-pem"></a>
+<a id="copy-ca-pem"></a>
 
 You should now have a directory at `/etc/sensu/tls` that contains the following files:
 
@@ -172,7 +172,7 @@ export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-backend-pem"></a>
+<a id="copy-backend-pem"></a>
 
 You should now have a set of files for each backend:
 
@@ -219,7 +219,7 @@ export NAME=agent
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="" -profile=agent - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-agent-pem"></a>
+<a id="copy-agent-pem"></a>
 
 You should now have a set of files for use by Sensu agents:
 

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -291,7 +291,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
 {{% /notice %}}
 
-<a name="translate-metric-checks"></a>
+<a id="translate-metric-checks"></a>
 
 **Translate metric checks**
 
@@ -302,14 +302,14 @@ This allowed Sensu Core to process output metrics via a handler even when the ch
 Sensu Go treats output metrics as first-class objects, so you can process check status as well as output metrics via different event pipelines.
 See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes and use `output_metric_tags` to enrich extracted metrics output.
 
-<a name="translate-proxy-requests-entities"></a>
+<a id="translate-proxy-requests-entities"></a>
 
 **Translate proxy requests and proxy entities**
 
 See the [guide to monitoring external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
 See the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
-<a name="translate-hooks"></a>
+<a id="translate-hooks"></a>
 
 **Translate hooks**
 

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
@@ -386,7 +386,7 @@ timeout: 20s
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="tls-vault"></a>
+<a id="tls-vault"></a>
 
 tls          | 
 -------------|------ 
@@ -445,7 +445,7 @@ version: v1
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="rate-limiter-attributes"></a>
+<a id="rate-limiter-attributes"></a>
 
 #### Rate limiter attributes
 

--- a/content/sensu-go/6.2/plugins/assets.md
+++ b/content/sensu-go/6.2/plugins/assets.md
@@ -939,7 +939,7 @@ sha512: 4f926bf4328...
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="filters"></a>
+<a id="filters-attribute"></a>
 
 filters      | 
 -------------|------ 
@@ -1252,7 +1252,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [39]: ../../web-ui/search#search-for-labels
 [40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[42]: #filters
+[42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1

--- a/content/sensu-go/6.2/release-notes.md
+++ b/content/sensu-go/6.2/release-notes.md
@@ -1788,7 +1788,7 @@ To get started with Sensu Go:
 [176]: /sensu-go/6.1/api/authproviders/#authproviders-get-specification
 [177]: /sensu-go/6.1/api/secrets/#providers-get-specification
 [178]: /sensu-go/6.1/web-ui/search/
-[179]: /sensu-go/6.1/operations/deploy-sensu/datastore/#strict
+[179]: /sensu-go/6.1/operations/deploy-sensu/datastore/#strict-attribute
 [180]: /sensu-go/6.1/operations/control-access/oidc-auth/#oidc-spec-attributes
 [181]: /sensu-go/6.1/operations/deploy-sensu/datastore/#spec-attributes
 [182]: /sensu-go/6.1/observability-pipeline/observe-schedule/checks#output-metric-tags

--- a/content/sensu-go/6.2/web-ui/_index.md
+++ b/content/sensu-go/6.2/web-ui/_index.md
@@ -10,7 +10,7 @@ menu:
     identifier: web-ui
 ---
 
-<a name="federated-webui"></a>
+<a id="federated-webui"></a>
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 

--- a/content/sensu-go/6.2/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.2/web-ui/webconfig-reference.md
@@ -225,7 +225,7 @@ created_by: admin
 
 ### Spec attributes
 
-<a name="show-local-cluster"></a>
+<a id="show-local-cluster"></a>
 
 always_show_local_cluster | 
 -------------|------ 

--- a/content/sensu-go/6.3/api/events.md
+++ b/content/sensu-go/6.3/api/events.md
@@ -966,6 +966,6 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 [6]: ../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../observability-pipeline/observe-schedule/checks#check-specification
 [8]: ../../observability-pipeline/observe-events/events/#events-specification
-[9]: ../../observability-pipeline/observe-events/events#metrics
+[9]: ../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -885,7 +885,7 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="annotations"></a>
+<a id="annotations-attribute"></a>
 
 | annotations |     |
 -------------|------
@@ -1737,7 +1737,7 @@ cpu_percent: 0.12639
 [17]: ../../observe-entities/monitor-external-resources/
 [18]: ../../observe-schedule/checks/#round-robin-checks
 [19]: #proxy-entities-managed
-[20]: #annotations
+[20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
 [22]: ../../../operations/control-access/rbac/
 [23]: ../../../web-ui/search#search-for-labels

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -1380,7 +1380,7 @@ id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="sequence-attribute"></a>
+<a id="sequence-attribute"></a>
 
 sequence     |      |
 -------------|------
@@ -1504,7 +1504,7 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="checks"></a>
+<a id="checks-attribute"></a>
 
 |check       |      |
 -------------|------
@@ -1614,7 +1614,7 @@ check:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="metrics"></a>
+<a id="metrics-attribute"></a>
 
 |metrics     |      |
 -------------|------
@@ -2094,7 +2094,7 @@ value: 0.005
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes
-[22]: #metrics
+[22]: #metrics-attribute
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -926,7 +926,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 
-<a name="agent-managed-entity"></a>
+<a id="agent-managed-entity"></a>
 
 | agent-managed-entity |      |
 -------------|------
@@ -943,7 +943,7 @@ sensu-agent start --agent-managed-entity{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
 
-<a name="allow-list"></a>
+<a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
@@ -996,7 +996,7 @@ sensu-agent start --assets-rate-limit 1.39{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
-<a name="backend-handshake-timeout"></a>
+<a id="backend-handshake-timeout"></a>
 
 | backend-handshake-timeout |      |
 ----------------------------|------
@@ -1009,7 +1009,7 @@ sensu-agent start --backend-handshake-timeout 20{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
-<a name="backend-heartbeat-interval"></a>
+<a id="backend-heartbeat-interval"></a>
 
 | backend-heartbeat-interval |      |
 -----------------------------|------
@@ -1022,7 +1022,7 @@ sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
-<a name="backend-heartbeat-timeout"></a>
+<a id="backend-heartbeat-timeout"></a>
 
 | backend-heartbeat-timeout |      |
 ----------------------------|------
@@ -1053,7 +1053,7 @@ backend-url:
   - "ws://0.0.0.0:8082"
 {{< /code >}}
 
-<a name="cache-dir"></a>
+<a id="cache-dir"></a>
 
 | cache-dir   |      |
 --------------|------
@@ -1066,7 +1066,7 @@ sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
-<a name="config-file"></a>
+<a id="config-file"></a>
 
 | config-file |      |
 --------------|------
@@ -1079,7 +1079,7 @@ sensu-agent start --config-file /sensu/agent.yml
 sensu-agent start -c /sensu/agent.yml
 {{< /code >}}
 
-<a name="disable-assets"></a>
+<a id="disable-assets"></a>
 
 | disable-assets |      |
 --------------|------
@@ -1092,7 +1092,7 @@ sensu-agent start --disable-assets{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
-<a name="discover-processes"></a>
+<a id="discover-processes"></a>
 
 | discover-processes |      |
 --------------|------
@@ -1109,8 +1109,6 @@ command line example   | {{< code shell >}}
 sensu-agent start --discover-processes{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 discover-processes: true{{< /code >}}
-
-<a name="labels"></a>
 
 | labels     |      |
 -------------|------
@@ -1130,7 +1128,7 @@ labels:
   proxy_type: website
 {{< /code >}}
 
-<a name="name"></a>
+<a id="name-attribute"></a>
 
 | name        |      |
 --------------|------
@@ -1143,7 +1141,7 @@ sensu-agent start --name agent-01{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
-<a name="log-level"></a>
+<a id="log-level"></a>
 
 | log-level   |      |
 --------------|------
@@ -1156,7 +1154,7 @@ sensu-agent start --log-level debug{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
-<a name="subscriptions-flag"></a>
+<a id="subscriptions-flag"></a>
 
 | subscriptions |      |
 ----------------|------
@@ -1255,7 +1253,7 @@ sensu-agent start --deregistration-handler deregister{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
-<a name="detect-cloud-provider-flag"></a>
+<a id="detect-cloud-provider-flag"></a>
 
 | detect-cloud-provider  |      |
 -------------------------|------
@@ -1272,7 +1270,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1282,7 +1280,7 @@ sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
-<a name="keepalive-handlers-flag"></a>
+<a id="keepalive-handlers-flag"></a>
 
 | keepalive-handlers |      |
 --------------------|------
@@ -1311,7 +1309,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`
@@ -1422,7 +1420,7 @@ sensu-agent start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -417,7 +417,7 @@ sensu-backend start --api-listen-address [::]:8080{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
-<a name="api-request-limit"></a>
+<a id="api-request-limit"></a>
 
 | api-request-limit |      |
 -------------|------
@@ -485,7 +485,7 @@ sensu-backend start --config-file /etc/sensu/backend.yml
 sensu-backend start -c /etc/sensu/backend.yml
 {{< /code >}}
 
-<a name="debug-attribute"></a>
+<a id="debug-attribute"></a>
 
 | debug     |      |
 ------------|------
@@ -667,7 +667,7 @@ sensu-backend start --insecure-skip-tls-verify{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
-<a name="jwt-attributes"></a>
+<a id="jwt-attributes"></a>
 
 | jwt-private-key-file |      |
 -------------|------
@@ -707,7 +707,7 @@ sensu-backend start --key-file /path/to/ssl/key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 key-file: "/path/to/ssl/key.pem"{{< /code >}}
 
-<a name="fips-openssl"></a>
+<a id="fips-openssl"></a>
 
 | require-fips |      |
 ------------------|------
@@ -833,7 +833,7 @@ sensu-backend start --etcd-cert-file ./client.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-cert-file: "./client.pem"{{< /code >}}
 
-<a name="etcd-cipher-suites"></a>
+<a id="etcd-cipher-suites"></a>
 
 | etcd-cipher-suites    |      |
 ------------------------|------
@@ -1001,7 +1001,7 @@ sensu-backend start --etcd-key-file ./client-key.pem{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-key-file: "./client-key.pem"{{< /code >}}
 
-<a name="etcd-listen-client-urls"></a>
+<a id="etcd-listen-client-urls"></a>
 
 | etcd-listen-client-urls |      |
 --------------------------|------
@@ -1231,7 +1231,7 @@ sensu-backend start --etcd-election-timeout 1000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
-<a name="etcd-heartbeat-interval"></a>
+<a id="etcd-heartbeat-interval"></a>
 
 | etcd-heartbeat-interval |      |
 -----------------------|------

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -742,7 +742,7 @@ command: /etc/sensu/plugins/check-chef-client.go
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-subscriptions"></a>
+<a id="check-subscriptions"></a>
 
 |subscriptions|     |
 -------------|------
@@ -763,7 +763,7 @@ subscriptions:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="handlers-array"></a>
+<a id="handlers-array"></a>
 
 |handlers    |      |
 -------------|------
@@ -820,7 +820,7 @@ cron: 0 0 * * *
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="publish-attribute"></a>
+<a id="publish-attribute"></a>
 
 |publish     |      |
 -------------|------
@@ -855,7 +855,7 @@ timeout: 30
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ttl-attribute"></a>
+<a id="ttl-attribute"></a>
 
 |ttl         |      |
 -------------|------
@@ -892,7 +892,7 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="flap-thresholds"></a>
+<a id="flap-thresholds"></a>
 
 |low_flap_threshold ||
 -------------|------
@@ -945,7 +945,7 @@ runtime_assets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="check-hooks-attribute"></a>
+<a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
 -------------|------
@@ -984,7 +984,7 @@ check_hooks:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-entity-name-attribute"></a>
+<a id="proxy-entity-name-attribute"></a>
 
 |proxy_entity_name|   |
 -------------|------
@@ -1003,7 +1003,7 @@ proxy_entity_name: switch-dc-01
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="proxy-requests-top-level"></a>
+<a id="proxy-requests-top-level"></a>
 
 |proxy_requests|    |
 -------------|------
@@ -1075,7 +1075,7 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="scheduler-attribute"></a>
+<a id="scheduler-attribute"></a>
 
 |scheduler  |     |
 ------------|-----
@@ -1093,7 +1093,7 @@ scheduler: postgres
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-format"></a>
+<a id="output-metric-format"></a>
 
 |output_metric_format    |      |
 -------------|------
@@ -1114,7 +1114,7 @@ output_metric_format:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-handlers"></a>
+<a id="output-metric-handlers"></a>
 
 |output_metric_handlers    |      |
 -------------|------
@@ -1135,7 +1135,7 @@ output_metric_handlers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="output-metric-tags"></a>
+<a id="output-metric-tags"></a>
 
 |output_metric_tags    |      |
 -------------|------
@@ -1172,7 +1172,7 @@ output_metric_tags:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-attribute"></a>
+<a id="round-robin-attribute"></a>
 
 |round_robin |      |
 -------------|------
@@ -1638,7 +1638,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [47]: http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
 [48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
-[50]: ../../observe-events/events/#metrics
+[50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
 [52]: #round-robin-checks
 [53]: https://regex101.com/r/zo9mQU/2

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -506,7 +506,7 @@ The event specification describes [metrics attributes in events][5].
 [2]: ../../observe-process/aggregate-metrics-statsd/
 [3]: ../checks/#output-metric-handlers
 [4]: #extract-metrics-from-check-output
-[5]: ../../observe-events/events/#metrics
+[5]: ../../observe-events/events/#metrics-attribute
 [6]: #metric-check-example
 [7]: ../prometheus-metrics/
 [8]: https://bonsai.sensu.io/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -592,7 +592,7 @@ required:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="rule-properties"></a>
+<a id="rule-properties"></a>
 
 properties   | 
 -------------|------ 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
@@ -167,7 +167,7 @@ Two of the six Windows servers *should* execute the SQL Server metrics check, so
 
 [1]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [2]: ../agent/#subscriptions-flag
-[10]: ../agent/#name
+[10]: ../agent/#name-attribute
 [11]: ../checks/#ad-hoc-scheduling
 [12]: ../checks/#publish-attribute
 [13]: ../checks/#check-scheduling

--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -398,7 +398,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-groups-prefix"></a>
+<a id="ad-groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -416,7 +416,7 @@ groups_prefix: ad
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="ad-username-prefix"></a>
+<a id="ad-username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.3/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ldap-auth.md
@@ -386,7 +386,7 @@ servers:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="groups-prefix"></a>
+<a id="groups-prefix"></a>
 
 | groups_prefix |   |
 -------------|------
@@ -404,7 +404,7 @@ groups_prefix: ldap
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="username-prefix"></a>
+<a id="username-prefix"></a>
 
 | username_prefix | |
 -------------|------

--- a/content/sensu-go/6.3/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.3/operations/control-access/namespaces.md
@@ -263,4 +263,3 @@ name: production
 [9]: ../../deploy-sensu/install-sensu/#install-sensuctl
 [10]: ../../../sensuctl/create-manage-resources/#create-resources
 [11]: #spec-attributes
-[12]: ../../../observability-pipeline/observe-schedule/agent/#labels

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -259,12 +259,12 @@ username: alice
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password"></a>
+<a id="password-attribute"></a>
 
 password     | 
 -------------|------ 
 description  | User's password. Passwords must have at least eight characters.{{% notice note %}}
-**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the `password` or the [`password_hash`](#password-hash-attribute) (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required     | true
 type         | String
@@ -317,12 +317,12 @@ disabled: false
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="password-hash"></a>
+<a id="password-hash-attribute"></a>
 
 password_hash | 
 --------------|------ 
 description   | [Bcrypt][35] password hash. You can use the `password_hash` in your user definitions instead of storing cleartext passwords. {{% notice note %}}
-**NOTE**: You only need to set either the [`password`](#password) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
+**NOTE**: You only need to set either the [`password`](#password-attribute) or the `password_hash` (not both). We recommend using the `password_hash` because it eliminates the need to store cleartext passwords.
 {{% /notice %}}
 required      | false
 type          | String

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -436,7 +436,7 @@ pool_size: 20
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="strict"></a>
+<a id="strict-attribute"></a>
 
 strict       |      |
 -------------|------
@@ -455,7 +455,7 @@ strict: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="round-robin-postgresql"></a>
+<a id="round-robin-postgresql"></a>
 
 enable_round_robin |      |
 -------------|------

--- a/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
@@ -510,7 +510,7 @@ resource: Role
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="namespace-attribute"></a>
+<a id="namespace-attribute"></a>
 
 namespace    |      |
 -------------|-------

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -107,7 +107,7 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
 
-<a name="copy-ca-pem"></a>
+<a id="copy-ca-pem"></a>
 
 You should now have a directory at `/etc/sensu/tls` that contains the following files:
 
@@ -172,7 +172,7 @@ export NAME=backend-3.example.com
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -profile="backend" -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-backend-pem"></a>
+<a id="copy-backend-pem"></a>
 
 You should now have a set of files for each backend:
 
@@ -219,7 +219,7 @@ export NAME=agent
 echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="" -profile=agent - | cfssljson -bare $NAME
 {{< /code >}}
 
-<a name="copy-agent-pem"></a>
+<a id="copy-agent-pem"></a>
 
 You should now have a set of files for use by Sensu agents:
 

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -291,7 +291,7 @@ Review your Sensu Core check configuration for the following attributes, and mak
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.` (for example: `sensu.io.json_attributes`), use the `index` function. For example, `{{index .annotations "web_url"}}` substitutes the value of the `web_url` annotation; `{{index .annotations "production.ID"}}` substitutes the value of the `production.ID` annotation.
 {{% /notice %}}
 
-<a name="translate-metric-checks"></a>
+<a id="translate-metric-checks"></a>
 
 **Translate metric checks**
 
@@ -302,14 +302,14 @@ This allowed Sensu Core to process output metrics via a handler even when the ch
 Sensu Go treats output metrics as first-class objects, so you can process check status as well as output metrics via different event pipelines.
 See the [guide to metric output][57] to update your metric checks with the `output_metric_handlers` and `output_metric_format` attributes and use `output_metric_tags` to enrich extracted metrics output.
 
-<a name="translate-proxy-requests-entities"></a>
+<a id="translate-proxy-requests-entities"></a>
 
 **Translate proxy requests and proxy entities**
 
 See the [guide to monitoring external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
 See the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
-<a name="translate-hooks"></a>
+<a id="translate-hooks"></a>
 
 **Translate hooks**
 

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -386,7 +386,7 @@ timeout: 20s
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="tls-vault"></a>
+<a id="tls-vault"></a>
 
 tls          | 
 -------------|------ 
@@ -445,7 +445,7 @@ version: v1
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="rate-limiter-attributes"></a>
+<a id="rate-limiter-attributes"></a>
 
 #### Rate limiter attributes
 

--- a/content/sensu-go/6.3/plugins/assets.md
+++ b/content/sensu-go/6.3/plugins/assets.md
@@ -939,7 +939,7 @@ sha512: 4f926bf4328...
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a name="filters"></a>
+<a id="filters-attribute"></a>
 
 filters      | 
 -------------|------ 
@@ -1252,7 +1252,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [39]: ../../web-ui/search#search-for-labels
 [40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[42]: #filters
+[42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -1788,7 +1788,7 @@ To get started with Sensu Go:
 [176]: /sensu-go/6.1/api/authproviders/#authproviders-get-specification
 [177]: /sensu-go/6.1/api/secrets/#providers-get-specification
 [178]: /sensu-go/6.1/web-ui/search/
-[179]: /sensu-go/6.1/operations/deploy-sensu/datastore/#strict
+[179]: /sensu-go/6.1/operations/deploy-sensu/datastore/#strict-attribute
 [180]: /sensu-go/6.1/operations/control-access/oidc-auth/#oidc-spec-attributes
 [181]: /sensu-go/6.1/operations/deploy-sensu/datastore/#spec-attributes
 [182]: /sensu-go/6.1/observability-pipeline/observe-schedule/checks#output-metric-tags

--- a/content/sensu-go/6.3/web-ui/_index.md
+++ b/content/sensu-go/6.3/web-ui/_index.md
@@ -10,7 +10,7 @@ menu:
     identifier: web-ui
 ---
 
-<a name="federated-webui"></a>
+<a id="federated-webui"></a>
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 

--- a/content/sensu-go/6.3/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.3/web-ui/webconfig-reference.md
@@ -225,7 +225,7 @@ created_by: admin
 
 ### Spec attributes
 
-<a name="show-local-cluster"></a>
+<a id="show-local-cluster"></a>
 
 always_show_local_cluster | 
 -------------|------ 


### PR DESCRIPTION
## Description
Change all anchor links to use `<a id` rather than `<a name` throughout the docs. The `<a name` anchor link format is [obsolete](https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features).

## Motivation and Context
Noticed when working on something else