### PR TITLE
Add info about emptying namespaces before deleting

### DIFF
--- a/content/sensu-go/6.0/api/namespaces.md
+++ b/content/sensu-go/6.0/api/namespaces.md
@@ -144,6 +144,14 @@ http://127.0.0.1:8080/api/core/v2/namespaces/development \
 HTTP/1.1 204 No Content
 {{< /code >}}
 
+Namespaces must be empty before you can delete them.
+If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, use this sensuctl dump command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
+{{< /code >}}
+
 ### API Specification {#namespacesnamespace-delete-specification}
 
 /namespaces/:namespace (DELETE) | 

--- a/content/sensu-go/6.0/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.0/operations/control-access/namespaces.md
@@ -82,7 +82,7 @@ sensuctl namespace list
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
 {{% /notice %}}
 
 ### Create namespaces
@@ -101,7 +101,15 @@ Namespace names can contain alphanumeric characters and hyphens and must begin a
 To delete a namespace:
 
 {{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
+sensuctl namespace delete <namespace-name>
+{{< /code >}}
+
+Namespaces must be empty before you can delete them.
+If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, run this command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
 {{< /code >}}
 
 ### Assign a resource to a namespace

--- a/content/sensu-go/6.1/api/namespaces.md
+++ b/content/sensu-go/6.1/api/namespaces.md
@@ -144,6 +144,14 @@ http://127.0.0.1:8080/api/core/v2/namespaces/development \
 HTTP/1.1 204 No Content
 {{< /code >}}
 
+Namespaces must be empty before you can delete them.
+If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, use this sensuctl dump command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
+{{< /code >}}
+
 ### API Specification {#namespacesnamespace-delete-specification}
 
 /namespaces/:namespace (DELETE) | 

--- a/content/sensu-go/6.1/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.1/operations/control-access/namespaces.md
@@ -82,7 +82,7 @@ sensuctl namespace list
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
 {{% /notice %}}
 
 ### Create namespaces
@@ -101,7 +101,15 @@ Namespace names can contain alphanumeric characters and hyphens and must begin a
 To delete a namespace:
 
 {{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
+sensuctl namespace delete <namespace-name>
+{{< /code >}}
+
+Namespaces must be empty before you can delete them.
+If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, run this command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
 {{< /code >}}
 
 ### Assign a resource to a namespace

--- a/content/sensu-go/6.2/api/namespaces.md
+++ b/content/sensu-go/6.2/api/namespaces.md
@@ -144,6 +144,14 @@ http://127.0.0.1:8080/api/core/v2/namespaces/development \
 HTTP/1.1 204 No Content
 {{< /code >}}
 
+Namespaces must be empty before you can delete them.
+If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, use this sensuctl dump command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
+{{< /code >}}
+
 ### API Specification {#namespacesnamespace-delete-specification}
 
 /namespaces/:namespace (DELETE) | 

--- a/content/sensu-go/6.2/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.2/operations/control-access/namespaces.md
@@ -82,7 +82,7 @@ sensuctl namespace list
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
 {{% /notice %}}
 
 ### Create namespaces
@@ -101,7 +101,15 @@ Namespace names can contain alphanumeric characters and hyphens and must begin a
 To delete a namespace:
 
 {{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
+sensuctl namespace delete <namespace-name>
+{{< /code >}}
+
+Namespaces must be empty before you can delete them.
+If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, run this command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
 {{< /code >}}
 
 ### Assign a resource to a namespace

--- a/content/sensu-go/6.3/api/namespaces.md
+++ b/content/sensu-go/6.3/api/namespaces.md
@@ -145,8 +145,8 @@ HTTP/1.1 204 No Content
 {{< /code >}}
 
 Namespaces must be empty before you can delete them.
-If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events.
-To remove all resources (including events) so that you can delete a namespace, use this sensuctl dump command:
+If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, use this sensuctl dump command (replace `<namespace-name>` with the namespace you want to empty):
 
 {{< code shell >}}
 sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete

--- a/content/sensu-go/6.3/api/namespaces.md
+++ b/content/sensu-go/6.3/api/namespaces.md
@@ -144,6 +144,14 @@ http://127.0.0.1:8080/api/core/v2/namespaces/development \
 HTTP/1.1 204 No Content
 {{< /code >}}
 
+Namespaces must be empty before you can delete them.
+If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events.
+To remove all resources (including events) so that you can delete a namespace, use this sensuctl dump command:
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
+{{< /code >}}
+
 ### API Specification {#namespacesnamespace-delete-specification}
 
 /namespaces/:namespace (DELETE) | 

--- a/content/sensu-go/6.3/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.3/operations/control-access/namespaces.md
@@ -101,7 +101,15 @@ Namespace names can contain alphanumeric characters and hyphens and must begin a
 To delete a namespace:
 
 {{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
+sensuctl namespace delete <namespace-name>
+{{< /code >}}
+
+Namespaces must be empty before you can delete them.
+If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events.
+To remove all resources (including events) so that you can delete a namespace, run:
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
 {{< /code >}}
 
 ### Assign a resource to a namespace

--- a/content/sensu-go/6.3/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.3/operations/control-access/namespaces.md
@@ -82,7 +82,7 @@ sensuctl namespace list
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
 {{% /notice %}}
 
 ### Create namespaces
@@ -105,8 +105,8 @@ sensuctl namespace delete <namespace-name>
 {{< /code >}}
 
 Namespaces must be empty before you can delete them.
-If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events.
-To remove all resources (including events) so that you can delete a namespace, run:
+If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, run this command (replace `<namespace-name>` with the namespace you want to empty):
 
 {{< code shell >}}
 sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete

--- a/content/sensu-go/6.4/api/namespaces.md
+++ b/content/sensu-go/6.4/api/namespaces.md
@@ -144,6 +144,14 @@ http://127.0.0.1:8080/api/core/v2/namespaces/development \
 HTTP/1.1 204 No Content
 {{< /code >}}
 
+Namespaces must be empty before you can delete them.
+If the response to your delete request includes `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, use this sensuctl dump command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
+{{< /code >}}
+
 ### API Specification {#namespacesnamespace-delete-specification}
 
 /namespaces/:namespace (DELETE) | 

--- a/content/sensu-go/6.4/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.4/operations/control-access/namespaces.md
@@ -82,7 +82,7 @@ sensuctl namespace list
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions,`sensuctl namespace list` lists only the namespaces that the current user has access to.
+**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
 {{% /notice %}}
 
 ### Create namespaces
@@ -101,7 +101,15 @@ Namespace names can contain alphanumeric characters and hyphens and must begin a
 To delete a namespace:
 
 {{< code shell >}}
-sensuctl namespace delete [NAMESPACE-NAME]
+sensuctl namespace delete <namespace-name>
+{{< /code >}}
+
+Namespaces must be empty before you can delete them.
+If the response to `sensuctl namespace delete` is `Error: resource is invalid: namespace is not empty`, the namespace may still contain events or other resources.
+To remove all resources and events so that you can delete a namespace, run this command (replace `<namespace-name>` with the namespace you want to empty):
+
+{{< code shell >}}
+sensuctl dump entities,events,assets,checks,filters,handlers,secrets/v1.Secret --namespace <namespace-name> | sensuctl delete
 {{< /code >}}
 
 ### Assign a resource to a namespace


### PR DESCRIPTION
## Description
Adds information about how to empty a namespace with sensuctl dump before deleting to avoid the "namespace must be empty" error in namespace API and sensuctl namespace delete docs.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3205