### PR TITLE
Replace etcd 3.3.x links with latest

### DIFF
--- a/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/cluster-sensu.md
@@ -377,20 +377,20 @@ See the [etcd failure modes documentation][8] for information about cluster fail
 See the [etcd recovery guide][9] for disaster recovery information.
 
 
-[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
-[4]: https://etcd.io/docs/v3.3.13/
-[5]: https://etcd.io/docs/v3.3.13/platforms/
+[1]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/latest/op-guide/clustering/
+[3]: https://etcd.io/docs/latest/op-guide/configuration/
+[4]: https://etcd.io/docs/latest/
+[5]: https://etcd.io/docs/latest/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
-[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
+[8]: https://etcd.io/docs/latest/op-guide/failures/
+[9]: https://etcd.io/docs/latest/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.3.13/op-guide/
+[11]: https://etcd.io/docs/latest/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/latest/op-guide/
 [13]: ../generate-certificates/
-[14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[14]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [15]: ../../../reference/backend/
 [16]: ../secure-sensu/
 [17]: ../../../sensuctl/

--- a/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/deployment-architecture.md
@@ -161,6 +161,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../../../reference/datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[11]: https://etcd.io/docs/latest/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../../../reference/datastore/#scale-event-storage

--- a/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/generate-certificates.md
@@ -278,7 +278,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[7]: https://etcd.io/docs/latest/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/install-sensu.md
@@ -562,7 +562,7 @@ sensuctl license info
 [37]: ../../../guides/influx-db-metric-handler/
 [38]: ../../../sensuctl/back-up-recover/
 [39]: ../../../sensuctl/create-manage-resources/#create-resources
-[40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[40]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [41]: ../../../reference/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
 [43]: ../../../reference/backend/#debug-attribute

--- a/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/5.21/operations/deploy-sensu/secure-sensu.md
@@ -234,7 +234,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../../reference/rbac/
 [4]: ../../control-access/create-read-only-user/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../reference/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/5.21/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/5.21/operations/maintain-sensu/troubleshoot.md
@@ -655,7 +655,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../reference/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../reference/agent/#restart-the-service
 [6]: ../../../reference/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -665,7 +665,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[14]: https://etcd.io/docs/latest/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../../reference/datastore/#scale-event-storage
 [17]: ../../../reference/datastore/#use-default-event-storage

--- a/content/sensu-go/5.21/reference/backend.md
+++ b/content/sensu-go/5.21/reference/backend.md
@@ -792,7 +792,7 @@ dashboard-port: 4000{{< /code >}}
 | etcd-advertise-client-urls |      |
 --------------|------
 description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
@@ -812,7 +812,7 @@ etcd-advertise-client-urls:
 | etcd-cert-file |      |
 -----------------|------
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -830,7 +830,7 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br><To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br><To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
@@ -858,7 +858,7 @@ etcd-cipher-suites:
 | etcd-client-cert-auth |      |
 ------------------------|------
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | Boolean
@@ -874,7 +874,7 @@ etcd-client-cert-auth: true{{< /code >}}
 | etcd-client-urls      |      |
 ------------------------|------
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -894,7 +894,7 @@ etcd-client-urls:
 | etcd-discovery        |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -912,7 +912,7 @@ etcd-discovery:
 | etcd-discovery-srv    |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -930,7 +930,7 @@ etcd-discovery-srv:
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
@@ -950,7 +950,7 @@ etcd-initial-advertise-peer-urls:
 | etcd-initial-cluster |      |
 -----------------------|------
 description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -966,7 +966,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 | etcd-initial-cluster-state |      |
 -----------------------------|------
 description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -982,7 +982,7 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 | etcd-initial-cluster-token |      |
 -----------------------------|------
 description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -998,7 +998,7 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1014,7 +1014,7 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 | etcd-listen-client-urls |      |
 --------------------------|------
 description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
@@ -1034,7 +1034,7 @@ etcd-listen-client-urls:
 | etcd-listen-peer-urls |      |
 ------------------------|------
 description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -1054,7 +1054,7 @@ etcd-listen-peer-urls:
 | etcd-name      |      |
 -----------------|------
 description      | Human-readable name for this member.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1070,7 +1070,7 @@ etcd-name: "backend-0"{{< /code >}}
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                  | String
@@ -1085,7 +1085,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
 description                  | Enable peer client certificate authentication.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | Boolean
@@ -1101,7 +1101,7 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                 | String
@@ -1116,7 +1116,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                        | String
@@ -1131,7 +1131,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 | etcd-trusted-ca-file |      |
 -----------------------|------
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -1147,7 +1147,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 | no-embed-etcd  |      |
 -----------------|------
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | Boolean
@@ -1257,7 +1257,7 @@ pipelined-workers: 100{{< /code >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1275,7 +1275,7 @@ etcd-election-timeout: 1000{{< /code >}}
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1293,7 +1293,7 @@ etcd-heartbeat-interval: 100{{< /code >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1311,7 +1311,7 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer

--- a/content/sensu-go/5.21/reference/datastore.md
+++ b/content/sensu-go/5.21/reference/datastore.md
@@ -328,7 +328,7 @@ pool_size: 20
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [6]: ../../operations/deploy-sensu/deployment-architecture/
-[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[7]: https://etcd.io/docs/latest/op-guide/clustering/
 [8]: ../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../web-ui/
 [10]: ../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -765,7 +765,7 @@ dashboard-port: 4000{{< /code >}}
 | etcd-advertise-client-urls |      |
 --------------|------
 description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
@@ -784,7 +784,7 @@ etcd-advertise-client-urls:
 | etcd-cert-file |      |
 -----------------|------
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -800,7 +800,7 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
@@ -827,7 +827,7 @@ etcd-cipher-suites:
 | etcd-client-cert-auth |      |
 ------------------------|------
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | Boolean
@@ -841,7 +841,7 @@ etcd-client-cert-auth: true{{< /code >}}
 | etcd-client-urls      |      |
 ------------------------|------
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -860,7 +860,7 @@ etcd-client-urls:
 | etcd-discovery        |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -876,7 +876,7 @@ etcd-discovery:
 | etcd-discovery-srv    |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -892,7 +892,7 @@ etcd-discovery-srv:
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
@@ -911,7 +911,7 @@ etcd-initial-advertise-peer-urls:
 | etcd-initial-cluster |      |
 -----------------------|------
 description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -925,7 +925,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 | etcd-initial-cluster-state |      |
 -----------------------------|------
 description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -939,7 +939,7 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 | etcd-initial-cluster-token |      |
 -----------------------------|------
 description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -953,7 +953,7 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -968,7 +968,7 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 | etcd-listen-client-urls |      |
 --------------------------|------
 description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
@@ -987,7 +987,7 @@ etcd-listen-client-urls:
 | etcd-listen-peer-urls |      |
 ------------------------|------
 description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -1006,7 +1006,7 @@ etcd-listen-peer-urls:
 | etcd-name      |      |
 -----------------|------
 description      | Human-readable name for this member.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1020,7 +1020,7 @@ etcd-name: "backend-0"{{< /code >}}
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                  | String
@@ -1033,7 +1033,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
 description                  | Enable peer client certificate authentication.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | Boolean
@@ -1047,7 +1047,7 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                 | String
@@ -1060,7 +1060,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                        | String
@@ -1073,7 +1073,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 | etcd-trusted-ca-file |      |
 -----------------------|------
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -1087,7 +1087,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 | no-embed-etcd  |      |
 -----------------|------
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | Boolean
@@ -1182,7 +1182,7 @@ pipelined-workers: 100{{< /code >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1199,7 +1199,7 @@ etcd-election-timeout: 1000{{< /code >}}
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1215,7 +1215,7 @@ etcd-heartbeat-interval: 100{{< /code >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1231,7 +1231,7 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer

--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -384,20 +384,20 @@ See the [etcd recovery guide][9] for disaster recovery information.
 To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
 
 
-[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
-[4]: https://etcd.io/docs/v3.3.13/
-[5]: https://etcd.io/docs/v3.3.13/platforms/
+[1]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/latest/op-guide/clustering/
+[3]: https://etcd.io/docs/latest/op-guide/configuration/
+[4]: https://etcd.io/docs/latest/
+[5]: https://etcd.io/docs/latest/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
-[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
+[8]: https://etcd.io/docs/latest/op-guide/failures/
+[9]: https://etcd.io/docs/latest/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.3.13/op-guide/
+[11]: https://etcd.io/docs/latest/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/latest/op-guide/
 [13]: ../generate-certificates/
-[14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[14]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
 [16]: ../secure-sensu/
 [17]: ../../../sensuctl/

--- a/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
@@ -365,7 +365,7 @@ pool_size: 20
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [6]: ../deployment-architecture/
-[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[7]: https://etcd.io/docs/latest/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/deployment-architecture.md
@@ -161,6 +161,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[11]: https://etcd.io/docs/latest/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/generate-certificates.md
@@ -311,7 +311,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#configure-sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[7]: https://etcd.io/docs/latest/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -573,7 +573,7 @@ sensuctl license info
 [37]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
 [38]: ../../../sensuctl/back-up-recover/
 [39]: ../../../sensuctl/create-manage-resources/#create-resources
-[40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[40]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
 [43]: ../../../observability-pipeline/observe-schedule/backend/#debug-attribute

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -246,7 +246,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
@@ -657,7 +657,7 @@ If you wait until cluster nodes are failing, it may not be possible to make a ba
 For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
 If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -773,7 +773,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -783,7 +783,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[14]: https://etcd.io/docs/latest/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -779,7 +779,7 @@ dashboard-port: 4000{{< /code >}}
 | etcd-advertise-client-urls |      |
 --------------|------
 description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
@@ -798,7 +798,7 @@ etcd-advertise-client-urls:
 | etcd-cert-file |      |
 -----------------|------
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -814,7 +814,7 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
@@ -841,7 +841,7 @@ etcd-cipher-suites:
 | etcd-client-cert-auth |      |
 ------------------------|------
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | Boolean
@@ -855,7 +855,7 @@ etcd-client-cert-auth: true{{< /code >}}
 | etcd-client-urls      |      |
 ------------------------|------
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -874,7 +874,7 @@ etcd-client-urls:
 | etcd-discovery        |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -890,7 +890,7 @@ etcd-discovery:
 | etcd-discovery-srv    |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -906,7 +906,7 @@ etcd-discovery-srv:
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
@@ -925,7 +925,7 @@ etcd-initial-advertise-peer-urls:
 | etcd-initial-cluster |      |
 -----------------------|------
 description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -939,7 +939,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 | etcd-initial-cluster-state |      |
 -----------------------------|------
 description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -953,7 +953,7 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 | etcd-initial-cluster-token |      |
 -----------------------------|------
 description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -967,7 +967,7 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -982,7 +982,7 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 | etcd-listen-client-urls |      |
 --------------------------|------
 description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
@@ -1001,7 +1001,7 @@ etcd-listen-client-urls:
 | etcd-listen-peer-urls |      |
 ------------------------|------
 description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -1020,7 +1020,7 @@ etcd-listen-peer-urls:
 | etcd-name      |      |
 -----------------|------
 description      | Human-readable name for this member.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1034,7 +1034,7 @@ etcd-name: "backend-0"{{< /code >}}
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                  | String
@@ -1047,7 +1047,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
 description                  | Enable peer client certificate authentication.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | Boolean
@@ -1061,7 +1061,7 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                 | String
@@ -1074,7 +1074,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                        | String
@@ -1087,7 +1087,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 | etcd-trusted-ca-file |      |
 -----------------------|------
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -1101,7 +1101,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 | no-embed-etcd  |      |
 -----------------|------
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | Boolean
@@ -1196,7 +1196,7 @@ pipelined-workers: 100{{< /code >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1213,7 +1213,7 @@ etcd-election-timeout: 1000{{< /code >}}
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1229,7 +1229,7 @@ etcd-heartbeat-interval: 100{{< /code >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1245,7 +1245,7 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -384,20 +384,20 @@ See the [etcd recovery guide][9] for disaster recovery information.
 To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
 
 
-[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
-[4]: https://etcd.io/docs/v3.3.13/
-[5]: https://etcd.io/docs/v3.3.13/platforms/
+[1]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/latest/op-guide/clustering/
+[3]: https://etcd.io/docs/latest/op-guide/configuration/
+[4]: https://etcd.io/docs/latest/
+[5]: https://etcd.io/docs/latest/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
-[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
+[8]: https://etcd.io/docs/latest/op-guide/failures/
+[9]: https://etcd.io/docs/latest/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.3.13/op-guide/
+[11]: https://etcd.io/docs/latest/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/latest/op-guide/
 [13]: ../generate-certificates/
-[14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[14]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
 [16]: ../secure-sensu/
 [17]: ../../../sensuctl/

--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -457,7 +457,7 @@ strict: true
 [3]: https://aws.amazon.com/rds/
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [6]: ../deployment-architecture/
-[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[7]: https://etcd.io/docs/latest/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/deployment-architecture.md
@@ -160,6 +160,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[11]: https://etcd.io/docs/latest/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/generate-certificates.md
@@ -311,7 +311,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#configure-sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[7]: https://etcd.io/docs/latest/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -573,7 +573,7 @@ sensuctl license info
 [37]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
 [38]: ../../../sensuctl/back-up-recover/
 [39]: ../../../sensuctl/create-manage-resources/#create-resources
-[40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[40]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
 [43]: ../../../observability-pipeline/observe-schedule/backend/#debug-attribute

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -246,7 +246,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -685,7 +685,7 @@ If you wait until cluster nodes are failing, it may not be possible to make a ba
 For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
 If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -801,7 +801,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -811,7 +811,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[14]: https://etcd.io/docs/latest/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -779,7 +779,7 @@ dashboard-port: 4000{{< /code >}}
 | etcd-advertise-client-urls |      |
 --------------|------
 description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
@@ -798,7 +798,7 @@ etcd-advertise-client-urls:
 | etcd-cert-file |      |
 -----------------|------
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -814,7 +814,7 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/). Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/). Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
 etcd-cipher-suites:
@@ -840,7 +840,7 @@ etcd-cipher-suites:
 | etcd-client-cert-auth |      |
 ------------------------|------
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | Boolean
@@ -854,7 +854,7 @@ etcd-client-cert-auth: true{{< /code >}}
 | etcd-client-urls      |      |
 ------------------------|------
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -873,7 +873,7 @@ etcd-client-urls:
 | etcd-discovery        |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -889,7 +889,7 @@ etcd-discovery:
 | etcd-discovery-srv    |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -905,7 +905,7 @@ etcd-discovery-srv:
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
@@ -924,7 +924,7 @@ etcd-initial-advertise-peer-urls:
 | etcd-initial-cluster |      |
 -----------------------|------
 description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -938,7 +938,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 | etcd-initial-cluster-state |      |
 -----------------------------|------
 description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -952,7 +952,7 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 | etcd-initial-cluster-token |      |
 -----------------------------|------
 description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -966,7 +966,7 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -981,7 +981,7 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 | etcd-listen-client-urls |      |
 --------------------------|------
 description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
@@ -1000,7 +1000,7 @@ etcd-listen-client-urls:
 | etcd-listen-peer-urls |      |
 ------------------------|------
 description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -1019,7 +1019,7 @@ etcd-listen-peer-urls:
 | etcd-name      |      |
 -----------------|------
 description      | Human-readable name for this member.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1033,7 +1033,7 @@ etcd-name: "backend-0"{{< /code >}}
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                  | String
@@ -1046,7 +1046,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
 description                  | Enable peer client certificate authentication.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | Boolean
@@ -1060,7 +1060,7 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                 | String
@@ -1073,7 +1073,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                        | String
@@ -1086,7 +1086,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 | etcd-trusted-ca-file |      |
 -----------------------|------
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -1100,7 +1100,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 | no-embed-etcd  |      |
 -----------------|------
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | Boolean
@@ -1195,7 +1195,7 @@ pipelined-workers: 100{{< /code >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1213,7 +1213,7 @@ etcd-election-timeout: 1000{{< /code >}}
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1229,7 +1229,7 @@ etcd-heartbeat-interval: 100{{< /code >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1245,7 +1245,7 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -384,20 +384,20 @@ See the [etcd recovery guide][9] for disaster recovery information.
 To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
 
 
-[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
-[4]: https://etcd.io/docs/v3.3.13/
-[5]: https://etcd.io/docs/v3.3.13/platforms/
+[1]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/latest/op-guide/clustering/
+[3]: https://etcd.io/docs/latest/op-guide/configuration/
+[4]: https://etcd.io/docs/latest/
+[5]: https://etcd.io/docs/latest/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
-[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
+[8]: https://etcd.io/docs/latest/op-guide/failures/
+[9]: https://etcd.io/docs/latest/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.3.13/op-guide/
+[11]: https://etcd.io/docs/latest/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/latest/op-guide/
 [13]: ../generate-certificates/
-[14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[14]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
 [16]: ../secure-sensu/
 [17]: ../../../sensuctl/

--- a/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
@@ -481,7 +481,7 @@ enable_round_robin: true
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [5]: ../../../observability-pipeline/observe-schedule/checks/#round-robin-checks
 [6]: ../deployment-architecture/
-[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[7]: https://etcd.io/docs/latest/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.2/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/deployment-architecture.md
@@ -160,6 +160,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[11]: https://etcd.io/docs/latest/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -311,7 +311,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#configure-sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[7]: https://etcd.io/docs/latest/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
@@ -573,7 +573,7 @@ sensuctl license info
 [37]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
 [38]: ../../../sensuctl/back-up-recover/
 [39]: ../../../sensuctl/create-manage-resources/#create-resources
-[40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[40]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
 [43]: ../../../observability-pipeline/observe-schedule/backend/#debug-attribute

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -246,7 +246,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -685,7 +685,7 @@ If you wait until cluster nodes are failing, it may not be possible to make a ba
 For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
 If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -801,7 +801,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -811,7 +811,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[14]: https://etcd.io/docs/latest/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -807,7 +807,7 @@ dashboard-port: 4000{{< /code >}}
 | etcd-advertise-client-urls |      |
 --------------|------
 description   | List of this member's client URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
@@ -826,7 +826,7 @@ etcd-advertise-client-urls:
 | etcd-cert-file |      |
 -----------------|------
 description      | Path to the etcd client API TLS certificate file. Secures communication between the embedded etcd client API and any etcd clients. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -842,7 +842,7 @@ etcd-cert-file: "./client.pem"{{< /code >}}
 | etcd-cipher-suites    |      |
 ------------------------|------
 description             | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][18]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. Go determines the default cipher suites based on the hardware used. {{% notice note %}}
-**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use TLS 1.3, add the following environment variable: `GODEBUG="tls13=1"`.<br><br>To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 recommended             | {{< code shell >}}
@@ -869,7 +869,7 @@ etcd-cipher-suites:
 | etcd-client-cert-auth |      |
 ------------------------|------
 description             | If `true`, enable client certificate authentication. Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | Boolean
@@ -883,7 +883,7 @@ etcd-client-cert-auth: true{{< /code >}}
 | etcd-client-urls      |      |
 ------------------------|------
 description             | List of client URLs to use when a sensu-backend is not operating as an etcd member. To configure sensu-backend for use with an external etcd instance, use this flag in conjunction with `--no-embed-etcd` when executing sensu-backend start or [sensu-backend init][22]. If you do not use this flag when using `--no-embed-etcd`, sensu-backend start and sensu-backend-init will fall back to [--etcd-listen-client-urls][23].{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -902,7 +902,7 @@ etcd-client-urls:
 | etcd-discovery        |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][19]. Attempts to use [etcd discovery][20] to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -918,7 +918,7 @@ etcd-discovery:
 | etcd-discovery-srv    |      |
 ------------------------|------
 description             | Exposes [etcd's embedded auto-discovery features][17]. Attempts to use a [DNS SRV][21] record to get the cluster configuration.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | String
@@ -934,7 +934,7 @@ etcd-discovery-srv:
 | etcd-initial-advertise-peer-urls |      |
 -----------------------------------|------
 description                        | List of this member's peer URLs to advertise to the rest of the cluster.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
@@ -953,7 +953,7 @@ etcd-initial-advertise-peer-urls:
 | etcd-initial-cluster |      |
 -----------------------|------
 description            | Initial cluster configuration for bootstrapping.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -967,7 +967,7 @@ etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.
 | etcd-initial-cluster-state |      |
 -----------------------------|------
 description                  | Initial cluster state (`new` or `existing`).{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -981,7 +981,7 @@ etcd-initial-cluster-state: "existing"{{< /code >}}
 | etcd-initial-cluster-token |      |
 -----------------------------|------
 description                  | Unique token for the etcd cluster. Provide the same `etcd-initial-cluster-token` value for each cluster member. The `etcd-initial-cluster-token` allows etcd to generate unique cluster IDs and member IDs even for clusters with otherwise identical configurations, which prevents cross-cluster-interaction and potential cluster corruption.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | String
@@ -995,7 +995,7 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 | etcd-key-file  |      |
 -----------------|------
 description      | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1010,7 +1010,7 @@ etcd-key-file: "./client-key.pem"{{< /code >}}
 | etcd-listen-client-urls |      |
 --------------------------|------
 description               | List of URLs to listen on for client traffic. Sensu's default embedded etcd configuration listens for unencrypted client communication on port 2379.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
@@ -1029,7 +1029,7 @@ etcd-listen-client-urls:
 | etcd-listen-peer-urls |      |
 ------------------------|------
 description             | List of URLs to listen on for peer traffic. Sensu's default embedded etcd configuration listens for unencrypted peer communication on port 2380.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
@@ -1048,7 +1048,7 @@ etcd-listen-peer-urls:
 | etcd-name      |      |
 -----------------|------
 description      | Human-readable name for this member.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | String
@@ -1062,7 +1062,7 @@ etcd-name: "backend-0"{{< /code >}}
 | etcd-peer-cert-file |      |
 ----------------------|------
 description           | Path to the peer server TLS certificate file. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                  | String
@@ -1075,7 +1075,7 @@ etcd-peer-cert-file: "./backend-0.pem"{{< /code >}}
 | etcd-peer-client-cert-auth |      |
 -----------------------------|------
 description                  | Enable peer client certificate authentication.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                         | Boolean
@@ -1089,7 +1089,7 @@ etcd-peer-client-cert-auth: true{{< /code >}}
 | etcd-peer-key-file |      |
 ---------------------|------
 description          | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                 | String
@@ -1102,7 +1102,7 @@ etcd-peer-key-file: "./backend-0-key.pem"{{< /code >}}
 | etcd-peer-trusted-ca-file |      |
 ----------------------------|------
 description                 | Path to the etcd peer API server TLS trusted CA file. Secures communication between etcd cluster members.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                        | String
@@ -1115,7 +1115,7 @@ etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 | etcd-trusted-ca-file |      |
 -----------------------|------
 description            | Path to the client server TLS trusted CA certificate file. Secures communication with the etcd client server.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
@@ -1129,7 +1129,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 | no-embed-etcd  |      |
 -----------------|------
 description      | If `true`, do not embed etcd (use external etcd instead). Otherwise, `false`.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type             | Boolean
@@ -1224,7 +1224,7 @@ pipelined-workers: 100{{< /code >}}
 description            | Time that a follower node will go without hearing a heartbeat before attempting to become leader itself. In milliseconds (ms). Set to at least 10 times the [etcd-heartbeat-interval][36]. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same election timeout value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1241,7 +1241,7 @@ etcd-election-timeout: 1000{{< /code >}}
 -----------------------|------
 description            | Interval at which the etcd leader will notify followers that it is still the leader. In milliseconds (ms). Best practice is to set the interval based on round-trip time between members. See [etcd time parameter documentation][16] for details and other considerations. {{% notice warning %}}
 **WARNING**: Make sure to set the same heartbeat interval value for all etcd members in one cluster. Setting different values for etcd members may reduce cluster stability.{{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1257,7 +1257,7 @@ etcd-heartbeat-interval: 100{{< /code >}}
 description            | Maximum etcd request size in bytes that can be sent to an etcd server by a client. Increasing this value allows etcd to process events with large outputs at the cost of overall latency. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.
 {{% /notice %}}{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
@@ -1272,7 +1272,7 @@ etcd-max-request-bytes: 1572864{{< /code >}}
 -----------------------|------
 description            | Maximum etcd database size in bytes. Increasing this value allows for a larger etcd database at the cost of performance. {{% notice warning %}}
 **WARNING**: Use with caution. This configuration option requires familiarity with etcd. Improper use of this option can result in a non-functioning Sensu instance.{{% notice note %}}
-**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/v3.3.13/op-guide/clustering/).
+**NOTE**: To use Sensu with an [external etcd cluster](../../../operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster), follow etcd's [clustering guide](https://etcd.io/docs/latest/op-guide/clustering/).
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 {{% /notice %}}

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -384,20 +384,20 @@ See the [etcd recovery guide][9] for disaster recovery information.
 To redeploy a cluster due to an issue like loss of quorum among cluster members, etcd corruption, or hardware failure, read [Remove and redeploy a cluster][23].
 
 
-[1]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
-[2]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
-[3]: https://etcd.io/docs/v3.3.13/op-guide/configuration/
-[4]: https://etcd.io/docs/v3.3.13/
-[5]: https://etcd.io/docs/v3.3.13/platforms/
+[1]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
+[2]: https://etcd.io/docs/latest/op-guide/clustering/
+[3]: https://etcd.io/docs/latest/op-guide/configuration/
+[4]: https://etcd.io/docs/latest/
+[5]: https://etcd.io/docs/latest/platforms/
 [6]: #manage-and-monitor-clusters-with-sensuctl
 [7]: https://github.com/sensu/sensu-go/blob/main/docker-compose.yaml
-[8]: https://etcd.io/docs/v3.3.13/op-guide/failures/
-[9]: https://etcd.io/docs/v3.3.13/op-guide/recovery/
+[8]: https://etcd.io/docs/latest/op-guide/failures/
+[9]: https://etcd.io/docs/latest/op-guide/recovery/
 [10]: https://github.com/cloudflare/cfssl
-[11]: https://etcd.io/docs/v3.3.13/op-guide/clustering/#self-signed-certificates
-[12]: https://etcd.io/docs/v3.3.13/op-guide/
+[11]: https://etcd.io/docs/latest/op-guide/clustering/#self-signed-certificates
+[12]: https://etcd.io/docs/latest/op-guide/
 [13]: ../generate-certificates/
-[14]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[14]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [15]: ../../../observability-pipeline/observe-schedule/backend/
 [16]: ../secure-sensu/
 [17]: ../../../sensuctl/

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -481,7 +481,7 @@ enable_round_robin: true
 [4]: https://pkg.go.dev/github.com/lib/pq@v1.2.0#hdr-Connection_String_Parameters
 [5]: ../../../observability-pipeline/observe-schedule/checks/#round-robin-checks
 [6]: ../deployment-architecture/
-[7]: https://etcd.io/docs/v3.3.13/op-guide/clustering/
+[7]: https://etcd.io/docs/latest/op-guide/clustering/
 [8]: ../cluster-sensu/#use-an-external-etcd-cluster
 [9]: ../../../web-ui/
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event

--- a/content/sensu-go/6.3/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/deployment-architecture.md
@@ -160,6 +160,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 [8]: ../datastore/
 [9]: ../../../commercial/
 [10]: https://github.com/sensu/sensu-perf
-[11]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[11]: https://etcd.io/docs/latest/tuning/#disk
 [12]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [13]: ../datastore/#scale-event-storage

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -311,7 +311,7 @@ Now that you have generated the required certificates and copied them to the app
 [4]: ../secure-sensu/#secure-sensu-agent-to-server-communication
 [5]: ../secure-sensu/#configure-sensu-agent-mtls-authentication
 [6]: https://github.com/cloudflare/cfssl
-[7]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[7]: https://etcd.io/docs/latest/op-guide/security/
 [8]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [9]: ../../manage-secrets/secrets-management/
 [10]: ../../deploy-sensu/install-sensu/

--- a/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
@@ -573,7 +573,7 @@ sensuctl license info
 [37]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
 [38]: ../../../sensuctl/back-up-recover/
 [39]: ../../../sensuctl/create-manage-resources/#create-resources
-[40]: https://etcd.io/docs/v3.3.13/op-guide/runtime-configuration/
+[40]: https://etcd.io/docs/latest/op-guide/runtime-configuration/
 [41]: ../../../observability-pipeline/observe-schedule/checks/#subscriptions
 [42]: https://bonsai.sensu.io/
 [43]: ../../../observability-pipeline/observe-schedule/backend/#debug-attribute

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -246,7 +246,7 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [5]: ../../../commercial/
-[6]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -685,7 +685,7 @@ If you wait until cluster nodes are failing, it may not be possible to make a ba
 For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
 If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/v3.3.13/op-guide/recovery/).
+For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -801,7 +801,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
 [3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[4]: https://etcd.io/docs/v3.3.13/op-guide/security/
+[4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post
 [7]: https://dzone.com/articles/what-is-structured-logging
@@ -811,7 +811,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 [11]: ../../monitor-sensu/log-sensu-systemd/
 [12]: https://github.com/systemd/systemd/issues/2913
 [13]: https://github.com/etcd-io/etcd/releases
-[14]: https://etcd.io/docs/v3.3.13/tuning/#disk
+[14]: https://etcd.io/docs/latest/tuning/#disk
 [15]: https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd
 [16]: ../../deploy-sensu/datastore/#scale-event-storage
 [17]: ../../deploy-sensu/datastore/#use-default-event-storage


### PR DESCRIPTION
## Description
Replaces version-specific etcd links to 3.3.x with links that use `latest` instead.

## Motivation and Context
https://sensu.slack.com/archives/C60EEQFH8/p1621545501471000