### PR TITLE
Add anchor links for agent transport rate limiting flags

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -597,6 +597,8 @@ sensu-backend start --agent-auth-trusted-ca-file /path/to/ssl/ca.pem{{< /code >}
 /etc/sensu/backend.yml example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/ssl/ca.pem{{< /code >}}
 
+<a id="agent-burst-limit"></a>
+
 | agent-burst-limit   |      |
 --------------|------
 description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections.
@@ -629,6 +631,8 @@ command line example   | {{< code shell >}}
 sensu-backend start --agent-port 8081{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
+
+<a id="agent-rate-limit"></a>
 
 | agent-rate-limit   |      |
 --------------|------


### PR DESCRIPTION
## Description
Adds anchor links in the backend reference for the two agent transport rate limiting flags, agent-burst-limit and agent-rate-limit.

## Motivation and Context
Allows links to the two backend config flags from the 6.3.0 release notes