### PR TITLE
update LDAP and AD auth to include new allow_groups attribute

### DIFF
--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -406,9 +406,9 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed AD group strings to include in the tokenized identity claim. This maybe needed in circumstances when authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
 required     | false
-type         | Array of strings
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
@@ -421,8 +421,6 @@ allowed_groups:
 }
 {{< /code >}}
 {{< /language-toggle >}}
-
-
 
 <a id="ad-groups-prefix"></a>
 

--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -79,6 +79,7 @@ api_version: authentication/v2
 metadata:
   name: activedirectory
 spec:
+  allowed_groups: []
   groups_prefix: ad
   servers:
   - binding:
@@ -140,6 +141,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   },
@@ -288,6 +290,7 @@ spec:
       attribute: sAMAccountName
       name_attribute: displayName
       object_class: person
+  allowed_groups: []
   groups_prefix: ad
   username_prefix: ad
 {{< /code >}}
@@ -323,6 +326,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   }
@@ -397,6 +401,28 @@ servers:
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed AD group strings to include in the tokenized identity claim. This maybe needed in circumstances when authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array of strings
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [ "sensu-viewers", "sensu-operators" ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+
 
 <a id="ad-groups-prefix"></a>
 

--- a/content/sensu-go/6.3/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ldap-auth.md
@@ -78,6 +78,7 @@ api_version: authentication/v2
 metadata:
   name: openldap
 spec:
+  allowed_groups: []
   groups_prefix: ldap
   servers:
   - binding:
@@ -135,6 +136,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   },
@@ -281,6 +283,7 @@ spec:
       attribute: uid
       name_attribute: cn
       object_class: person
+  allowed_groups: []
   groups_prefix: ldap
   username_prefix: ldap
 
@@ -315,6 +318,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   }
@@ -382,6 +386,26 @@ servers:
       }
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed LDAP group strings to include in the tokenized identity claim. This maybe needed in circumstances when authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array of strings
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups: 
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [ "sensu-viewers", "sensu-operators" ]
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ldap-auth.md
@@ -394,7 +394,7 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed LDAP group strings to include in the tokenized identity claim. This maybe needed in circumstances when authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed LDAP group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
 required     | false
 type         | Array of strings
 example      | {{< language-toggle >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/master/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
This is a documentation update that corresponds to a merged commercial feature enhancement

LDAP and AD auth provider api has been extended with a new optional attribute allowed_groups  

## Motivation and Context
#3099 

## Review Instructions
Features changes are now merged in sensu-enterprise-go. I expect this to be something we can test as part of 6.3  test releases.  
