### PR TITLE
6.4.0: Update sensuctl config option to Sensu Backend API URL

### DIFF
--- a/content/sensu-go/6.4/learn/demo.md
+++ b/content/sensu-go/6.4/learn/demo.md
@@ -24,7 +24,7 @@ Run `sensuctl configure` and enter the following information:
 
 {{< code shell >}}
 ? Authentication method: username/password
-? Sensu Backend URL: https://caviar.tf.sensu.io:8080
+? Sensu Backend API URL: https://caviar.tf.sensu.io:8080
 ? Namespace: default
 ? Preferred output format: tabular
 ? Username: guest

--- a/content/sensu-go/6.4/sensuctl/_index.md
+++ b/content/sensu-go/6.4/sensuctl/_index.md
@@ -52,7 +52,7 @@ This example shows the username/password authentication method:
 
 {{< code shell >}}
 ? Authentication method: username/password
-? Sensu Backend URL: http://127.0.0.1:8080
+? Sensu Backend API URL: http://127.0.0.1:8080
 ? Namespace: default
 ? Preferred output format: tabular
 ? Username: YOUR_USERNAME
@@ -68,7 +68,7 @@ This example shows the OIDC authentication method:
 
 {{< code shell >}}
 ? Authentication method: OIDC
-? Sensu Backend URL: http://127.0.0.1:8080
+? Sensu Backend API URL: http://127.0.0.1:8080
 ? Namespace: default
 ? Preferred output format: tabular
 Launching browser to complete the login via your OIDC provider at following URL:


### PR DESCRIPTION
## Description
In sensuctl configure response options, changes `Sensu Backend URL` to `Sensu Backend API URL`

## Motivation and Context
https://github.com/sensu/sensu-go/pull/4297