### PR TITLE
Update agent and backend examples for consistency

### DIFF
--- a/content/sensu-go/6.0/files/agent.yml
+++ b/content/sensu-go/6.0/files/agent.yml
@@ -55,7 +55,7 @@ log-level: "debug" # available log levels: panic, fatal, error, warn, info, debu
 # api configuration
 ##
 #api-host: "127.0.0.1"
-#api-port: 4041
+#api-port: 3031
 #disable-api: false
 #events-burst-limit: 10
 #events-rate-limit: 10.0

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -1019,15 +1019,28 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-command line example   | {{< code shell >}}
-sensu-agent start --backend-url ws://0.0.0.0:8081
-sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
+command line example   | {{< language-toggle >}}
+{{< code shell "ws" >}}
+sensu-agent start --backend-url ws://127.0.0.1:8081
+sensu-agent start --backend-url ws://127.0.0.1:8081 --backend-url ws://127.0.0.1:8082
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+{{< code shell "wss" >}}
+sensu-agent start --backend-url wss://127.0.0.1:8081
+sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
+{{< /code >}}
+{{< /language-toggle >}}
+/etc/sensu/agent.yml example | {{< language-toggle >}}
+{{< code shell "ws" >}}
 backend-url:
-  - "ws://0.0.0.0:8081"
-  - "ws://0.0.0.0:8082"
+  - "ws://127.0.0.1:8081"
+  - "ws://127.0.0.1:8082"
 {{< /code >}}
+{{< code shell "wss" >}}
+backend-url:
+  - "wss://127.0.0.1:8081"
+  - "wss://127.0.0.1:8082"
+{{< /code >}}
+{{< /language-toggle >}}
 
 <a id="cache-dir"></a>
 
@@ -1153,9 +1166,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --api-host 0.0.0.0{{< /code >}}
+sensu-agent start --api-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-host: "0.0.0.0"{{< /code >}}
+api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
 --------------|------
@@ -1164,9 +1177,9 @@ type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --api-port 4041{{< /code >}}
+sensu-agent start --api-port 3031{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-port: 4041{{< /code >}}
+api-port: 3031{{< /code >}}
 
 | disable-api |      |
 --------------|------
@@ -1432,9 +1445,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+sensu-agent start --socket-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-host: "0.0.0.0"{{< /code >}}
+socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
 --------------|------
@@ -1443,9 +1456,9 @@ type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-port 4030{{< /code >}}
+sensu-agent start --socket-port 3030{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-port: 4030{{< /code >}}
+socket-port: 3030{{< /code >}}
 
 | disable-sockets |      |
 ------------------|------
@@ -1504,9 +1517,9 @@ type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-host: "0.0.0.0"{{< /code >}}
+statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1515,9 +1528,9 @@ type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+sensu-agent start --statsd-metrics-port 8125{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-port: 6125{{< /code >}}
+statsd-metrics-port: 8125{{< /code >}}
 
 ### Allow list configuration commands
 

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -454,9 +454,9 @@ type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
-sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-cache-dir: "/cache/sensu-backend"{{< /code >}}
+cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
 --------------|------
@@ -509,6 +509,8 @@ sensu-backend start --labels example_key1="example value" example_key2="example 
 /etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
+  example_key1: "example value"
+  example_key2: "example value"
 {{< /code >}}
 
 | log-level  |      |

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -212,8 +212,8 @@ If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
-api-port: 4041
-socket-port: 4030
+api-port: 3031
+socket-port: 3030
 {{< /code >}}
 
 You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.

--- a/content/sensu-go/6.1/files/agent.yml
+++ b/content/sensu-go/6.1/files/agent.yml
@@ -55,7 +55,7 @@ log-level: "debug" # available log levels: panic, fatal, error, warn, info, debu
 # api configuration
 ##
 #api-host: "127.0.0.1"
-#api-port: 4041
+#api-port: 3031
 #disable-api: false
 #events-burst-limit: 10
 #events-rate-limit: 10.0

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -1019,15 +1019,28 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-command line example   | {{< code shell >}}
-sensu-agent start --backend-url ws://0.0.0.0:8081
-sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
+command line example | {{< language-toggle >}}
+{{< code shell "ws" >}}
+sensu-agent start --backend-url ws://127.0.0.1:8081
+sensu-agent start --backend-url ws://127.0.0.1:8081 --backend-url ws://127.0.0.1:8082
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+{{< code shell "wss" >}}
+sensu-agent start --backend-url wss://127.0.0.1:8081
+sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
+{{< /code >}}
+{{< /language-toggle >}}
+/etc/sensu/agent.yml example | {{< language-toggle >}}
+{{< code shell "ws" >}}
 backend-url:
-  - "ws://0.0.0.0:8081"
-  - "ws://0.0.0.0:8082"
+  - "ws://127.0.0.1:8081"
+  - "ws://127.0.0.1:8082"
 {{< /code >}}
+{{< code shell "wss" >}}
+backend-url:
+  - "wss://127.0.0.1:8081"
+  - "wss://127.0.0.1:8082"
+{{< /code >}}
+{{< /language-toggle >}}
 
 <a id="cache-dir"></a>
 
@@ -1153,9 +1166,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --api-host 0.0.0.0{{< /code >}}
+sensu-agent start --api-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-host: "0.0.0.0"{{< /code >}}
+api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
 --------------|------
@@ -1164,9 +1177,9 @@ type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --api-port 4041{{< /code >}}
+sensu-agent start --api-port 3031{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-port: 4041{{< /code >}}
+api-port: 3031{{< /code >}}
 
 | disable-api |      |
 --------------|------
@@ -1432,9 +1445,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+sensu-agent start --socket-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-host: "0.0.0.0"{{< /code >}}
+socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
 --------------|------
@@ -1443,9 +1456,9 @@ type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-port 4030{{< /code >}}
+sensu-agent start --socket-port 3030{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-port: 4030{{< /code >}}
+socket-port: 3030{{< /code >}}
 
 | disable-sockets |      |
 ------------------|------
@@ -1504,9 +1517,9 @@ type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-host: "0.0.0.0"{{< /code >}}
+statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1515,9 +1528,9 @@ type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+sensu-agent start --statsd-metrics-port 8125{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-port: 6125{{< /code >}}
+statsd-metrics-port: 8125{{< /code >}}
 
 ### Allow list configuration commands
 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -468,9 +468,9 @@ type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
-sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-cache-dir: "/cache/sensu-backend"{{< /code >}}
+cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
 --------------|------
@@ -523,6 +523,8 @@ sensu-backend start --labels example_key1="example value" example_key2="example 
 /etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
+  example_key1: "example value"
+  example_key2: "example value"
 {{< /code >}}
 
 | log-level  |      |

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -212,8 +212,8 @@ If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
-api-port: 4041
-socket-port: 4030
+api-port: 3031
+socket-port: 3030
 {{< /code >}}
 
 You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.

--- a/content/sensu-go/6.2/files/agent.yml
+++ b/content/sensu-go/6.2/files/agent.yml
@@ -55,7 +55,7 @@ log-level: "debug" # available log levels: panic, fatal, error, warn, info, debu
 # api configuration
 ##
 #api-host: "127.0.0.1"
-#api-port: 4041
+#api-port: 3031
 #disable-api: false
 #events-burst-limit: 10
 #events-rate-limit: 10.0

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -1043,15 +1043,28 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-command line example   | {{< code shell >}}
-sensu-agent start --backend-url ws://0.0.0.0:8081
-sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
+command line example | {{< language-toggle >}}
+{{< code shell "ws" >}}
+sensu-agent start --backend-url ws://127.0.0.1:8081
+sensu-agent start --backend-url ws://127.0.0.1:8081 --backend-url ws://127.0.0.1:8082
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+{{< code shell "wss" >}}
+sensu-agent start --backend-url wss://127.0.0.1:8081
+sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
+{{< /code >}}
+{{< /language-toggle >}}
+/etc/sensu/agent.yml example | {{< language-toggle >}}
+{{< code shell "ws" >}}
 backend-url:
-  - "ws://0.0.0.0:8081"
-  - "ws://0.0.0.0:8082"
+  - "ws://127.0.0.1:8081"
+  - "ws://127.0.0.1:8082"
 {{< /code >}}
+{{< code shell "wss" >}}
+backend-url:
+  - "wss://127.0.0.1:8081"
+  - "wss://127.0.0.1:8082"
+{{< /code >}}
+{{< /language-toggle >}}
 
 <a id="cache-dir"></a>
 
@@ -1177,9 +1190,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --api-host 0.0.0.0{{< /code >}}
+sensu-agent start --api-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-host: "0.0.0.0"{{< /code >}}
+api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
 --------------|------
@@ -1188,9 +1201,9 @@ type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --api-port 4041{{< /code >}}
+sensu-agent start --api-port 3031{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-port: 4041{{< /code >}}
+api-port: 3031{{< /code >}}
 
 | disable-api |      |
 --------------|------
@@ -1456,9 +1469,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+sensu-agent start --socket-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-host: "0.0.0.0"{{< /code >}}
+socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
 --------------|------
@@ -1467,9 +1480,9 @@ type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-port 4030{{< /code >}}
+sensu-agent start --socket-port 3030{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-port: 4030{{< /code >}}
+socket-port: 3030{{< /code >}}
 
 | disable-sockets |      |
 ------------------|------
@@ -1528,9 +1541,9 @@ type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-host: "0.0.0.0"{{< /code >}}
+statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1539,9 +1552,9 @@ type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+sensu-agent start --statsd-metrics-port 8125{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-port: 6125{{< /code >}}
+statsd-metrics-port: 8125{{< /code >}}
 
 ### Allow list configuration commands
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -468,9 +468,9 @@ type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
-sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-cache-dir: "/cache/sensu-backend"{{< /code >}}
+cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
 --------------|------
@@ -523,6 +523,8 @@ sensu-backend start --labels example_key1="example value" example_key2="example 
 /etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
+  example_key1: "example value"
+  example_key2: "example value"
 {{< /code >}}
 
 | log-level  |      |

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -212,8 +212,8 @@ If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
-api-port: 4041
-socket-port: 4030
+api-port: 3031
+socket-port: 3030
 {{< /code >}}
 
 You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.

--- a/content/sensu-go/6.3/files/agent.yml
+++ b/content/sensu-go/6.3/files/agent.yml
@@ -55,7 +55,7 @@ log-level: "debug" # available log levels: panic, fatal, error, warn, info, debu
 # api configuration
 ##
 #api-host: "127.0.0.1"
-#api-port: 4041
+#api-port: 3031
 #disable-api: false
 #events-burst-limit: 10
 #events-rate-limit: 10.0

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -1040,15 +1040,28 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 type          | List
 default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-command line example   | {{< code shell >}}
-sensu-agent start --backend-url ws://0.0.0.0:8081
-sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
+command line example | {{< language-toggle >}}
+{{< code shell "ws" >}}
+sensu-agent start --backend-url ws://127.0.0.1:8081
+sensu-agent start --backend-url ws://127.0.0.1:8081 --backend-url ws://127.0.0.1:8082
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+{{< code shell "wss" >}}
+sensu-agent start --backend-url wss://127.0.0.1:8081
+sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
+{{< /code >}}
+{{< /language-toggle >}}
+/etc/sensu/agent.yml example | {{< language-toggle >}}
+{{< code shell "ws" >}}
 backend-url:
-  - "ws://0.0.0.0:8081"
-  - "ws://0.0.0.0:8082"
+  - "ws://127.0.0.1:8081"
+  - "ws://127.0.0.1:8082"
 {{< /code >}}
+{{< code shell "wss" >}}
+backend-url:
+  - "wss://127.0.0.1:8081"
+  - "wss://127.0.0.1:8082"
+{{< /code >}}
+{{< /language-toggle >}}
 
 <a id="cache-dir"></a>
 
@@ -1174,9 +1187,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --api-host 0.0.0.0{{< /code >}}
+sensu-agent start --api-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-host: "0.0.0.0"{{< /code >}}
+api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
 --------------|------
@@ -1185,9 +1198,9 @@ type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --api-port 4041{{< /code >}}
+sensu-agent start --api-port 3031{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-port: 4041{{< /code >}}
+api-port: 3031{{< /code >}}
 
 | disable-api |      |
 --------------|------
@@ -1453,9 +1466,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+sensu-agent start --socket-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-host: "0.0.0.0"{{< /code >}}
+socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
 --------------|------
@@ -1464,9 +1477,9 @@ type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-port 4030{{< /code >}}
+sensu-agent start --socket-port 3030{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-port: 4030{{< /code >}}
+socket-port: 3030{{< /code >}}
 
 | disable-sockets |      |
 ------------------|------
@@ -1525,9 +1538,9 @@ type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-host: "0.0.0.0"{{< /code >}}
+statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1536,9 +1549,9 @@ type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+sensu-agent start --statsd-metrics-port 8125{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-port: 6125{{< /code >}}
+statsd-metrics-port: 8125{{< /code >}}
 
 ### Allow list configuration commands
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -470,9 +470,9 @@ type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
-sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-cache-dir: "/cache/sensu-backend"{{< /code >}}
+cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
 --------------|------
@@ -525,6 +525,8 @@ sensu-backend start --labels example_key1="example value" example_key2="example 
 /etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
+  example_key1: "example value"
+  example_key2: "example value"
 {{< /code >}}
 
 | log-level  |      |

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -212,8 +212,8 @@ If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
-api-port: 4041
-socket-port: 4030
+api-port: 3031
+socket-port: 3030
 {{< /code >}}
 
 You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.

--- a/content/sensu-go/6.4/files/agent.yml
+++ b/content/sensu-go/6.4/files/agent.yml
@@ -55,7 +55,7 @@ log-level: "debug" # available log levels: panic, fatal, error, warn, info, debu
 # api configuration
 ##
 #api-host: "127.0.0.1"
-#api-port: 4041
+#api-port: 3031
 #disable-api: false
 #events-burst-limit: 10
 #events-rate-limit: 10.0

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1038,17 +1038,30 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
+default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
 environment variable | `SENSU_BACKEND_URL`
-command line example   | {{< code shell >}}
-sensu-agent start --backend-url ws://0.0.0.0:8081
-sensu-agent start --backend-url ws://0.0.0.0:8081 --backend-url ws://0.0.0.0:8082
+command line example | {{< language-toggle >}}
+{{< code shell "ws" >}}
+sensu-agent start --backend-url ws://127.0.0.1:8081
+sensu-agent start --backend-url ws://127.0.0.1:8081 --backend-url ws://127.0.0.1:8082
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+{{< code shell "wss" >}}
+sensu-agent start --backend-url wss://127.0.0.1:8081
+sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
+{{< /code >}}
+{{< /language-toggle >}}
+/etc/sensu/agent.yml example | {{< language-toggle >}}
+{{< code shell "ws" >}}
 backend-url:
-  - "ws://0.0.0.0:8081"
-  - "ws://0.0.0.0:8082"
+  - "ws://127.0.0.1:8081"
+  - "ws://127.0.0.1:8082"
 {{< /code >}}
+{{< code shell "wss" >}}
+backend-url:
+  - "wss://127.0.0.1:8081"
+  - "wss://127.0.0.1:8082"
+{{< /code >}}
+{{< /language-toggle >}}
 
 <a id="cache-dir"></a>
 
@@ -1174,9 +1187,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --api-host 0.0.0.0{{< /code >}}
+sensu-agent start --api-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-host: "0.0.0.0"{{< /code >}}
+api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
 --------------|------
@@ -1185,9 +1198,9 @@ type          | Integer
 default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --api-port 4041{{< /code >}}
+sensu-agent start --api-port 3031{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-api-port: 4041{{< /code >}}
+api-port: 3031{{< /code >}}
 
 | disable-api |      |
 --------------|------
@@ -1453,9 +1466,9 @@ type          | String
 default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-host 0.0.0.0{{< /code >}}
+sensu-agent start --socket-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-host: "0.0.0.0"{{< /code >}}
+socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
 --------------|------
@@ -1464,9 +1477,9 @@ type          | Integer
 default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --socket-port 4030{{< /code >}}
+sensu-agent start --socket-port 3030{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-socket-port: 4030{{< /code >}}
+socket-port: 3030{{< /code >}}
 
 | disable-sockets |      |
 ------------------|------
@@ -1525,9 +1538,9 @@ type                  | String
 default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-host 0.0.0.0{{< /code >}}
+sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-host: "0.0.0.0"{{< /code >}}
+statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
 ----------------------|------
@@ -1536,9 +1549,9 @@ type                  | Integer
 default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
-sensu-agent start --statsd-metrics-port 6125{{< /code >}}
+sensu-agent start --statsd-metrics-port 8125{{< /code >}}
 /etc/sensu/agent.yml example | {{< code shell >}}
-statsd-metrics-port: 6125{{< /code >}}
+statsd-metrics-port: 8125{{< /code >}}
 
 ### Allow list configuration commands
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -471,9 +471,9 @@ type          | String
 default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
-sensu-backend start --cache-dir /cache/sensu-backend{{< /code >}}
+sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-cache-dir: "/cache/sensu-backend"{{< /code >}}
+cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
 --------------|------
@@ -537,6 +537,8 @@ sensu-backend start --labels example_key1="example value" example_key2="example 
 /etc/sensu/backend.yml example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
+  example_key1: "example value"
+  example_key2: "example value"
 {{< /code >}}
 
 <a id="backend-log-level"></a>

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -212,8 +212,8 @@ If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
-api-port: 4041
-socket-port: 4030
+api-port: 3031
+socket-port: 3030
 {{< /code >}}
 
 You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.


### PR DESCRIPTION
## Description
Updates agent and backend configuration table examples to use 127.0.0.1 and the default port numbers for consistency.

## Motivation and Context
https://github.com/sensu/sensu-docs/pull/3191#discussion_r647653121
