### PR TITLE
Fix links for namespace information in sensuctl create doc

### DIFF
--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -159,7 +159,9 @@ The following table describes the command-specific flags.
 
 If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation.
 This allows you to replicate resources across namespaces without manual editing.
-To learn more about namespaces and namespaced resource types, see the [RBAC reference][21].
+
+To learn more about namespaces, read the [namespaces reference][21].
+The RBAC reference includes a list of [namespaced resource types][38].
 
 The `sensuctl create` command applies namespaces to resources in the following order, from highest precedence to lowest:
 
@@ -325,7 +327,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl hook`][18]
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
-- [`sensuctl namespace`][1]
+- [`sensuctl namespace`][21]
 - [`sensuctl role`][1]
 - [`sensuctl role-binding`][1]
 - [`sensuctl secrets`][28]
@@ -459,7 +461,7 @@ sensuctl event resolve webserver1 check-http
 
 #### sensuctl namespace
 
-See the [RBAC reference][21] for information about using access control with namespaces.
+See the [namespaces reference][21] for information about using access control with namespaces.
 
 #### sensuctl user
 
@@ -656,3 +658,4 @@ Sensuctl supports the following formats:
 [35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
+[38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -159,7 +159,9 @@ The following table describes the command-specific flags.
 
 If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation.
 This allows you to replicate resources across namespaces without manual editing.
-To learn more about namespaces and namespaced resource types, see the [RBAC reference][21].
+
+To learn more about namespaces, read the [namespaces reference][21].
+The RBAC reference includes a list of [namespaced resource types][38].
 
 The `sensuctl create` command applies namespaces to resources in the following order, from highest precedence to lowest:
 
@@ -325,7 +327,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl hook`][18]
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
-- [`sensuctl namespace`][1]
+- [`sensuctl namespace`][21]
 - [`sensuctl role`][1]
 - [`sensuctl role-binding`][1]
 - [`sensuctl secrets`][28]
@@ -459,7 +461,7 @@ sensuctl event resolve webserver1 check-http
 
 #### sensuctl namespace
 
-See the [RBAC reference][21] for information about using access control with namespaces.
+See the [namespaces reference][21] for information about using access control with namespaces.
 
 #### sensuctl user
 
@@ -660,3 +662,4 @@ Sensuctl supports the following formats:
 [35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
+[38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -164,7 +164,9 @@ The following table describes the command-specific flags.
 
 If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation.
 This allows you to replicate resources across namespaces without manual editing.
-To learn more about namespaces and namespaced resource types, see the [RBAC reference][21].
+
+To learn more about namespaces, read the [namespaces reference][21].
+The RBAC reference includes a list of [namespaced resource types][38].
 
 The `sensuctl create` command applies namespaces to resources in the following order, from highest precedence to lowest:
 
@@ -335,7 +337,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl hook`][18]
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
-- [`sensuctl namespace`][1]
+- [`sensuctl namespace`][21]
 - [`sensuctl role`][1]
 - [`sensuctl role-binding`][1]
 - [`sensuctl secrets`][28]
@@ -469,7 +471,7 @@ sensuctl event resolve webserver1 check-http
 
 #### sensuctl namespace
 
-See the [RBAC reference][21] for information about using access control with namespaces.
+See the [namespaces reference][21] for information about using access control with namespaces.
 
 #### sensuctl user
 
@@ -674,3 +676,4 @@ Sensuctl supports the following formats:
 [35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
+[38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -164,7 +164,9 @@ The following table describes the command-specific flags.
 
 If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation.
 This allows you to replicate resources across namespaces without manual editing.
-To learn more about namespaces and namespaced resource types, see the [RBAC reference][21].
+
+To learn more about namespaces, read the [namespaces reference][21].
+The RBAC reference includes a list of [namespaced resource types][38].
 
 The `sensuctl create` command applies namespaces to resources in the following order, from highest precedence to lowest:
 
@@ -335,7 +337,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl hook`][18]
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
-- [`sensuctl namespace`][1]
+- [`sensuctl namespace`][21]
 - [`sensuctl role`][1]
 - [`sensuctl role-binding`][1]
 - [`sensuctl secrets`][28]
@@ -469,7 +471,7 @@ sensuctl event resolve webserver1 check-http
 
 #### sensuctl namespace
 
-See the [RBAC reference][21] for information about using access control with namespaces.
+See the [namespaces reference][21] for information about using access control with namespaces.
 
 #### sensuctl user
 
@@ -676,3 +678,4 @@ Sensuctl supports the following formats:
 [35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
+[38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -164,7 +164,9 @@ The following table describes the command-specific flags.
 
 If you omit the `namespace` attribute from resource definitions, you can use the `senusctl create --namespace` flag to specify the namespace for a group of resources at the time of creation.
 This allows you to replicate resources across namespaces without manual editing.
-To learn more about namespaces and namespaced resource types, see the [RBAC reference][21].
+
+To learn more about namespaces, read the [namespaces reference][21].
+The RBAC reference includes a list of [namespaced resource types][38].
 
 The `sensuctl create` command applies namespaces to resources in the following order, from highest precedence to lowest:
 
@@ -335,7 +337,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl hook`][18]
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
-- [`sensuctl namespace`][1]
+- [`sensuctl namespace`][21]
 - [`sensuctl role`][1]
 - [`sensuctl role-binding`][1]
 - [`sensuctl secrets`][28]
@@ -469,7 +471,7 @@ sensuctl event resolve webserver1 check-http
 
 #### sensuctl namespace
 
-See the [RBAC reference][21] for information about using access control with namespaces.
+See the [namespaces reference][21] for information about using access control with namespaces.
 
 #### sensuctl user
 
@@ -676,3 +678,4 @@ Sensuctl supports the following formats:
 [35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
+[38]: ../../operations/control-access/rbac/#namespaced-resource-types


### PR DESCRIPTION
## Description
Fixes incorrect links to RBAC reference (should be namespaces reference) and the list of namespaced resource types in https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#manage-resources

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3200