### PR TITLE
6.4.0: Describe minute, second, and seconds_since custom functions

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -1166,7 +1166,7 @@ spec:
   "spec": {
     "action": "allow",
     "expressions": [
-      "seconds_since(event.timestamp) > 30",
+      "seconds_since(event.timestamp) > 30"
     ],
     "runtime_assets": []
   }

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -1085,6 +1085,96 @@ spec:
 
 {{< /language-toggle >}}
 
+Add filter expressions that use the [`minute`][39] and [`second`][40] custom functions for more granular control.
+For example, if office hours are 8:30 AM to 5:30 PM:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: EventFilter
+api_version: core/v2
+metadata:
+  annotations: null
+  labels: null
+  name: 830_to_530
+  namespace: default
+spec:
+  action: allow
+  expressions:
+  - weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5
+  - hour(event.timestamp) >= 8 && minute(event.timestamp) >= 30
+  - hour(event.timestamp) <= 17 && minute(event.timestamp) <= 30
+  runtime_assets: []
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "830_to_530",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "weekday(event.timestamp) >= 1 && weekday(event.timestamp) <= 5",
+      "hour(event.timestamp) >= 8 && minute(event.timestamp) >= 30",
+      "hour(event.timestamp) <= 17 && minute(event.timestamp) <= 30"
+    ],
+    "runtime_assets": []
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Filter for events not processed within 30 seconds
+
+This event filter evaluates the event timestamp to determine if the event was created more than 30 seconds since the current time.
+In other words, this filter sets a 30-second time budget for event processing so you can identify and handle events that aren't processed within 30 seconds.
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+type: EventFilter
+api_version: core/v2
+metadata:
+  annotations: null
+  labels: null
+  name: budget_30
+  namespace: default
+spec:
+  action: allow
+  expressions:
+  - seconds_since(event.timestamp) > 30
+  runtime_assets: []
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "EventFilter",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "budget_30",
+    "namespace": "default",
+    "labels": null,
+    "annotations": null
+  },
+  "spec": {
+    "action": "allow",
+    "expressions": [
+      "seconds_since(event.timestamp) > 30",
+    ],
+    "runtime_assets": []
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
 
 [1]: #inclusive-and-exclusive-event-filters
 [2]: #when-attributes
@@ -1123,6 +1213,8 @@ spec:
 [36]: ../../../api#response-filtering
 [37]: ../../../sensuctl/filter-responses/
 [38]: https://en.wikipedia.org/wiki/Modulo_operation
+[39]: ../sensu-query-expressions/#minute
+[40]: ../sensu-query-expressions/#second
 [41]: ../../../web-ui/search#search-for-labels
 [42]: ../../../web-ui/search/
 [43]: ../

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/sensu-query-expressions.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/sensu-query-expressions.md
@@ -82,7 +82,22 @@ If an SQE returns a value besides `true` or `false`, an error is recorded in the
 
 ## Custom functions
 
-### hour
+### weekday, hour, minute, and second
+
+Together, the `weekday`, `hour`, `minute`, and `second` custom functions provide granular control of time-based filter expressions, comparable to cron scheduling.
+
+#### weekday
+
+The custom function `weekday` returns a number that represents the day of the week of a UNIX epoch time.
+Sunday is `0`.
+
+For example, if an `event.timestamp` equals 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC, the following SQE returns `false`:
+
+{{< code go >}}
+weekday(event.timestamp) == 0
+{{< /code >}}
+
+#### hour
 
 The custom function `hour` returns the hour of a UNIX epoch time (in UTC and 24-hour time notation).
 
@@ -92,15 +107,35 @@ For example, if an `event.timestamp` equals 1520275913, which is Monday, March 5
 hour(event.timestamp) >= 17
 {{< /code >}}
 
-### weekday
+#### minute
 
-The custom function `weekday` returns a number that represents the day of the week of a UNIX epoch time.
-Sunday is `0`.
+The custom function `minute` returns the minute of the hour (0 through 59) of a UNIX epoch time in UTC and 24-hour time notation.
 
 For example, if an `event.timestamp` equals 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC, the following SQE returns `false`:
 
 {{< code go >}}
-weekday(event.timestamp) == 0
+minute(event.timestamp) <= 30
+{{< /code >}}
+
+#### second
+
+The custom function `second` returns the second of the minute (0 through 59) of a UNIX epoch time in UTC and 24-hour time notation.
+
+For example, if an `event.timestamp` equals 1520275913, which is Monday, March 5, 2018 6:51:53 PM UTC, the following SQE returns `true`:
+
+{{< code go >}}
+second(event.timestamp) >= 30
+{{< /code >}}
+
+### seconds_since
+
+The custom function `seconds_since` returns the number of seconds (using float64) between the current time and an event's timestamp.
+
+For systems with event processing pressure, you can use `seconds_since` to create alerts for events that are not handled within a certain period.
+For example, the following SQE represents a 30-second time budget for event processing:
+
+{{< code go >}}
+seconds_since(event.timestamp) > 30
 {{< /code >}}
 
 ### sensu.CheckDependencies


### PR DESCRIPTION
## Description
- Adds description of custom functions for minute, second, and seconds_since in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/sensu-query-expressions/#custom-functions
- Adds examples for minute and seconds_since functions in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/filters/

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3207