### PR TITLE
Change code click event to track pre instead of clipboard icon

### DIFF
--- a/static/js/clip.js
+++ b/static/js/clip.js
@@ -40,7 +40,7 @@
         if (typeof ga !== "function") {
           return;
         }
-        ga('send','event','Pre test','Testing pre query selector',pageURL);
+        ga('send','event','Code examples','Clicks in code examples',pageURL);
        });
      });
 })();

--- a/static/js/clip.js
+++ b/static/js/clip.js
@@ -33,14 +33,14 @@
 (function() {
     var pageURL = document.location.pathname + document.location.search;
 
-    var buttonSet = document.querySelectorAll(".copy");
+    var buttonSet = document.querySelectorAll("pre");
     buttonSet.forEach(function (btn) {
       btn.addEventListener("click", function() {
         // noop if google analytics isn't initialized
         if (typeof ga !== "function") {
           return;
         }
-        ga('send','event','Clipboard','Code copied',pageURL);
+        ga('send','event','Pre test','Testing pre query selector',pageURL);
        });
      });
 })();


### PR DESCRIPTION
## Description
Changes the trigger for tracking clicks to copy code from `.code` to `pre` -- I believe this should track all clicks inside code examples as events. If I'm correct, we should see events in Google Analytics under the "Pre test" action.

## Motivation and Context
We were previously tracking clicks on the clipboard icon to determine the number of times code is copied. However, we discovered via crazyegg snapshot that more people seem to double-click or click-and-drag to highlight and copy from their keyboard.

Changing the trigger for a code-associated click event to `pre` should give us a more accurate picture of the number of people copying our code examples. The code to place the clipboard icon itself uses `pre`.