### PR TITLE
Add note about activating license on one backend in a cluster

### DIFF
--- a/content/sensu-go/5.21/api/license.md
+++ b/content/sensu-go/5.21/api/license.md
@@ -112,6 +112,10 @@ output         | {{< code shell >}}
 
 The `/license` API endpoint provides HTTP PUT access to activate a commercial license.
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 ### Example {#license-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/license` API endpoint to create the license definition.

--- a/content/sensu-go/5.21/commercial.md
+++ b/content/sensu-go/5.21/commercial.md
@@ -62,6 +62,10 @@ With the license file downloaded, you can use sensuctl to activate your commerci
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 Use sensuctl to view your license details at any time:
 
 {{< code shell >}}

--- a/content/sensu-go/5.21/reference/license.md
+++ b/content/sensu-go/5.21/reference/license.md
@@ -21,6 +21,10 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 
 With the license file downloaded, you can activate your license with sensuctl or the [license API][4].
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 To activate your license with sensuctl:
 
 {{< code shell >}}

--- a/content/sensu-go/6.0/api/license.md
+++ b/content/sensu-go/6.0/api/license.md
@@ -112,6 +112,10 @@ output         | {{< code shell >}}
 
 The `/license` API endpoint provides HTTP PUT access to activate a commercial license.
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 ### Example {#license-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/license` API endpoint to create the license definition.

--- a/content/sensu-go/6.0/commercial.md
+++ b/content/sensu-go/6.0/commercial.md
@@ -63,6 +63,10 @@ With the license file downloaded, you can use sensuctl to activate your commerci
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 Use sensuctl to view your license details at any time:
 
 {{< code shell >}}

--- a/content/sensu-go/6.0/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/license.md
@@ -23,6 +23,10 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 To activate your license with sensuctl:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.1/api/license.md
+++ b/content/sensu-go/6.1/api/license.md
@@ -112,6 +112,10 @@ output         | {{< code shell >}}
 
 The `/license` API endpoint provides HTTP PUT access to activate a commercial license.
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 ### Example {#license-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/license` API endpoint to create the license definition.

--- a/content/sensu-go/6.1/commercial.md
+++ b/content/sensu-go/6.1/commercial.md
@@ -62,6 +62,10 @@ With the license file downloaded, you can use sensuctl to activate your commerci
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 Use sensuctl to view your license details at any time:
 
 {{< code shell >}}

--- a/content/sensu-go/6.1/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/license.md
@@ -23,6 +23,10 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 To activate your license with sensuctl:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.2/api/license.md
+++ b/content/sensu-go/6.2/api/license.md
@@ -112,6 +112,10 @@ output         | {{< code shell >}}
 
 The `/license` API endpoint provides HTTP PUT access to activate a commercial license.
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 ### Example {#license-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/license` API endpoint to create the license definition.

--- a/content/sensu-go/6.2/commercial.md
+++ b/content/sensu-go/6.2/commercial.md
@@ -62,6 +62,10 @@ With the license file downloaded, you can use sensuctl to activate your commerci
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 Use sensuctl to view your license details at any time:
 
 {{< code shell >}}

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -23,6 +23,10 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 To activate your license with sensuctl:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.3/api/license.md
+++ b/content/sensu-go/6.3/api/license.md
@@ -111,6 +111,10 @@ output         | {{< code shell >}}
 
 The `/license` API endpoint provides HTTP PUT access to activate a commercial license.
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 ### Example {#license-put-example}
 
 In the following example, an HTTP PUT request is submitted to the `/license` API endpoint to create the license definition.

--- a/content/sensu-go/6.3/commercial.md
+++ b/content/sensu-go/6.3/commercial.md
@@ -64,6 +64,10 @@ With the license file downloaded, you can use sensuctl to activate your commerci
 sensuctl create --file sensu_license.json
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../operations/deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 Use sensuctl to view your license details at any time:
 
 {{< code shell >}}

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -23,6 +23,10 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
 With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
 
+{{% notice note %}}
+**NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.
+{{% /notice %}}
+
 To activate your license with sensuctl:
 
 {{< language-toggle >}}


### PR DESCRIPTION
## Description
Add note in commercial features page, license reference, and license API doc to explain that in clustered configurations, users only need to activate the license for one backend in the cluster.

## Motivation and Context
Slack discussion at https://sensu.slack.com/archives/C0FM2KPM5/p1621352022005300