### PR TITLE
Add trace to log-level flag info

### DIFF
--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -341,7 +341,7 @@ General Flags:
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
-      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
       --require-fips                        indicates whether fips support should be required in openssl
@@ -513,7 +513,7 @@ labels:
 
 | log-level  |      |
 -------------|------
-description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
+description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, or `trace`.
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -342,7 +342,7 @@ General Flags:
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
-      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
       --require-fips                        indicates whether fips support should be required in openssl
@@ -527,7 +527,7 @@ labels:
 
 | log-level  |      |
 -------------|------
-description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
+description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, or `trace`.
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -342,7 +342,7 @@ General Flags:
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
-      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
       --require-fips                        indicates whether fips support should be required in openssl
@@ -527,7 +527,7 @@ labels:
 
 | log-level  |      |
 -------------|------
-description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
+description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, or `trace`.
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -344,7 +344,7 @@ General Flags:
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
-      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
       --require-fips                        indicates whether fips support should be required in openssl
@@ -529,7 +529,7 @@ labels:
 
 | log-level  |      |
 -------------|------
-description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
+description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, or `trace`.
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -344,7 +344,7 @@ General Flags:
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
-      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "warn")
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
       --require-fips                        indicates whether fips support should be required in openssl
@@ -529,7 +529,7 @@ labels:
 
 | log-level  |      |
 -------------|------
-description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
+description  | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
 type         | String
 default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`


### PR DESCRIPTION
## Description
Add `trace` to backend log-level config flag descriptions in backend reference

## Motivation and Context
Noticed when working on https://github.com/sensu/sensu-docs/pull/3198
