### PR TITLE
Remove 5.21 folder

### DIFF
--- a/content/sensu-go/5.21
+++ b/content/sensu-go/5.21
@@ -1,1 +1,0 @@
-../../archived/sensu-go/5.21


### PR DESCRIPTION
## Description
Looks like the git mv command (https://github.com/sensu/sensu-docs/wiki/Release-related-docs-updates#archive-a-docs-version) copied the 5.21 folder to the archived dir but did not delete the folder itself. This PR deletes the 5.21 folder from the active content part of the docs site.

## Motivation and Context
Noticed when working on something else
