### PR TITLE
6.4.0: Update etcd 3.3 mentions to 3.5

### DIFF
--- a/content/sensu-go/6.4/api/version.md
+++ b/content/sensu-go/6.4/api/version.md
@@ -25,10 +25,10 @@ http://127.0.0.1:8080/version
 HTTP/1.1 200 OK
 {
   "etcd": {
-    "etcdserver": "3.3.22",
-    "etcdcluster": "3.3.0"
+    "etcdserver": "3.5.0",
+    "etcdcluster": "3.5.0"
   },
-  "sensu_backend": "6.0.0"
+  "sensu_backend": "6.4.0"
 }
 {{< /code >}}
 
@@ -43,9 +43,9 @@ response codes      | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Inte
 output         | {{< code shell >}}
 {
   "etcd": {
-    "etcdserver": "3.3.22",
-    "etcdcluster": "3.3.0"
+    "etcdserver": "3.5.0",
+    "etcdcluster": "3.5.0"
   },
-  "sensu_backend": "6.x.x"
+  "sensu_backend": "6.4.0"
 }
 {{< /code >}}

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -321,7 +321,7 @@ See [Secure Sensu][16] for information about cluster security.
 If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.
 {{% /notice %}}
 
-To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
+To use Sensu with an external etcd cluster, you must have etcd 3.5.0 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -321,7 +321,7 @@ See [Secure Sensu][16] for information about cluster security.
 If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.
 {{% /notice %}}
 
-To use Sensu with an external etcd cluster, you must have etcd 3.5.0 or newer.
+To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -28,7 +28,7 @@ Do not configure external etcd in Sensu via backend command line flags or the ba
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
-Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.5.x series.
+Sensu requires at least etcd 3.3.2 and is tested against etcd 3.5.
 etcd version 3.4.0 is compatible with Sensu but may result in slower performance.
 
 ## Scale event storage

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -28,8 +28,7 @@ Do not configure external etcd in Sensu via backend command line flags or the ba
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
-Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.3.x series.
-etcd version 3.4.0 is compatible with Sensu but may result in slower performance than the 3.3.x series.
+Sensu requires etcd 3.5.0.
 
 ## Scale event storage
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -28,7 +28,8 @@ Do not configure external etcd in Sensu via backend command line flags or the ba
 
 As your deployment grows beyond the proof-of-concept stage, review [Deployment architecture for Sensu][6] for more information about deployment considerations and recommendations for a production-ready Sensu deployment.
 
-Sensu requires etcd 3.5.0.
+Sensu requires at least etcd 3.3.2 and is tested against releases in the 3.5.x series.
+etcd version 3.4.0 is compatible with Sensu but may result in slower performance.
 
 ## Scale event storage
 

--- a/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
@@ -165,7 +165,7 @@ The following errors are expected when starting up a Sensu backend with the defa
 
 {{< code shell >}}
 {"component":"etcd","level":"warning","msg":"simple token is not cryptographically signed","pkg":"auth","time":"2019-11-04T10:26:31-05:00"}
-{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.3","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
+{"component":"etcd","level":"warning","msg":"set the initial cluster version to 3.5","pkg":"etcdserver/membership","time":"2019-11-04T10:26:31-05:00"}
 {"component":"etcd","level":"warning","msg":"serving insecure client requests on 127.0.0.1:2379, this is strongly discouraged!","pkg":"embed","time":"2019-11-04T10:26:33-05:00"}
 {{< /code >}}
 
@@ -643,9 +643,9 @@ etcdctl endpoint status
 The response will list the current cluster status and database size:
 
 {{< code shell >}}
-https://backend01:2379, 88db026f7feb72b4, 3.3.22, 2.1GB, false, 144, 18619245
-https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 2.1GB, true, 144, 18619245
-https://backend03:2379, bc4e39432cbb36d, 3.3.22, 2.1GB, false, 144, 18619245
+https://backend01:2379, 88db026f7feb72b4, 3.5.0, 2.1GB, false, 144, 18619245
+https://backend02:2379, e98ad7a888d16bd6, 3.5.0, 2.1GB, true, 144, 18619245
+https://backend03:2379, bc4e39432cbb36d, 3.5.0, 2.1GB, false, 144, 18619245
 {{< /code >}}
 
 To restore an etcd cluster with a database size that exceeds 2 GB:
@@ -672,9 +672,9 @@ etcdctl endpoint status
 
    The response should list the current cluster status and database size:
 {{< code shell >}}
-https://backend01:2379, 88db026f7feb72b4, 3.3.22, 1.0 MB, false, 144, 18619245
-https://backend02:2379, e98ad7a888d16bd6, 3.3.22, 1.0 MB, true, 144, 18619245
-https://backend03:2379, bc4e39432cbb36d, 3.3.22, 1.0 MB, false, 144, 18619245
+https://backend01:2379, 88db026f7feb72b4, 3.5.0, 1.0 MB, false, 144, 18619245
+https://backend02:2379, e98ad7a888d16bd6, 3.5.0, 1.0 MB, true, 144, 18619245
+https://backend03:2379, bc4e39432cbb36d, 3.5.0, 1.0 MB, false, 144, 18619245
 {{< /code >}}
 
 ### Remove and redeploy a cluster


### PR DESCRIPTION
## Description
- Updates code examples to use 3.5 rather than 3.3.x
- Updates datastore etcd requirement statement to note that Sensu is tested against 3.5

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3213

## Additional Notes
I searched the 6.4 docs for the deprecated metrics names listed here: https://etcd.io/docs/v3.5/upgrades/upgrade_3_5/ (our docs do not include any of the deprecated names)
And searched the metrics names we list in https://docs.sensu.io/sensu-go/6.4/api/metrics/ to make sure they are listed here: https://etcd.io/docs/v3.5/metrics/etcd-metrics-latest.txt (all names used in our examples are in the etcd list)