### PR TITLE
Add general upgrade instructions at the top of the upgrade page

### DIFF
--- a/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
@@ -11,6 +11,26 @@ menu:
     parent: maintain-sensu
 ---
 
+To upgrade to the latest version of Sensu Go, [install the latest packages][1] and restart the services.
+
+{{% notice note %}}
+**NOTE**: For systems that use `systemd`, run `sudo systemctl daemon-reload` before restarting the services.
+{{% /notice %}}
+
+To restart the Sensu agent, run:
+
+{{< code shell >}}
+sudo service sensu-agent restart
+{{< /code >}}
+
+To restart the Sensu backend, run:
+
+{{< code shell >}}
+sudo service sensu-backend restart
+{{< /code >}}
+
+To confirm the installed version, run `sensu-agent version`, `sensu-backend version`, and `sensuctl version`.
+
 ## Upgrade to Sensu Go 6.2.0 from any previous version
 
 Prior to Sensu Go 6.0, sensu-backend allowed you to delete a namespace even when other resources still referenced that namespace. 


### PR DESCRIPTION
## Description
Adds general upgrade instructions for the latest Sensu Go version at the top of https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/upgrade/

## Motivation and Context
Reduce the possibility of confusion by presenting the general upgrade path before instructions with version-specific considerations