### PR TITLE
Fix a close bracket for a notice shortcode

### DIFF
--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -267,7 +267,7 @@ Most attributes are ready to use as-is, but you'll need to adjust your Sensu Go 
 
 {{% notice note %}}
 **NOTE**: To streamline a comparison of your Sensu Core configuration with your Sensu Go configuration, output your current Sensu Core configuration using the API: `curl -s http://127.0.0.1:4567/settings | jq . > sensu_config_original.json`.
-<<% /notice %}}
+{{% /notice %}}
 
 #### 2. Translate checks
 


### PR DESCRIPTION
## Description
Fix `<<% /notice %}}` in 6.3 migrate doc 

## Motivation and Context
Found while working on something else
