### PR TITLE
Alternative noindex meta tag conditional

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,7 +26,7 @@
       <meta name="docsearch:version" content="{{ .Page.Params.version }}" />
     {{ end}}
 
-    {{ if not (eq .Params.product "Sensu Go") }}
+    {{ if not (eq .Params.version "6.4") }}
     <meta name="robots" content="noindex">
     {{ end }}
 


### PR DESCRIPTION
## Description
We previously added a Hugo conditional statement in head.html partial that added a noindex meta tag for every page that did not have the `product: "Sensu Go"` frontmatter attribute.

This PR replaces the product-based conditional with a version-based conditional that will add a noindex meta tag for every page that does not have `version: "6.4"` in its frontmatter.

## Motivation and Context
After investigating with Google Search Console, it seems Google-selected canonicals are ignoring our "latest" designation. I'm hypothesizing that this conditional will prevent every version except "latest" (currently 6.4) from being indexed, thereby forcing Google to select "latest" as the canonical.

This PR will add a step to the release process because the conditional will need an update for every minor release.