### PR TITLE
Post-6.3 release cleanup

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -21,16 +21,6 @@
     var searchTerms = window.location.pathname.split("/");
     searchTerms.shift();
 
-    // Add notice about new 6.x pages that aren't present in 5.x
-    // TODO: Remove after all 5.x content is archived
-    if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "observability-pipeline") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">Sensu docs homepage</a>.`
-    }
-
-    if (searchTerms[0] === "sensu-go" && /^5\.\d+/.test(searchTerms[1]) && searchTerms[2] === "plugins") {
-      document.querySelector("#instructions").innerHTML = `We made some improvements in the version 6 docs that aren't reflected in earlier versions. Try the <a href="https://docs.sensu.io/sensu-go/">main Sensu Go ${searchTerms[1]} page</a> if you need to use pre-6.0 docs. You can also search the docs below or visit the <a href="/">Sensu docs homepage</a>.`
-    }
-
     // Scope the search results to a product/version (dirty)
     // Versions
     if (searchTerms[1]) {

--- a/static.json
+++ b/static.json
@@ -287,10 +287,6 @@
             "url": "/sensu-go/latest/api",
             "status": 301
         },
-        "~ ^/sensu-go/5.21/latest/api/?$": {
-            "url": "/sensu-go/5.21/api",
-            "status": 301
-        },
         "~ ^/sensu-go/latest/learn/prometheus-metrics/?$": {
             "url": "/sensu-go/latest/observability-pipeline/observe-schedule/prometheus-metrics",
             "status": 301
@@ -635,62 +631,6 @@
             "url": "/sensu-go/latest/observability-pipeline/observe-process/plan-maintenance",
             "status": 301
         },
-        "~ ^/sensu-go/5.21/operations/deploy-sensu/use-assets-to-install-plugins/?$": {
-            "url": "/sensu-go/5.21/guides/install-check-executables-with-assets",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/deploy-sensu/assets/?$": {
-            "url": "/sensu-go/5.21/reference/assets",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/deploy-sensu/datastore/?$": {
-            "url": "/sensu-go/5.21/reference/datastore",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/deploy-sensu/etcdreplicators/?$": {
-            "url": "/sensu-go/5.21/reference/etcdreplicators",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/control-access/apikeys/?$": {
-            "url": "/sensu-go/5.21/reference/apikeys",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/control-access/rbac/?$": {
-            "url": "/sensu-go/5.21/reference/rbac",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/maintain-sensu/license/?$": {
-            "url": "/sensu-go/5.21/reference/license",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/monitor-sensu/health/?$": {
-            "url": "/sensu-go/5.21/reference/health",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/monitor-sensu/tessen/?$": {
-            "url": "/sensu-go/5.21/reference/tessen",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/manage-secrets/secrets/?$": {
-            "url": "/sensu-go/5.21/reference/secrets",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/manage-secrets/secrets-providers/?$": {
-            "url": "/sensu-go/5.21/reference/secrets-providers",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/web-ui/searches/?$": {
-            "url": "/sensu-go/5.21/reference/searches",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/web-ui/webconfig-reference/?$": {
-            "url": "/sensu-go/5.21/reference/webconfig",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/migrate/?$": {
-            "url": "/sensu-go/5.21/operations/maintain-sensu/migrate",
-            "status": 301
-        },
         "~ ^/sensu-go/6.0/migrate/?$": {
             "url": "/sensu-go/6.0/operations/maintain-sensu/migrate",
             "status": 301
@@ -705,10 +645,6 @@
         },
         "~ ^/sensu-go/latest/migrate/web-ui/?$": {
             "url": "/sensu-go/latest/operations/maintain-sensu/migrate",
-            "status": 301
-        },
-        "~ ^/sensu-go/5.21/operations/control-access/auth/?$": {
-            "url": "/sensu-go/5.21/operations/control-access",
             "status": 301
         },
         "~ ^/sensu-go/6.0/operations/control-access/auth/?$": {

--- a/static.json
+++ b/static.json
@@ -279,6 +279,10 @@
             "url": "/sensu-go/latest/api",
             "status": 301
         },
+        "~ ^/sensu-go/5.21/latest/api/?$": {
+            "url": "/sensu-go/latest/api",
+            "status": 301
+        },
         "~ ^/sensu-go/5.2[0-9]/?((?<=\/).*)?/api/overview/?$": {
             "url": "/sensu-go/latest/api",
             "status": 301


### PR DESCRIPTION
## Description
Removes extraneous 5.21 redirects and special 404 page content used to accommodate the observability pipeline architecture introduced for 6.0+ docs versions.

## Motivation and Context
Keep docs tidy