### PR TITLE
Add package, binary, and Docker image links to versions page

### DIFF
--- a/content/sensu-go/6.0/versions.md
+++ b/content/sensu-go/6.0/versions.md
@@ -13,7 +13,7 @@ menu: "sensu-go-6.0"
 Update Sensu frequently to stay in sync with the latest features and fixes.
 See the [upgrade guide][1] to upgrade to the latest version.
 
-Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Sensu supports the latest versions of official distributions, including [packages][66], [binary-only distributions][67], and [Docker images][68].
 Learn more about Sensu [support and licensing][2].
 
 This table lists the supported versions of Sensu Go with links to active documentation (for supported versions) and offline documentation artifacts (for versions that are not supported).
@@ -123,3 +123,6 @@ This table lists the supported versions of Sensu Go with links to active documen
 [48]: https://docs.sensu.io/sensu-go/latest/release-notes/#5212-release-notes
 [61]: https://docs.sensu.io/sensu-go/latest/release-notes/#5214-release-notes
 [62]: https://docs.sensu.io/sensu-go/latest/release-notes/#5215-release-notes
+[66]: ../platforms/#supported-packages
+[67]: ../platforms/#binary-only-distributions
+[68]: ../platforms/#docker-images

--- a/content/sensu-go/6.1/versions.md
+++ b/content/sensu-go/6.1/versions.md
@@ -13,7 +13,7 @@ menu: "sensu-go-6.1"
 Update Sensu frequently to stay in sync with the latest features and fixes.
 See the [upgrade guide][1] to upgrade to the latest version.
 
-Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Sensu supports the latest versions of official distributions, including [packages][66], [binary-only distributions][67], and [Docker images][68].
 Learn more about Sensu [support and licensing][2].
 
 This table lists the supported versions of Sensu Go with links to active documentation (for supported versions) and offline documentation artifacts (for versions that are not supported).
@@ -134,3 +134,6 @@ This table lists the supported versions of Sensu Go with links to active documen
 [54]: https://docs.sensu.io/sensu-go/latest/release-notes/#614-release-notes
 [61]: https://docs.sensu.io/sensu-go/latest/release-notes/#5214-release-notes
 [62]: https://docs.sensu.io/sensu-go/latest/release-notes/#5215-release-notes
+[66]: ../platforms/#supported-packages
+[67]: ../platforms/#binary-only-distributions
+[68]: ../platforms/#docker-images

--- a/content/sensu-go/6.2/versions.md
+++ b/content/sensu-go/6.2/versions.md
@@ -13,7 +13,7 @@ menu: "sensu-go-6.2"
 Update Sensu frequently to stay in sync with the latest features and fixes.
 See the [upgrade guide][1] to upgrade to the latest version.
 
-Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Sensu supports the latest versions of official distributions, including [packages][66], [binary-only distributions][67], and [Docker images][68].
 Learn more about Sensu [support and licensing][2].
 
 This table lists the supported versions of Sensu Go with links to active documentation (for supported versions) and offline documentation artifacts (for versions that are not supported).
@@ -150,3 +150,6 @@ This table lists the supported versions of Sensu Go with links to active documen
 [62]: https://docs.sensu.io/sensu-go/latest/release-notes/#5215-release-notes
 [63]: https://docs.sensu.io/sensu-go/latest/release-notes/#626-release-notes
 [64]: https://docs.sensu.io/sensu-go/latest/release-notes/#627-release-notes
+[66]: ../platforms/#supported-packages
+[67]: ../platforms/#binary-only-distributions
+[68]: ../platforms/#docker-images

--- a/content/sensu-go/6.3/versions.md
+++ b/content/sensu-go/6.3/versions.md
@@ -13,7 +13,7 @@ menu: "sensu-go-6.3"
 Update Sensu frequently to stay in sync with the latest features and fixes.
 See the [upgrade guide][1] to upgrade to the latest version.
 
-Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Sensu supports the latest versions of official distributions, including [packages][66], [binary-only distributions][67], and [Docker images][68].
 Learn more about Sensu [support and licensing][2].
 
 This table lists the supported versions of Sensu Go with links to active documentation (for supported versions) and offline documentation artifacts (for versions that are not supported).
@@ -152,3 +152,6 @@ This table lists the supported versions of Sensu Go with links to active documen
 [63]: https://docs.sensu.io/sensu-go/latest/release-notes/#626-release-notes
 [64]: https://docs.sensu.io/sensu-go/latest/release-notes/#627-release-notes
 [65]: https://docs.sensu.io/sensu-go/latest/release-notes/#630-release-notes
+[66]: ../platforms/#supported-packages
+[67]: ../platforms/#binary-only-distributions
+[68]: ../platforms/#docker-images

--- a/content/sensu-go/6.4/versions.md
+++ b/content/sensu-go/6.4/versions.md
@@ -13,7 +13,7 @@ menu: "sensu-go-6.4"
 Update Sensu frequently to stay in sync with the latest features and fixes.
 See the [upgrade guide][1] to upgrade to the latest version.
 
-Sensu supports the latest versions of official distributions, including packages, binary-only distributions, and Docker images.
+Sensu supports the latest versions of official distributions, including [packages][66], [binary-only distributions][67], and [Docker images][68].
 Learn more about Sensu [support and licensing][2].
 
 This table lists the supported versions of Sensu Go with links to active documentation (for supported versions) and offline documentation artifacts (for versions that are not supported).
@@ -152,3 +152,6 @@ This table lists the supported versions of Sensu Go with links to active documen
 [63]: https://docs.sensu.io/sensu-go/latest/release-notes/#626-release-notes
 [64]: https://docs.sensu.io/sensu-go/latest/release-notes/#627-release-notes
 [65]: https://docs.sensu.io/sensu-go/latest/release-notes/#630-release-notes
+[66]: ../platforms/#supported-packages
+[67]: ../platforms/#binary-only-distributions
+[68]: ../platforms/#docker-images


### PR DESCRIPTION
## Description
Adds links to platforms page for packages, binaries, and Docker images at the top of the Supported versions page at https://docs.sensu.io/sensu-go/latest/versions/

## Motivation and Context
https://sumologic.slack.com/archives/C024PCF29KR/p1624039694044800

Iryna also updated the link on the downloads page (sensu.io/downloads, "Visit our docs to install older versions of Sensu Go") which previously pointed to /versions rather than /platforms.

Thank you @mgibson323 and @iryna-iur !
