### PR TITLE
Fix :. error in Generate certificates

### DIFF
--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -183,7 +183,7 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system:.
+Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system.
 For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -183,7 +183,7 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system:.
+Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system.
 For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -183,7 +183,7 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system:.
+Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system.
 For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -183,7 +183,7 @@ filename               | description                  | required on backend?|
 `backend-*-key.pem`    | Backend server private key   | {{< check >}}       |
 `backend-*.csr`        | Certificate signing request  |                     |
 
-Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system:.
+Again, make sure to copy all backend PEM files and the CA root certificate to the corresponding backend system.
 For example, the directory listing of /etc/sensu/tls on backend-1 should include:
 
 {{< code shell >}}


### PR DESCRIPTION
## Description
Fix `:.` to `.` in Generate certificates

## Motivation and Context
Missed it in https://github.com/sensu/sensu-docs/pull/3160
