### PR TITLE
6.3: Add poll_interval attribute for GlobalConfig resource

### DIFF
--- a/content/sensu-go/6.3/api/webconfig.md
+++ b/content/sensu-go/6.3/api/webconfig.md
@@ -47,6 +47,7 @@ HTTP/1.1 200 OK
     "spec": {
       "always_show_local_cluster": false,
       "default_preferences": {
+        "poll_interval": 120000,
         "page_size": 50,
         "theme": "sensu"
       },
@@ -86,6 +87,7 @@ output         | {{< code shell >}}
     "spec": {
       "always_show_local_cluster": false,
       "default_preferences": {
+        "poll_interval": 120000,
         "page_size": 50,
         "theme": "sensu"
       },
@@ -129,6 +131,7 @@ HTTP/1.1 200 OK
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "sensu"
     },
@@ -166,6 +169,7 @@ output               | {{< code json >}}
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "sensu"
     },
@@ -206,6 +210,7 @@ curl -X PUT \
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "sensu"
     },
@@ -244,6 +249,7 @@ payload         | {{< code shell >}}
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "sensu"
     },

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -102,7 +102,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][207]) The [agent transport health API endpoint][212] repsonse now includes PostgreSQL health information.
-- ([Commercial feature][162]) Added the [`poll_interval` default preferences][223] attribute to the `GlobalConfig` resource so administrators can adjust how often the web UI pages poll for new data.
+- ([Commercial feature][207]) Added the [`poll_interval` default preferences][223] attribute to the `GlobalConfig` resource so administrators can adjust how often the web UI pages poll for new data.
 - ([Commercial feature][207]) In the web UI, some form fields now include examples of valid values.
 - Added the `--api-key` [global flag][214] for sensuctl commands. Use this flag with sensuctl commands to bypass username/password authentication.
 - Logs for JavaScript filter evaluation errors now include more context.

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -102,6 +102,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][207]) The [agent transport health API endpoint][212] repsonse now includes PostgreSQL health information.
+- ([Commercial feature][162]) Added the [`poll_interval` default preferences][223] attribute to the `GlobalConfig` resource so administrators can adjust how often the web UI pages poll for new data.
 - ([Commercial feature][207]) In the web UI, some form fields now include examples of valid values.
 - Added the `--api-key` [global flag][214] for sensuctl commands. Use this flag with sensuctl commands to bypass username/password authentication.
 - Logs for JavaScript filter evaluation errors now include more context.
@@ -1854,3 +1855,4 @@ To get started with Sensu Go:
 [212]: /sensu-go/6.3/api/health/#get-health-data-for-your-agent-transport
 [213]: /sensu-go/6.3/observability-pipeline/observe-entities/#service-entities
 [214]: /sensu-go/6.3/sensuctl/#global-flags
+[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes

--- a/content/sensu-go/6.3/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.3/web-ui/webconfig-reference.md
@@ -252,7 +252,7 @@ always_show_local_cluster: false
 
 default_preferences | 
 -------------|------ 
-description  | Global [default preferences attributes][1] for all users: poll interval, page size, and theme preferences.
+description  | Global [default preferences][1] for all users: poll interval, page size, and theme preferences.
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
@@ -311,17 +311,16 @@ link_policy:
 
 poll_interval | 
 -------------|------ 
-description  | The frequency at which web UI pages will poll for new data from the Sensu backend. Increase the `poll_interval` value if web UI sessions are causing heavy load. In milliseconds.
+description  | The frequency at which web UI pages will poll for new data from the Sensu backend, in milliseconds. Useful for increasing the polling interval duration if web UI sessions are causing heavy load. If you set the poll interval, all web UI views will use the poll interval value instead of their individual polling defaults.
 required     | false
 type         | Integer
-default      | `10000`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-poll_interval: 10000
+poll_interval: 120000
 {{< /code >}}
 {{< code json >}}
 {
-  "poll_interval": 10000
+  "poll_interval": 120000
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.3/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.3/web-ui/webconfig-reference.md
@@ -43,6 +43,7 @@ metadata:
 spec:
   always_show_local_cluster: false
   default_preferences:
+    poll_interval: 120000
     page_size: 50
     theme: classic
   link_policy:
@@ -67,6 +68,7 @@ spec:
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "classic"
     },
@@ -155,6 +157,7 @@ example      | {{< language-toggle >}}
 spec:
   always_show_local_cluster: false
   default_preferences:
+    poll_interval: 120000
     page_size: 50
     theme: classic
   link_policy:
@@ -172,6 +175,7 @@ spec:
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "classic"
     },
@@ -248,18 +252,20 @@ always_show_local_cluster: false
 
 default_preferences | 
 -------------|------ 
-description  | Global default page size and theme preferences for all users.
+description  | Global [default preferences attributes][1] for all users: poll interval, page size, and theme preferences.
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 default_preferences:
+  poll_interval: 120000
   page_size: 50
   theme: classic
 {{< /code >}}
 {{< code json >}}
 {
   "default_preferences": {
+    "poll_interval": 120000,
     "page_size": 50,
     "theme": "classic"
   }
@@ -302,6 +308,23 @@ link_policy:
 {{< /language-toggle >}}
 
 #### Default preferences attributes
+
+poll_interval | 
+-------------|------ 
+description  | The frequency at which web UI pages will poll for new data from the Sensu backend. Increase the `poll_interval` value if web UI sessions are causing heavy load. In milliseconds.
+required     | false
+type         | Integer
+default      | `10000`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+poll_interval: 10000
+{{< /code >}}
+{{< code json >}}
+{
+  "poll_interval": 10000
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 page_size | 
 -------------|------ 
@@ -391,6 +414,7 @@ urls:
 {{< /language-toggle >}}
 
 
+[1]: #default-preferences-attributes
 [2]: ../../api/webconfig/
 [3]: ../../web-ui/
 [4]: #spec-attributes

--- a/content/sensu-go/6.4/api/webconfig.md
+++ b/content/sensu-go/6.4/api/webconfig.md
@@ -47,6 +47,7 @@ HTTP/1.1 200 OK
     "spec": {
       "always_show_local_cluster": false,
       "default_preferences": {
+        "poll_interval": 120000,
         "page_size": 500,
         "theme": "sensu"
       },
@@ -100,6 +101,7 @@ output         | {{< code shell >}}
     "spec": {
       "always_show_local_cluster": false,
       "default_preferences": {
+        "poll_interval": 120000,
         "page_size": 500,
         "theme": "sensu"
       },
@@ -157,6 +159,7 @@ HTTP/1.1 200 OK
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 500,
       "theme": "sensu"
     },
@@ -208,6 +211,7 @@ output               | {{< code json >}}
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 500,
       "theme": "sensu"
     },
@@ -261,6 +265,7 @@ curl -X PUT \
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 500,
       "theme": "sensu"
     },
@@ -312,6 +317,7 @@ payload         | {{< code shell >}}
   "spec": {
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 500,
       "theme": "sensu"
     },

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -142,6 +142,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][207]) The [agent transport health API endpoint][212] repsonse now includes PostgreSQL health information.
+- ([Commercial feature][207]) Added the [`poll_interval` default preferences][223] attribute to the `GlobalConfig` resource so administrators can adjust how often the web UI pages poll for new data.
 - ([Commercial feature][207]) In the web UI, some form fields now include examples of valid values.
 - Added the `--api-key` [global flag][214] for sensuctl commands. Use this flag with sensuctl commands to bypass username/password authentication.
 - Logs for JavaScript filter evaluation errors now include more context.
@@ -1902,3 +1903,4 @@ To get started with Sensu Go:
 [220]: /sensu-go/6.4/web-ui/webconfig-reference/#sign-in-message
 [221]: /sensu-go/6.4/web-ui/webconfig-reference/#page-preferences-attributes
 [222]: /sensu-go/6.4/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
+[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes

--- a/content/sensu-go/6.4/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.4/web-ui/webconfig-reference.md
@@ -48,6 +48,7 @@ spec:
   signin_message: with your LDAP or system credentials
   always_show_local_cluster: false
   default_preferences:
+    poll_interval: 120000
     page_size: 50
     theme: classic
   page_preferences:
@@ -81,6 +82,7 @@ spec:
     "signin_message": "with your LDAP or system credentials",
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "classic"
     },
@@ -183,6 +185,7 @@ spec:
   signin_message: with your LDAP or system credentials
   always_show_local_cluster: false
   default_preferences:
+    poll_interval: 120000
     page_size: 50
     theme: classic
   page_preferences:
@@ -209,6 +212,7 @@ spec:
     "signin_message": "with your LDAP or system credentials",
     "always_show_local_cluster": false,
     "default_preferences": {
+      "poll_interval": 120000,
       "page_size": 50,
       "theme": "classic"
     },
@@ -317,18 +321,20 @@ always_show_local_cluster: false
 
 default_preferences | 
 -------------|------ 
-description  | Global [default][1] page size and theme preferences for all users.
+description  | Global [default preferences][1] page size and theme preferences for all users.
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 default_preferences:
+  poll_interval: 120000
   page_size: 50
   theme: classic
 {{< /code >}}
 {{< code json >}}
 {
   "default_preferences": {
+    "poll_interval": 120000,
     "page_size": 50,
     "theme": "classic"
   }
@@ -406,6 +412,22 @@ link_policy:
 {{< /language-toggle >}}
 
 #### Default preferences attributes
+
+poll_interval | 
+-------------|------ 
+description  | The frequency at which web UI pages will poll for new data from the Sensu backend, in milliseconds. Useful for increasing the polling interval duration if web UI sessions are causing heavy load. If you set the poll interval, all web UI views will use the poll interval value instead of their individual polling defaults.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+poll_interval: 120000
+{{< /code >}}
+{{< code json >}}
+{
+  "poll_interval": 120000
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 page_size | 
 -------------|------ 


### PR DESCRIPTION
## Description
Adds documentation for the poll_interval attribute for the GlobalConfig resource

## Motivation and Context
https://github.com/sensu/sensu-enterprise-go/pull/1576
