### PR TITLE
Add SSO page with auth provider config info

### DIFF
--- a/content/sensu-go/6.1/api/authproviders.md
+++ b/content/sensu-go/6.1/api/authproviders.md
@@ -1,7 +1,7 @@
 ---
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
-description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider for single sign-on (SSO)."
 api_title: "Authentication providers API"
 type: "api"
 version: "6.1"
@@ -12,7 +12,7 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/operations/control-access/_index.md
+++ b/content/sensu-go/6.1/operations/control-access/_index.md
@@ -27,7 +27,7 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when [external authentication providers][15] are configured by the administrator.
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
@@ -38,76 +38,17 @@ The basic authentication provider does not depend on external services and is no
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].
 
-### Use an authentication provider
+### Use a single sign-on (SSO) authentication provider
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
+In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using external authentication providers via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC).
 
-#### Configure authentication providers
-
-**1. Write an authentication provider configuration definition**
-
-* Standards-compliant LDAP tools like OpenLDAP: [LDAP configuration examples][29] and [specification][30]
-* Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
-* OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
-
-Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
-
-**2. Apply the configuration with sensuctl**
-
-Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl create --file authconfig.yml
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl create --file authconfig.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Use sensuctl to verify that your provider configuration was applied successfully:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-The response will list your authentication provider types and names:
-
-{{< code shell >}}
- Type     Name    
-────── ────────── 
- ldap   openldap  
-{{< /code >}}
-
-#### Manage authentication providers
-
-View and delete authentication providers with the [authentication providers API][27] or these sensuctl commands.
-
-To view active authentication providers:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-To view configuration details for an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth info openldap
-{{< /code >}}
-
-To delete an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth delete openldap
-{{< /code >}}
+Read [Configure single sign-on (SSO) authentication][6] for general information about configuring an SSO authentication provider.
+Read the [LDAP][44], [AD][37], or [OIDC][7] reference documentation for provider-specific information.
 
 ## Authorization
 
@@ -133,31 +74,19 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
+[6]: sso/
 [7]: oidc-auth/
 [8]: ../../api/
-[9]: oidc-auth/#oidc-configuration-examples
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: rbac#roles-and-cluster-roles
-[12]: oidc-auth/#oidc-specification
 [13]: rbac#role-bindings-and-cluster-role-bindings
 [14]: #use-built-in-basic-authentication
-[15]: #use-an-authentication-provider
+[15]: #use-a-single-sign-on-sso-authentication-provider
 [16]: rbac/#view-users
 [17]: rbac#namespaced-resource-types
 [18]: rbac#cluster-wide-resource-types
 [19]: ../maintain-sensu/troubleshoot#log-levels
-[20]: ../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[21]: ldap-auth/#ldap-group-search-attributes
-[22]: ldap-auth/#ldap-user-search-attributes
-[23]: ad-auth/#ad-metadata-attributes
-[24]: ldap-auth/#ldap-metadata-attributes
-[25]: /oidc-auth/#oidc-spec-attributes
+[20]: ../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [26]: https://en.wikipedia.org/wiki/Bcrypt
-[27]: ../../api/authproviders/
-[29]: ldap-auth/#ldap-configuration-examples
-[30]: ldap-auth/#ldap-specification
-[31]: ad-auth/#ad-configuration-examples
-[32]: ad-auth/#ad-specification
 [36]: ../../sensuctl/#first-time-setup-and-authentication
 [37]: ad-auth/
 [38]: ../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.1/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ad-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Active Directory (AD) authentication"
-linktitle: "Authenticate with AD"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
-weight: 10
+title: "Active Directory (AD) reference"
+linktitle: "AD Reference"
+reference_title: "Active Directory (AD)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
+weight: 50
 version: "6.1"
 product: "Sensu Go"
 menu:
@@ -11,18 +13,18 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## AD configuration examples
 
@@ -81,6 +83,7 @@ api_version: authentication/v2
 metadata:
   name: activedirectory
 spec:
+  allowed_groups: []
   groups_prefix: ad
   servers:
   - binding:
@@ -142,6 +145,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   },
@@ -290,6 +294,7 @@ spec:
       attribute: sAMAccountName
       name_attribute: displayName
       object_class: person
+  allowed_groups: []
   groups_prefix: ad
   username_prefix: ad
 {{< /code >}}
@@ -325,6 +330,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   }
@@ -395,6 +401,29 @@ servers:
         "object_class": "person"
       }
     }
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [
+    "sensu-viewers",
+    "sensu-operators"
   ]
 }
 {{< /code >}}
@@ -856,10 +885,11 @@ The troubleshooting steps in the [LDAP troubleshooting][49] section also apply f
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [8]: ../../../api/
 [10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [23]: #ad-metadata-attributes
 [38]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.1/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.1/operations/control-access/create-limited-service-accounts.md
@@ -4,7 +4,7 @@ linkTitle: "Create Limited Service Accounts"
 guide_title: "Create limited service accounts with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to create limited service accounts so that applications can access and interact with Sensu resources. Read this guide to create limited service accounts with Sensu RBAC."
-weight: 65
+weight: 40
 version: "6.1"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.1/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.1/operations/control-access/create-read-only-user.md
@@ -4,7 +4,7 @@ linkTitle: "Create a Read-only User"
 guide_title: "Create a read-only user with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources. Use RBAC rules to achieve multitenancy so different projects and teams can share a Sensu instance. Read this guide to create users with Sensu RBAC."
-weight: 60
+weight: 30
 version: "6.1"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.1/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/ldap-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Lightweight Directory Access Protocol (LDAP) authentication"
-linktitle: "Authenticate with LDAP"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
-weight: 20
+title: "Lightweight Directory Access Protocol (LDAP) reference"
+linktitle: "LDAP Reference"
+reference_title: "Lightweight Directory Access Protocol (LDAP)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
+weight: 55
 version: "6.1"
 product: "Sensu Go"
 menu:
@@ -11,17 +13,17 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## LDAP configuration examples
 
@@ -80,6 +82,7 @@ api_version: authentication/v2
 metadata:
   name: openldap
 spec:
+  allowed_groups: []
   groups_prefix: ldap
   servers:
   - binding:
@@ -137,6 +140,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   },
@@ -232,6 +236,7 @@ spec:
       attribute: uid
       name_attribute: cn
       object_class: person
+  allowed_groups: []
   groups_prefix: ldap
   username_prefix: ldap
 
@@ -266,6 +271,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   }
@@ -332,6 +338,29 @@ servers:
         "object_class": "person"
       }
     }
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed LDAP group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array of strings
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [
+    "sensu-viewers",
+    "sensu-operators"
   ]
 }
 {{< /code >}}
@@ -835,11 +864,11 @@ For example:
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [7]: https://www.openldap.org/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [21]: #ldap-group-search-attributes
 [22]: #ldap-user-search-attributes

--- a/content/sensu-go/6.1/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.1/operations/control-access/oidc-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure OpenID Connect 1.0 protocol (OIDC) authentication"
-linktitle: "Authenticate with OIDC"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
-weight: 30
+title: "OpenID Connect 1.0 protocol (OIDC) reference"
+linktitle: "OIDC Reference"
+reference_title: "OpenID Connect 1.0 protocol (OIDC)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
+weight: 60
 version: "6.1"
 product: "Sensu Go"
 menu:
@@ -11,16 +13,16 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 {{% notice warning %}}
 **WARNING**: Defining multiple OIDC providers can lead to inconsistent authentication behavior.
@@ -441,7 +443,6 @@ For example, if you have an Okta group `groups` and you set the `groups_prefix` 
 #### Sensuctl login with OIDC
 
 1. Run `sensuctl login oidc`.
-
 2. If you are using a desktop, a browser will open to `OIDC provider` and allow you to authenticate and log in.
 If a browser does not open, launch a browser to complete the login via your OIDC provider at:
 
@@ -450,19 +451,18 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [3]: ../#authorization
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../../deploy-sensu/install-sensu/#ports
 [6]: ../../../commercial/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [17]: ../rbac#namespaced-resource-types
 [18]: ../rbac#cluster-wide-resource-types
 [19]: ../../maintain-sensu/troubleshoot#log-levels
 [25]: #oidc-spec-attributes
-[27]: ../../../api/authproviders/
 [36]: ../../../sensuctl/#first-time-setup-and-authentication
 [38]: ../../../sensuctl/create-manage-resources/#create-resources
 [41]: https://en.wikipedia.org/wiki/Fully_qualified_domain_name

--- a/content/sensu-go/6.1/operations/control-access/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/rbac.md
@@ -2240,7 +2240,7 @@ spec:
 [29]: #create-role-bindings-and-cluster-role-bindings
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
-[32]: ../#use-an-authentication-provider
+[32]: ../sso/
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.1/operations/control-access/sso.md
+++ b/content/sensu-go/6.1/operations/control-access/sso.md
@@ -3,10 +3,10 @@ title: "Configure single sign-on (SSO) authentication"
 linktitle: "Configure SSO Authentication"
 description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an SSO authentication provider."
 weight: 10
-version: "6.4"
+version: "6.1"
 product: "Sensu Go"
 menu:
-  sensu-go-6.4:
+  sensu-go-6.1:
     parent: control-access
 ---
 

--- a/content/sensu-go/6.1/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.1/operations/control-access/use-apikeys.md
@@ -4,7 +4,7 @@ linkTitle: "Use API Keys"
 guide_title: "Use API keys to authenticate to Sensu"
 type: "guide"
 description: "Sensu's API key feature improves integration efficiency, security, and administrative control. Read this guide to use Sensu's API key for authentication."
-weight: 50
+weight: 20
 version: "6.1"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.2/api/authproviders.md
+++ b/content/sensu-go/6.2/api/authproviders.md
@@ -1,7 +1,7 @@
 ---
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
-description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider for single sign-on (SSO)."
 api_title: "Authentication providers API"
 type: "api"
 version: "6.2"
@@ -12,7 +12,7 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/operations/control-access/_index.md
+++ b/content/sensu-go/6.2/operations/control-access/_index.md
@@ -27,7 +27,7 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when [external authentication providers][15] are configured by the administrator.
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
@@ -38,76 +38,17 @@ The basic authentication provider does not depend on external services and is no
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].
 
-### Use an authentication provider
+### Use a single sign-on (SSO) authentication provider
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
+In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using external authentication providers via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC).
 
-#### Configure authentication providers
-
-**1. Write an authentication provider configuration definition**
-
-* Standards-compliant LDAP tools like OpenLDAP: [LDAP configuration examples][29] and [specification][30]
-* Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
-* OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
-
-Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
-
-**2. Apply the configuration with sensuctl**
-
-Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl create --file authconfig.yml
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl create --file authconfig.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Use sensuctl to verify that your provider configuration was applied successfully:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-The response will list your authentication provider types and names:
-
-{{< code shell >}}
- Type     Name    
-────── ────────── 
- ldap   openldap  
-{{< /code >}}
-
-#### Manage authentication providers
-
-View and delete authentication providers with the [authentication providers API][27] or these sensuctl commands.
-
-To view active authentication providers:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-To view configuration details for an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth info openldap
-{{< /code >}}
-
-To delete an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth delete openldap
-{{< /code >}}
+Read [Configure single sign-on (SSO) authentication][6] for general information about configuring an SSO authentication provider.
+Read the [LDAP][44], [AD][37], or [OIDC][7] reference documentation for provider-specific information.
 
 ## Authorization
 
@@ -133,31 +74,19 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
+[6]: sso/
 [7]: oidc-auth/
 [8]: ../../api/
-[9]: oidc-auth/#oidc-configuration-examples
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: rbac#roles-and-cluster-roles
-[12]: oidc-auth/#oidc-specification
 [13]: rbac#role-bindings-and-cluster-role-bindings
 [14]: #use-built-in-basic-authentication
-[15]: #use-an-authentication-provider
+[15]: #use-a-single-sign-on-sso-authentication-provider
 [16]: rbac/#view-users
 [17]: rbac#namespaced-resource-types
 [18]: rbac#cluster-wide-resource-types
 [19]: ../maintain-sensu/troubleshoot#log-levels
-[20]: ../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[21]: ldap-auth/#ldap-group-search-attributes
-[22]: ldap-auth/#ldap-user-search-attributes
-[23]: ad-auth/#ad-metadata-attributes
-[24]: ldap-auth/#ldap-metadata-attributes
-[25]: /oidc-auth/#oidc-spec-attributes
+[20]: ../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [26]: https://en.wikipedia.org/wiki/Bcrypt
-[27]: ../../api/authproviders/
-[29]: ldap-auth/#ldap-configuration-examples
-[30]: ldap-auth/#ldap-specification
-[31]: ad-auth/#ad-configuration-examples
-[32]: ad-auth/#ad-specification
 [36]: ../../sensuctl/#first-time-setup-and-authentication
 [37]: ad-auth/
 [38]: ../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.2/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ad-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Active Directory (AD) authentication"
-linktitle: "Authenticate with AD"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
-weight: 10
+title: "Active Directory (AD) reference"
+linktitle: "AD Reference"
+reference_title: "Active Directory (AD)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
+weight: 50
 version: "6.2"
 product: "Sensu Go"
 menu:
@@ -11,18 +13,18 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## AD configuration examples
 
@@ -81,6 +83,7 @@ api_version: authentication/v2
 metadata:
   name: activedirectory
 spec:
+  allowed_groups: []
   groups_prefix: ad
   servers:
   - binding:
@@ -142,6 +145,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   },
@@ -290,6 +294,7 @@ spec:
       attribute: sAMAccountName
       name_attribute: displayName
       object_class: person
+  allowed_groups: []
   groups_prefix: ad
   username_prefix: ad
 {{< /code >}}
@@ -325,6 +330,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   }
@@ -395,6 +401,29 @@ servers:
         "object_class": "person"
       }
     }
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [
+    "sensu-viewers",
+    "sensu-operators"
   ]
 }
 {{< /code >}}
@@ -856,10 +885,11 @@ The troubleshooting steps in the [LDAP troubleshooting][49] section also apply f
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [8]: ../../../api/
 [10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [23]: #ad-metadata-attributes
 [38]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
@@ -4,7 +4,7 @@ linkTitle: "Create Limited Service Accounts"
 guide_title: "Create limited service accounts with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to create limited service accounts so that applications can access and interact with Sensu resources. Read this guide to create limited service accounts with Sensu RBAC."
-weight: 65
+weight: 40
 version: "6.2"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
@@ -4,7 +4,7 @@ linkTitle: "Create a Read-only User"
 guide_title: "Create a read-only user with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources. Use RBAC rules to achieve multitenancy so different projects and teams can share a Sensu instance. Read this guide to create users with Sensu RBAC."
-weight: 60
+weight: 30
 version: "6.2"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.2/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/ldap-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Lightweight Directory Access Protocol (LDAP) authentication"
-linktitle: "Authenticate with LDAP"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
-weight: 20
+title: "Lightweight Directory Access Protocol (LDAP) reference"
+linktitle: "LDAP Reference"
+reference_title: "Lightweight Directory Access Protocol (LDAP)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
+weight: 55
 version: "6.2"
 product: "Sensu Go"
 menu:
@@ -11,17 +13,17 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## LDAP configuration examples
 
@@ -80,6 +82,7 @@ api_version: authentication/v2
 metadata:
   name: openldap
 spec:
+  allowed_groups: []
   groups_prefix: ldap
   servers:
   - binding:
@@ -137,6 +140,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   },
@@ -283,6 +287,7 @@ spec:
       attribute: uid
       name_attribute: cn
       object_class: person
+  allowed_groups: []
   groups_prefix: ldap
   username_prefix: ldap
 
@@ -317,6 +322,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   }
@@ -383,6 +389,29 @@ servers:
         "object_class": "person"
       }
     }
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed LDAP group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array of strings
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [
+    "sensu-viewers",
+    "sensu-operators"
   ]
 }
 {{< /code >}}
@@ -886,11 +915,11 @@ For example:
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [7]: https://www.openldap.org/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [21]: #ldap-group-search-attributes
 [22]: #ldap-user-search-attributes

--- a/content/sensu-go/6.2/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.2/operations/control-access/oidc-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure OpenID Connect 1.0 protocol (OIDC) authentication"
-linktitle: "Authenticate with OIDC"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
-weight: 30
+title: "OpenID Connect 1.0 protocol (OIDC) reference"
+linktitle: "OIDC Reference"
+reference_title: "OpenID Connect 1.0 protocol (OIDC)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
+weight: 60
 version: "6.2"
 product: "Sensu Go"
 menu:
@@ -11,16 +13,16 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 {{% notice warning %}}
 **WARNING**: Defining multiple OIDC providers can lead to inconsistent authentication behavior.
@@ -454,20 +456,19 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [3]: ../#authorization
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../../deploy-sensu/install-sensu/#ports
 [6]: ../../../commercial/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [17]: ../rbac#namespaced-resource-types
 [18]: ../rbac#cluster-wide-resource-types
 [19]: ../../maintain-sensu/troubleshoot#log-levels
 [25]: #oidc-spec-attributes
-[27]: ../../../api/authproviders/
-[36]: ../../../sensuctl/#first-time-setup-and-authentication-and-authentication
+[36]: ../../../sensuctl/#first-time-setup-and-authentication
 [38]: ../../../sensuctl/create-manage-resources/#create-resources
 [41]: https://en.wikipedia.org/wiki/Fully_qualified_domain_name
 [42]: https://regex101.com/r/zo9mQU/2

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -2240,7 +2240,7 @@ spec:
 [29]: #create-role-bindings-and-cluster-role-bindings
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
-[32]: ../#use-an-authentication-provider
+[32]: ../sso/
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.2/operations/control-access/sso.md
+++ b/content/sensu-go/6.2/operations/control-access/sso.md
@@ -3,10 +3,10 @@ title: "Configure single sign-on (SSO) authentication"
 linktitle: "Configure SSO Authentication"
 description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an SSO authentication provider."
 weight: 10
-version: "6.4"
+version: "6.2"
 product: "Sensu Go"
 menu:
-  sensu-go-6.4:
+  sensu-go-6.2:
     parent: control-access
 ---
 

--- a/content/sensu-go/6.2/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.2/operations/control-access/use-apikeys.md
@@ -4,7 +4,7 @@ linkTitle: "Use API Keys"
 guide_title: "Use API keys to authenticate to Sensu"
 type: "guide"
 description: "Sensu's API key feature improves integration efficiency, security, and administrative control. Read this guide to use Sensu's API key for authentication."
-weight: 50
+weight: 20
 version: "6.2"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/api/authproviders.md
+++ b/content/sensu-go/6.3/api/authproviders.md
@@ -1,7 +1,7 @@
 ---
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
-description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider for single sign-on (SSO)."
 api_title: "Authentication providers API"
 type: "api"
 version: "6.3"
@@ -12,7 +12,7 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/operations/control-access/_index.md
+++ b/content/sensu-go/6.3/operations/control-access/_index.md
@@ -27,7 +27,7 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when [external authentication providers][15] are configured by the administrator.
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
@@ -38,76 +38,17 @@ The basic authentication provider does not depend on external services and is no
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].
 
-### Use an authentication provider
+### Use a single sign-on (SSO) authentication provider
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
+In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using external authentication providers via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC).
 
-#### Configure authentication providers
-
-**1. Write an authentication provider configuration definition**
-
-* Standards-compliant LDAP tools like OpenLDAP: [LDAP configuration examples][29] and [specification][30]
-* Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
-* OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
-
-Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
-
-**2. Apply the configuration with sensuctl**
-
-Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl create --file authconfig.yml
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl create --file authconfig.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Use sensuctl to verify that your provider configuration was applied successfully:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-The response will list your authentication provider types and names:
-
-{{< code shell >}}
- Type     Name    
-────── ────────── 
- ldap   openldap  
-{{< /code >}}
-
-#### Manage authentication providers
-
-View and delete authentication providers with the [authentication providers API][27] or these sensuctl commands.
-
-To view active authentication providers:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-To view configuration details for an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth info openldap
-{{< /code >}}
-
-To delete an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth delete openldap
-{{< /code >}}
+Read [Configure single sign-on (SSO) authentication][6] for general information about configuring an SSO authentication provider.
+Read the [LDAP][44], [AD][37], or [OIDC][7] reference documentation for provider-specific information.
 
 ## Authorization
 
@@ -133,31 +74,19 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
+[6]: sso/
 [7]: oidc-auth/
 [8]: ../../api/
-[9]: oidc-auth/#oidc-configuration-examples
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: rbac#roles-and-cluster-roles
-[12]: oidc-auth/#oidc-specification
 [13]: rbac#role-bindings-and-cluster-role-bindings
 [14]: #use-built-in-basic-authentication
-[15]: #use-an-authentication-provider
+[15]: #use-a-single-sign-on-sso-authentication-provider
 [16]: rbac/#view-users
 [17]: rbac#namespaced-resource-types
 [18]: rbac#cluster-wide-resource-types
 [19]: ../maintain-sensu/troubleshoot#log-levels
-[20]: ../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[21]: ldap-auth/#ldap-group-search-attributes
-[22]: ldap-auth/#ldap-user-search-attributes
-[23]: ad-auth/#ad-metadata-attributes
-[24]: ldap-auth/#ldap-metadata-attributes
-[25]: /oidc-auth/#oidc-spec-attributes
+[20]: ../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [26]: https://en.wikipedia.org/wiki/Bcrypt
-[27]: ../../api/authproviders/
-[29]: ldap-auth/#ldap-configuration-examples
-[30]: ldap-auth/#ldap-specification
-[31]: ad-auth/#ad-configuration-examples
-[32]: ad-auth/#ad-specification
 [36]: ../../sensuctl/#first-time-setup-and-authentication
 [37]: ad-auth/
 [38]: ../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Active Directory (AD) authentication"
-linktitle: "Authenticate with AD"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
-weight: 10
+title: "Active Directory (AD) reference"
+linktitle: "AD Reference"
+reference_title: "Active Directory (AD)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
+weight: 50
 version: "6.3"
 product: "Sensu Go"
 menu:
@@ -11,18 +13,18 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## AD configuration examples
 
@@ -81,6 +83,7 @@ api_version: authentication/v2
 metadata:
   name: activedirectory
 spec:
+  allowed_groups: []
   groups_prefix: ad
   servers:
   - binding:
@@ -142,6 +145,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   },
@@ -290,6 +294,7 @@ spec:
       attribute: sAMAccountName
       name_attribute: displayName
       object_class: person
+  allowed_groups: []
   groups_prefix: ad
   username_prefix: ad
 {{< /code >}}
@@ -325,6 +330,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ad",
     "username_prefix": "ad"
   }
@@ -395,6 +401,29 @@ servers:
         "object_class": "person"
       }
     }
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [
+    "sensu-viewers",
+    "sensu-operators"
   ]
 }
 {{< /code >}}
@@ -856,10 +885,11 @@ The troubleshooting steps in the [LDAP troubleshooting][49] section also apply f
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [8]: ../../../api/
 [10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [23]: #ad-metadata-attributes
 [38]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -4,7 +4,7 @@ linkTitle: "Create Limited Service Accounts"
 guide_title: "Create limited service accounts with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to create limited service accounts so that applications can access and interact with Sensu resources. Read this guide to create limited service accounts with Sensu RBAC."
-weight: 65
+weight: 40
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
@@ -4,7 +4,7 @@ linkTitle: "Create a Read-only User"
 guide_title: "Create a read-only user with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources. Use RBAC rules to achieve multitenancy so different projects and teams can share a Sensu instance. Read this guide to create users with Sensu RBAC."
-weight: 60
+weight: 30
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ldap-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Lightweight Directory Access Protocol (LDAP) authentication"
-linktitle: "Authenticate with LDAP"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
-weight: 20
+title: "Lightweight Directory Access Protocol (LDAP) reference"
+linktitle: "LDAP Reference"
+reference_title: "Lightweight Directory Access Protocol (LDAP)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
+weight: 55
 version: "6.3"
 product: "Sensu Go"
 menu:
@@ -11,17 +13,17 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## LDAP configuration examples
 
@@ -80,6 +82,7 @@ api_version: authentication/v2
 metadata:
   name: openldap
 spec:
+  allowed_groups: []
   groups_prefix: ldap
   servers:
   - binding:
@@ -137,6 +140,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   },
@@ -283,6 +287,7 @@ spec:
       attribute: uid
       name_attribute: cn
       object_class: person
+  allowed_groups: []
   groups_prefix: ldap
   username_prefix: ldap
 
@@ -317,6 +322,7 @@ spec:
         }
       }
     ],
+    "allowed_groups": [],
     "groups_prefix": "ldap",
     "username_prefix": "ldap"
   }
@@ -383,6 +389,29 @@ servers:
         "object_class": "person"
       }
     }
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="allowed-groups"></a>
+
+| allowed_groups |   |
+-------------|------
+description  | An array of allowed LDAP group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+required     | false
+type         | Array of strings
+example      | {{< language-toggle >}}
+{{< code yml >}}
+allowed_groups:
+- sensu-viewers
+- sensu-operators
+{{< /code >}}
+{{< code json >}}
+{
+  "allowed_groups": [
+    "sensu-viewers",
+    "sensu-operators"
   ]
 }
 {{< /code >}}
@@ -886,11 +915,11 @@ For example:
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [7]: https://www.openldap.org/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [21]: #ldap-group-search-attributes
 [22]: #ldap-user-search-attributes

--- a/content/sensu-go/6.3/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/oidc-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure OpenID Connect 1.0 protocol (OIDC) authentication"
-linktitle: "Authenticate with OIDC"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
-weight: 30
+title: "OpenID Connect 1.0 protocol (OIDC) reference"
+linktitle: "OIDC Reference"
+reference_title: "OpenID Connect 1.0 protocol (OIDC)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
+weight: 60
 version: "6.3"
 product: "Sensu Go"
 menu:
@@ -11,16 +13,16 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 {{% notice warning %}}
 **WARNING**: Defining multiple OIDC providers can lead to inconsistent authentication behavior.
@@ -454,19 +456,18 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [3]: ../#authorization
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../../deploy-sensu/install-sensu/#ports
 [6]: ../../../commercial/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [17]: ../rbac#namespaced-resource-types
 [18]: ../rbac#cluster-wide-resource-types
 [19]: ../../maintain-sensu/troubleshoot#log-levels
 [25]: #oidc-spec-attributes
-[27]: ../../../api/authproviders/
 [36]: ../../../sensuctl/#first-time-setup-and-authentication
 [38]: ../../../sensuctl/create-manage-resources/#create-resources
 [41]: https://en.wikipedia.org/wiki/Fully_qualified_domain_name

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -2240,7 +2240,7 @@ spec:
 [29]: #create-role-bindings-and-cluster-role-bindings
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
-[32]: ../#use-an-authentication-provider
+[32]: ../sso/
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.3/operations/control-access/sso.md
+++ b/content/sensu-go/6.3/operations/control-access/sso.md
@@ -3,10 +3,10 @@ title: "Configure single sign-on (SSO) authentication"
 linktitle: "Configure SSO Authentication"
 description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an SSO authentication provider."
 weight: 10
-version: "6.4"
+version: "6.3"
 product: "Sensu Go"
 menu:
-  sensu-go-6.4:
+  sensu-go-6.3:
     parent: control-access
 ---
 

--- a/content/sensu-go/6.3/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.3/operations/control-access/use-apikeys.md
@@ -4,7 +4,7 @@ linkTitle: "Use API Keys"
 guide_title: "Use API keys to authenticate to Sensu"
 type: "guide"
 description: "Sensu's API key feature improves integration efficiency, security, and administrative control. Read this guide to use Sensu's API key for authentication."
-weight: 50
+weight: 20
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/api/authproviders.md
+++ b/content/sensu-go/6.4/api/authproviders.md
@@ -1,7 +1,7 @@
 ---
 title: "Authentication providers API"
 linkTitle: "Authentication Providers API"
-description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider."
+description: "The Sensu authentication providers API endpoint provides HTTP access to authentication provider configuration. This reference includes examples of how to return the list of active authentication providers and create or update an authentication provider for single sign-on (SSO)."
 api_title: "Authentication providers API"
 type: "api"
 version: "6.4"
@@ -12,7 +12,7 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/operations/control-access/_index.md
+++ b/content/sensu-go/6.4/operations/control-access/_index.md
@@ -27,7 +27,7 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when [external authentication providers][15] are configured by the administrator.
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
@@ -38,76 +38,17 @@ The basic authentication provider does not depend on external services and is no
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].
 
-### Use an authentication provider
+### Use a single sign-on (SSO) authentication provider
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access authentication providers in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-In addition to built-in authentication, Sensu includes commercial support for authentication using external authentication providers via [Lightweight Directory Access Protocol (LDAP)][44], [Active Directory (AD)][37], or [OpenID Connect 1.0 protocol (OIDC)][7].
+In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using external authentication providers via Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC).
 
-#### Configure authentication providers
-
-**1. Write an authentication provider configuration definition**
-
-* Standards-compliant LDAP tools like OpenLDAP: [LDAP configuration examples][29] and [specification][30]
-* Microsoft AD, including Azure AD: [AD configuration examples][31] and [specification][32]
-* OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
-
-Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
-
-**2. Apply the configuration with sensuctl**
-
-Log in to sensuctl as the [default admin user][3] and use sensuctl to apply the configuration to Sensu:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl create --file authconfig.yml
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl create --file authconfig.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Use sensuctl to verify that your provider configuration was applied successfully:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-The response will list your authentication provider types and names:
-
-{{< code shell >}}
- Type     Name    
-────── ────────── 
- ldap   openldap  
-{{< /code >}}
-
-#### Manage authentication providers
-
-View and delete authentication providers with the [authentication providers API][27] or these sensuctl commands.
-
-To view active authentication providers:
-
-{{< code shell >}}
-sensuctl auth list
-{{< /code >}}
-
-To view configuration details for an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth info openldap
-{{< /code >}}
-
-To delete an authentication provider named `openldap`:
-
-{{< code shell >}}
-sensuctl auth delete openldap
-{{< /code >}}
+Read [Configure single sign-on (SSO) authentication][6] for general information about configuring an SSO authentication provider.
+Read the [LDAP][44], [AD][37], or [OIDC][7] reference documentation for provider-specific information.
 
 ## Authorization
 
@@ -133,31 +74,19 @@ Users do *not* need to provide the username prefix for the authentication provid
 [3]: rbac#default-users
 [4]: rbac/
 [5]: create-read-only-user/
+[6]: sso/
 [7]: oidc-auth/
 [8]: ../../api/
-[9]: oidc-auth/#oidc-configuration-examples
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
 [11]: rbac#roles-and-cluster-roles
-[12]: oidc-auth/#oidc-specification
 [13]: rbac#role-bindings-and-cluster-role-bindings
 [14]: #use-built-in-basic-authentication
-[15]: #use-an-authentication-provider
+[15]: #use-a-single-sign-on-sso-authentication-provider
 [16]: rbac/#view-users
 [17]: rbac#namespaced-resource-types
 [18]: rbac#cluster-wide-resource-types
 [19]: ../maintain-sensu/troubleshoot#log-levels
-[20]: ../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
-[21]: ldap-auth/#ldap-group-search-attributes
-[22]: ldap-auth/#ldap-user-search-attributes
-[23]: ad-auth/#ad-metadata-attributes
-[24]: ldap-auth/#ldap-metadata-attributes
-[25]: /oidc-auth/#oidc-spec-attributes
+[20]: ../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [26]: https://en.wikipedia.org/wiki/Bcrypt
-[27]: ../../api/authproviders/
-[29]: ldap-auth/#ldap-configuration-examples
-[30]: ldap-auth/#ldap-specification
-[31]: ad-auth/#ad-configuration-examples
-[32]: ad-auth/#ad-specification
 [36]: ../../sensuctl/#first-time-setup-and-authentication
 [37]: ad-auth/
 [38]: ../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.4/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ad-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Active Directory (AD) authentication"
-linktitle: "Authenticate with AD"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
-weight: 10
+title: "Active Directory (AD) reference"
+linktitle: "AD Reference"
+reference_title: "Active Directory (AD)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Active Directory (AD). Read this guide to configure an AD authentication provider."
+weight: 50
 version: "6.4"
 product: "Sensu Go"
 menu:
@@ -11,18 +13,18 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access active directory (AD) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access active directory (AD) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## AD configuration examples
 
@@ -883,10 +885,11 @@ The troubleshooting steps in the [LDAP troubleshooting][49] section also apply f
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [8]: ../../../api/
 [10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [23]: #ad-metadata-attributes
 [38]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -4,7 +4,7 @@ linkTitle: "Create Limited Service Accounts"
 guide_title: "Create limited service accounts with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to create limited service accounts so that applications can access and interact with Sensu resources. Read this guide to create limited service accounts with Sensu RBAC."
-weight: 65
+weight: 40
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
@@ -4,7 +4,7 @@ linkTitle: "Create a Read-only User"
 guide_title: "Create a read-only user with role-based access control (RBAC)"
 type: "guide"
 description: "Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources. Use RBAC rules to achieve multitenancy so different projects and teams can share a Sensu instance. Read this guide to create users with Sensu RBAC."
-weight: 60
+weight: 30
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ldap-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure Lightweight Directory Access Protocol (LDAP) authentication"
-linktitle: "Authenticate with LDAP"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
-weight: 20
+title: "Lightweight Directory Access Protocol (LDAP) reference"
+linktitle: "LDAP Reference"
+reference_title: "Lightweight Directory Access Protocol"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
+weight: 55
 version: "6.4"
 product: "Sensu Go"
 menu:
@@ -11,17 +13,17 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access Lightweight Directory Access Protocol (LDAP) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for authentication.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 ## LDAP configuration examples
 
@@ -913,11 +915,11 @@ For example:
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [6]: ../../../commercial/
 [7]: https://www.openldap.org/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [21]: #ldap-group-search-attributes
 [22]: #ldap-user-search-attributes

--- a/content/sensu-go/6.4/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ldap-auth.md
@@ -1,7 +1,7 @@
 ---
 title: "Lightweight Directory Access Protocol (LDAP) reference"
 linktitle: "LDAP Reference"
-reference_title: "Lightweight Directory Access Protocol"
+reference_title: "Lightweight Directory Access Protocol (LDAP)"
 type: "reference"
 description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP). Read this guide to configure an LDAP authentication provider."
 weight: 55

--- a/content/sensu-go/6.4/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/oidc-auth.md
@@ -1,8 +1,10 @@
 ---
-title: "Configure OpenID Connect 1.0 protocol (OIDC) authentication"
-linktitle: "Authenticate with OIDC"
-description: "In addition to built-in basic authentication, Sensu includes commercial support for authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
-weight: 30
+title: "OpenID Connect 1.0 protocol (OIDC) reference"
+linktitle: "OIDC Reference"
+reference_title: "OpenID Connect 1.0 protocol (OIDC)"
+type: "reference"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an authentication provider."
+weight: 60
 version: "6.4"
 product: "Sensu Go"
 menu:
@@ -11,16 +13,16 @@ menu:
 ---
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access OpenID Connect 1.0 protocol (OIDC) authentication for single sign-on (SSO) in the packaged Sensu Go distribution.
 For more information, see [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the built-in basic authentication provider, Sensu offers [commercial support][6] for authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
-For general information about configuring authentication providers, see [Use an authentication provider][12].
+For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].
 
 {{% notice warning %}}
 **WARNING**: Defining multiple OIDC providers can lead to inconsistent authentication behavior.
@@ -454,19 +456,18 @@ If a browser does not open, launch a browser to complete the login via your OIDC
 
 [1]: ../../../web-ui/
 [2]: ../../../sensuctl/
+[4]: ../#use-built-in-basic-authentication
 [3]: ../#authorization
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../../deploy-sensu/install-sensu/#ports
 [6]: ../../../commercial/
 [8]: ../../../api/
-[10]: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-ldaps
-[12]: ../#use-an-authentication-provider
+[12]: ../sso/
 [13]: ../rbac#role-bindings-and-cluster-role-bindings
 [17]: ../rbac#namespaced-resource-types
 [18]: ../rbac#cluster-wide-resource-types
 [19]: ../../maintain-sensu/troubleshoot#log-levels
 [25]: #oidc-spec-attributes
-[27]: ../../../api/authproviders/
 [36]: ../../../sensuctl/#first-time-setup-and-authentication
 [38]: ../../../sensuctl/create-manage-resources/#create-resources
 [41]: https://en.wikipedia.org/wiki/Fully_qualified_domain_name

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -2240,7 +2240,7 @@ spec:
 [29]: #create-role-bindings-and-cluster-role-bindings
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
-[32]: ../#use-an-authentication-provider
+[32]: ../sso/
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.4/operations/control-access/sso.md
+++ b/content/sensu-go/6.4/operations/control-access/sso.md
@@ -1,0 +1,102 @@
+---
+title: "Configure single sign-on (SSO) authentication"
+linktitle: "Configure SSO Authentication"
+description: "In addition to built-in basic authentication, Sensu includes commercial support for single sign-on (SSO) authentication using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC). Read this guide to configure an SSO authentication provider."
+weight: 10
+version: "6.4"
+product: "Sensu Go"
+menu:
+  sensu-go-6.4:
+    parent: control-access
+---
+
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access authentication providers for single sign-on (SSO) in the packaged Sensu Go distribution.
+For more information, see [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
+
+Sensu requires username and password authentication to access the [web UI][1], [API][3], and [sensuctl][2] command line tool.
+
+In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
+
+This guide describes general information for configuring an authentication provider for SSO.
+Read the [LDAP][8], [AD][6], or [OIDC][7] reference documentation for provider-specific examples and specifications.
+
+## Configure authentication providers
+
+To configure an external authentication provider for SSO, first write an authentication provider configuration definition.
+Follow the examples and specifications for your provider:
+
+- Standards-compliant LDAP tools like OpenLDAP: [LDAP configuration examples][11] and [specification][13]
+- Microsoft AD, including Azure AD: [AD configuration examples][14] and [specification][15]
+- OIDC tools like Okta and PingFederate: [OIDC configuration examples][9] and [specification][12]
+
+Save your configuration definition to a file, such as `authconfig.yaml` or `authconfig.json`.
+
+After you have a saved configuration definition, you can apply the configuration with sensuctl.
+Log in to sensuctl as the [default admin user][3] and use sensuctl to apply your authentication provider configuration to Sensu:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl create --file authconfig.yml
+{{< /code >}}
+
+{{< code shell "JSON" >}}
+sensuctl create --file authconfig.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Use sensuctl to verify that your provider configuration was applied successfully:
+
+{{< code shell >}}
+sensuctl auth list
+{{< /code >}}
+
+The response will list your authentication provider types and names:
+
+{{< code shell >}}
+ Type     Name    
+────── ────────── 
+ ldap   openldap  
+{{< /code >}}
+
+## Manage authentication providers
+
+View and delete authentication providers with the [authentication providers API][10] or these sensuctl commands.
+
+To view active authentication providers:
+
+{{< code shell >}}
+sensuctl auth list
+{{< /code >}}
+
+To view configuration details for an authentication provider named `openldap`:
+
+{{< code shell >}}
+sensuctl auth info openldap
+{{< /code >}}
+
+To delete an authentication provider named `openldap`:
+
+{{< code shell >}}
+sensuctl auth delete openldap
+{{< /code >}}
+
+
+[1]: ../../../web-ui/
+[2]: ../../../sensuctl/
+[3]: ../../../api/
+[4]: ../#use-built-in-basic-authentication
+[5]: ../../../commercial/
+[6]: ../ad-auth/
+[7]: ../oidc-auth/
+[8]: ../ldap-auth/
+[9]: ../oidc-auth/#oidc-configuration-examples
+[10]: ../../../api/authproviders/
+[11]: ../ldap-auth/#ldap-configuration-examples
+[12]: ../oidc-auth/#oidc-specification
+[13]: ../ldap-auth/#ldap-specification
+[14]: ../ad-auth/#ad-configuration-examples
+[15]: ../ad-auth/#ad-specification

--- a/content/sensu-go/6.4/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.4/operations/control-access/use-apikeys.md
@@ -4,7 +4,7 @@ linkTitle: "Use API Keys"
 guide_title: "Use API keys to authenticate to Sensu"
 type: "guide"
 description: "Sensu's API key feature improves integration efficiency, security, and administrative control. Read this guide to use Sensu's API key for authentication."
-weight: 50
+weight: 20
 version: "6.4"
 product: "Sensu Go"
 platformContent: false


### PR DESCRIPTION
## Description
- Adds a page "Configure single sign-on (SSO) authentication" to include the general auth provider config info previously included at https://docs.sensu.io/sensu-go/latest/operations/control-access/#use-an-authentication-provider
- Updates frontmatter for AD, LDAP, and OIDC pages to recharacterize them as references

## Motivation and Context
https://sumologic.slack.com/archives/C0257A32C30/p1626192724003700