### PR TITLE
Update details about PostgresHealth object in health API and reference docs

### DIFF
--- a/content/sensu-go/6.2/api/health.md
+++ b/content/sensu-go/6.2/api/health.md
@@ -49,6 +49,10 @@ HTTP/1.1 200 OK
 }
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: If your Sensu instance is not configured to use a [PostgreSQL datastore](../../operations/deploy-sensu/datastore/#scale-event-storage), the backend health payload will not include `PostgresHealth`.
+{{% /notice %}}
+
 ### API Specification {#health-get-specification}
 
 /health (GET)    | 
@@ -118,14 +122,7 @@ HTTP/1.1 200 OK
     "cluster_id": 4255616344056076734,
     "member_id": 2882886652148554927,
     "raft_term": 26
-  },
-  "PostgresHealth": [
-    {
-      "Name": "my-postgres",
-      "Active": false,
-      "Healthy": false
-    }
-  ]
+  }
 }
 {{< /code >}}
 
@@ -158,13 +155,6 @@ output           | {{< code shell >}}
     "cluster_id": 4255616344056076734,
     "member_id": 2882886652148554927,
     "raft_term": 26
-  },
-  "PostgresHealth": [
-    {
-      "Name": "my-postgres",
-      "Active": false,
-      "Healthy": false
-    }
-  ]
+  }
 }
 {{< /code >}}

--- a/content/sensu-go/6.2/operations/monitor-sensu/health.md
+++ b/content/sensu-go/6.2/operations/monitor-sensu/health.md
@@ -12,7 +12,7 @@ menu:
     parent: monitor-sensu
 ---
 
-Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
+Use Sensu's [health API][1] to make sure your agent transport and backend are running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
 
 A request to the health endpoint retrieves a JSON map with health data for your Sensu instance.
 

--- a/content/sensu-go/6.3/api/health.md
+++ b/content/sensu-go/6.3/api/health.md
@@ -49,6 +49,10 @@ HTTP/1.1 200 OK
 }
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: If your Sensu instance is not configured to use a [PostgreSQL datastore](../../operations/deploy-sensu/datastore/#scale-event-storage), the health payload will not include `PostgresHealth`.
+{{% /notice %}}
+
 ### API Specification {#health-get-specification}
 
 /health (GET)    | 
@@ -128,6 +132,10 @@ HTTP/1.1 200 OK
   ]
 }
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: If your Sensu instance is not configured to use a [PostgreSQL datastore](../../operations/deploy-sensu/datastore/#scale-event-storage), the health payload will not include `PostgresHealth`.
+{{% /notice %}}
 
 #### API Specification
 


### PR DESCRIPTION
## Description
In 6.2 health API doc:
- Adds note after backend example that payload will not included PostgresHealth if instance is not configured to use PostgreSQL
- Removes PostgresHealth object from agent transport example

In 6.2 and 6.3 health reference docs:
- Mentions agent transport endpoint in intro

In 6.3 health API doc:
- Adds note after backend and agent transport examples that payload will not included PostgresHealth if instance is not configured to use PostgreSQL

## Motivation and Context
Discussion at https://sensu.slack.com/archives/C60EEQFH8/p1620229790278900