### PR TITLE
Remove 5.19.0 from prune alpha note

### DIFF
--- a/content/sensu-go/5.21/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/5.21/sensuctl/create-manage-resources.md
@@ -385,7 +385,7 @@ See the [RBAC reference][22] for information about local user management with se
 #### sensuctl prune
 
 {{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
+**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -468,7 +468,7 @@ See the [RBAC reference][22] for information about local user management with se
 #### sensuctl prune
 
 {{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
+**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -468,7 +468,7 @@ See the [RBAC reference][22] for information about local user management with se
 #### sensuctl prune
 
 {{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
+**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -478,7 +478,7 @@ See the [RBAC reference][22] for information about local user management with se
 #### sensuctl prune
 
 {{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
+**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -478,7 +478,7 @@ See the [RBAC reference][22] for information about local user management with se
 #### sensuctl prune
 
 {{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature in release 5.19.0 and may include breaking changes.
+**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.


### PR DESCRIPTION
## Description
Remove "in release 5.19.0" from the notes about the prune alpha feature throughout docs.

## Motivation and Context
The information about the 5.19.0 release is no longer relevant in 5.21+ docs.
