### PR TITLE
Address change in cert handling as of Go 1.15

### DIFF
--- a/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
@@ -173,12 +173,12 @@ The `serving insecure client requests` warning is an expected warning from the e
 [TLS configuration][3] is recommended but not required.
 For more information, see [etcd security documentation][4].
 
-### CommonName deprecation in Go 1.15
+## CommonName deprecation in Go 1.15
 
 Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
-[As of Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
+As of [Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
 
-The following error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
+The following logged error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
 
 {{< code shell >}}
 {"component":"agent","error":"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0","level":"error","msg":"reconnection attempt failed","time":"2021-06-29T11:07:51+02:00"}

--- a/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
@@ -173,6 +173,19 @@ The `serving insecure client requests` warning is an expected warning from the e
 [TLS configuration][3] is recommended but not required.
 For more information, see [etcd security documentation][4].
 
+### CommonName deprecation in Go 1.15
+
+Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
+[As of Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
+
+The following error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
+
+{{< code shell >}}
+{"component":"agent","error":"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0","level":"error","msg":"reconnection attempt failed","time":"2021-06-29T11:07:51+02:00"}
+{{< /code >}}
+
+To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
+
 ## Permission issues
 
 The Sensu user and group must own files and folders within `/var/cache/sensu/` and `/var/lib/sensu/`.
@@ -824,3 +837,5 @@ The backend will stop listening on those ports when the etcd database is unavail
 [24]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
 [25]: ../../../observability-pipeline/observe-schedule/backend/#initialization
 [26]: https://etcd.io/docs/latest/op-guide/recovery/#restoring-a-cluster
+[27]: https://golang.google.cn/doc/go1.15#commonname
+[28]: ../../deploy-sensu/generate-certificates/

--- a/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
@@ -45,6 +45,13 @@ If you make a full etcd database backup before upgrading to 6.4.0, you will be a
 
 After creating a full backup of your embedded etcd database, you can follow the [standard upgrade process][10] to upgrade to 6.4.0.
 
+### CommonName deprecation in Go 1.15
+
+Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
+[As of Go 1.15][11], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
+
+To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][12] to make sure your certificates' SAN fields include their CNs.
+
 ## Upgrade to Sensu Go 6.2.0 from any previous version
 
 Prior to Sensu Go 6.0, sensu-backend allowed you to delete a namespace even when other resources still referenced that namespace. 
@@ -276,4 +283,6 @@ sudo service sensu-backend restart
 [7]: https://stedolan.github.io/jq/
 [8]: ../../../api/#authenticate-with-an-api-key
 [9]: https://etcd.io/docs/latest/op-guide/recovery/
-[10]: ../../../operations/maintain-sensu/upgrade/
+[10]: ../../maintain-sensu/upgrade/
+[11]: https://golang.google.cn/doc/go1.15#commonname
+[12]: ../../deploy-sensu/generate-certificates/

--- a/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
@@ -48,7 +48,7 @@ After creating a full backup of your embedded etcd database, you can follow the 
 ### CommonName deprecation in Go 1.15
 
 Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
-[As of Go 1.15][11], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
+As of [Go 1.15][11], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
 
 To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][12] to make sure your certificates' SAN fields include their CNs.
 


### PR DESCRIPTION
## Description
Adds information about a connection error users may experience if they upgrade to Sensu GO 6.4.0 but do not use proper cert config with regard to CommonName and Subject Alternative Name as of Go version 1.15.

Added in:
- https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
- https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/troubleshoot/#sensu-backend-startup-errors

## Motivation and Context
https://sumologic.slack.com/archives/C024XK35Z3Q/p1625168009384100