### PR TITLE
Fix event.check.state example that causes an error in web UI

### DIFF
--- a/content/sensu-go/6.1/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.1/web-ui/view-manage-resources.md
@@ -37,7 +37,7 @@ Click the triple-bar icon at the top of the left-navigation menu to expand the m
 
 ## Manage events
 
-The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != 0`):
+The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != passing`):
 
 {{< figure src="/images/events-page-default.png" alt="Sensu web UI default Events page" link="/images/events-page-default.png" target="_blank" >}}
 

--- a/content/sensu-go/6.2/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.2/web-ui/view-manage-resources.md
@@ -37,7 +37,7 @@ Click the triple-bar icon at the top of the left-navigation menu to expand the m
 
 ## Manage events
 
-The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != 0`):
+The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != passing`):
 
 {{< figure src="/images/events-page-default.png" alt="Sensu web UI default Events page" link="/images/events-page-default.png" target="_blank" >}}
 

--- a/content/sensu-go/6.3/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.3/web-ui/view-manage-resources.md
@@ -37,7 +37,7 @@ Click the triple-bar icon at the top of the left-navigation menu to expand the m
 
 ## Manage events
 
-The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != 0`):
+The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != passing`):
 
 {{< figure src="/images/events-page-default.png" alt="Sensu web UI default Events page" link="/images/events-page-default.png" target="_blank" >}}
 

--- a/content/sensu-go/6.4/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.4/web-ui/view-manage-resources.md
@@ -37,7 +37,7 @@ Click the triple-bar icon at the top of the left-navigation menu to expand the m
 
 ## Manage events
 
-The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != 0`):
+The Events page opens by default when you navigate to a namespace, with an automatic filter to show only events with a non-passing status (i.e. `event.check.state != passing`):
 
 {{< figure src="/images/events-page-default.png" alt="Sensu web UI default Events page" link="/images/events-page-default.png" target="_blank" >}}
 


### PR DESCRIPTION
## Description
Change `event.check.state != 0` to `event.check.state != passing` in web UI docs

## Motivation and Context
Web UI docs use events search example `event.check.state != 0` but this example will result in an error message `Unexpected token (1:22)`
