### PR TITLE
Remove outdated notices about Sensu versions

### DIFF
--- a/content/sensu-go/5.21/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/5.21/operations/control-access/oidc-auth.md
@@ -387,7 +387,7 @@ Use the instructions listed in this section to register an OIDC application for 
 #### Requirements
 
 - Access to the Okta Administrator Dashboard
-- Sensu Go 5.12.0 or later (plus a valid commercial license for Sensu Go versions 5.12.0 through 5.14.2)
+- Sensu Go with a valid commercial license
 
 #### Create an Okta application
 

--- a/content/sensu-go/5.21/reference/agent.md
+++ b/content/sensu-go/5.21/reference/agent.md
@@ -814,8 +814,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 ### Configuration summary
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
@@ -1056,9 +1056,7 @@ disable-assets: true{{< /code >}}
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/5.21/reference/assets.md
+++ b/content/sensu-go/5.21/reference/assets.md
@@ -1176,7 +1176,7 @@ example      | {{< code yml >}}
 
 ## Delete assets
 
-As of Sensu Go 5.12, you can delete assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
+Delete assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
 When you remove an asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 

--- a/content/sensu-go/5.21/reference/checks.md
+++ b/content/sensu-go/5.21/reference/checks.md
@@ -554,7 +554,7 @@ type: CheckConfig
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For checks in Sensu backend version 5.4 and later, this attribute should always be `core/v2`.
+description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
 required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/5.21/reference/entities.md
+++ b/content/sensu-go/5.21/reference/entities.md
@@ -596,9 +596,7 @@ subscriptions:
 system       | 
 -------------|------ 
 description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1019,9 +1017,7 @@ example        | {{< language-toggle >}}
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1194,8 +1190,8 @@ handler: email-handler
 ### Processes attributes
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -816,9 +816,7 @@ subscriptions:
 system       | 
 -------------|------ 
 description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1238,9 +1236,7 @@ example        | {{< language-toggle >}}
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1413,8 +1409,8 @@ handler: email-handler
 ### Processes attributes
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -835,9 +835,7 @@ You must present the whole chain to the remote so it can determine whether it tr
 ### Configuration summary
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 To view configuration information for the sensu-agent start command, run:
@@ -1076,9 +1074,7 @@ disable-assets: true{{< /code >}}
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false
@@ -1754,7 +1750,7 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 
 {{% notice important %}}
 **IMPORTANT**: To use HTTP proxy environment variables, upgrade to Sensu Go 6.1.4 or later.
-In earlier versions of Sensu Go 6.1, the agent will not respect HTTP proxy environment variables when `trusted-ca-file` is configured.
+In earlier versions of Sensu Go, the agent will not respect HTTP proxy environment variables when `trusted-ca-file` is configured.
 Upgrade to Sensu Go 6.1.4 or later to avoid this issue.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/checks.md
@@ -539,7 +539,7 @@ type: CheckConfig
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For checks in Sensu backend version 5.4 and later, this attribute should always be `core/v2`.
+description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
 required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.0/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/oidc-auth.md
@@ -387,7 +387,7 @@ Use the instructions listed in this section to register an OIDC application for 
 #### Requirements
 
 - Access to the Okta Administrator Dashboard
-- Sensu Go 5.12.0 or later (plus a valid commercial license for Sensu Go versions 5.12.0 through 5.14.2)
+- Sensu Go with a valid commercial license
 
 #### Create an Okta application
 

--- a/content/sensu-go/6.0/plugins/assets.md
+++ b/content/sensu-go/6.0/plugins/assets.md
@@ -1206,7 +1206,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-As of Sensu Go 5.12, you can delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
+Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
 When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -816,9 +816,7 @@ subscriptions:
 system       | 
 -------------|------ 
 description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1238,9 +1236,7 @@ example        | {{< language-toggle >}}
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1413,8 +1409,8 @@ handler: email-handler
 ### Processes attributes
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -835,9 +835,7 @@ You must present the whole chain to the remote so it can determine whether it tr
 ### Configuration summary
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 To view configuration information for the sensu-agent start command, run:
@@ -1076,9 +1074,7 @@ disable-assets: true{{< /code >}}
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
@@ -541,7 +541,7 @@ type: CheckConfig
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For checks in Sensu backend version 5.4 and later, this attribute should always be `core/v2`.
+description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
 required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.1/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/oidc-auth.md
@@ -387,7 +387,7 @@ Use the instructions listed in this section to register an OIDC application for 
 #### Requirements
 
 - Access to the Okta Administrator Dashboard
-- Sensu Go 5.12.0 or later (plus a valid commercial license for Sensu Go versions 5.12.0 through 5.14.2)
+- Sensu Go with a valid commercial license
 
 #### Create an Okta application
 

--- a/content/sensu-go/6.1/plugins/assets.md
+++ b/content/sensu-go/6.1/plugins/assets.md
@@ -1206,7 +1206,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-As of Sensu Go 5.12, you can delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
+Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
 When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -833,9 +833,7 @@ subscriptions:
 system       | 
 -------------|------ 
 description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1255,9 +1253,7 @@ example        | {{< language-toggle >}}
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1430,8 +1426,8 @@ handler: email-handler
 ### Processes attributes
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -839,8 +839,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 ### Configuration summary
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
@@ -1098,9 +1098,7 @@ disable-assets: true{{< /code >}}
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
@@ -549,7 +549,7 @@ type: CheckConfig
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For checks in Sensu backend version 5.4 and later, this attribute should always be `core/v2`.
+description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
 required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.2/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/oidc-auth.md
@@ -387,7 +387,7 @@ Use the instructions listed in this section to register an OIDC application for 
 #### Requirements
 
 - Access to the Okta Administrator Dashboard
-- Sensu Go 5.12.0 or later (plus a valid commercial license for Sensu Go versions 5.12.0 through 5.14.2)
+- Sensu Go with a valid commercial license
 
 #### Create an Okta application
 

--- a/content/sensu-go/6.2/plugins/assets.md
+++ b/content/sensu-go/6.2/plugins/assets.md
@@ -1206,7 +1206,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-As of Sensu Go 5.12, you can delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
+Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
 When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -227,11 +227,6 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 If you prefer, you can manage agent entities via the agent rather than the backend.
 To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-{{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
-Upgrade to [Sensu Go 6.2.3](../../../release-notes/#623-release-notes) to use the agent-managed-entity configuration flag.
-{{% /notice %}}
-
 When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in agent.yml, the agent becomes responsible for managing its entity configuration.
 An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
 You cannot update these agent-managed entities via the Sensu backend REST API.
@@ -960,9 +955,7 @@ subscriptions:
 system       | 
 -------------|------ 
 description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1382,9 +1375,7 @@ example        | {{< language-toggle >}}
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1557,8 +1548,8 @@ handler: email-handler
 ### Processes attributes
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -839,8 +839,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 ### Configuration summary
 
 {{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
@@ -930,10 +930,7 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 | agent-managed-entity |      |
 -------------|------
-description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.<br>{{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
-Upgrade to [Sensu Go 6.2.3](../../../release-notes/#623-release-notes) to use the agent-managed-entity configuration flag.
-{{% /notice %}}
+description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.
 required     | false
 type         | Boolean
 default      | false
@@ -1098,9 +1095,7 @@ disable-assets: true{{< /code >}}
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in [release 5.20.2](../../../release-notes/#5202-release-notes).
-As of 5.20.2, the `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -549,7 +549,7 @@ type: CheckConfig
 
 api_version  | 
 -------------|------
-description  | Top-level attribute that specifies the Sensu API group and version. For checks in Sensu backend version 5.4 and later, this attribute should always be `core/v2`.
+description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
 required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/oidc-auth.md
@@ -387,7 +387,7 @@ Use the instructions listed in this section to register an OIDC application for 
 #### Requirements
 
 - Access to the Okta Administrator Dashboard
-- Sensu Go 5.12.0 or later (plus a valid commercial license for Sensu Go versions 5.12.0 through 5.14.2)
+- Sensu Go with a valid commercial license
 
 #### Create an Okta application
 

--- a/content/sensu-go/6.3/plugins/assets.md
+++ b/content/sensu-go/6.3/plugins/assets.md
@@ -1206,7 +1206,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-As of Sensu Go 5.12, you can delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
+Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
 When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 


### PR DESCRIPTION
## Description
Removes or adjusts outdated notices about Sensu versions (for example, notes about version 5.12 that are still in versions 6.x+).

## Motivation and Context
Noticed when altering note for prune.