### PR TITLE
Fix license API URL

### DIFF
--- a/content/sensu-go/6.0/api/license.md
+++ b/content/sensu-go/6.0/api/license.md
@@ -28,7 +28,7 @@ The following example demonstrates a request to the `/license` API endpoint, res
 
 {{< code shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/json'
 
@@ -156,7 +156,7 @@ curl -X PUT \
     "metadata": {}
   }
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/6.1/api/license.md
+++ b/content/sensu-go/6.1/api/license.md
@@ -28,7 +28,7 @@ The following example demonstrates a request to the `/license` API endpoint, res
 
 {{< code shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/json'
 
@@ -156,7 +156,7 @@ curl -X PUT \
     "metadata": {}
   }
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/6.2/api/license.md
+++ b/content/sensu-go/6.2/api/license.md
@@ -28,7 +28,7 @@ The following example demonstrates a request to the `/license` API endpoint, res
 
 {{< code shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/json'
 
@@ -156,7 +156,7 @@ curl -X PUT \
     "metadata": {}
   }
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license
 
 HTTP/1.1 201 Created
 {{< /code >}}

--- a/content/sensu-go/6.3/api/license.md
+++ b/content/sensu-go/6.3/api/license.md
@@ -27,7 +27,7 @@ The following example demonstrates a request to the `/license` API endpoint, res
 
 {{< code shell >}}
 curl -X GET \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license \
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license \
 -H "Authorization: Key $SENSU_API_KEY" \
 -H 'Content-Type: application/json'
 
@@ -155,7 +155,7 @@ curl -X PUT \
     "metadata": {}
   }
 }' \
-http://127.0.0.1:8080/api/core/v2/namespaces/default/license
+http://127.0.0.1:8080/api/enterprise/licensing/v2/license
 
 HTTP/1.1 201 Created
 {{< /code >}}


### PR DESCRIPTION
## Description
In licensing API docs, fixes http://127.0.0.1:8080/api/core/v2/namespaces/default/license to use the correct URL: http://127.0.0.1:8080/api/enterprise/licensing/v2/license

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3185
