### PR TITLE
Update link to sensu.io/license

### DIFF
--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -556,7 +556,7 @@ sensuctl license info
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/
 [11]: https://sensu.io/contact?subject=contact-sales/
 [12]: ../../../observability-pipeline/observe-process/send-email-alerts/
-[13]: https://sensu.io/sensu-license/
+[13]: https://sensu.io/licenses
 [14]: ../../../learn/learn-sensu-sandbox/
 [15]: ../../../observability-pipeline/observe-schedule/agent/#events-post-example
 [16]: https://etcd.io/

--- a/content/sensu-go/6.0/platforms.md
+++ b/content/sensu-go/6.0/platforms.md
@@ -357,7 +357,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [4]: #binary-only-distributions
 [5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
-[7]: https://sensu.io/sensu-license/
+[7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -556,7 +556,7 @@ sensuctl license info
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/
 [11]: https://sensu.io/contact?subject=contact-sales/
 [12]: ../../../observability-pipeline/observe-process/send-email-alerts/
-[13]: https://sensu.io/sensu-license/
+[13]: https://sensu.io/licenses
 [14]: ../../../learn/learn-sensu-sandbox/
 [15]: ../../../observability-pipeline/observe-schedule/agent/#events-post-example
 [16]: https://etcd.io/

--- a/content/sensu-go/6.1/platforms.md
+++ b/content/sensu-go/6.1/platforms.md
@@ -357,7 +357,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [4]: #binary-only-distributions
 [5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
-[7]: https://sensu.io/sensu-license/
+[7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/

--- a/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
@@ -556,7 +556,7 @@ sensuctl license info
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/
 [11]: https://sensu.io/contact?subject=contact-sales/
 [12]: ../../../observability-pipeline/observe-process/send-email-alerts/
-[13]: https://sensu.io/sensu-license/
+[13]: https://sensu.io/licenses
 [14]: ../../../learn/learn-sensu-sandbox/
 [15]: ../../../observability-pipeline/observe-schedule/agent/#events-post-example
 [16]: https://etcd.io/

--- a/content/sensu-go/6.2/platforms.md
+++ b/content/sensu-go/6.2/platforms.md
@@ -357,7 +357,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [4]: #binary-only-distributions
 [5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
-[7]: https://sensu.io/sensu-license/
+[7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/

--- a/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
@@ -556,7 +556,7 @@ sensuctl license info
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/
 [11]: https://sensu.io/contact?subject=contact-sales/
 [12]: ../../../observability-pipeline/observe-process/send-email-alerts/
-[13]: https://sensu.io/sensu-license/
+[13]: https://sensu.io/licenses
 [14]: ../../../learn/learn-sensu-sandbox/
 [15]: ../../../observability-pipeline/observe-schedule/agent/#events-post-example
 [16]: https://etcd.io/

--- a/content/sensu-go/6.3/platforms.md
+++ b/content/sensu-go/6.3/platforms.md
@@ -357,7 +357,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [4]: #binary-only-distributions
 [5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
-[7]: https://sensu.io/sensu-license/
+[7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/

--- a/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
@@ -556,7 +556,7 @@ sensuctl license info
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/
 [11]: https://sensu.io/contact?subject=contact-sales/
 [12]: ../../../observability-pipeline/observe-process/send-email-alerts/
-[13]: https://sensu.io/sensu-license/
+[13]: https://sensu.io/licenses
 [14]: ../../../learn/learn-sensu-sandbox/
 [15]: ../../../observability-pipeline/observe-schedule/agent/#events-post-example
 [16]: https://etcd.io/

--- a/content/sensu-go/6.4/platforms.md
+++ b/content/sensu-go/6.4/platforms.md
@@ -357,7 +357,7 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 [4]: #binary-only-distributions
 [5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
 [6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
-[7]: https://sensu.io/sensu-license/
+[7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads
 [10]: https://hub.docker.com/r/sensu/sensu/


### PR DESCRIPTION
## Description
Updates link from sensu.io/sensu-licenses/ to sensu.io/licenses to avoid error page or redirect due to trailing slash

## Motivation and Context
Discovered during June sync with Sales
