### PR TITLE
Add missing close-paren for commercial features note on AD page

### DIFF
--- a/content/sensu-go/6.0/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.0/operations/control-access/ad-auth.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features](../../../commercial/.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.

--- a/content/sensu-go/6.1/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ad-auth.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features](../../../commercial/.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.

--- a/content/sensu-go/6.2/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ad-auth.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features](../../../commercial/.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.

--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features](../../../commercial/.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.

--- a/content/sensu-go/6.4/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ad-auth.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
-For more information, see [Get started with commercial features](../../../commercial/.
+For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.


### PR DESCRIPTION
Add missing close-parentheses for commercial features link in note on AD auth page.
