### PR TITLE
Add cluster redeploy and update faulty cluster member restore instructions

### DIFF
--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -136,7 +136,7 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
+Here is an example backend-url configuration for all agents connecting to the cluster over WebSocket:
 
 {{< code yml >}}
 backend-url:
@@ -182,7 +182,7 @@ For the new node `backend-4` with IP address `10.0.0.4`:
 etcd-advertise-client-urls: "http://10.0.0.4:2379"
 etcd-listen-client-urls: "http://10.0.0.4:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
 etcd-initial-cluster-state: "existing"
 etcd-initial-cluster-token: "unique_token_for_this_cluster"
@@ -191,12 +191,14 @@ etcd-name: "backend-4"
 
    {{% notice note %}}
 **NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+
+Also, when you are adding a cluster member, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
 {{% /notice %}}
 
 2. Run the sensuctl command to add the new cluster member:
 
    {{< code shell >}}
-sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+sensuctl cluster member-add backend-4 http://10.0.0.4:2380
 {{< /code >}}
 
    You will receive a sensuctl response to confirm that the new member was added:
@@ -234,10 +236,10 @@ You will receive a sensuctl response that lists all cluster members:
 {{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
-a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
-c3d9f4b8d0dd1ac9   backend-2    https://10.0.0.2:2380     https://10.0.0.2:2379
-c8f63ae435a5e6bf   backend-3    https://10.0.0.3:2380     https://10.0.0.3:2379
-2f7ae42c315f8c2d   backend-4    https://10.0.0.4:2380     https://10.0.0.4:2379
+a32e8f613b529ad4   backend-1    http://10.0.0.1:2380      http://10.0.0.1:2379  
+c3d9f4b8d0dd1ac9   backend-2    http://10.0.0.2:2380      http://10.0.0.2:2379
+c8f63ae435a5e6bf   backend-3    http://10.0.0.3:2380      http://10.0.0.3:2379
+2f7ae42c315f8c2d   backend-4    http://10.0.0.4:2380      http://10.0.0.4:2379
 {{< /code >}}
 
 ### Remove a cluster member
@@ -256,11 +258,15 @@ Removed member 2f7ae42c315f8c2d from cluster
 
 ### Replace a faulty cluster member
 
-To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
-For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
+To replace a faulty cluster member to restore a cluster's health:
 
-In this example, the response indicates that cluster member `backend-4` is faulty:
+1. Get cluster health status and etcd alarm information:
+{{< code shell >}}
+sensuctl cluster health
+{{< /code >}}
 
+    In the response, for a faulty cluster member, the Error column will include an error message and the Healthy column will list `false`.
+    In this example, the response indicates that cluster member `backend-4` is faulty:
 {{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
@@ -271,32 +277,22 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 {{< /code >}}
 
-Then, delete the faulty cluster member.
-To continue this example, you will delete cluster member `backend-4` using its ID:
-
+2. Remove the faulty cluster member &mdash; in this example, `backend-4` &mdash; using its ID.
+Removing the faulty cluster member prevents the cluster size from growing.
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
 {{< /code >}}
 
-The response should indicate that the cluster member was removed:
-
+    The response should indicate that the cluster member was removed:
 {{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
-Finally, add a newly created member to the cluster.
-You can use the same name and IP address as the faulty member you deleted, with one change to the configuration: specify the `etcd-initial-cluster-state` as `existing`.
-
-{{< code yml >}}
-etcd-advertise-client-urls: "http://10.0.0.4:2379"
-etcd-listen-client-urls: "http://10.0.0.4:2379"
-etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
-etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
-etcd-initial-cluster-state: "existing"
-etcd-initial-cluster-token: ""
-etcd-name: "backend-4"
-{{< /code >}}
+3. Follow the steps in [Add a cluster member][22] to configure the replacement cluster member.
+{{% notice note %}}
+**NOTE**: You can use the same name and IP address as the removed faulty member for the replacement cluster member.
+When updating the replacement member's backend configuration file, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
+{{% /notice %}}
 
 If replacing the faulty cluster member does not resolve the problem, see the [etcd operations guide][12] for more information.
 
@@ -305,7 +301,7 @@ If replacing the faulty cluster member does not resolve the problem, see the [et
 Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
-sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+sensuctl cluster member-update c8f63ae435a5e6bf http://10.0.0.4:2380
 {{< /code >}}
 
 You will receive a sensuctl response to confirm that the cluster member was updated:
@@ -383,6 +379,10 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 
 See the [etcd recovery guide][9] for disaster recovery information.
 
+### Redeploy a cluster
+
+To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
+
 
 [1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
@@ -405,3 +405,5 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
 [21]: ../install-sensu/
+[22]: #add-a-cluster-member
+[23]: ../../maintain-sensu/troubleshoot/#remove-and-redeploy-a-cluster

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -136,7 +136,7 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
+Here is an example backend-url configuration for all agents connecting to the cluster over WebSocket:
 
 {{< code yml >}}
 backend-url:
@@ -182,7 +182,7 @@ For the new node `backend-4` with IP address `10.0.0.4`:
 etcd-advertise-client-urls: "http://10.0.0.4:2379"
 etcd-listen-client-urls: "http://10.0.0.4:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
 etcd-initial-cluster-state: "existing"
 etcd-initial-cluster-token: "unique_token_for_this_cluster"
@@ -191,12 +191,14 @@ etcd-name: "backend-4"
 
    {{% notice note %}}
 **NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+
+Also, when you are adding a cluster member, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
 {{% /notice %}}
 
 2. Run the sensuctl command to add the new cluster member:
 
    {{< code shell >}}
-sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+sensuctl cluster member-add backend-4 http://10.0.0.4:2380
 {{< /code >}}
 
    You will receive a sensuctl response to confirm that the new member was added:
@@ -234,10 +236,10 @@ You will receive a sensuctl response that lists all cluster members:
 {{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
-a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
-c3d9f4b8d0dd1ac9   backend-2    https://10.0.0.2:2380     https://10.0.0.2:2379
-c8f63ae435a5e6bf   backend-3    https://10.0.0.3:2380     https://10.0.0.3:2379
-2f7ae42c315f8c2d   backend-4    https://10.0.0.4:2380     https://10.0.0.4:2379
+a32e8f613b529ad4   backend-1    http://10.0.0.1:2380      http://10.0.0.1:2379  
+c3d9f4b8d0dd1ac9   backend-2    http://10.0.0.2:2380      http://10.0.0.2:2379
+c8f63ae435a5e6bf   backend-3    http://10.0.0.3:2380      http://10.0.0.3:2379
+2f7ae42c315f8c2d   backend-4    http://10.0.0.4:2380      http://10.0.0.4:2379
 {{< /code >}}
 
 ### Remove a cluster member
@@ -256,11 +258,15 @@ Removed member 2f7ae42c315f8c2d from cluster
 
 ### Replace a faulty cluster member
 
-To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
-For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
+To replace a faulty cluster member to restore a cluster's health:
 
-In this example, the response indicates that cluster member `backend-4` is faulty:
+1. Get cluster health status and etcd alarm information:
+{{< code shell >}}
+sensuctl cluster health
+{{< /code >}}
 
+    In the response, for a faulty cluster member, the Error column will include an error message and the Healthy column will list `false`.
+    In this example, the response indicates that cluster member `backend-4` is faulty:
 {{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
@@ -271,32 +277,22 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 {{< /code >}}
 
-Then, delete the faulty cluster member.
-To continue this example, you will delete cluster member `backend-4` using its ID:
-
+2. Remove the faulty cluster member &mdash; in this example, `backend-4` &mdash; using its ID.
+Removing the faulty cluster member prevents the cluster size from growing.
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
 {{< /code >}}
 
-The response should indicate that the cluster member was removed:
-
+    The response should indicate that the cluster member was removed:
 {{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
-Finally, add a newly created member to the cluster.
-You can use the same name and IP address as the faulty member you deleted, with one change to the configuration: specify the `etcd-initial-cluster-state` as `existing`.
-
-{{< code yml >}}
-etcd-advertise-client-urls: "http://10.0.0.4:2379"
-etcd-listen-client-urls: "http://10.0.0.4:2379"
-etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
-etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
-etcd-initial-cluster-state: "existing"
-etcd-initial-cluster-token: ""
-etcd-name: "backend-4"
-{{< /code >}}
+3. Follow the steps in [Add a cluster member][22] to configure the replacement cluster member.
+{{% notice note %}}
+**NOTE**: You can use the same name and IP address as the removed faulty member for the replacement cluster member.
+When updating the replacement member's backend configuration file, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
+{{% /notice %}}
 
 If replacing the faulty cluster member does not resolve the problem, see the [etcd operations guide][12] for more information.
 
@@ -305,7 +301,7 @@ If replacing the faulty cluster member does not resolve the problem, see the [et
 Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
-sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+sensuctl cluster member-update c8f63ae435a5e6bf http://10.0.0.4:2380
 {{< /code >}}
 
 You will receive a sensuctl response to confirm that the cluster member was updated:
@@ -383,6 +379,10 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 
 See the [etcd recovery guide][9] for disaster recovery information.
 
+### Redeploy a cluster
+
+To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
+
 
 [1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
@@ -405,3 +405,5 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
 [21]: ../install-sensu/
+[22]: #add-a-cluster-member
+[23]: ../../maintain-sensu/troubleshoot/#remove-and-redeploy-a-cluster

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -677,6 +677,65 @@ https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 {{< /code >}}
 
+### Remove and redeploy a cluster
+
+{{% notice protip %}}
+**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
+If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+{{% /notice %}}
+
+You may need to completely remove a cluster and redeploy it in cases such as:
+
+- Failure to reach consensus after losing more than `(N-1)/2` cluster members
+- Etcd configuration issues
+- Etcd corruption, perhaps from disk filling
+- Unrecoverable hardware failure
+
+To remove and redeploy a cluster:
+
+1. Open a terminal window for each cluster member.
+
+2. Stop each cluster member backend:
+{{< code shell >}}
+systemctl stop sensu-backend
+{{< /code >}}
+
+3. Confirm that each backend stopped:
+{{< code shell >}}
+systemctl status sensu-backend
+{{< /code >}}
+
+    For each backend, the response should begin with the following lines:
+    {{< code shell >}}
+● sensu-backend.service - The Sensu Backend service.
+Loaded: loaded (/usr/lib/systemd/system/sensu-backend.service; disabled; vendor preset: disabled)
+Active: inactive (dead)
+{{< /code >}}
+
+4. Delete the etcd directories for each cluster member:
+{{< code shell >}}
+rm -rf /var/lib/sensu/sensu-backend/etcd/
+{{< /code >}}
+
+5. Follow the [Sensu backend configuration][23] instructions to reconfigure a new cluster.
+
+6. [Initialize][25] a backend to specify admin credentials:
+{{< code shell >}}
+sensu-backend init --interactive
+{{< /code >}}
+    
+    When you receive prompts for your username and password, replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with the administrator username and password you want to use for the cluster members:
+{{< code shell >}}
+Admin Username: <YOUR_USERNAME>
+Admin Password: <YOUR_PASSWORD>
+{{< /code >}}
+
+7. Use sensuctl create to [restore your resources from backup][24].
+
 ## Datastore performance
 
 In a default deployment, Sensu uses [etcd datastore][17] for both configuration and state.
@@ -759,3 +818,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [18]: ../../../api/metrics/
 [19]: ../../deploy-sensu/hardware-requirements/#backend-recommended-configuration
 [21]: https://www.computerhope.com/unix/sha512sum.htm
+[22]: ../../../sensuctl/back-up-recover/
+[23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
+[24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
+[25]: ../../../observability-pipeline/observe-schedule/backend/#initialization

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -381,7 +381,7 @@ See the [etcd recovery guide][9] for disaster recovery information.
 
 ### Redeploy a cluster
 
-To redeploy a cluster due to an issue like etcd corruption, loss of quorum among cluster members, or unrecoverable hardware failure, read [Remove and redeploy a cluster][23].
+To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
 
 
 [1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -136,7 +136,7 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
+Here is an example backend-url configuration for all agents connecting to the cluster over WebSocket:
 
 {{< code yml >}}
 backend-url:
@@ -182,7 +182,7 @@ For the new node `backend-4` with IP address `10.0.0.4`:
 etcd-advertise-client-urls: "http://10.0.0.4:2379"
 etcd-listen-client-urls: "http://10.0.0.4:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
 etcd-initial-cluster-state: "existing"
 etcd-initial-cluster-token: "unique_token_for_this_cluster"
@@ -191,12 +191,14 @@ etcd-name: "backend-4"
 
    {{% notice note %}}
 **NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+
+Also, when you are adding a cluster member, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
 {{% /notice %}}
 
 2. Run the sensuctl command to add the new cluster member:
 
    {{< code shell >}}
-sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+sensuctl cluster member-add backend-4 http://10.0.0.4:2380
 {{< /code >}}
 
    You will receive a sensuctl response to confirm that the new member was added:
@@ -234,10 +236,10 @@ You will receive a sensuctl response that lists all cluster members:
 {{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
-a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
-c3d9f4b8d0dd1ac9   backend-2    https://10.0.0.2:2380     https://10.0.0.2:2379
-c8f63ae435a5e6bf   backend-3    https://10.0.0.3:2380     https://10.0.0.3:2379
-2f7ae42c315f8c2d   backend-4    https://10.0.0.4:2380     https://10.0.0.4:2379
+a32e8f613b529ad4   backend-1    http://10.0.0.1:2380      http://10.0.0.1:2379  
+c3d9f4b8d0dd1ac9   backend-2    http://10.0.0.2:2380      http://10.0.0.2:2379
+c8f63ae435a5e6bf   backend-3    http://10.0.0.3:2380      http://10.0.0.3:2379
+2f7ae42c315f8c2d   backend-4    http://10.0.0.4:2380      http://10.0.0.4:2379
 {{< /code >}}
 
 ### Remove a cluster member
@@ -256,11 +258,15 @@ Removed member 2f7ae42c315f8c2d from cluster
 
 ### Replace a faulty cluster member
 
-To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
-For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
+To replace a faulty cluster member to restore a cluster's health:
 
-In this example, the response indicates that cluster member `backend-4` is faulty:
+1. Get cluster health status and etcd alarm information:
+{{< code shell >}}
+sensuctl cluster health
+{{< /code >}}
 
+    In the response, for a faulty cluster member, the Error column will include an error message and the Healthy column will list `false`.
+    In this example, the response indicates that cluster member `backend-4` is faulty:
 {{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
@@ -271,32 +277,22 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 {{< /code >}}
 
-Then, delete the faulty cluster member.
-To continue this example, you will delete cluster member `backend-4` using its ID:
-
+2. Remove the faulty cluster member &mdash; in this example, `backend-4` &mdash; using its ID.
+Removing the faulty cluster member prevents the cluster size from growing.
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
 {{< /code >}}
 
-The response should indicate that the cluster member was removed:
-
+    The response should indicate that the cluster member was removed:
 {{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
-Finally, add a newly created member to the cluster.
-You can use the same name and IP address as the faulty member you deleted, with one change to the configuration: specify the `etcd-initial-cluster-state` as `existing`.
-
-{{< code yml >}}
-etcd-advertise-client-urls: "http://10.0.0.4:2379"
-etcd-listen-client-urls: "http://10.0.0.4:2379"
-etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
-etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
-etcd-initial-cluster-state: "existing"
-etcd-initial-cluster-token: ""
-etcd-name: "backend-4"
-{{< /code >}}
+3. Follow the steps in [Add a cluster member][22] to configure the replacement cluster member.
+{{% notice note %}}
+**NOTE**: You can use the same name and IP address as the removed faulty member for the replacement cluster member.
+When updating the replacement member's backend configuration file, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
+{{% /notice %}}
 
 If replacing the faulty cluster member does not resolve the problem, see the [etcd operations guide][12] for more information.
 
@@ -305,7 +301,7 @@ If replacing the faulty cluster member does not resolve the problem, see the [et
 Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
-sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+sensuctl cluster member-update c8f63ae435a5e6bf http://10.0.0.4:2380
 {{< /code >}}
 
 You will receive a sensuctl response to confirm that the cluster member was updated:
@@ -375,6 +371,8 @@ sensu-backend start \
 
 ## Troubleshoot clusters
 
+If you want to restart a cluster, read [Remove and redeploy a cluster][23].
+
 ### Failure modes
 
 See the [etcd failure modes documentation][8] for information about cluster failure modes.
@@ -405,3 +403,5 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
 [21]: ../install-sensu/
+[22]: #add-a-cluster-member
+[23]: ../../maintain-sensu/troubleshoot/#remove-and-redeploy-a-cluster

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -371,8 +371,6 @@ sensu-backend start \
 
 ## Troubleshoot clusters
 
-If you want to restart a cluster, read [Remove and redeploy a cluster][23].
-
 ### Failure modes
 
 See the [etcd failure modes documentation][8] for information about cluster failure modes.
@@ -380,6 +378,10 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 ### Disaster recovery
 
 See the [etcd recovery guide][9] for disaster recovery information.
+
+### Redeploy a cluster
+
+To redeploy a cluster due to an issue like etcd corruption, loss of quorum among cluster members, or unrecoverable hardware failure, read [Remove and redeploy a cluster][23].
 
 
 [1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -677,6 +677,48 @@ https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 {{< /code >}}
 
+### Remove and redeploy a cluster
+
+In some cases, you may need to completely remove a cluster and redeploy it.
+
+{{% notice protip %}}
+**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+
+If 1 node fails, you will still be able to run sensuctl dump.
+If 2 nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+{{% /notice %}}
+
+To remove and redeploy a cluster:
+
+1. Open a terminal window for each cluster member.
+
+2. Stop each cluster member backend:
+{{< code shell >}}
+systemctl stop sensu-backend
+{{< /code >}}
+
+3. Confirm that each backend stopped:
+{{< code shell >}}
+systemctl status sensu-backend
+{{< /code >}}
+
+    For each backend, the response should begin with the following lines:
+    {{< code shell >}}
+● sensu-backend.service - The Sensu Backend service.
+Loaded: loaded (/usr/lib/systemd/system/sensu-backend.service; disabled; vendor preset: disabled)
+Active: inactive (dead)
+{{< /code >}}
+
+4. Delete the etcd directories for each cluster member:
+{{< code shell >}}
+rm -rf /var/lib/sensu/sensu-backend/etcd/
+{{< /code >}}
+
+5. Follow the [Sensu backend configuration][23] instructions to reconfigure a new cluster.
+
+6. Use sensuctl create to [restore your resources from backup][24].
+
 ## Datastore performance
 
 In a default deployment, Sensu uses [etcd datastore][17] for both configuration and state.
@@ -760,3 +802,6 @@ The backend will stop listening on those ports when the etcd database is unavail
 [19]: ../../deploy-sensu/hardware-requirements/#backend-recommended-configuration
 [20]: ../../deploy-sensu/datastore/#round-robin-postgresql
 [21]: https://www.computerhope.com/unix/sha512sum.htm
+[22]: ../../../sensuctl/back-up-recover/
+[23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
+[24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -679,15 +679,22 @@ https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 
 ### Remove and redeploy a cluster
 
-In some cases, you may need to completely remove a cluster and redeploy it.
-
 {{% notice protip %}}
 **PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
 If you wait until cluster nodes are failing, it may not be possible to make a backup.
 
-If 1 node fails, you will still be able to run sensuctl dump.
-If 2 nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
+If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+
+For information about using etcd snapshots for recovery, read the [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
 {{% /notice %}}
+
+You may want to completely remove a cluster and redeploy it in cases such as:
+
+- Etcd configuration issues
+- Etcd corruption, perhaps from disk filling
+- Failure to reach consensus after losing more than `(N-1)/2` cluster members
+- Unrecoverable hardware failure
 
 To remove and redeploy a cluster:
 
@@ -717,12 +724,12 @@ rm -rf /var/lib/sensu/sensu-backend/etcd/
 
 5. Follow the [Sensu backend configuration][23] instructions to reconfigure a new cluster.
 
-6. [Initialize][25] each backend to specify admin credentials:
+6. [Initialize][25] a backend to specify admin credentials:
 {{< code shell >}}
 sensu-backend init --interactive
 {{< /code >}}
     
-    When you receive prompts for your username and password, replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with the administrator username and password you wish to use:
+    When you receive prompts for your username and password, replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with the administrator username and password you want to use for the cluster members:
 {{< code shell >}}
 Admin Username: <YOUR_USERNAME>
 Admin Password: <YOUR_PASSWORD>

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -682,18 +682,17 @@ https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 {{% notice protip %}}
 **PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
 If you wait until cluster nodes are failing, it may not be possible to make a backup.
-
 For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
 If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
 
-For information about using etcd snapshots for recovery, read the [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
 {{% /notice %}}
 
-You may want to completely remove a cluster and redeploy it in cases such as:
+You may need to completely remove a cluster and redeploy it in cases such as:
 
+- Failure to reach consensus after losing more than `(N-1)/2` cluster members
 - Etcd configuration issues
 - Etcd corruption, perhaps from disk filling
-- Failure to reach consensus after losing more than `(N-1)/2` cluster members
 - Unrecoverable hardware failure
 
 To remove and redeploy a cluster:

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -717,7 +717,18 @@ rm -rf /var/lib/sensu/sensu-backend/etcd/
 
 5. Follow the [Sensu backend configuration][23] instructions to reconfigure a new cluster.
 
-6. Use sensuctl create to [restore your resources from backup][24].
+6. [Initialize][25] each backend to specify admin credentials:
+{{< code shell >}}
+sensu-backend init --interactive
+{{< /code >}}
+    
+    When you receive prompts for your username and password, replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with the administrator username and password you wish to use:
+{{< code shell >}}
+Admin Username: <YOUR_USERNAME>
+Admin Password: <YOUR_PASSWORD>
+{{< /code >}}
+
+7. Use sensuctl create to [restore your resources from backup][24].
 
 ## Datastore performance
 
@@ -805,3 +816,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [22]: ../../../sensuctl/back-up-recover/
 [23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
 [24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
+[25]: ../../../observability-pipeline/observe-schedule/backend/#initialization

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -136,7 +136,7 @@ sudo systemctl start sensu-backend
 Each Sensu agent should have the following entries in `/etc/sensu/agent.yml` to ensure the agent is aware of all cluster members.
 This allows the agent to reconnect to a working backend if the backend it is currently connected to goes into an unhealthy state.
 
-Here is an exmaple backend-url configuration for all agents connecting to the cluster over WebSocket:
+Here is an example backend-url configuration for all agents connecting to the cluster over WebSocket:
 
 {{< code yml >}}
 backend-url:
@@ -182,7 +182,7 @@ For the new node `backend-4` with IP address `10.0.0.4`:
 etcd-advertise-client-urls: "http://10.0.0.4:2379"
 etcd-listen-client-urls: "http://10.0.0.4:2379"
 etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=https://10.0.0.4:2380"
+etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
 etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
 etcd-initial-cluster-state: "existing"
 etcd-initial-cluster-token: "unique_token_for_this_cluster"
@@ -191,12 +191,14 @@ etcd-name: "backend-4"
 
    {{% notice note %}}
 **NOTE**: To make sure the new member is added to the correct cluster, specify the same `etcd-initial-cluster-token` value that you used for the other members in the cluster.
+
+Also, when you are adding a cluster member, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
 {{% /notice %}}
 
 2. Run the sensuctl command to add the new cluster member:
 
    {{< code shell >}}
-sensuctl cluster member-add backend-4 https://10.0.0.4:2380
+sensuctl cluster member-add backend-4 http://10.0.0.4:2380
 {{< /code >}}
 
    You will receive a sensuctl response to confirm that the new member was added:
@@ -234,10 +236,10 @@ You will receive a sensuctl response that lists all cluster members:
 {{< code shell >}}
        ID            Name             Peer URLs                Client URLs
 ────────────────── ─────────── ───────────────────────── ─────────────────────────
-a32e8f613b529ad4   backend-1    https://10.0.0.1:2380     https://10.0.0.1:2379  
-c3d9f4b8d0dd1ac9   backend-2    https://10.0.0.2:2380     https://10.0.0.2:2379
-c8f63ae435a5e6bf   backend-3    https://10.0.0.3:2380     https://10.0.0.3:2379
-2f7ae42c315f8c2d   backend-4    https://10.0.0.4:2380     https://10.0.0.4:2379
+a32e8f613b529ad4   backend-1    http://10.0.0.1:2380      http://10.0.0.1:2379  
+c3d9f4b8d0dd1ac9   backend-2    http://10.0.0.2:2380      http://10.0.0.2:2379
+c8f63ae435a5e6bf   backend-3    http://10.0.0.3:2380      http://10.0.0.3:2379
+2f7ae42c315f8c2d   backend-4    http://10.0.0.4:2380      http://10.0.0.4:2379
 {{< /code >}}
 
 ### Remove a cluster member
@@ -256,11 +258,15 @@ Removed member 2f7ae42c315f8c2d from cluster
 
 ### Replace a faulty cluster member
 
-To replace a faulty cluster member to restore a cluster's health, start by running `sensuctl cluster health` to identify the faulty cluster member.
-For a faulty cluster member, the `Error` column will include an error message and the `Healthy` column will list `false`.
+To replace a faulty cluster member to restore a cluster's health:
 
-In this example, the response indicates that cluster member `backend-4` is faulty:
+1. Get cluster health status and etcd alarm information:
+{{< code shell >}}
+sensuctl cluster health
+{{< /code >}}
 
+    In the response, for a faulty cluster member, the Error column will include an error message and the Healthy column will list `false`.
+    In this example, the response indicates that cluster member `backend-4` is faulty:
 {{< code shell >}}
        ID            Name                          Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────── ─────────
@@ -271,32 +277,22 @@ c8f63ae435a5e6bf   backend-3                                                    
 
 {{< /code >}}
 
-Then, delete the faulty cluster member.
-To continue this example, you will delete cluster member `backend-4` using its ID:
-
+2. Remove the faulty cluster member &mdash; in this example, `backend-4` &mdash; using its ID.
+Removing the faulty cluster member prevents the cluster size from growing.
 {{< code shell >}}
 sensuctl cluster member-remove 2f7ae42c315f8c2d
 {{< /code >}}
 
-The response should indicate that the cluster member was removed:
-
+    The response should indicate that the cluster member was removed:
 {{< code shell >}}
 Removed member 2f7ae42c315f8c2d from cluster
 {{< /code >}}
 
-Finally, add a newly created member to the cluster.
-You can use the same name and IP address as the faulty member you deleted, with one change to the configuration: specify the `etcd-initial-cluster-state` as `existing`.
-
-{{< code yml >}}
-etcd-advertise-client-urls: "http://10.0.0.4:2379"
-etcd-listen-client-urls: "http://10.0.0.4:2379"
-etcd-listen-peer-urls: "http://0.0.0.0:2380"
-etcd-initial-cluster: "backend-1=http://10.0.0.1:2380,backend-2=http://10.0.0.2:2380,backend-3=http://10.0.0.3:2380,backend-4=http://10.0.0.4:2380"
-etcd-initial-advertise-peer-urls: "http://10.0.0.4:2380"
-etcd-initial-cluster-state: "existing"
-etcd-initial-cluster-token: ""
-etcd-name: "backend-4"
-{{< /code >}}
+3. Follow the steps in [Add a cluster member][22] to configure the replacement cluster member.
+{{% notice note %}}
+**NOTE**: You can use the same name and IP address as the removed faulty member for the replacement cluster member.
+When updating the replacement member's backend configuration file, make sure the `etcd-initial-cluster-state` value is `existing`, **not** `new`.
+{{% /notice %}}
 
 If replacing the faulty cluster member does not resolve the problem, see the [etcd operations guide][12] for more information.
 
@@ -305,7 +301,7 @@ If replacing the faulty cluster member does not resolve the problem, see the [et
 Update the peer URLs of a member in a cluster:
 
 {{< code shell >}}
-sensuctl cluster member-update c8f63ae435a5e6bf https://10.0.0.4:2380
+sensuctl cluster member-update c8f63ae435a5e6bf http://10.0.0.4:2380
 {{< /code >}}
 
 You will receive a sensuctl response to confirm that the cluster member was updated:
@@ -383,6 +379,10 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 
 See the [etcd recovery guide][9] for disaster recovery information.
 
+### Redeploy a cluster
+
+To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
+
 
 [1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
 [2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
@@ -405,3 +405,5 @@ See the [etcd recovery guide][9] for disaster recovery information.
 [19]: #sensu-backend-configuration
 [20]: ../../../api/
 [21]: ../install-sensu/
+[22]: #add-a-cluster-member
+[23]: ../../maintain-sensu/troubleshoot/#remove-and-redeploy-a-cluster

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -677,6 +677,65 @@ https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
 https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 {{< /code >}}
 
+### Remove and redeploy a cluster
+
+{{% notice protip %}}
+**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
+If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+{{% /notice %}}
+
+You may need to completely remove a cluster and redeploy it in cases such as:
+
+- Failure to reach consensus after losing more than `(N-1)/2` cluster members
+- Etcd configuration issues
+- Etcd corruption, perhaps from disk filling
+- Unrecoverable hardware failure
+
+To remove and redeploy a cluster:
+
+1. Open a terminal window for each cluster member.
+
+2. Stop each cluster member backend:
+{{< code shell >}}
+systemctl stop sensu-backend
+{{< /code >}}
+
+3. Confirm that each backend stopped:
+{{< code shell >}}
+systemctl status sensu-backend
+{{< /code >}}
+
+    For each backend, the response should begin with the following lines:
+    {{< code shell >}}
+● sensu-backend.service - The Sensu Backend service.
+Loaded: loaded (/usr/lib/systemd/system/sensu-backend.service; disabled; vendor preset: disabled)
+Active: inactive (dead)
+{{< /code >}}
+
+4. Delete the etcd directories for each cluster member:
+{{< code shell >}}
+rm -rf /var/lib/sensu/sensu-backend/etcd/
+{{< /code >}}
+
+5. Follow the [Sensu backend configuration][23] instructions to reconfigure a new cluster.
+
+6. [Initialize][25] a backend to specify admin credentials:
+{{< code shell >}}
+sensu-backend init --interactive
+{{< /code >}}
+    
+    When you receive prompts for your username and password, replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with the administrator username and password you want to use for the cluster members:
+{{< code shell >}}
+Admin Username: <YOUR_USERNAME>
+Admin Password: <YOUR_PASSWORD>
+{{< /code >}}
+
+7. Use sensuctl create to [restore your resources from backup][24].
+
 ## Datastore performance
 
 In a default deployment, Sensu uses [etcd datastore][17] for both configuration and state.
@@ -760,3 +819,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [19]: ../../deploy-sensu/hardware-requirements/#backend-recommended-configuration
 [20]: ../../deploy-sensu/datastore/#round-robin-postgresql
 [21]: https://www.computerhope.com/unix/sha512sum.htm
+[22]: ../../../sensuctl/back-up-recover/
+[23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
+[24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
+[25]: ../../../observability-pipeline/observe-schedule/backend/#initialization


### PR DESCRIPTION
## Description
- In Troubleshoot Sensu, adds a section of instructions for completely removing a cluster and redeploying from scratch.
- In Run a Sensu cluster, adds the reason to remove a faulty cluster member, cleans up instructions for replacing a faulty cluster member, adds a note to emphasize "existing" rather than "new" in config for the new member, and adds a link to the redeploy cluster in troubleshooting.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1702
