### PR TITLE
Add commercial features shortcode and formatting

### DIFF
--- a/content/sensu-go/6.0/api/_index.md
+++ b/content/sensu-go/6.0/api/_index.md
@@ -313,8 +313,10 @@ Content-Length: 54
 
 ## Response filtering
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access API response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 The Sensu API supports response filtering for all GET endpoints that return an array.
 You can filter resources based on their labels with the `labelSelector` query parameter and based on certain pre-determined fields with the `fieldSelector` query parameter.
@@ -696,7 +698,6 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [5]: health/
 [6]: metrics/
 [7]: ../sensuctl/environment-variables/
-[8]: ../commercial/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: ../operations/deploy-sensu/cluster-sensu/
 [11]: auth/#authtoken-post

--- a/content/sensu-go/6.0/api/authproviders.md
+++ b/content/sensu-go/6.0/api/authproviders.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the authentication providers API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -336,5 +338,4 @@ example url               | http://hostname:8080/api/enterprise/authentication/v
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../operations/control-access/
-[2]: ../../commercial/
 [3]: ../#pagination

--- a/content/sensu-go/6.0/api/federation.md
+++ b/content/sensu-go/6.0/api/federation.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the federation API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -510,5 +512,3 @@ description               | Deletes the specified cluster from Sensu.
 example url               | http://hostname:8080/api/enterprise/federation/v1/clusters/us-west-2a
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.0/api/prune.md
+++ b/content/sensu-go/6.0/api/prune.md
@@ -10,8 +10,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.0/api/prune.md
+++ b/content/sensu-go/6.0/api/prune.md
@@ -10,25 +10,22 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: The prune API is an alpha feature and may include breaking changes.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
+The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+
+Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
-
-{{% notice note %}}
-**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.0/api/searches.md
+++ b/content/sensu-go/6.0/api/searches.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the searches API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the searches API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -275,4 +277,3 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 
 
 [1]: ../#response-filtering
-[2]: ../../commercial/

--- a/content/sensu-go/6.0/api/secrets.md
+++ b/content/sensu-go/6.0/api/secrets.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
-**COMMERCIAL FEATURE**: Access secrets management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the secrets API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the secrets API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -458,5 +460,4 @@ example url               | http://hostname:8080/api/enterprise/secrets/v1/names
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 
-[1]: ../../commercial/
 [4]: ../#response-filtering

--- a/content/sensu-go/6.0/api/webconfig.md
+++ b/content/sensu-go/6.0/api/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the web UI configuration API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -279,5 +281,3 @@ description               | Removes the specified global web UI configuration fr
 example url               | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.0/commercial.md
+++ b/content/sensu-go/6.0/commercial.md
@@ -10,8 +10,15 @@ product: "Sensu Go"
 
 Sensu Go offers commercial features designed for monitoring at scale.
 All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
-
 If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
+
+In addition to the [summary][25] on this page, we describe commercial features in detail throughout the documentation.
+Watch for this notice to identify commercial features:
+
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access <feature_name> in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 ## Commercial features in Sensu Go
 
@@ -105,3 +112,4 @@ These resources will help you get started with commercial features in Sensu Go:
 [21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [24]: ../plugins/supported-integrations/
+[25]: #commercial-features-in-sensu-go

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -815,8 +815,8 @@ subscriptions:
 
 system       | 
 -------------|------ 
-description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1235,8 +1235,8 @@ example        | {{< language-toggle >}}
 
 processes    | 
 -------------|------ 
-description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1408,8 +1408,8 @@ handler: email-handler
 
 ### Processes attributes
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-entities/entities.md
@@ -1408,18 +1408,15 @@ handler: email-handler
 
 ### Processes attributes
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
+
 {{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
-{{% /notice %}}
-
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag][27] in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
-
-{{% notice note %}}
-**NOTE**: The `processes` field is populated in the packaged Sensu Go distributions.
-In OSS builds, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 name         | 
@@ -1598,7 +1595,6 @@ cpu_percent: 0.12639
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
-[27]: ../../observe-schedule/agent/#discover-processes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
 [29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [30]: ../../../web-ui/filter/

--- a/content/sensu-go/6.0/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-filter/filters.md
@@ -13,7 +13,7 @@ menu:
     parent: observe-filter
 ---
 
-Sensu executes event filters during the **[filter][43]** stage of the [observability pipeline][44].
+Sensu executes event filters during the **[filter][39]** stage of the [observability pipeline][44].
 
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the observation data in events.
@@ -410,8 +410,10 @@ For more information about event attributes, see the [event reference][28].
 
 ## Build event filter expressions with JavaScript execution functions
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access built-in JavaScript event filter execution functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][44].
+For more information, see [Get started with commercial features](../../../commercial).
+{{% /notice %}}
 
 In addition to [Sensu query expressions][27], Sensu includes several built-in JavaScript functions for event filter execution:
 
@@ -1123,7 +1125,8 @@ spec:
 [36]: ../../../api#response-filtering
 [37]: ../../../sensuctl/filter-responses/
 [38]: https://en.wikipedia.org/wiki/Modulo_operation
+[39]: ../
 [41]: ../../../web-ui/filter#filter-with-label-selectors  
 [42]: ../../../web-ui/filter/
-[43]: ../
+[43]: ../../../api/events/
 [44]: ../../../observability-pipeline/

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/agent.md
@@ -834,8 +834,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 
 ### Configuration summary
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 To view configuration information for the sensu-agent start command, run:
@@ -1085,8 +1085,8 @@ disable-assets: true{{< /code >}}
 
 | discover-processes |      |
 --------------|------
-description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false
@@ -1760,8 +1760,8 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 
 #### Use environment variables to specify an HTTP proxy for agent use
 
-{{% notice important %}}
-**IMPORTANT**: To use HTTP proxy environment variables, upgrade to Sensu Go 6.1.4 or later.
+{{% notice warning %}}
+**WARNING**: To use HTTP proxy environment variables, upgrade to Sensu Go 6.1.4 or later.
 In earlier versions of Sensu Go, the agent will not respect HTTP proxy environment variables when `trusted-ca-file` is configured.
 Upgrade to Sensu Go 6.1.4 or later to avoid this issue.
 {{% /notice %}}

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -1348,8 +1348,10 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Event logging
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access event logging in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][14].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
@@ -1442,7 +1444,6 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [11]: ../../observe-process/handlers/
 [12]: #datastore-and-cluster-configuration-flags
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
-[14]: ../../../commercial/
 [15]: #general-configuration-flags
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml

--- a/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.0/observability-pipeline/observe-schedule/backend.md
@@ -72,8 +72,8 @@ Sensu does not apply a default admin username or password for Ubuntu/Debian or R
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
 {{% /notice %}}
 
 ### Docker initialization

--- a/content/sensu-go/6.0/operations/control-access/_index.md
+++ b/content/sensu-go/6.0/operations/control-access/_index.md
@@ -40,8 +40,10 @@ Sensu hashes user passwords using the [bcrypt][26] algorithm and records the bas
 
 ### Use an authentication provider
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
 
@@ -131,7 +133,6 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
-[6]: ../../commercial/
 [7]: oidc-auth/
 [8]: ../../api/
 [9]: oidc-auth/#oidc-configuration-examples

--- a/content/sensu-go/6.0/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/ad-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/.
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.0/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/ldap-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.0/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/oidc-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/cluster-sensu.md
@@ -119,8 +119,8 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
-{{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+{{% notice warning %}}
+**WARNING**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
 Specify the same `etcd-initial-cluster-token` value for all three backends.
 This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}

--- a/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/datastore.md
@@ -33,8 +33,10 @@ etcd version 3.4.0 is compatible with Sensu but may result in slower performance
 
 ## Scale event storage
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][13].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu supports using an external PostgreSQL instance for event storage in place of etcd.
 PostgreSQL can handle significantly higher volumes of Sensu events, which allows you to scale Sensu beyond etcd's 8-GB limit.
@@ -371,7 +373,6 @@ pool_size: 20
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event
 [11]: ../../../api/events/
 [12]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
-[13]: ../../../commercial/
 [14]: https://www.postgresql.org
 [15]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 [16]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.0/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/etcdreplicators.md
@@ -12,8 +12,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the EtcdReplicator datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
@@ -546,7 +548,6 @@ replication_interval_seconds: 30
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/federation/
 [3]: ../../control-access/rbac/
 [4]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/install-sensu.md
@@ -187,8 +187,8 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
 {{% /notice %}}
 
 ### 3. Initialize

--- a/content/sensu-go/6.0/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/scale-event-storage.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu Go's datastore feature enables scaling your monitoring to many thousands of events per second.
 

--- a/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/secure-sensu.md
@@ -165,8 +165,10 @@ See [Run a Sensu cluster](../cluster-sensu/) for more information about how to c
 
 ## Optional: Configure Sensu agent mTLS authentication
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access client mutual transport layer security (mTLS) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3].
@@ -246,7 +248,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
-[5]: ../../../commercial/
 [6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.0/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.0/operations/deploy-sensu/use-federation.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
@@ -426,7 +428,6 @@ Learn more about configuring RBAC policies in our [RBAC reference documentation]
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: ../../../sensuctl/create-manage-resources/#update-resources
 [7]: ../../../sensuctl/create-manage-resources/#delete-resources
-[8]: ../../../commercial/
 [10]: ../../control-access/rbac/
 [11]: ../../../api/federation#get-all-clusters
 [12]: https://github.com/etcd-io/etcd/blob/master/etcdctl/README.md#make-mirror-options-destination

--- a/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/migrate.md
@@ -24,9 +24,9 @@ Sensu Go also includes many powerful [commercial features][27] to make monitorin
 Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
-{{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
-If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
+{{% notice warning %}}
+**WARNING**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core or Sensu Enterprise to Sensu Go:

--- a/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.0/operations/maintain-sensu/upgrade.md
@@ -13,8 +13,8 @@ menu:
 
 ## Upgrade to Sensu Go 6.0 from a 5.x deployment
 
-{{% notice important %}}
-**IMPORTANT**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
+{{% notice warning %}}
+**WARNING**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
 You will not be able to downgrade to a Sensu 5.x version after you upgrade your database to Sensu 6.0 in step 3 of this process.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.0/operations/manage-secrets/secrets-management.md
@@ -13,8 +13,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][20].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
 In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
@@ -477,7 +479,6 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[20]: ../../../commercial/
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler

--- a/content/sensu-go/6.0/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.0/operations/manage-secrets/secrets-providers.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].

--- a/content/sensu-go/6.0/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.0/operations/manage-secrets/secrets.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
@@ -299,7 +301,6 @@ provider: vault
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands

--- a/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.0/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -233,8 +233,10 @@ spec:
 
 ## Monitor Postgres
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale Postgres event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Larger Sensu deployments may use [Postgres as an alternative datastore][4] to process larger numbers of events.
 The connection to Postgres is exposed on Sensu's `/health` endpoint and will look like the example below:
@@ -361,5 +363,4 @@ A successful PostgreSQL health check result will look like this:
 [1]: ../../../plugins/use-assets-to-install-plugins/
 [2]: ../../../api/health/
 [3]: https://bonsai.sensu.io/assets/sensu/monitoring-plugins
-[4]: https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/scale-event-storage/
-[5]: ../../../commercial/
+[4]: ../../deploy-sensu/scale-event-storage/

--- a/content/sensu-go/6.0/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/ansible.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Ansible Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The Sensu Ansible Handler plugin is a Sensu [handler][1] that launches Ansible Tower job templates for automated remediation based on Sensu event data.
 
@@ -45,8 +47,7 @@ The [documentation site][8] includes installation instructions, example playbook
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://galaxy.ansible.com/sensu/sensu_go
 [8]: https://sensu.github.io/sensu-go-ansible/
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/elasticsearch.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Elasticsearch Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Elasticsearch Handler plugin][4] is a Sensu [handler][1] that sends observation data from Sensu events and metrics to Elasticsearch.
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
@@ -42,7 +44,6 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/
 [8]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags

--- a/content/sensu-go/6.0/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/jira.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Jira Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Jira Handler plugin][4] is a Sensu [handler][1] that creates and updates Jira issues based on observation data from Sensu events.
 
@@ -37,6 +39,5 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/rundeck.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Rundeck Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Rundeck Handler plugin][4] is a Sensu [handler][1] that initiates Rundeck jobs for automated remediation based on Sensu event data.
 
@@ -42,7 +44,6 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/saltstack.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu SaltStack Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu SaltStack Handler plugin][4] is a Sensu [handler][1] that launches SaltStack functions for automated remediation based on Sensu event data.
 
@@ -39,6 +41,5 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.0/plugins/supported-integrations/servicenow.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu ServiceNow Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu ServiceNow Handler plugin][4] is a Sensu [handler][1] that creates and updates ServiceNow incidents and events based on observation data from Sensu events.
 
@@ -42,8 +44,7 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
 [8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.0/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.0/sensuctl/back-up-recover.md
@@ -333,8 +333,8 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice important %}}
-**IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
+{{% notice note %}}
+**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -469,8 +469,8 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.0/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.0/sensuctl/create-manage-resources.md
@@ -469,18 +469,18 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-{{% /notice %}}
-
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][30].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
+
+`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}
 

--- a/content/sensu-go/6.0/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.0/sensuctl/filter-responses.md
@@ -11,8 +11,10 @@ menu:
     parent: sensuctl
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensuctl supports response filtering for all [commands using the `list` verb][1].
 For information about response filtering methods and available label and field selectors, see [API response filtering][2].
@@ -118,6 +120,5 @@ sensuctl check list --label-selector 'region == "us-west-1"' --field-selector 's
 [1]: ../create-manage-resources/#subcommands
 [2]: ../../api#response-filtering
 [3]: ../../api#field-selector
-[4]: ../../commercial/
 [5]: ../../api/#operators
 [6]: #examples

--- a/content/sensu-go/6.0/web-ui/_index.md
+++ b/content/sensu-go/6.0/web-ui/_index.md
@@ -12,8 +12,10 @@ menu:
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/web-ui.png" alt="Sensu web UI homepage" link="/images/web-ui.png" target="_blank" >}}
 
@@ -46,5 +48,4 @@ Use the preferences menu to change the theme or switch to the dark theme.
 [3]: ../operations/control-access/rbac/
 [4]: ../operations/control-access/rbac#default-users
 [5]: ../operations/control-access/rbac#create-users
-[6]: ../commercial/
 [7]: ../api/auth/

--- a/content/sensu-go/6.0/web-ui/filter.md
+++ b/content/sensu-go/6.0/web-ui/filter.md
@@ -35,8 +35,10 @@ You can also sort events and silences using the **SORT** dropdown menu:
 
 ## Advanced filters
 
-**COMMERCIAL FEATURE**: Access advanced filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access advanced web UI filtering in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensu supports advanced web UI filtering using a wider range of attributes, including custom labels.
 You can use the same methods, selectors, and examples for web UI filtering as for [API response filtering][3], with some [syntax differences][4].
@@ -182,8 +184,10 @@ fieldSelector:slack in check.handlers
 
 ## Save a filtered search
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access saved filtered searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 To save a filtered search:
 

--- a/content/sensu-go/6.0/web-ui/searches.md
+++ b/content/sensu-go/6.0/web-ui/searches.md
@@ -13,8 +13,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
@@ -503,7 +505,6 @@ parameters:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../operations/control-access/rbac/#namespaced-resource-types
 [3]: ../../web-ui/filter/#save-a-filtered-search
 [4]: ../../api/searches

--- a/content/sensu-go/6.0/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.0/web-ui/view-manage-resources.md
@@ -20,8 +20,10 @@ By default, the web UI displays the `default` namespace.
 
 To switch namespaces, select the menu icon in the upper-left corner and choose a namespace from the dropdown.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, the namespace switcher will list only the namespaces to which the current user has access.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/namespace-switcher-1.png" alt="Sensu web UI namespace switcher" link="/images/namespace-switcher-1.png" target="_blank" >}}
 
@@ -44,11 +46,11 @@ After you create a silence, it will be listed in the web UI Silences page until 
 
 ## Manage checks, handlers, event filters, and mutators
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 Execute checks on demand from individual check pages to test your observability pipeline.
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.0/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.0/web-ui/webconfig-reference.md
@@ -12,8 +12,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -380,7 +382,6 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../../web-ui/
 [4]: #spec-attributes

--- a/content/sensu-go/6.0/web-ui/webconfig.md
+++ b/content/sensu-go/6.0/web-ui/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -90,7 +92,6 @@ In a single-cluster environment, the namespace switcher will only list a local-c
 {{% /notice %}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../
 [4]: ../webconfig-reference/

--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -361,8 +361,10 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK`.
 
 ## Response filtering
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access API response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 The Sensu API supports response filtering for all GET endpoints that return an array.
 You can filter resources based on their labels with the `labelSelector` query parameter and based on certain pre-determined fields with the `fieldSelector` query parameter.
@@ -743,7 +745,6 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [5]: health/
 [6]: metrics/
 [7]: ../sensuctl/environment-variables/
-[8]: ../commercial/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
 [11]: auth/#authtoken-post

--- a/content/sensu-go/6.1/api/authproviders.md
+++ b/content/sensu-go/6.1/api/authproviders.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the authentication providers API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -337,5 +339,4 @@ example url               | http://hostname:8080/api/enterprise/authentication/v
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../operations/control-access/
-[2]: ../../commercial/
 [3]: ../#pagination

--- a/content/sensu-go/6.1/api/federation.md
+++ b/content/sensu-go/6.1/api/federation.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the federation API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -510,5 +512,3 @@ description               | Deletes the specified cluster from Sensu.
 example url               | http://hostname:8080/api/enterprise/federation/v1/clusters/us-west-2a
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.1/api/prune.md
+++ b/content/sensu-go/6.1/api/prune.md
@@ -10,8 +10,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.1/api/prune.md
+++ b/content/sensu-go/6.1/api/prune.md
@@ -10,25 +10,22 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: The prune API is an alpha feature and may include breaking changes.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
+The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+
+Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
-
-{{% notice note %}}
-**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.1/api/searches.md
+++ b/content/sensu-go/6.1/api/searches.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the searches API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the searches API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -275,4 +277,3 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 
 
 [1]: ../#response-filtering
-[2]: ../../commercial/

--- a/content/sensu-go/6.1/api/secrets.md
+++ b/content/sensu-go/6.1/api/secrets.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
-**COMMERCIAL FEATURE**: Access secrets management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the secrets API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the secrets API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -459,5 +461,4 @@ example url               | http://hostname:8080/api/enterprise/secrets/v1/names
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 
-[1]: ../../commercial/
 [4]: ../#response-filtering

--- a/content/sensu-go/6.1/api/webconfig.md
+++ b/content/sensu-go/6.1/api/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the web UI configuration API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -285,5 +287,3 @@ description               | Removes the specified global web UI configuration fr
 example url               | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.1/commercial.md
+++ b/content/sensu-go/6.1/commercial.md
@@ -10,8 +10,15 @@ product: "Sensu Go"
 
 Sensu Go offers commercial features designed for monitoring at scale.
 All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
-
 If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
+
+In addition to the [summary][25] on this page, we describe commercial features in detail throughout the documentation.
+Watch for this notice to identify commercial features:
+
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access <feature_name> in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 ## Commercial features in Sensu Go
 
@@ -104,3 +111,4 @@ These resources will help you get started with commercial features in Sensu Go:
 [21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [24]: ../plugins/supported-integrations/
+[25]: #commercial-features-in-sensu-go

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -1408,18 +1408,15 @@ handler: email-handler
 
 ### Processes attributes
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
+
 {{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
-{{% /notice %}}
-
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag][27] in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
-
-{{% notice note %}}
-**NOTE**: The `processes` field is populated in the packaged Sensu Go distributions.
-In OSS builds, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 name         | 
@@ -1598,7 +1595,6 @@ cpu_percent: 0.12639
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
-[27]: ../../observe-schedule/agent/#discover-processes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
 [29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [30]: ../../../web-ui/search/

--- a/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-entities/entities.md
@@ -815,8 +815,8 @@ subscriptions:
 
 system       | 
 -------------|------ 
-description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1235,8 +1235,8 @@ example        | {{< language-toggle >}}
 
 processes    | 
 -------------|------ 
-description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1408,8 +1408,8 @@ handler: email-handler
 
 ### Processes attributes
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/filters.md
@@ -13,7 +13,7 @@ menu:
     parent: observe-filter
 ---
 
-Sensu executes event filters during the **[filter][43]** stage of the [observability pipeline][44].
+Sensu executes event filters during the **[filter][39]** stage of the [observability pipeline][44].
 
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the observation data in events.
@@ -410,8 +410,10 @@ For more information about event attributes, see the [event reference][28].
 
 ## Build event filter expressions with JavaScript execution functions
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access built-in JavaScript event filter execution functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][44].
+For more information, see [Get started with commercial features](../../../commercial).
+{{% /notice %}}
 
 In addition to [Sensu query expressions][27], Sensu includes several built-in JavaScript functions for event filter execution:
 
@@ -1123,7 +1125,8 @@ spec:
 [36]: ../../../api#response-filtering
 [37]: ../../../sensuctl/filter-responses/
 [38]: https://en.wikipedia.org/wiki/Modulo_operation
+[39]: ../
 [41]: ../../../web-ui/search#search-for-labels
 [42]: ../../../web-ui/search/
-[43]: ../
+[43]: ../../../api/events/
 [44]: ../../../observability-pipeline/

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -834,8 +834,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 
 ### Configuration summary
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 To view configuration information for the sensu-agent start command, run:
@@ -1085,8 +1085,8 @@ disable-assets: true{{< /code >}}
 
 | discover-processes |      |
 --------------|------
-description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false
@@ -1760,8 +1760,8 @@ For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file,
 
 #### Use environment variables to specify an HTTP proxy for agent use
 
-{{% notice important %}}
-**IMPORTANT**: To use HTTP proxy environment variables, upgrade to Sensu Go 6.1.4 or later.
+{{% notice warning %}}
+**WARNING**: To use HTTP proxy environment variables, upgrade to Sensu Go 6.1.4 or later.
 In earlier versions of Sensu Go 6.1, the agent will not respect HTTP proxy environment variables when `trusted-ca-file` is configured.
 Upgrade to Sensu Go 6.1.4 or later to avoid this issue.
 {{% /notice %}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -72,8 +72,8 @@ Sensu does not apply a default admin username or password for Ubuntu/Debian or R
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
 {{% /notice %}}
 
 ### Docker initialization

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -1362,8 +1362,10 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Event logging
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access event logging in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][14].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
@@ -1456,7 +1458,6 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [11]: ../../observe-process/handlers/
 [12]: #datastore-and-cluster-configuration-flags
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
-[14]: ../../../commercial/
 [15]: #general-configuration-flags
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml

--- a/content/sensu-go/6.1/operations/control-access/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/_index.md
@@ -40,8 +40,10 @@ Sensu hashes user passwords using the [bcrypt][26] algorithm and records the bas
 
 ### Use an authentication provider
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
 
@@ -131,7 +133,6 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
-[6]: ../../commercial/
 [7]: oidc-auth/
 [8]: ../../api/
 [9]: oidc-auth/#oidc-configuration-examples

--- a/content/sensu-go/6.1/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ad-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/.
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.1/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ldap-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.1/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/oidc-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -119,8 +119,8 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
-{{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+{{% notice warning %}}
+**WARNING**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
 Specify the same `etcd-initial-cluster-token` value for all three backends.
 This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}

--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -33,8 +33,10 @@ etcd version 3.4.0 is compatible with Sensu but may result in slower performance
 
 ## Scale event storage
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][13].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu supports using an external PostgreSQL instance for event storage in place of etcd.
 PostgreSQL can handle significantly higher volumes of Sensu events, which allows you to scale Sensu beyond etcd's 8-GB limit.
@@ -463,7 +465,6 @@ strict: true
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event
 [11]: ../../../api/events/
 [12]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
-[13]: ../../../commercial/
 [14]: https://www.postgresql.org
 [15]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 [16]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.1/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/etcdreplicators.md
@@ -12,8 +12,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the EtcdReplicator datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
@@ -546,7 +548,6 @@ replication_interval_seconds: 30
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/federation/
 [3]: ../../control-access/rbac/
 [4]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/install-sensu.md
@@ -187,8 +187,8 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
 {{% /notice %}}
 
 ### 3. Initialize

--- a/content/sensu-go/6.1/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/scale-event-storage.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu Go's datastore feature enables scaling your monitoring to many thousands of events per second.
 

--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -165,8 +165,10 @@ See [Run a Sensu cluster](../cluster-sensu/) for more information about how to c
 
 ## Optional: Configure Sensu agent mTLS authentication
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access client mutual transport layer security (mTLS) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3].
@@ -246,7 +248,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
-[5]: ../../../commercial/
 [6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
@@ -426,7 +428,6 @@ Learn more about configuring RBAC policies in our [RBAC reference documentation]
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: ../../../sensuctl/create-manage-resources/#update-resources
 [7]: ../../../sensuctl/create-manage-resources/#delete-resources
-[8]: ../../../commercial/
 [10]: ../../control-access/rbac/
 [11]: ../../../api/federation#get-all-clusters
 [12]: https://github.com/etcd-io/etcd/blob/master/etcdctl/README.md#make-mirror-options-destination

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -24,9 +24,9 @@ Sensu Go also includes many powerful [commercial features][27] to make monitorin
 Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
-{{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
-If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
+{{% notice warning %}}
+**WARNING**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core or Sensu Enterprise to Sensu Go:

--- a/content/sensu-go/6.1/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/upgrade.md
@@ -41,8 +41,8 @@ This pause may extend to API request processing, so sensuctl and the web UI may 
 
 ## Upgrade to Sensu Go 6.0 from a 5.x deployment
 
-{{% notice important %}}
-**IMPORTANT**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
+{{% notice warning %}}
+**WARNING**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
 You will not be able to downgrade to a Sensu 5.x version after you upgrade your database to Sensu 6.0 in step 3 of this process.
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets-management.md
@@ -13,8 +13,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][20].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
 In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
@@ -477,7 +479,6 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[20]: ../../../commercial/
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
@@ -310,7 +312,6 @@ provider: vault
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands

--- a/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.1/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -233,8 +233,10 @@ spec:
 
 ## Monitor Postgres
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale Postgres event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Larger Sensu deployments may use [Postgres as an alternative datastore][4] to process larger numbers of events.
 The connection to Postgres is exposed on Sensu's `/health` endpoint and will look like the example below:
@@ -368,5 +370,4 @@ A successful PostgreSQL health check result will look like this:
 [1]: ../../../plugins/use-assets-to-install-plugins/
 [2]: ../../../api/health/
 [3]: https://bonsai.sensu.io/assets/sensu/monitoring-plugins
-[4]: https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/scale-event-storage/
-[5]: ../../../commercial/
+[4]: ../../deploy-sensu/scale-event-storage/

--- a/content/sensu-go/6.1/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/ansible.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Ansible Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The Sensu Ansible Handler plugin is a Sensu [handler][1] that launches Ansible Tower job templates for automated remediation based on Sensu event data.
 
@@ -45,8 +47,7 @@ The [documentation site][8] includes installation instructions, example playbook
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://galaxy.ansible.com/sensu/sensu_go
 [8]: https://sensu.github.io/sensu-go-ansible/
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/elasticsearch.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Elasticsearch Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Elasticsearch Handler plugin][4] is a Sensu [handler][1] that sends observation data from Sensu events and metrics to Elasticsearch.
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
@@ -42,7 +44,6 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/
 [8]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags

--- a/content/sensu-go/6.1/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/jira.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Jira Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Jira Handler plugin][4] is a Sensu [handler][1] that creates and updates Jira issues based on observation data from Sensu events.
 
@@ -37,6 +39,5 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/rundeck.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Rundeck Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Rundeck Handler plugin][4] is a Sensu [handler][1] that initiates Rundeck jobs for automated remediation based on Sensu event data.
 
@@ -42,7 +44,6 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/saltstack.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu SaltStack Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu SaltStack Handler plugin][4] is a Sensu [handler][1] that launches SaltStack functions for automated remediation based on Sensu event data.
 
@@ -39,6 +41,5 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.1/plugins/supported-integrations/servicenow.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu ServiceNow Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu ServiceNow Handler plugin][4] is a Sensu [handler][1] that creates and updates ServiceNow incidents and events based on observation data from Sensu events.
 
@@ -42,8 +44,7 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
 [8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.1/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.1/sensuctl/back-up-recover.md
@@ -333,8 +333,8 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice important %}}
-**IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
+{{% notice note %}}
+**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -469,8 +469,8 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -469,18 +469,18 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-{{% /notice %}}
-
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][30].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
+
+`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.1/sensuctl/filter-responses.md
@@ -11,8 +11,10 @@ menu:
     parent: sensuctl
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensuctl supports response filtering for all [commands using the `list` verb][1].
 For information about response filtering methods and available label and field selectors, see [API response filtering][2].
@@ -118,6 +120,5 @@ sensuctl check list --label-selector 'region == "us-west-1"' --field-selector 's
 [1]: ../create-manage-resources/#subcommands
 [2]: ../../api#response-filtering
 [3]: ../../api#field-selector
-[4]: ../../commercial/
 [5]: ../../api/#operators
 [6]: #examples

--- a/content/sensu-go/6.1/web-ui/_index.md
+++ b/content/sensu-go/6.1/web-ui/_index.md
@@ -12,8 +12,10 @@ menu:
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/web-ui.png" alt="Sensu web UI homepage" link="/images/web-ui.png" target="_blank" >}}
 
@@ -46,5 +48,4 @@ Use the preferences menu to change the theme or switch to the dark theme.
 [3]: ../operations/control-access/rbac/
 [4]: ../operations/control-access/rbac#default-users
 [5]: ../operations/control-access/rbac#create-users
-[6]: ../commercial/
 [7]: ../api/auth/

--- a/content/sensu-go/6.1/web-ui/search.md
+++ b/content/sensu-go/6.1/web-ui/search.md
@@ -66,8 +66,10 @@ If you are using the [basic web UI search functions][5], you can create a search
 
 ## Create advanced searches
 
-**COMMERCIAL FEATURE**: Access advanced search functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access advanced web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensu supports advanced web UI searches using a wider range of attributes, including custom labels.
 You can use the same methods, fields, and examples for web UI searches as for [API response filtering][3], with some [syntax differences][4].
@@ -187,8 +189,10 @@ To return events that include a `windows` check subscription and any email handl
 
 ## Save a search
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 To save a web UI search:
 

--- a/content/sensu-go/6.1/web-ui/searches-reference.md
+++ b/content/sensu-go/6.1/web-ui/searches-reference.md
@@ -13,8 +13,10 @@ menu:
     parent: web-ui
 ---
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
@@ -465,7 +467,6 @@ parameters:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../operations/control-access/rbac/#namespaced-resource-types
 [3]: ../../web-ui/search/#save-a-search
 [4]: ../../api/searches

--- a/content/sensu-go/6.1/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.1/web-ui/view-manage-resources.md
@@ -20,8 +20,10 @@ By default, the web UI displays the `default` namespace.
 
 To switch namespaces, select the menu icon in the upper-left corner and choose a namespace from the dropdown.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, the namespace switcher will list only the namespaces to which the current user has access.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/namespace-switcher-1.png" alt="Sensu web UI namespace switcher" link="/images/namespace-switcher-1.png" target="_blank" >}}
 
@@ -44,11 +46,11 @@ After you create a silence, it will be listed in the web UI Silences page until 
 
 ## Manage checks, handlers, event filters, and mutators
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 Execute checks on demand from individual check pages to test your observability pipeline.
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.1/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.1/web-ui/webconfig-reference.md
@@ -12,8 +12,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -389,7 +391,6 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../../web-ui/
 [4]: #spec-attributes

--- a/content/sensu-go/6.1/web-ui/webconfig.md
+++ b/content/sensu-go/6.1/web-ui/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -90,7 +92,6 @@ In a single-cluster environment, the namespace switcher will only list a local-c
 {{% /notice %}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../
 [4]: ../webconfig-reference/

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -361,8 +361,10 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK`.
 
 ## Response filtering
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access API response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 The Sensu API supports response filtering for all GET endpoints that return an array.
 You can filter resources based on their labels with the `labelSelector` query parameter and based on certain pre-determined fields with the `fieldSelector` query parameter.
@@ -743,7 +745,6 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [5]: health/
 [6]: metrics/
 [7]: ../sensuctl/environment-variables/
-[8]: ../commercial/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
 [11]: auth/#authtoken-post

--- a/content/sensu-go/6.2/api/authproviders.md
+++ b/content/sensu-go/6.2/api/authproviders.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the authentication providers API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -337,5 +339,4 @@ example url               | http://hostname:8080/api/enterprise/authentication/v
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../operations/control-access/
-[2]: ../../commercial/
 [3]: ../#pagination

--- a/content/sensu-go/6.2/api/federation.md
+++ b/content/sensu-go/6.2/api/federation.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the federation API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -510,5 +512,3 @@ description               | Deletes the specified cluster from Sensu.
 example url               | http://hostname:8080/api/enterprise/federation/v1/clusters/us-west-2a
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.2/api/prune.md
+++ b/content/sensu-go/6.2/api/prune.md
@@ -10,8 +10,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.2/api/prune.md
+++ b/content/sensu-go/6.2/api/prune.md
@@ -10,25 +10,22 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: The prune API is an alpha feature and may include breaking changes.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
+The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+
+Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
-
-{{% notice note %}}
-**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.2/api/searches.md
+++ b/content/sensu-go/6.2/api/searches.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the searches API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the searches API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -275,4 +277,3 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 
 
 [1]: ../#response-filtering
-[2]: ../../commercial/

--- a/content/sensu-go/6.2/api/secrets.md
+++ b/content/sensu-go/6.2/api/secrets.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
-**COMMERCIAL FEATURE**: Access secrets management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the secrets API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the secrets API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -459,5 +461,4 @@ example url               | http://hostname:8080/api/enterprise/secrets/v1/names
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 
-[1]: ../../commercial/
 [4]: ../#response-filtering

--- a/content/sensu-go/6.2/api/webconfig.md
+++ b/content/sensu-go/6.2/api/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the web UI configuration API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -285,5 +287,3 @@ description               | Removes the specified global web UI configuration fr
 example url               | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.2/commercial.md
+++ b/content/sensu-go/6.2/commercial.md
@@ -10,8 +10,15 @@ product: "Sensu Go"
 
 Sensu Go offers commercial features designed for monitoring at scale.
 All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
-
 If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
+
+In addition to the [summary][25] on this page, we describe commercial features in detail throughout the documentation.
+Watch for this notice to identify commercial features:
+
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access <feature_name> in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 ## Commercial features in Sensu Go
 
@@ -104,3 +111,4 @@ These resources will help you get started with commercial features in Sensu Go:
 [21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [24]: ../plugins/supported-integrations/
+[25]: #commercial-features-in-sensu-go

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -1425,18 +1425,15 @@ handler: email-handler
 
 ### Processes attributes
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
+
 {{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
-{{% /notice %}}
-
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag][27] in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
-
-{{% notice note %}}
-**NOTE**: The `processes` field is populated in the packaged Sensu Go distributions.
-In OSS builds, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 name         | 
@@ -1616,7 +1613,6 @@ cpu_percent: 0.12639
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
-[27]: ../../observe-schedule/agent/#discover-processes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
 [29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [30]: ../../../web-ui/search/

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -226,8 +226,8 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 If you prefer, you can manage agent entities via the agent rather than the backend.
 To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-{{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
+{{% notice warning %}}
+**WARNING**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
 Upgrade to [Sensu Go 6.2.3](../../../release-notes/#623-release-notes) to use the agent-managed-entity configuration flag.
 {{% /notice %}}
 
@@ -832,8 +832,8 @@ subscriptions:
 
 system       | 
 -------------|------ 
-description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1252,8 +1252,8 @@ example        | {{< language-toggle >}}
 
 processes    | 
 -------------|------ 
-description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1425,8 +1425,8 @@ handler: email-handler
 
 ### Processes attributes
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
@@ -13,7 +13,7 @@ menu:
     parent: observe-filter
 ---
 
-Sensu executes event filters during the **[filter][43]** stage of the [observability pipeline][44].
+Sensu executes event filters during the **[filter][39]** stage of the [observability pipeline][44].
 
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the observation data in events.
@@ -410,8 +410,10 @@ For more information about event attributes, see the [event reference][28].
 
 ## Build event filter expressions with JavaScript execution functions
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access built-in JavaScript event filter execution functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][44].
+For more information, see [Get started with commercial features](../../../commercial).
+{{% /notice %}}
 
 In addition to [Sensu query expressions][27], Sensu includes several built-in JavaScript functions for event filter execution:
 
@@ -1123,7 +1125,8 @@ spec:
 [36]: ../../../api#response-filtering
 [37]: ../../../sensuctl/filter-responses/
 [38]: https://en.wikipedia.org/wiki/Modulo_operation
+[39]: ../
 [41]: ../../../web-ui/search#search-for-labels
 [42]: ../../../web-ui/search/
-[43]: ../
+[43]: ../../../api/events/
 [44]: ../../../observability-pipeline/

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -838,8 +838,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 
 ### Configuration summary
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -930,8 +930,8 @@ See the [example agent configuration file][5] (also provided with Sensu packages
 
 | agent-managed-entity |      |
 -------------|------
-description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.<br>{{% notice important%}}
-**IMPORTANT**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
+description  | Indicates whether the agent's entity solely managed by the agent rather than the backend API. Agent-managed entity definitions will include the label `sensu.io/managed_by: sensu-agent`, and you cannot update these agent-managed entities via the Sensu backend REST API.<br>{{% notice warning %}}
+**WARNING**: In Sensu Go 6.2.1 and 6.2.2, the agent-managed-entity configuration flag can prevent the agent from starting.
 Upgrade to [Sensu Go 6.2.3](../../../release-notes/#623-release-notes) to use the agent-managed-entity configuration flag.
 {{% /notice %}}
 required     | false
@@ -1109,8 +1109,8 @@ disable-assets: true{{< /code >}}
 
 | discover-processes |      |
 --------------|------
-description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -72,8 +72,8 @@ Sensu does not apply a default admin username or password for Ubuntu/Debian or R
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
 {{% /notice %}}
 
 ### Docker initialization

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -1362,8 +1362,10 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Event logging
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access event logging in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][14].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
@@ -1456,7 +1458,6 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [11]: ../../observe-process/handlers/
 [12]: #datastore-and-cluster-configuration-flags
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
-[14]: ../../../commercial/
 [15]: #general-configuration-flags
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml

--- a/content/sensu-go/6.2/operations/control-access/_index.md
+++ b/content/sensu-go/6.2/operations/control-access/_index.md
@@ -40,8 +40,10 @@ Sensu hashes user passwords using the [bcrypt][26] algorithm and records the bas
 
 ### Use an authentication provider
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
 
@@ -131,7 +133,6 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
-[6]: ../../commercial/
 [7]: oidc-auth/
 [8]: ../../api/
 [9]: oidc-auth/#oidc-configuration-examples

--- a/content/sensu-go/6.2/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ad-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/.
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.2/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ldap-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.2/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/oidc-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -119,8 +119,8 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
-{{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+{{% notice warning %}}
+**WARNING**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
 Specify the same `etcd-initial-cluster-token` value for all three backends.
 This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}

--- a/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
@@ -33,8 +33,10 @@ etcd version 3.4.0 is compatible with Sensu but may result in slower performance
 
 ## Scale event storage
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][13].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu supports using an external PostgreSQL instance for event storage in place of etcd.
 PostgreSQL can handle significantly higher volumes of Sensu events, which allows you to scale Sensu beyond etcd's 8-GB limit.
@@ -487,7 +489,6 @@ enable_round_robin: true
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event
 [11]: ../../../api/events/
 [12]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
-[13]: ../../../commercial/
 [14]: https://www.postgresql.org
 [15]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 [16]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.2/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/etcdreplicators.md
@@ -12,8 +12,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the EtcdReplicator datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
@@ -546,7 +548,6 @@ replication_interval_seconds: 30
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/federation/
 [3]: ../../control-access/rbac/
 [4]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/install-sensu.md
@@ -187,8 +187,8 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
 {{% /notice %}}
 
 ### 3. Initialize

--- a/content/sensu-go/6.2/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/scale-event-storage.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu Go's datastore feature enables scaling your monitoring to many thousands of events per second.
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -165,8 +165,10 @@ See [Run a Sensu cluster](../cluster-sensu/) for more information about how to c
 
 ## Optional: Configure Sensu agent mTLS authentication
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access client mutual transport layer security (mTLS) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3].
@@ -246,7 +248,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
-[5]: ../../../commercial/
 [6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
@@ -426,7 +428,6 @@ Learn more about configuring RBAC policies in our [RBAC reference documentation]
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: ../../../sensuctl/create-manage-resources/#update-resources
 [7]: ../../../sensuctl/create-manage-resources/#delete-resources
-[8]: ../../../commercial/
 [10]: ../../control-access/rbac/
 [11]: ../../../api/federation#get-all-clusters
 [12]: https://github.com/etcd-io/etcd/blob/master/etcdctl/README.md#make-mirror-options-destination

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -24,9 +24,9 @@ Sensu Go also includes many powerful [commercial features][27] to make monitorin
 Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
-{{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
-If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
+{{% notice warning %}}
+**WARNING**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core or Sensu Enterprise to Sensu Go:

--- a/content/sensu-go/6.2/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/upgrade.md
@@ -105,8 +105,8 @@ This pause may extend to API request processing, so sensuctl and the web UI may 
 
 ## Upgrade to Sensu Go 6.0 from a 5.x deployment
 
-{{% notice important %}}
-**IMPORTANT**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
+{{% notice warning %}}
+**WARNING**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
 You will not be able to downgrade to a Sensu 5.x version after you upgrade your database to Sensu 6.0 in step 3 of this process.
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-management.md
@@ -13,8 +13,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][20].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
 In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
@@ -477,7 +479,6 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[20]: ../../../commercial/
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
@@ -310,7 +312,6 @@ provider: vault
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands

--- a/content/sensu-go/6.2/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.2/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -233,8 +233,10 @@ spec:
 
 ## Monitor Postgres
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale Postgres event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Larger Sensu deployments may use [Postgres as an alternative datastore][4] to process larger numbers of events.
 The connection to Postgres is exposed on Sensu's `/health` endpoint and will look like the example below:
@@ -368,5 +370,4 @@ A successful PostgreSQL health check result will look like this:
 [1]: ../../../plugins/use-assets-to-install-plugins/
 [2]: ../../../api/health/
 [3]: https://bonsai.sensu.io/assets/sensu/monitoring-plugins
-[4]: https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/scale-event-storage/
-[5]: ../../../commercial/
+[4]: ../../deploy-sensu/scale-event-storage/

--- a/content/sensu-go/6.2/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/ansible.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Ansible Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The Sensu Ansible Handler plugin is a Sensu [handler][1] that launches Ansible Tower job templates for automated remediation based on Sensu event data.
 
@@ -45,8 +47,7 @@ The [documentation site][8] includes installation instructions, example playbook
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://galaxy.ansible.com/sensu/sensu_go
 [8]: https://sensu.github.io/sensu-go-ansible/
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/elasticsearch.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Elasticsearch Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Elasticsearch Handler plugin][4] is a Sensu [handler][1] that sends observation data from Sensu events and metrics to Elasticsearch.
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
@@ -42,7 +44,6 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/
 [8]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags

--- a/content/sensu-go/6.2/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/jira.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Jira Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Jira Handler plugin][4] is a Sensu [handler][1] that creates and updates Jira issues based on observation data from Sensu events.
 
@@ -37,6 +39,5 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/rundeck.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Rundeck Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Rundeck Handler plugin][4] is a Sensu [handler][1] that initiates Rundeck jobs for automated remediation based on Sensu event data.
 
@@ -42,7 +44,6 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/saltstack.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu SaltStack Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu SaltStack Handler plugin][4] is a Sensu [handler][1] that launches SaltStack functions for automated remediation based on Sensu event data.
 
@@ -39,6 +41,5 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.2/plugins/supported-integrations/servicenow.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu ServiceNow Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu ServiceNow Handler plugin][4] is a Sensu [handler][1] that creates and updates ServiceNow incidents and events based on observation data from Sensu events.
 
@@ -42,8 +44,7 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
 [8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.2/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.2/sensuctl/back-up-recover.md
@@ -333,8 +333,8 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice important %}}
-**IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
+{{% notice note %}}
+**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -479,18 +479,18 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-{{% /notice %}}
-
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][30].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
+
+`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -479,8 +479,8 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.2/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.2/sensuctl/filter-responses.md
@@ -11,8 +11,10 @@ menu:
     parent: sensuctl
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensuctl supports response filtering for all [commands using the `list` verb][1].
 For information about response filtering methods and available label and field selectors, see [API response filtering][2].
@@ -118,6 +120,5 @@ sensuctl check list --label-selector 'region == "us-west-1"' --field-selector 's
 [1]: ../create-manage-resources/#subcommands
 [2]: ../../api#response-filtering
 [3]: ../../api#field-selector
-[4]: ../../commercial/
 [5]: ../../api/#operators
 [6]: #examples

--- a/content/sensu-go/6.2/web-ui/_index.md
+++ b/content/sensu-go/6.2/web-ui/_index.md
@@ -12,8 +12,10 @@ menu:
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/web-ui.png" alt="Sensu web UI homepage" link="/images/web-ui.png" target="_blank" >}}
 
@@ -46,5 +48,4 @@ Use the preferences menu to change the theme or switch to the dark theme.
 [3]: ../operations/control-access/rbac/
 [4]: ../operations/control-access/rbac#default-users
 [5]: ../operations/control-access/rbac#create-users
-[6]: ../commercial/
 [7]: ../api/auth/

--- a/content/sensu-go/6.2/web-ui/search.md
+++ b/content/sensu-go/6.2/web-ui/search.md
@@ -66,8 +66,10 @@ If you are using the [basic web UI search functions][5], you can create a search
 
 ## Create advanced searches
 
-**COMMERCIAL FEATURE**: Access advanced search functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access advanced web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensu supports advanced web UI searches using a wider range of attributes, including custom labels.
 You can use the same methods, fields, and examples for web UI searches as for [API response filtering][3], with some [syntax differences][4].
@@ -187,8 +189,10 @@ To return events that include a `windows` check subscription and any email handl
 
 ## Save a search
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 To save a web UI search:
 

--- a/content/sensu-go/6.2/web-ui/searches-reference.md
+++ b/content/sensu-go/6.2/web-ui/searches-reference.md
@@ -13,8 +13,10 @@ menu:
     parent: web-ui
 ---
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
@@ -465,7 +467,6 @@ parameters:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../operations/control-access/rbac/#namespaced-resource-types
 [3]: ../../web-ui/search/#save-a-search
 [4]: ../../api/searches

--- a/content/sensu-go/6.2/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.2/web-ui/view-manage-resources.md
@@ -20,8 +20,10 @@ By default, the web UI displays the `default` namespace.
 
 To switch namespaces, select the menu icon in the upper-left corner and choose a namespace from the dropdown.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, the namespace switcher will list only the namespaces to which the current user has access.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/namespace-switcher-1.png" alt="Sensu web UI namespace switcher" link="/images/namespace-switcher-1.png" target="_blank" >}}
 
@@ -44,11 +46,11 @@ After you create a silence, it will be listed in the web UI Silences page until 
 
 ## Manage checks, handlers, event filters, and mutators
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 Execute checks on demand from individual check pages to test your observability pipeline.
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.2/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.2/web-ui/webconfig-reference.md
@@ -12,8 +12,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -389,7 +391,6 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../../web-ui/
 [4]: #spec-attributes

--- a/content/sensu-go/6.2/web-ui/webconfig.md
+++ b/content/sensu-go/6.2/web-ui/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -90,7 +92,6 @@ In a single-cluster environment, the namespace switcher will only list a local-c
 {{% /notice %}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../
 [4]: ../webconfig-reference/

--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -361,8 +361,10 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK`.
 
 ## Response filtering
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access API response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 The Sensu API supports response filtering for all GET endpoints that return an array.
 You can filter resources based on their labels with the `labelSelector` query parameter and based on certain pre-determined fields with the `fieldSelector` query parameter.
@@ -743,7 +745,6 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [5]: health/
 [6]: metrics/
 [7]: ../sensuctl/environment-variables/
-[8]: ../commercial/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
 [11]: auth/#authtoken-post

--- a/content/sensu-go/6.3/api/authproviders.md
+++ b/content/sensu-go/6.3/api/authproviders.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the authentication providers API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -337,5 +339,4 @@ example url               | http://hostname:8080/api/enterprise/authentication/v
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../operations/control-access/
-[2]: ../../commercial/
 [3]: ../#pagination

--- a/content/sensu-go/6.3/api/business-service-monitoring.md
+++ b/content/sensu-go/6.3/api/business-service-monitoring.md
@@ -17,7 +17,7 @@ For more information, see [Get started with commercial features](../../commercia
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change.
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.
 
 Requests to the business service monitoring API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 

--- a/content/sensu-go/6.3/api/business-service-monitoring.md
+++ b/content/sensu-go/6.3/api/business-service-monitoring.md
@@ -11,8 +11,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/api/business-service-monitoring.md
+++ b/content/sensu-go/6.3/api/business-service-monitoring.md
@@ -11,15 +11,15 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the business service monitoring API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: Business service monitoring is in public preview and is subject to change.
+
+Requests to the business service monitoring API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
@@ -1027,5 +1027,3 @@ description               | Deletes the specified rule template from Sensu.
 example url               | http://hostname:8080/api/enterprise/bsm/v1/rule-templates/status-threshold
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.3/api/federation.md
+++ b/content/sensu-go/6.3/api/federation.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the federation API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -510,5 +512,3 @@ description               | Deletes the specified cluster from Sensu.
 example url               | http://hostname:8080/api/enterprise/federation/v1/clusters/us-west-2a
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.3/api/prune.md
+++ b/content/sensu-go/6.3/api/prune.md
@@ -10,8 +10,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/api/prune.md
+++ b/content/sensu-go/6.3/api/prune.md
@@ -10,25 +10,22 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: The prune API is an alpha feature and may include breaking changes.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
+The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+
+Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
-
-{{% notice note %}}
-**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.3/api/searches.md
+++ b/content/sensu-go/6.3/api/searches.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the searches API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the searches API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -275,4 +277,3 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 
 
 [1]: ../#response-filtering
-[2]: ../../commercial/

--- a/content/sensu-go/6.3/api/secrets.md
+++ b/content/sensu-go/6.3/api/secrets.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
-**COMMERCIAL FEATURE**: Access secrets management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the secrets API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the secrets API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -459,5 +461,4 @@ example url               | http://hostname:8080/api/enterprise/secrets/v1/names
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 
-[1]: ../../commercial/
 [4]: ../#response-filtering

--- a/content/sensu-go/6.3/api/webconfig.md
+++ b/content/sensu-go/6.3/api/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the web UI configuration API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -285,5 +287,3 @@ description               | Removes the specified global web UI configuration fr
 example url               | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.3/commercial.md
+++ b/content/sensu-go/6.3/commercial.md
@@ -13,6 +13,13 @@ All commercial features are available in the official Sensu Go distribution, and
 
 If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
 
+Throughout the documentation, the following notice marks commercial features:
+
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access <feature_name> in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
+
 ## Commercial features in Sensu Go
 
 - **Integrate your Sensu observability pipeline with industry-standard tools** like ServiceNow and Jira with [supported integrations][24] and [enterprise-tier dynamic runtime assets][11].

--- a/content/sensu-go/6.3/commercial.md
+++ b/content/sensu-go/6.3/commercial.md
@@ -10,10 +10,10 @@ product: "Sensu Go"
 
 Sensu Go offers commercial features designed for monitoring at scale.
 All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
-
 If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
 
-Throughout the documentation, the following notice marks commercial features:
+In addition to the [summary][25] on this page, we describe commercial features in detail throughout the documentation.
+Watch for this notice to identify commercial features:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access <feature_name> in the packaged Sensu Go distribution.
@@ -114,3 +114,4 @@ These resources will help you get started with commercial features in Sensu Go:
 [22]: ../operations/manage-secrets/secrets-management/
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/supported-integrations/
+[25]: #commercial-features-in-sensu-go

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
@@ -179,12 +179,17 @@ See [Monitor external resources][1] to learn how to use a proxy entity to monito
 
 ## Service entities
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service entities, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
+
 A service entity represents a business service in [business service monitoring (BSM)][8].
 Sensu processes service entity events just like events generated for agent and proxy entities.
 You can also use service entities for proxy check requests and events.
 
 {{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
 {{% /notice %}}
 
 This example shows a service entity resource definition:

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
@@ -183,8 +183,8 @@ A service entity represents a business service in [business service monitoring (
 Sensu processes service entity events just like events generated for agent and proxy entities.
 You can also use service entities for proxy check requests and events.
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 This example shows a service entity resource definition:

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -322,11 +322,11 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
-You can create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
 
 ### Service entity example
 
@@ -954,8 +954,8 @@ subscriptions:
 
 system       | 
 -------------|------ 
-description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1374,8 +1374,8 @@ example        | {{< language-toggle >}}
 
 processes    | 
 -------------|------ 
-description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1547,8 +1547,8 @@ handler: email-handler
 
 ### Processes attributes
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -1547,18 +1547,15 @@ handler: email-handler
 
 ### Processes attributes
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
+
 {{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
-{{% /notice %}}
-
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag][27] in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
-
-{{% notice note %}}
-**NOTE**: The `processes` field is populated in the packaged Sensu Go distributions.
-In OSS builds, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 name         | 
@@ -1738,7 +1735,6 @@ cpu_percent: 0.12639
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
-[27]: ../../observe-schedule/agent/#discover-processes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
 [29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [30]: ../../../web-ui/search/

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -319,11 +319,16 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 
 ## Create and manage service entities
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service entities, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
+
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
 {{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
 {{% /notice %}}
 
 Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -13,7 +13,7 @@ menu:
     parent: observe-filter
 ---
 
-Sensu executes event filters during the **[filter][43]** stage of the [observability pipeline][44].
+Sensu executes event filters during the **[filter][39]** stage of the [observability pipeline][44].
 
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the observation data in events.
@@ -410,8 +410,10 @@ For more information about event attributes, see the [event reference][28].
 
 ## Build event filter expressions with JavaScript execution functions
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access built-in JavaScript event filter execution functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][44].
+For more information, see [Get started with commercial features](../../../commercial).
+{{% /notice %}}
 
 In addition to [Sensu query expressions][27], Sensu includes several built-in JavaScript functions for event filter execution:
 
@@ -1123,7 +1125,8 @@ spec:
 [36]: ../../../api#response-filtering
 [37]: ../../../sensuctl/filter-responses/
 [38]: https://en.wikipedia.org/wiki/Modulo_operation
+[39]: ../
 [41]: ../../../web-ui/search#search-for-labels
 [42]: ../../../web-ui/search/
-[43]: ../
+[43]: ../../../api/events/
 [44]: ../../../observability-pipeline/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -838,8 +838,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 
 ### Configuration summary
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -1106,8 +1106,8 @@ disable-assets: true{{< /code >}}
 
 | discover-processes |      |
 --------------|------
-description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1390,8 +1390,10 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Event logging
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access event logging in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][14].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
@@ -1484,7 +1486,6 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [11]: ../../observe-process/handlers/
 [12]: #datastore-and-cluster-configuration-flags
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
-[14]: ../../../commercial/
 [15]: #general-configuration-flags
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -72,8 +72,8 @@ Sensu does not apply a default admin username or password for Ubuntu/Debian or R
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
 {{% /notice %}}
 
 ### Docker initialization

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -11,12 +11,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Sensu's business service monitoring (BSM) feature uses a dedicated SDK of JavaScript-based expressions that provide additional functionality.
 Use the BSM SDK to create custom JavaScript expressions with complex logic.
@@ -130,4 +132,3 @@ if (sensu.Percentage("critical") >= 35) {
 [1]: https://github.com/robertkrimen/otto
 [2]: ../backend/#event-logging
 [3]: ../rule-templates/
-[4]: ../../../commercial/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -11,8 +11,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -11,8 +11,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
@@ -20,11 +20,6 @@ For more information, see [Get started with commercial features][6].
 
 Sensu's business service monitoring (BSM) provides high-level visibility into the current health of any number of your business services.
 Use BSM to monitor every component in your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
-
-{{% notice note %}}
-**NOTE**: BSM requires high event throughput.
-Configure a [PostgreSQL datastore](../../../operations/deploy-sensu/scale-event-storage/) to achieve the required throughput and use the BSM feature.
-{{% /notice %}}
 
 BSM requires two resources that work together to achieve top-down monitoring: [service components][1] and [rule templates][2].
 Service components are the elements that make up your business services.
@@ -44,6 +39,11 @@ BSM allows you to customize rule templates that apply a threshold for taking act
 
 To continue the company website example, if the primary webserver fails but the backup webserver does not, you might use a rule template that creates a service ticket to address the next workday (in addition to the rule template that is emitting "OK" events for the current status page).
 Another monitoring rule might trigger an alert to the on-call operator should both webservers or the inventory database fail.
+
+{{% notice note %}}
+**NOTE**: BSM requires high event throughput.
+Configure a [PostgreSQL datastore](../../../operations/deploy-sensu/scale-event-storage/) to achieve the required throughput and use the BSM feature.
+{{% /notice %}}
 
 ## Service component example
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -11,12 +11,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Sensu's business service monitoring (BSM) provides high-level visibility into the current health of any number of your business services.
 Use BSM to monitor every component in your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
@@ -227,4 +229,3 @@ You can also use [sensuctl][5] to create and manage service components and rule 
 [3]: ../../../web-ui/bsm-module/
 [4]: #service-component-example
 [5]: ../../../sensuctl/
-[6]: ../../../commercial/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -12,8 +12,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM), including rule templates, in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -12,12 +12,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including rule templates, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including rule templates, in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Rule templates are the resources that Sensu applies to [service components][3] for business service monitoring.
 A rule template applies to selections of events defined by a service component's query.
@@ -644,7 +646,6 @@ properties:
 [1]: https://json-schema.org/
 [2]: #rule-properties
 [3]: ../service-components/
-[4]: ../../../commercial/
 [5]: #spec-attributes
 [6]: ../../../operations/control-access/namespaces
 [7]: #arguments-attributes

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
@@ -12,8 +12,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service components, in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
@@ -12,12 +12,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service components, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service components, in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Service components are resources for defining and managing elements of a business service in business service monitoring.
 A [service entity][10] consists of a number of underlying service components.

--- a/content/sensu-go/6.3/operations/control-access/_index.md
+++ b/content/sensu-go/6.3/operations/control-access/_index.md
@@ -40,8 +40,10 @@ Sensu hashes user passwords using the [bcrypt][26] algorithm and records the bas
 
 ### Use an authentication provider
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
 
@@ -131,7 +133,6 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
-[6]: ../../commercial/
 [7]: oidc-auth/
 [8]: ../../api/
 [9]: oidc-auth/#oidc-configuration-examples

--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/.
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.3/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ldap-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.3/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/oidc-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -119,8 +119,8 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
-{{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+{{% notice warning %}}
+**WARNING**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
 Specify the same `etcd-initial-cluster-token` value for all three backends.
 This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -33,8 +33,10 @@ etcd version 3.4.0 is compatible with Sensu but may result in slower performance
 
 ## Scale event storage
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][13].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu supports using an external PostgreSQL instance for event storage in place of etcd.
 PostgreSQL can handle significantly higher volumes of Sensu events, which allows you to scale Sensu beyond etcd's 8-GB limit.
@@ -487,7 +489,6 @@ enable_round_robin: true
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event
 [11]: ../../../api/events/
 [12]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
-[13]: ../../../commercial/
 [14]: https://www.postgresql.org
 [15]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 [16]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
@@ -12,8 +12,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the EtcdReplicator datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
@@ -546,7 +548,6 @@ replication_interval_seconds: 30
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/federation/
 [3]: ../../control-access/rbac/
 [4]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
@@ -187,8 +187,8 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
 {{% /notice %}}
 
 ### 3. Initialize

--- a/content/sensu-go/6.3/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/scale-event-storage.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu Go's datastore feature enables scaling your monitoring to many thousands of events per second.
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -165,8 +165,10 @@ See [Run a Sensu cluster](../cluster-sensu/) for more information about how to c
 
 ## Optional: Configure Sensu agent mTLS authentication
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access client mutual transport layer security (mTLS) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3].
@@ -246,7 +248,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
-[5]: ../../../commercial/
 [6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
@@ -426,7 +428,6 @@ Learn more about configuring RBAC policies in our [RBAC reference documentation]
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: ../../../sensuctl/create-manage-resources/#update-resources
 [7]: ../../../sensuctl/create-manage-resources/#delete-resources
-[8]: ../../../commercial/
 [10]: ../../control-access/rbac/
 [11]: ../../../api/federation#get-all-clusters
 [12]: https://github.com/etcd-io/etcd/blob/master/etcdctl/README.md#make-mirror-options-destination

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -24,9 +24,9 @@ Sensu Go also includes many powerful [commercial features][27] to make monitorin
 Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
-{{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
-If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
+{{% notice warning %}}
+**WARNING**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core or Sensu Enterprise to Sensu Go:

--- a/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
@@ -125,8 +125,8 @@ This pause may extend to API request processing, so sensuctl and the web UI may 
 
 ## Upgrade to Sensu Go 6.0 from a 5.x deployment
 
-{{% notice important %}}
-**IMPORTANT**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
+{{% notice warning %}}
+**WARNING**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
 You will not be able to downgrade to a Sensu 5.x version after you upgrade your database to Sensu 6.0 in step 3 of this process.
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
@@ -13,8 +13,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][20].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
 In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
@@ -477,7 +479,6 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[20]: ../../../commercial/
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
@@ -310,7 +312,6 @@ provider: vault
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands

--- a/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -233,8 +233,10 @@ spec:
 
 ## Monitor Postgres
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale Postgres event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Larger Sensu deployments may use [Postgres as an alternative datastore][4] to process larger numbers of events.
 The connection to Postgres is exposed on Sensu's `/health` endpoint and will look like the example below:
@@ -368,5 +370,4 @@ A successful PostgreSQL health check result will look like this:
 [1]: ../../../plugins/use-assets-to-install-plugins/
 [2]: ../../../api/health/
 [3]: https://bonsai.sensu.io/assets/sensu/monitoring-plugins
-[4]: https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/scale-event-storage/
-[5]: ../../../commercial/
+[4]: ../../deploy-sensu/scale-event-storage/

--- a/content/sensu-go/6.3/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/ansible.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Ansible Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The Sensu Ansible Handler plugin is a Sensu [handler][1] that launches Ansible Tower job templates for automated remediation based on Sensu event data.
 
@@ -45,8 +47,7 @@ The [documentation site][8] includes installation instructions, example playbook
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://galaxy.ansible.com/sensu/sensu_go
 [8]: https://sensu.github.io/sensu-go-ansible/
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/elasticsearch.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Elasticsearch Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Elasticsearch Handler plugin][4] is a Sensu [handler][1] that sends observation data from Sensu events and metrics to Elasticsearch.
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
@@ -42,7 +44,6 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/
 [8]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags

--- a/content/sensu-go/6.3/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/jira.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Jira Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Jira Handler plugin][4] is a Sensu [handler][1] that creates and updates Jira issues based on observation data from Sensu events.
 
@@ -37,6 +39,5 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/rundeck.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Rundeck Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Rundeck Handler plugin][4] is a Sensu [handler][1] that initiates Rundeck jobs for automated remediation based on Sensu event data.
 
@@ -42,7 +44,6 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/saltstack.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu SaltStack Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu SaltStack Handler plugin][4] is a Sensu [handler][1] that launches SaltStack functions for automated remediation based on Sensu event data.
 
@@ -39,6 +41,5 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/servicenow.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu ServiceNow Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu ServiceNow Handler plugin][4] is a Sensu [handler][1] that creates and updates ServiceNow incidents and events based on observation data from Sensu events.
 
@@ -42,8 +44,7 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
 [8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -333,8 +333,8 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice important %}}
-**IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
+{{% notice note %}}
+**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -479,18 +479,18 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-{{% /notice %}}
-
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][30].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
+
+`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -479,8 +479,8 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.3/sensuctl/filter-responses.md
@@ -11,8 +11,10 @@ menu:
     parent: sensuctl
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensuctl supports response filtering for all [commands using the `list` verb][1].
 For information about response filtering methods and available label and field selectors, see [API response filtering][2].
@@ -118,6 +120,5 @@ sensuctl check list --label-selector 'region == "us-west-1"' --field-selector 's
 [1]: ../create-manage-resources/#subcommands
 [2]: ../../api#response-filtering
 [3]: ../../api#field-selector
-[4]: ../../commercial/
 [5]: ../../api/#operators
 [6]: #examples

--- a/content/sensu-go/6.3/web-ui/_index.md
+++ b/content/sensu-go/6.3/web-ui/_index.md
@@ -12,8 +12,10 @@ menu:
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/web-ui.png" alt="Sensu web UI homepage" link="/images/web-ui.png" target="_blank" >}}
 
@@ -46,5 +48,4 @@ Use the preferences menu to change the theme or switch to the dark theme.
 [3]: ../operations/control-access/rbac/
 [4]: ../operations/control-access/rbac#default-users
 [5]: ../operations/control-access/rbac#create-users
-[6]: ../commercial/
 [7]: ../api/auth/

--- a/content/sensu-go/6.3/web-ui/bsm-module.md
+++ b/content/sensu-go/6.3/web-ui/bsm-module.md
@@ -11,12 +11,14 @@ menu:
     parent: web-ui
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 The Sensu web UI includes a module to help you build and configure business service monitoring (BSM) [service entities][4] with [service components][1] and [rule templates][2].
 
@@ -58,5 +60,4 @@ You can also edit, silence, and delete the component from the detail page.
 
 [1]: ../../observability-pipeline/observe-schedule/service-components/
 [2]: ../../observability-pipeline/observe-schedule/rule-templates/
-[3]: ../../commercial/
 [4]: ../../observability-pipeline/observe-entities/#service-entities

--- a/content/sensu-go/6.3/web-ui/bsm-module.md
+++ b/content/sensu-go/6.3/web-ui/bsm-module.md
@@ -11,8 +11,8 @@ menu:
     parent: web-ui
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.3/web-ui/search.md
+++ b/content/sensu-go/6.3/web-ui/search.md
@@ -66,8 +66,10 @@ If you are using the [basic web UI search functions][5], you can create a search
 
 ## Create advanced searches
 
-**COMMERCIAL FEATURE**: Access advanced search functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access advanced web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensu supports advanced web UI searches using a wider range of attributes, including custom labels.
 You can use the same methods, fields, and examples for web UI searches as for [API response filtering][3], with some [syntax differences][4].
@@ -187,8 +189,10 @@ To return events that include a `windows` check subscription and any email handl
 
 ## Save a search
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 To save a web UI search:
 

--- a/content/sensu-go/6.3/web-ui/searches-reference.md
+++ b/content/sensu-go/6.3/web-ui/searches-reference.md
@@ -13,8 +13,10 @@ menu:
     parent: web-ui
 ---
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
@@ -465,7 +467,6 @@ parameters:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../operations/control-access/rbac/#namespaced-resource-types
 [3]: ../../web-ui/search/#save-a-search
 [4]: ../../api/searches

--- a/content/sensu-go/6.3/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.3/web-ui/view-manage-resources.md
@@ -20,8 +20,10 @@ By default, the web UI displays the `default` namespace.
 
 To switch namespaces, select the menu icon in the upper-left corner and choose a namespace from the dropdown.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, the namespace switcher will list only the namespaces to which the current user has access.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/namespace-switcher-1.png" alt="Sensu web UI namespace switcher" link="/images/namespace-switcher-1.png" target="_blank" >}}
 
@@ -44,11 +46,11 @@ After you create a silence, it will be listed in the web UI Silences page until 
 
 ## Manage checks, handlers, event filters, and mutators
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 Execute checks on demand from individual check pages to test your observability pipeline.
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.3/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.3/web-ui/webconfig-reference.md
@@ -12,8 +12,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -389,7 +391,6 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../../web-ui/
 [4]: #spec-attributes

--- a/content/sensu-go/6.3/web-ui/webconfig.md
+++ b/content/sensu-go/6.3/web-ui/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -90,7 +92,6 @@ In a single-cluster environment, the namespace switcher will only list a local-c
 {{% /notice %}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../
 [4]: ../webconfig-reference/

--- a/content/sensu-go/6.4/api/_index.md
+++ b/content/sensu-go/6.4/api/_index.md
@@ -361,8 +361,10 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK`.
 
 ## Response filtering
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access API response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 The Sensu API supports response filtering for all GET endpoints that return an array.
 You can filter resources based on their labels with the `labelSelector` query parameter and based on certain pre-determined fields with the `fieldSelector` query parameter.
@@ -743,7 +745,6 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/cor
 [5]: health/
 [6]: metrics/
 [7]: ../sensuctl/environment-variables/
-[8]: ../commercial/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
 [11]: auth/#authtoken-post

--- a/content/sensu-go/6.4/api/authproviders.md
+++ b/content/sensu-go/6.4/api/authproviders.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the authentication providers API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -337,5 +339,4 @@ example url               | http://hostname:8080/api/enterprise/authentication/v
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 [1]: ../../operations/control-access/
-[2]: ../../commercial/
 [3]: ../#pagination

--- a/content/sensu-go/6.4/api/business-service-monitoring.md
+++ b/content/sensu-go/6.4/api/business-service-monitoring.md
@@ -17,7 +17,7 @@ For more information, see [Get started with commercial features](../../commercia
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change.
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.
 
 Requests to the business service monitoring API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 

--- a/content/sensu-go/6.4/api/business-service-monitoring.md
+++ b/content/sensu-go/6.4/api/business-service-monitoring.md
@@ -11,8 +11,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/api/business-service-monitoring.md
+++ b/content/sensu-go/6.4/api/business-service-monitoring.md
@@ -11,15 +11,15 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the business service monitoring API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: Business service monitoring is in public preview and is subject to change.
+
+Requests to the business service monitoring API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
@@ -1027,5 +1027,3 @@ description               | Deletes the specified rule template from Sensu.
 example url               | http://hostname:8080/api/enterprise/bsm/v1/rule-templates/status-threshold
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.4/api/federation.md
+++ b/content/sensu-go/6.4/api/federation.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the federation API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -510,5 +512,3 @@ description               | Deletes the specified cluster from Sensu.
 example url               | http://hostname:8080/api/enterprise/federation/v1/clusters/us-west-2a
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.4/api/prune.md
+++ b/content/sensu-go/6.4/api/prune.md
@@ -10,8 +10,8 @@ menu:
     parent: api
 ---
 
-{{% notice important %}}
-**IMPORTANT**: The prune API is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/api/prune.md
+++ b/content/sensu-go/6.4/api/prune.md
@@ -10,25 +10,22 @@ menu:
     parent: api
 ---
 
-{{% notice note %}}
-**NOTE**: The prune API is an alpha feature and may include breaking changes.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access the prune API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
-
 {{% notice note %}}
-**NOTE**: Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
+**NOTE**: The prune API is an alpha feature and may include breaking changes.
+The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+
+Requests to the prune API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
 The code examples in this document use the [environment variable](../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests. 
 {{% /notice %}}
 
 ## Create a new pruning command
 
 The `/prune/v1alpha` API endpoint provides HTTP POST access to create a pruning command to delete resources that are not specified in the request body.
-
-{{% notice note %}}
-**NOTE**: The prune API requires [cluster-level privileges](../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-{{% /notice %}}
 
 ### Example {#prune-v1alpha-post-example}
 

--- a/content/sensu-go/6.4/api/searches.md
+++ b/content/sensu-go/6.4/api/searches.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the searches API in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][2].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the searches API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -275,4 +277,3 @@ response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Miss
 
 
 [1]: ../#response-filtering
-[2]: ../../commercial/

--- a/content/sensu-go/6.4/api/secrets.md
+++ b/content/sensu-go/6.4/api/secrets.md
@@ -10,8 +10,10 @@ menu:
     parent: api
 ---
 
-**COMMERCIAL FEATURE**: Access secrets management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the secrets API in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the secrets API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -459,5 +461,4 @@ example url               | http://hostname:8080/api/enterprise/secrets/v1/names
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
 
-[1]: ../../commercial/
 [4]: ../#response-filtering

--- a/content/sensu-go/6.4/api/webconfig.md
+++ b/content/sensu-go/6.4/api/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: api
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: Requests to the web UI configuration API require you to authenticate with a Sensu [access token](../#authenticate-with-the-authentication-api) or [API key](../#authenticate-with-an-api-key).
@@ -285,5 +287,3 @@ description               | Removes the specified global web UI configuration fr
 example url               | http://hostname:8080/api/enterprise/web/v1/config/custom-web-ui
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.4/commercial.md
+++ b/content/sensu-go/6.4/commercial.md
@@ -10,8 +10,15 @@ product: "Sensu Go"
 
 Sensu Go offers commercial features designed for monitoring at scale.
 All commercial features are available in the official Sensu Go distribution, and you can use them for free [up to an entity limit of 100][7].
-
 If you have more than 100 entities, [contact the Sensu sales team][1] for a free trial.
+
+In addition to the [summary][25] on this page, we describe commercial features in detail throughout the documentation.
+Watch for this notice to identify commercial features:
+
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access <feature_name> in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 ## Commercial features in Sensu Go
 
@@ -107,3 +114,5 @@ These resources will help you get started with commercial features in Sensu Go:
 [22]: ../operations/manage-secrets/secrets-management/
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/supported-integrations/
+[25]: #commercial-features-in-sensu-go
+[25]: #commercial-features-in-sensu-go

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
@@ -179,12 +179,17 @@ See [Monitor external resources][1] to learn how to use a proxy entity to monito
 
 ## Service entities
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service entities, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
+
 A service entity represents a business service in [business service monitoring (BSM)][8].
 Sensu processes service entity events just like events generated for agent and proxy entities.
 You can also use service entities for proxy check requests and events.
 
 {{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
 {{% /notice %}}
 
 This example shows a service entity resource definition:

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
@@ -183,8 +183,8 @@ A service entity represents a business service in [business service monitoring (
 Sensu processes service entity events just like events generated for agent and proxy entities.
 You can also use service entities for proxy check requests and events.
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 This example shows a service entity resource definition:

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -322,11 +322,11 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
-You can create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
 
 ### Service entity example
 
@@ -954,8 +954,8 @@ subscriptions:
 
 system       | 
 -------------|------ 
-description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | System information about the entity, such as operating system and platform. See [system attributes][1] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false
 type         | Map
@@ -1374,8 +1374,8 @@ example        | {{< language-toggle >}}
 
 processes    | 
 -------------|------ 
-description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description  | List of processes on the local agent. See [processes attributes][26] for more information.{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. New events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 required     | false 
 type         | Map
@@ -1547,8 +1547,8 @@ handler: email-handler
 
 ### Processes attributes
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -1547,18 +1547,15 @@ handler: email-handler
 
 ### Processes attributes
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
+
 {{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu.
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
-{{% /notice %}}
-
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag][27] in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
-
-{{% notice note %}}
-**NOTE**: The `processes` field is populated in the packaged Sensu Go distributions.
-In OSS builds, the field will be empty: `"processes": null`.
 {{% /notice %}}
 
 name         | 
@@ -1738,7 +1735,6 @@ cpu_percent: 0.12639
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
-[27]: ../../observe-schedule/agent/#discover-processes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
 [29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
 [30]: ../../../web-ui/search/

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -319,11 +319,16 @@ Use [proxy entity filters][19] to establish a many-to-many relationship between 
 
 ## Create and manage service entities
 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service entities, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
+
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
 {{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
 {{% /notice %}}
 
 Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -13,7 +13,7 @@ menu:
     parent: observe-filter
 ---
 
-Sensu executes event filters during the **[filter][43]** stage of the [observability pipeline][44].
+Sensu executes event filters during the **[filter][45]** stage of the [observability pipeline][44].
 
 Sensu event filters are applied when you configure event handlers to use one or more filters.
 Before executing a handler, the Sensu backend will apply any event filters configured for the handler to the observation data in events.
@@ -410,8 +410,10 @@ For more information about event attributes, see the [event reference][28].
 
 ## Build event filter expressions with JavaScript execution functions
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access built-in JavaScript event filter execution functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][44].
+For more information, see [Get started with commercial features](../../../commercial).
+{{% /notice %}}
 
 In addition to [Sensu query expressions][27], Sensu includes several built-in JavaScript functions for event filter execution:
 
@@ -1217,5 +1219,6 @@ spec:
 [40]: ../sensu-query-expressions/#second
 [41]: ../../../web-ui/search#search-for-labels
 [42]: ../../../web-ui/search/
-[43]: ../
+[43]: ../../../api/events/
 [44]: ../../../observability-pipeline/
+[45]: ../

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -838,8 +838,8 @@ You must present the whole chain to the remote so it can determine whether it tr
 
 ### Configuration summary
 
-{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu.
+{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu.
 The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -1106,8 +1106,8 @@ disable-assets: true{{< /code >}}
 
 | discover-processes |      |
 --------------|------
-description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice important %}}
-**IMPORTANT**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
+description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.<br><br>**COMMERCIAL FEATURE**: Access the `discover-processes` flag in the packaged Sensu Go distribution. For more information, see [Get started with commercial features][55].{{% notice note %}}
+**NOTE**: Process discovery is disabled in this version of Sensu. The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
 type          | Boolean
 default       | false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -72,8 +72,8 @@ Sensu does not apply a default admin username or password for Ubuntu/Debian or R
 This step bootstraps the first admin user account for your Sensu installation.
 This account will be granted the cluster admin role.
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../../../operations/deploy-sensu/cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you initialize.
 {{% /notice %}}
 
 ### Docker initialization

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1404,8 +1404,10 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Event logging
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access event logging in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][14].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 If you wish, you can log all Sensu events to a file in JSON format.
 You can use this file as an input source for your favorite data lake solution.
@@ -1498,7 +1500,6 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [11]: ../../observe-process/handlers/
 [12]: #datastore-and-cluster-configuration-flags
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
-[14]: ../../../commercial/
 [15]: #general-configuration-flags
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -11,12 +11,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Sensu's business service monitoring (BSM) feature uses a dedicated SDK of JavaScript-based expressions that provide additional functionality.
 Use the BSM SDK to create custom JavaScript expressions with complex logic.
@@ -130,4 +132,3 @@ if (sensu.Percentage("critical") >= 35) {
 [1]: https://github.com/robertkrimen/otto
 [2]: ../backend/#event-logging
 [3]: ../rule-templates/
-[4]: ../../../commercial/

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -11,8 +11,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -11,8 +11,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
@@ -20,11 +20,6 @@ For more information, see [Get started with commercial features][6].
 
 Sensu's business service monitoring (BSM) provides high-level visibility into the current health of any number of your business services.
 Use BSM to monitor every component in your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
-
-{{% notice note %}}
-**NOTE**: BSM requires high event throughput.
-Configure a [PostgreSQL datastore](../../../operations/deploy-sensu/scale-event-storage/) to achieve the required throughput and use the BSM feature.
-{{% /notice %}}
 
 BSM requires two resources that work together to achieve top-down monitoring: [service components][1] and [rule templates][2].
 Service components are the elements that make up your business services.
@@ -44,6 +39,11 @@ BSM allows you to customize rule templates that apply a threshold for taking act
 
 To continue the company website example, if the primary webserver fails but the backup webserver does not, you might use a rule template that creates a service ticket to address the next workday (in addition to the rule template that is emitting "OK" events for the current status page).
 Another monitoring rule might trigger an alert to the on-call operator should both webservers or the inventory database fail.
+
+{{% notice note %}}
+**NOTE**: BSM requires high event throughput.
+Configure a [PostgreSQL datastore](../../../operations/deploy-sensu/scale-event-storage/) to achieve the required throughput and use the BSM feature.
+{{% /notice %}}
 
 ## Service component example
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -11,12 +11,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Sensu's business service monitoring (BSM) provides high-level visibility into the current health of any number of your business services.
 Use BSM to monitor every component in your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
@@ -227,4 +229,3 @@ You can also use [sensuctl][5] to create and manage service components and rule 
 [3]: ../../../web-ui/bsm-module/
 [4]: #service-component-example
 [5]: ../../../sensuctl/
-[6]: ../../../commercial/

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -12,8 +12,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM), including rule templates, in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -12,12 +12,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including rule templates, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including rule templates, in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Rule templates are the resources that Sensu applies to [service components][3] for business service monitoring.
 A rule template applies to selections of events defined by a service component's query.
@@ -644,7 +646,6 @@ properties:
 [1]: https://json-schema.org/
 [2]: #rule-properties
 [3]: ../service-components/
-[4]: ../../../commercial/
 [5]: #spec-attributes
 [6]: ../../../operations/control-access/namespaces
 [7]: #arguments-attributes

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -12,8 +12,8 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service components, in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -12,12 +12,14 @@ menu:
     parent: observe-schedule
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service components, in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM), including service components, in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][9].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 Service components are resources for defining and managing elements of a business service in business service monitoring.
 A [service entity][10] consists of a number of underlying service components.

--- a/content/sensu-go/6.4/operations/control-access/_index.md
+++ b/content/sensu-go/6.4/operations/control-access/_index.md
@@ -40,8 +40,10 @@ Sensu hashes user passwords using the [bcrypt][26] algorithm and records the bas
 
 ### Use an authentication provider
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
 
@@ -131,7 +133,6 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
-[6]: ../../commercial/
 [7]: oidc-auth/
 [8]: ../../api/
 [9]: oidc-auth/#oidc-configuration-examples

--- a/content/sensu-go/6.4/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ad-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/.
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.4/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ldap-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.4/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/oidc-auth.md
@@ -10,8 +10,10 @@ menu:
     parent: control-access
 ---
 
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -119,8 +119,8 @@ etcd-initial-cluster-token: "unique_token_for_this_cluster"
 etcd-name: "backend-3"
 {{< /code >}}
 
-{{% notice important %}}
-**IMPORTANT**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
+{{% notice warning %}}
+**WARNING**: To properly secure etcd communication, replace the default URLs for `etcd-advertise-client-urls`, `etcd-listen-client-urls`, `etcd-listen-peer-urls`, and `etcd-initial-cluster` in the store configurations for your backends with non-default values.<br><br>
 Specify the same `etcd-initial-cluster-token` value for all three backends.
 This allows etcd to generate unique cluster IDs and member IDs even for clusters that have otherwise identical configurations and prevents cross-cluster-interaction.
 {{% /notice %}}

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -33,8 +33,10 @@ etcd version 3.4.0 is compatible with Sensu but may result in slower performance
 
 ## Scale event storage
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][13].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu supports using an external PostgreSQL instance for event storage in place of etcd.
 PostgreSQL can handle significantly higher volumes of Sensu events, which allows you to scale Sensu beyond etcd's 8-GB limit.
@@ -487,7 +489,6 @@ enable_round_robin: true
 [10]: ../../../sensuctl/create-manage-resources/#sensuctl-event
 [11]: ../../../api/events/
 [12]: ../../../observability-pipeline/observe-process/populate-metrics-influxdb/
-[13]: ../../../commercial/
 [14]: https://www.postgresql.org
 [15]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 [16]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.4/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/etcdreplicators.md
@@ -12,8 +12,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the EtcdReplicator datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 {{% notice note %}}
 **NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
@@ -546,7 +548,6 @@ replication_interval_seconds: 30
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/federation/
 [3]: ../../control-access/rbac/
 [4]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
@@ -187,8 +187,8 @@ service sensu-backend status
 
 For a complete list of configuration options, see the [backend reference][6].
 
-{{% notice important %}}
-**IMPORTANT**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
+{{% notice warning %}}
+**WARNING**: If you plan to [run a Sensu cluster](../cluster-sensu/), make sure that each of your backend nodes is configured, running, and a member of the cluster before you continue the installation process.
 {{% /notice %}}
 
 ### 3. Initialize

--- a/content/sensu-go/6.4/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/scale-event-storage.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the datastore feature in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu Go's datastore feature enables scaling your monitoring to many thousands of events per second.
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
@@ -165,8 +165,10 @@ See [Run a Sensu cluster](../cluster-sensu/) for more information about how to c
 
 ## Optional: Configure Sensu agent mTLS authentication
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access client mutual transport layer security (mTLS) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 By default, Sensu agents require username and password authentication to communicate with Sensu backends.
 For Sensu's [default user credentials][2] and details about configuring Sensu role-based access control (RBAC), see the [RBAC reference][3].
@@ -246,7 +248,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [2]: ../../control-access/rbac/#default-users
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
-[5]: ../../../commercial/
 [6]: https://etcd.io/docs/latest/op-guide/security/
 [7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -13,8 +13,10 @@ menu:
     parent: deploy-sensu
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access federation in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][8].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
@@ -426,7 +428,6 @@ Learn more about configuring RBAC policies in our [RBAC reference documentation]
 [5]: ../../../sensuctl/create-manage-resources/#create-resources
 [6]: ../../../sensuctl/create-manage-resources/#update-resources
 [7]: ../../../sensuctl/create-manage-resources/#delete-resources
-[8]: ../../../commercial/
 [10]: ../../control-access/rbac/
 [11]: ../../../api/federation#get-all-clusters
 [12]: https://github.com/etcd-io/etcd/blob/master/etcdctl/README.md#make-mirror-options-destination

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -24,9 +24,9 @@ Sensu Go also includes many powerful [commercial features][27] to make monitorin
 Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
 The Sensu Go agent is also available for Windows.
 
-{{% notice important %}}
-**IMPORTANT**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
-If you need to upgrade, please [contact Sensu](https://sensu.io/contact).
+{{% notice warning %}}
+**WARNING**: To install Sensu Go alongside your current Sensu instance, you must upgrade to at least Sensu Core 1.9.0-2.
+If you need to upgrade, [contact Sensu](https://sensu.io/contact).
 {{% /notice %}}
 
 Aside from this migration guide, these resources can help you migrate from Sensu Core or Sensu Enterprise to Sensu Go:

--- a/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
@@ -125,8 +125,8 @@ This pause may extend to API request processing, so sensuctl and the web UI may 
 
 ## Upgrade to Sensu Go 6.0 from a 5.x deployment
 
-{{% notice important %}}
-**IMPORTANT**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
+{{% notice warning %}}
+**WARNING**: Before you upgrade to Sensu 6.0, use [`sensuctl dump`](../../../sensuctl/back-up-recover) to create a backup of your existing installation.
 You will not be able to downgrade to a Sensu 5.x version after you upgrade your database to Sensu 6.0 in step 3 of this process.
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
@@ -13,8 +13,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][20].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
 In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
@@ -477,7 +479,6 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[20]: ../../../commercial/
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Env and VaultProvider secrets provider datatypes in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets.md
@@ -12,8 +12,10 @@ menu:
     parent: manage-secrets
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Secret datatype in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Sensu's secrets management eliminates the need to expose secrets in your Sensu configuration.
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
@@ -310,7 +312,6 @@ provider: vault
 {{< /language-toggle >}}
 
 
-[1]: ../../../commercial/
 [2]: ../../../api/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -233,8 +233,10 @@ spec:
 
 ## Monitor Postgres
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access enterprise-scale Postgres event storage in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][5].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 Larger Sensu deployments may use [Postgres as an alternative datastore][4] to process larger numbers of events.
 The connection to Postgres is exposed on Sensu's `/health` endpoint and will look like the example below:
@@ -368,5 +370,4 @@ A successful PostgreSQL health check result will look like this:
 [1]: ../../../plugins/use-assets-to-install-plugins/
 [2]: ../../../api/health/
 [3]: https://bonsai.sensu.io/assets/sensu/monitoring-plugins
-[4]: https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/scale-event-storage/
-[5]: ../../../commercial/
+[4]: ../../deploy-sensu/scale-event-storage/

--- a/content/sensu-go/6.4/plugins/supported-integrations/ansible.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/ansible.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Ansible Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The Sensu Ansible Handler plugin is a Sensu [handler][1] that launches Ansible Tower job templates for automated remediation based on Sensu event data.
 
@@ -45,8 +47,7 @@ The [documentation site][8] includes installation instructions, example playbook
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/ansible-tower.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://galaxy.ansible.com/sensu/sensu_go
 [8]: https://sensu.github.io/sensu-go-ansible/
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.4/plugins/supported-integrations/elasticsearch.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/elasticsearch.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Elasticsearch Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Elasticsearch Handler plugin][4] is a Sensu [handler][1] that sends observation data from Sensu events and metrics to Elasticsearch.
 With this handler, the Sensu observation data you send to Elasticsearch is available for indexing and visualization in Kibana.
@@ -42,7 +44,6 @@ Add the [Sensu Elasticsearch Handler plugin][4] with a dynamic runtime asset fro
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/elasticsearch.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-elasticsearch-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/
 [8]: ../../../observability-pipeline/observe-schedule/checks/#output-metric-tags

--- a/content/sensu-go/6.4/plugins/supported-integrations/jira.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/jira.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Jira Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Jira Handler plugin][4] is a Sensu [handler][1] that creates and updates Jira issues based on observation data from Sensu events.
 
@@ -37,6 +39,5 @@ Add the [Sensu Jira Handler plugin][4] with a dynamic runtime asset from Bonsai,
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/jira-servicedesk.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.4/plugins/supported-integrations/rundeck.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/rundeck.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Rundeck Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu Rundeck Handler plugin][4] is a Sensu [handler][1] that initiates Rundeck jobs for automated remediation based on Sensu event data.
 
@@ -42,7 +44,6 @@ You can also add the [Sensu Rundeck Handler plugin][4] with a dynamic runtime as
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck-webhook.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/rundeck.yaml
 [8]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.4/plugins/supported-integrations/saltstack.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/saltstack.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu SaltStack Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu SaltStack Handler plugin][4] is a Sensu [handler][1] that launches SaltStack functions for automated remediation based on Sensu event data.
 
@@ -39,6 +41,5 @@ You can also add the [Sensu SaltStack Handler plugin][4] with a dynamic runtime 
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/remediation/saltstack.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.4/plugins/supported-integrations/servicenow.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/servicenow.md
@@ -9,8 +9,10 @@ menu:
     parent: supported-integrations
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu ServiceNow Handler integration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 
 The [Sensu ServiceNow Handler plugin][4] is a Sensu [handler][1] that creates and updates ServiceNow incidents and events based on observation data from Sensu events.
 
@@ -42,8 +44,7 @@ You can also add the [Sensu ServiceNow Handler plugin][4] with a dynamic runtime
 [2]: ../../../observability-pipeline/observe-process/handler-templates/
 [3]: https://github.com/sensu/catalog/blob/main/pipelines/event-storage/servicenow-events.yaml
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
-[5]: ../../assets
-[6]: ../../../commercial/
+[5]: ../../assets/
 [7]: https://github.com/sensu/catalog/blob/main/pipelines/incident-management/servicenow-incident.yaml
 [8]: https://github.com/sensu/catalog/blob/main/pipelines/entity-registration/servicenow-cmdb.yaml
 [9]: ../../../operations/manage-secrets/

--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -333,8 +333,8 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice important %}}
-**IMPORTANT**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
+{{% notice note %}}
+**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 {{% /notice %}}
 
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -479,18 +479,18 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-{{% /notice %}}
-
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][30].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
+
+`sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -479,8 +479,8 @@ See the [RBAC reference][22] for information about local user management with se
 
 #### sensuctl prune
 
-{{% notice important %}}
-**IMPORTANT**: `sensuctl prune` is an alpha feature and may include breaking changes.
+{{% notice note %}}
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.4/sensuctl/filter-responses.md
@@ -11,8 +11,10 @@ menu:
     parent: sensuctl
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl response filtering in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][4].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensuctl supports response filtering for all [commands using the `list` verb][1].
 For information about response filtering methods and available label and field selectors, see [API response filtering][2].
@@ -118,6 +120,5 @@ sensuctl check list --label-selector 'region == "us-west-1"' --field-selector 's
 [1]: ../create-manage-resources/#subcommands
 [2]: ../../api#response-filtering
 [3]: ../../api#field-selector
-[4]: ../../commercial/
 [5]: ../../api/#operators
 [6]: #examples

--- a/content/sensu-go/6.4/web-ui/_index.md
+++ b/content/sensu-go/6.4/web-ui/_index.md
@@ -12,8 +12,10 @@ menu:
 
 The Sensu backend includes the **Sensu web UI**: a unified view of your events, entities, and checks with user-friendly tools to reduce alert fatigue.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu web UI homepage (shown below) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][6].
+For more information, see [Get started with commercial features](../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/web-ui.png" alt="Sensu web UI homepage" link="/images/web-ui.png" target="_blank" >}}
 
@@ -46,5 +48,4 @@ Use the preferences menu to change the theme or switch to the dark theme.
 [3]: ../operations/control-access/rbac/
 [4]: ../operations/control-access/rbac#default-users
 [5]: ../operations/control-access/rbac#create-users
-[6]: ../commercial/
 [7]: ../api/auth/

--- a/content/sensu-go/6.4/web-ui/bsm-module.md
+++ b/content/sensu-go/6.4/web-ui/bsm-module.md
@@ -11,12 +11,14 @@ menu:
     parent: web-ui
 ---
 
-{{% notice note %}}
-**NOTE**: Business service monitoring is in public preview and is subject to change. 
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-**COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][3].
+{{% notice note %}}
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change. 
+{{% /notice %}}
 
 The Sensu web UI includes a module to help you build and configure business service monitoring (BSM) [service entities][4] with [service components][1] and [rule templates][2].
 

--- a/content/sensu-go/6.4/web-ui/bsm-module.md
+++ b/content/sensu-go/6.4/web-ui/bsm-module.md
@@ -11,8 +11,8 @@ menu:
     parent: web-ui
 ---
 
-{{% notice important %}}
-**IMPORTANT**: Business service monitoring is in public preview and is subject to change. 
+{{% notice note %}}
+**NOTE**: Business service monitoring is in public preview and is subject to change. 
 {{% /notice %}}
 
 **COMMERCIAL FEATURE**: Access business service monitoring (BSM) in the packaged Sensu Go distribution.

--- a/content/sensu-go/6.4/web-ui/search.md
+++ b/content/sensu-go/6.4/web-ui/search.md
@@ -66,8 +66,10 @@ If you are using the [basic web UI search functions][5], you can create a search
 
 ## Create advanced searches
 
-**COMMERCIAL FEATURE**: Access advanced search functions in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access advanced web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Sensu supports advanced web UI searches using a wider range of attributes, including custom labels.
 You can use the same methods, fields, and examples for web UI searches as for [API response filtering][3], with some [syntax differences][4].
@@ -187,8 +189,10 @@ To return events that include a `windows` check subscription and any email handl
 
 ## Save a search
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 To save a web UI search:
 

--- a/content/sensu-go/6.4/web-ui/searches-reference.md
+++ b/content/sensu-go/6.4/web-ui/searches-reference.md
@@ -13,8 +13,10 @@ menu:
     parent: web-ui
 ---
 
-**COMMERCIAL FEATURE**: Access saved searches in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access saved web UI searches in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
@@ -465,7 +467,6 @@ parameters:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../operations/control-access/rbac/#namespaced-resource-types
 [3]: ../../web-ui/search/#save-a-search
 [4]: ../../api/searches

--- a/content/sensu-go/6.4/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.4/web-ui/view-manage-resources.md
@@ -20,8 +20,10 @@ By default, the web UI displays the `default` namespace.
 
 To switch namespaces, select the menu icon in the upper-left corner and choose a namespace from the dropdown.
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, the namespace switcher will list only the namespaces to which the current user has access.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 {{< figure src="/images/namespace-switcher-1.png" alt="Sensu web UI namespace switcher" link="/images/namespace-switcher-1.png" target="_blank" >}}
 
@@ -44,11 +46,11 @@ After you create a silence, it will be listed in the web UI Silences page until 
 
 ## Manage checks, handlers, event filters, and mutators
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access check, handler, event filter, and mutator management in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Create, edit, and delete Sensu checks, handlers, event filters, and mutators from their respective pages in the web UI.
 Execute checks on demand from individual check pages to test your observability pipeline.
 
-
-[1]: ../../commercial/

--- a/content/sensu-go/6.4/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.4/web-ui/webconfig-reference.md
@@ -12,8 +12,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -389,7 +391,6 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../../web-ui/
 [4]: #spec-attributes

--- a/content/sensu-go/6.4/web-ui/webconfig.md
+++ b/content/sensu-go/6.4/web-ui/webconfig.md
@@ -11,8 +11,10 @@ menu:
     parent: web-ui
 ---
 
+{{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access web UI configuration in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features][1].
+For more information, see [Get started with commercial features](../../commercial/).
+{{% /notice %}}
 
 Web UI configuration allows you to define certain display options for the Sensu [web UI][3], such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand.
 You can define a single custom web UI configuration to federate to all, some, or only one of your clusters.
@@ -90,7 +92,6 @@ In a single-cluster environment, the namespace switcher will only list a local-c
 {{% /notice %}}
 
 
-[1]: ../../commercial/
 [2]: ../../api/webconfig/
 [3]: ../
 [4]: ../webconfig-reference/

--- a/static/stylesheets/scss/_alert.scss
+++ b/static/stylesheets/scss/_alert.scss
@@ -49,6 +49,13 @@
   padding: 1rem;
 }
 
+.alert-commercial {
+  background-color: #9999ff;
+  color: #000099;
+  margin: 1rem 0;
+  padding: 1rem;
+}
+
 div.notices {
   margin: 2rem 0;
   position: relative;
@@ -86,4 +93,8 @@ div.notices.note p {
 div.notices.protip p {
   background: #dff0d8;
   color: #3c763d;
+}
+div.notices.commercial p {
+  background: #9999ff;
+  color: #000099;
 }

--- a/static/stylesheets/scss/_alert.scss
+++ b/static/stylesheets/scss/_alert.scss
@@ -24,36 +24,26 @@
 }
 
 .alert-note {
-  background-color: #d9edf7;
-  color: #31708f;
+  background-color: #e1e4f0;
+  color: #2C3458;
   margin: 1rem 0;
   padding: 1rem;
+  border-radius: 6px;
 }
-
 .alert-tip {
   @extend .alert-note;
-  background-color: #dff0d8;
-  color: #3c763d;
+  background-color: #c4ede9;
+  color: #0d5651;
 }
-
 .alert-warning {
   @extend .alert-note;
-  background-color: #fcf8e3;
-  color: #8a6d3b;
+  background-color: #ffebc8;
+  color: #671111;
 }
-
-.alert-important {
-  background-color: #f6eaae;
-  color: #691c1a;
-  margin: 1rem 0;
-  padding: 1rem;
-}
-
 .alert-commercial {
-  background-color: #9999ff;
-  color: #000099;
-  margin: 1rem 0;
-  padding: 1rem;
+  @extend .alert-note;
+  background-color: #d4eaaf;
+  color: #425a18;
 }
 
 div.notices {
@@ -78,23 +68,23 @@ div.notices p:first-child:after {
   top: 2px;
   left: 2rem;
 }
-div.notices.important p {
-  background: #f6eaae;
-  color: #691c1a;
-}
-div.notices.warning p {
-  background: #fcf8e3;
-  color: #8a6d3b;
-}
 div.notices.note p {
-  background: #d9edf7;
-  color: #31708f;
+  background-color: #e1e4f0;
+  color: #2C3458;
+  border-radius: 6px;
 }
 div.notices.protip p {
-  background: #dff0d8;
-  color: #3c763d;
+  background-color: #c4ede9;
+  color: #0d5651;
+  border-radius: 6px;
+}
+div.notices.warning p {
+  background-color: #ffebc8;
+  color: #671111;
+  border-radius: 6px;
 }
 div.notices.commercial p {
-  background: #9999ff;
-  color: #000099;
+  background-color: #d4eaaf;
+  color: #425a18;
+  border-radius: 6px;
 }


### PR DESCRIPTION
## Description
- Adds green color formatting for commercial features notices
- Updates commercial features notices to use shortcode formatting
- Removes important notice (replaced in the docs content by either note or warning notice, whichever is appropriate)
- Condenses notes where appropriate to help relieve notice fatigue
- Updates notice color scheme to use shades of Sensu brand colors
- Adds example commercial feature notice to the commercial features page (https://docs.sensu.io/sensu-go/latest/commercial/)

## Motivation and Context
Customer mentioned that it seemed difficult to identify commercial features. During sync with Sales this week, we decided these changes might help make these features more noticeable.