### PR TITLE
Replace training tile with learn tile on docs homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,10 +34,10 @@
           Ask questions, search answers, and help other Sensu users in Sensu's community forum
         </div>
       </a>
-      <a class="product-grid--product product-grid--product-sensu-enterprise-dashboard" href="./sensu-go/6.2/learn/interactive-tutorials/">
-        <div class="product-grid--product--title">Interactive Training</div>
+      <a class="product-grid--product product-grid--product-sensu-enterprise-dashboard" href="./sensu-go/6.2/learn/">
+        <div class="product-grid--product--title">Learn Sensu Go</div>
         <div class="product-grid--product--description">
-          Learn Sensu Go with interactive training tutorials
+          Build and test workflows with the sandbox, try the live web UI demo, and review terminology
         </div>
       </a>
       <a class="product-grid--product product-grid--product-uchiwa" href="sensu-go/6.2/plugins/">


### PR DESCRIPTION
## Description
At docs.sensu.io, replaces Interactive Training tile with Learn Sensu Go tile.

## Motivation and Context
Noticed while working on something else