### PR TITLE
Update values for external etcd flags in cluster guide

### DIFF
--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -359,9 +359,9 @@ To tell Sensu to use this external etcd data source, add the `sensu-backend` fla
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
---etcd-cert-file=./client.pem \
---etcd-key-file=./client-key.pem \
---etcd-client-urls=https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379 \
+--etcd-cert-file=./backend-1.pem \
+--etcd-key-file=./backend-1-key.pem \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /code >}}
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -359,9 +359,9 @@ To tell Sensu to use this external etcd data source, add the `sensu-backend` fla
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
---etcd-cert-file=./client.pem \
---etcd-key-file=./client-key.pem \
---etcd-client-urls=https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379 \
+--etcd-cert-file=./backend-1.pem \
+--etcd-key-file=./backend-1-key.pem \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /code >}}
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -359,9 +359,9 @@ To tell Sensu to use this external etcd data source, add the `sensu-backend` fla
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
---etcd-cert-file=./client.pem \
---etcd-key-file=./client-key.pem \
---etcd-client-urls=https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379 \
+--etcd-cert-file=./backend-1.pem \
+--etcd-key-file=./backend-1-key.pem \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /code >}}
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -359,9 +359,9 @@ To tell Sensu to use this external etcd data source, add the `sensu-backend` fla
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
---etcd-cert-file=./client.pem \
---etcd-key-file=./client-key.pem \
---etcd-client-urls=https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379 \
+--etcd-cert-file=./backend-1.pem \
+--etcd-key-file=./backend-1-key.pem \
+--etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
 --no-embed-etcd
 {{< /code >}}
 


### PR DESCRIPTION
## Description
In http://localhost:1313/sensu-go/6.4/operations/deploy-sensu/cluster-sensu/#use-an-external-etcd-cluster:
- Updates the values for --etcd-cert-file and --etcd-key-file to match the examples used in the backend reference
- Adds unspaced comma separators in the value for --etcd-client-urls

## Motivation and Context
Discussion w/Mike re: testing for Monitor Sensu with Sensu guide.