### PR TITLE
Recommend etcd snapshots and recovery process with sensuctl dump as backup

### DIFF
--- a/content/sensu-go/5.21/sensuctl/back-up-recover.md
+++ b/content/sensu-go/5.21/sensuctl/back-up-recover.md
@@ -52,6 +52,15 @@ sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yaml
 {{< /code >}}
 
 After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
+
+{{% notice note %}}
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
+
+Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
+Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
+{{% /notice %}}
+
 This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
 
 ## Back up before a Sensu version upgrade

--- a/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/troubleshoot.md
@@ -652,12 +652,12 @@ https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 ### Remove and redeploy a cluster
 
 {{% notice protip %}}
-**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
-If you wait until cluster nodes are failing, it may not be possible to make a backup.
-For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
-If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+**PRO TIP**: Use [etcd snapshots](https://etcd.io/docs/latest/op-guide/recovery/) to keep a backup so that you can restore your Sensu resources if you have to redeploy your cluster.
+For extra reassurance, take regular etcd snapshots and make regular backups with [sensuctl dump](../../../sensuctl/back-up-recover/) in addition to etcd's running snapshots.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+For example, in a three-node cluster, if one node fails, you will still be able to make a backup.
+If two nodes fail, the whole cluster will be down and you will not be able to create a snapshot or run sensuctl dump.
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -706,7 +706,7 @@ Admin Username: <YOUR_USERNAME>
 Admin Password: <YOUR_PASSWORD>
 {{< /code >}}
 
-7. Use sensuctl create to [restore your resources from backup][24].
+7. Follow the [etcd restore process][26] or use [sensuctl create][24] to restore your cluster from a snapshot or backup.
 
 ## Datastore performance
 
@@ -793,3 +793,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
 [24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
 [25]: ../../../observability-pipeline/observe-schedule/backend/#initialization
+[26]: https://etcd.io/docs/latest/op-guide/recovery/#restoring-a-cluster

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -11,8 +11,8 @@ menu:
     parent: sensuctl
 ---
 
-The `sensuctl dump` command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
-You can export all of your resources or a subset of them based on a list of resource types.
+The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
@@ -32,6 +32,20 @@ sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+
+{{% notice note %}}
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
+
+Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
+Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
+{{% /notice %}}
+
+This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
+
+## Example sensuctl dump commands
 
 To export only checks for only the current namespace to STDOUT in YAML or JSON format:
 
@@ -69,7 +83,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handle
 
 {{< /language-toggle >}}
 
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
 For example:
 
 {{< language-toggle >}}
@@ -120,8 +134,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json
 
 {{< /language-toggle >}}
 
-You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
-
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
 Here's an example that uses fully qualified names:
 
 {{< language-toggle >}}
@@ -157,9 +170,6 @@ sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
-
-After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
 
 ## Back up before a Sensu version upgrade
 
@@ -233,7 +243,7 @@ sensuctl dump core/v2.APIKey,core/v2.User \
 {{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
-Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
+Because users require this additional configuration and API keys cannot be restored from a sensuctl dump backup, consider exporting your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
@@ -314,10 +324,11 @@ sensuctl create -f backup/rbac.json
 {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>
-API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.<br><br>
-When you export users, required password attributes are not included.
+**NOTE**: When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
+
+You can't restore API keys or users from a sensuctl dump backup.
+API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}
 
 ## Supported resource types
@@ -326,7 +337,7 @@ You must add a [`password_hash`](../#generate-a-password-hash) or `password` to 
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
 **NOTE**: Short names are only supported for `core/v2` resources.

--- a/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/troubleshoot.md
@@ -680,12 +680,12 @@ https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 ### Remove and redeploy a cluster
 
 {{% notice protip %}}
-**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
-If you wait until cluster nodes are failing, it may not be possible to make a backup.
-For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
-If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+**PRO TIP**: Use [etcd snapshots](https://etcd.io/docs/latest/op-guide/recovery/) to keep a backup so that you can restore your Sensu resources if you have to redeploy your cluster.
+For extra reassurance, take regular etcd snapshots and make regular backups with [sensuctl dump](../../../sensuctl/back-up-recover/) in addition to etcd's running snapshots.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+For example, in a three-node cluster, if one node fails, you will still be able to make a backup.
+If two nodes fail, the whole cluster will be down and you will not be able to create a snapshot or run sensuctl dump.
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -734,7 +734,7 @@ Admin Username: <YOUR_USERNAME>
 Admin Password: <YOUR_PASSWORD>
 {{< /code >}}
 
-7. Use sensuctl create to [restore your resources from backup][24].
+7. Follow the [etcd restore process][26] or use [sensuctl create][24] to restore your cluster from a snapshot or backup.
 
 ## Datastore performance
 
@@ -822,3 +822,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
 [24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
 [25]: ../../../observability-pipeline/observe-schedule/backend/#initialization
+[26]: https://etcd.io/docs/latest/op-guide/recovery/#restoring-a-cluster

--- a/content/sensu-go/6.1/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.1/sensuctl/back-up-recover.md
@@ -11,8 +11,8 @@ menu:
     parent: sensuctl
 ---
 
-The `sensuctl dump` command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
-You can export all of your resources or a subset of them based on a list of resource types.
+The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
@@ -32,6 +32,20 @@ sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+
+{{% notice note %}}
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
+
+Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
+Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
+{{% /notice %}}
+
+This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
+
+## Example sensuctl dump commands
 
 To export only checks for only the current namespace to STDOUT in YAML or JSON format:
 
@@ -69,7 +83,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handle
 
 {{< /language-toggle >}}
 
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
 For example:
 
 {{< language-toggle >}}
@@ -120,8 +134,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json
 
 {{< /language-toggle >}}
 
-You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
-
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
 Here's an example that uses fully qualified names:
 
 {{< language-toggle >}}
@@ -157,9 +170,6 @@ sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
-
-After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
 
 ## Back up before a Sensu version upgrade
 
@@ -233,7 +243,7 @@ sensuctl dump core/v2.APIKey,core/v2.User \
 {{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
-Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
+Because users require this additional configuration and API keys cannot be restored from a sensuctl dump backup, consider exporting your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
@@ -314,10 +324,11 @@ sensuctl create -f backup/rbac.json
 {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>
-API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.<br><br>
-When you export users, required password attributes are not included.
+**NOTE**: When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
+
+You can't restore API keys or users from a sensuctl dump backup.
+API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}
 
 ## Supported resource types
@@ -326,7 +337,7 @@ You must add a [`password_hash`](../#generate-a-password-hash) or `password` to 
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
 **NOTE**: Short names are only supported for `core/v2` resources.

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -680,12 +680,12 @@ https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 ### Remove and redeploy a cluster
 
 {{% notice protip %}}
-**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
-If you wait until cluster nodes are failing, it may not be possible to make a backup.
-For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
-If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+**PRO TIP**: Use [etcd snapshots](https://etcd.io/docs/latest/op-guide/recovery/) to keep a backup so that you can restore your Sensu resources if you have to redeploy your cluster.
+For extra reassurance, take regular etcd snapshots and make regular backups with [sensuctl dump](../../../sensuctl/back-up-recover/) in addition to etcd's running snapshots.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+For example, in a three-node cluster, if one node fails, you will still be able to make a backup.
+If two nodes fail, the whole cluster will be down and you will not be able to create a snapshot or run sensuctl dump.
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -734,7 +734,7 @@ Admin Username: <YOUR_USERNAME>
 Admin Password: <YOUR_PASSWORD>
 {{< /code >}}
 
-7. Use sensuctl create to [restore your resources from backup][24].
+7. Follow the [etcd restore process][26] or use [sensuctl create][24] to restore your cluster from a snapshot or backup.
 
 ## Datastore performance
 
@@ -823,3 +823,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
 [24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
 [25]: ../../../observability-pipeline/observe-schedule/backend/#initialization
+[26]: https://etcd.io/docs/latest/op-guide/recovery/#restoring-a-cluster

--- a/content/sensu-go/6.2/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.2/sensuctl/back-up-recover.md
@@ -11,8 +11,8 @@ menu:
     parent: sensuctl
 ---
 
-The `sensuctl dump` command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
-You can export all of your resources or a subset of them based on a list of resource types.
+The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
@@ -32,6 +32,20 @@ sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+
+{{% notice note %}}
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
+
+Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
+Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
+{{% /notice %}}
+
+This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
+
+## Example sensuctl dump commands
 
 To export only checks for only the current namespace to STDOUT in YAML or JSON format:
 
@@ -69,7 +83,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handle
 
 {{< /language-toggle >}}
 
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
 For example:
 
 {{< language-toggle >}}
@@ -120,8 +134,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json
 
 {{< /language-toggle >}}
 
-You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
-
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
 Here's an example that uses fully qualified names:
 
 {{< language-toggle >}}
@@ -157,9 +170,6 @@ sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
-
-After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
 
 ## Back up before a Sensu version upgrade
 
@@ -233,7 +243,7 @@ sensuctl dump core/v2.APIKey,core/v2.User \
 {{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
-Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
+Because users require this additional configuration and API keys cannot be restored from a sensuctl dump backup, consider exporting your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
@@ -314,10 +324,11 @@ sensuctl create -f backup/rbac.json
 {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>
-API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.<br><br>
-When you export users, required password attributes are not included.
+**NOTE**: When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
+
+You can't restore API keys or users from a sensuctl dump backup.
+API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}
 
 ## Supported resource types
@@ -326,7 +337,7 @@ You must add a [`password_hash`](../#generate-a-password-hash) or `password` to 
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
 **NOTE**: Short names are only supported for `core/v2` resources.

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -680,12 +680,12 @@ https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
 ### Remove and redeploy a cluster
 
 {{% notice protip %}}
-**PRO TIP**: Make [regular backups with sensuctl dump](../../../sensuctl/back-up-recover/) so that you can restore your Sensu resources if you have to redeploy your cluster.
-If you wait until cluster nodes are failing, it may not be possible to make a backup.
-For example, in a three-node cluster, if one node fails, you will still be able to run sensuctl dump.
-If two nodes fail, the whole cluster will be down and you will not be able to run the sensuctl dump command.
+**PRO TIP**: Use [etcd snapshots](https://etcd.io/docs/latest/op-guide/recovery/) to keep a backup so that you can restore your Sensu resources if you have to redeploy your cluster.
+For extra reassurance, take regular etcd snapshots and make regular backups with [sensuctl dump](../../../sensuctl/back-up-recover/) in addition to etcd's running snapshots.
 
-For information about using etcd snapshots for recovery, read [etcd disaster recovery](https://etcd.io/docs/latest/op-guide/recovery/).
+If you wait until cluster nodes are failing, it may not be possible to make a backup.
+For example, in a three-node cluster, if one node fails, you will still be able to make a backup.
+If two nodes fail, the whole cluster will be down and you will not be able to create a snapshot or run sensuctl dump.
 {{% /notice %}}
 
 You may need to completely remove a cluster and redeploy it in cases such as:
@@ -734,7 +734,7 @@ Admin Username: <YOUR_USERNAME>
 Admin Password: <YOUR_PASSWORD>
 {{< /code >}}
 
-7. Use sensuctl create to [restore your resources from backup][24].
+7. Follow the [etcd restore process][26] or use [sensuctl create][24] to restore your cluster from a snapshot or backup.
 
 ## Datastore performance
 
@@ -823,3 +823,4 @@ The backend will stop listening on those ports when the etcd database is unavail
 [23]: ../../deploy-sensu/cluster-sensu/#sensu-backend-configuration
 [24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
 [25]: ../../../observability-pipeline/observe-schedule/backend/#initialization
+[26]: https://etcd.io/docs/latest/op-guide/recovery/#restoring-a-cluster

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -11,8 +11,8 @@ menu:
     parent: sensuctl
 ---
 
-The `sensuctl dump` command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
-You can export all of your resources or a subset of them based on a list of resource types.
+The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
@@ -32,6 +32,20 @@ sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+
+{{% notice note %}}
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
+
+Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
+Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
+{{% /notice %}}
+
+This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
+
+## Example sensuctl dump commands
 
 To export only checks for only the current namespace to STDOUT in YAML or JSON format:
 
@@ -69,7 +83,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handle
 
 {{< /language-toggle >}}
 
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any `sensuctl dump` command.
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
 For example:
 
 {{< language-toggle >}}
@@ -120,8 +134,7 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json
 
 {{< /language-toggle >}}
 
-You can use [fully qualified names or short names][6] to specify resources in `sensuctl dump` commands.
-
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
 Here's an example that uses fully qualified names:
 
 {{< language-toggle >}}
@@ -157,9 +170,6 @@ sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
-
-After you use `sensuctl dump` to back up your Sensu resources, you can [restore][3] them later with [`sensuctl create`][1].
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
 
 ## Back up before a Sensu version upgrade
 
@@ -233,7 +243,7 @@ sensuctl dump core/v2.APIKey,core/v2.User \
 {{% notice note %}}
 **NOTE**: Passwords are not included when you export users.
 You must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported `users` resources before you can use them with `sensuctl create`.<br><br>
-Because users require this additional configuration and API keys cannot be restored from a `sensuctl dump` backup, you might prefer to export your API keys and users to a different folder than `backup`.
+Because users require this additional configuration and API keys cannot be restored from a sensuctl dump backup, consider exporting your API keys and users to a different folder than `backup`.
 {{% /notice %}}
    
 5. Export your entity resources for all namespaces (if desired).
@@ -314,10 +324,11 @@ sensuctl create -f backup/rbac.json
 {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: You can't restore API keys or users from a `sensuctl dump` backup.<br><br>
-API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.<br><br>
-When you export users, required password attributes are not included.
+**NOTE**: When you export users, required password attributes are not included.
 You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
+
+You can't restore API keys or users from a sensuctl dump backup.
+API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}
 
 ## Supported resource types
@@ -326,7 +337,7 @@ You must add a [`password_hash`](../#generate-a-password-hash) or `password` to 
 **IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
-Use `sensuctl describe-type all` to retrieve the list of supported `sensuctl dump` resource types.
+Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
 **NOTE**: Short names are only supported for `core/v2` resources.
@@ -341,34 +352,32 @@ The response will list the names and other details for the supported resource ty
 {{< code shell >}}
       Fully Qualified Name           Short Name           API Version             Type          Namespaced  
  ────────────────────────────── ───────────────────── ─────────────────── ──────────────────── ──────────── 
-  authentication/v2.Provider                           authentication/v2   Provider             false       
-  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false       
-  store/v1.PostgresConfig                              store/v1            PostgresConfig       false       
-  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false       
-  federation/v1.Cluster                                federation/v1       Cluster              false       
-  secrets/v1.Secret                                    secrets/v1          Secret               true        
-  secrets/v1.Provider                                  secrets/v1          Provider             false       
-  searches/v1.Search                                   searches/v1         Search               true        
-  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false       
-  bsm/v1.RuleTemplate                                  bsm/v1              RuleTemplate         true        
-  bsm/v1.ServiceComponent                              bsm/v1              ServiceComponent     true        
-  core/v2.Namespace              namespaces            core/v2             Namespace            false       
-  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false       
-  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false       
-  core/v2.User                   users                 core/v2             User                 false       
-  core/v2.APIKey                 apikeys               core/v2             APIKey               false       
-  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false       
-  core/v2.Asset                  assets                core/v2             Asset                true        
-  core/v2.CheckConfig            checks                core/v2             CheckConfig          true        
-  core/v2.Entity                 entities              core/v2             Entity               true        
-  core/v2.Event                  events                core/v2             Event                true        
-  core/v2.EventFilter            filters               core/v2             EventFilter          true        
-  core/v2.Handler                handlers              core/v2             Handler              true        
-  core/v2.HookConfig             hooks                 core/v2             HookConfig           true        
-  core/v2.Mutator                mutators              core/v2             Mutator              true        
-  core/v2.Role                   roles                 core/v2             Role                 true        
-  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true        
-  core/v2.Silenced               silenced              core/v2             Silenced             true        
+  authentication/v2.Provider                           authentication/v2   Provider             false
+  licensing/v2.LicenseFile                             licensing/v2        LicenseFile          false
+  store/v1.PostgresConfig                              store/v1            PostgresConfig       false
+  federation/v1.Cluster                                federation/v1       Cluster              false
+  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator       false
+  secrets/v1.Secret                                    secrets/v1          Secret               true
+  secrets/v1.Provider                                  secrets/v1          Provider             false
+  searches/v1.Search                                   searches/v1         Search               true
+  web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  core/v2.Namespace              namespaces            core/v2             Namespace            false
+  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
+  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false
+  core/v2.User                   users                 core/v2             User                 false
+  core/v2.APIKey                 apikeys               core/v2             APIKey               false
+  core/v2.TessenConfig           tessen                core/v2             TessenConfig         false
+  core/v2.Asset                  assets                core/v2             Asset                true
+  core/v2.CheckConfig            checks                core/v2             CheckConfig          true
+  core/v2.Entity                 entities              core/v2             Entity               true
+  core/v2.Event                  events                core/v2             Event                true
+  core/v2.EventFilter            filters               core/v2             EventFilter          true
+  core/v2.Handler                handlers              core/v2             Handler              true
+  core/v2.HookConfig             hooks                 core/v2             HookConfig           true
+  core/v2.Mutator                mutators              core/v2             Mutator              true
+  core/v2.Role                   roles                 core/v2             Role                 true
+  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding          true
+  core/v2.Silenced               silenced              core/v2             Silenced             true  
 {{< /code >}}
 
 You can also list specific resource types by fully qualified name or short name:


### PR DESCRIPTION
## Description
- Updates note in troubleshooting doc to recommend using etcd snapshots/recovery as the primary method with sensuctl dump as an extra measure.
- Adds note to recommend etcd snapshots/recovery as the primary method in Back up and recover doc.
- Adds an H2 for examples in Back up and recover doc and moves some content up to condense and organize intro content.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3170