### PR TITLE
Update cluster doc with correct syntax and cert clarification for external etcd

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -864,7 +864,7 @@ type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 command line example   | {{< code shell >}}
-sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
+sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}

--- a/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/cluster-sensu.md
@@ -354,19 +354,19 @@ etcd \
 Without these settings, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using your CA:
+To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
 
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./backend-1.pem \
 --etcd-key-file=./backend-1-key.pem \
---etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls='https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379' \
 --no-embed-etcd
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `etcd-client-urls` value must be a space-delimited list or a YAML array.
+**NOTE**: The etcd and sensu-backend certificates must share a CA, and the `etcd-client-urls` value must be a space-delimited list or a YAML array.
 {{% /notice %}}
 
 ## Migrate from embedded etcd to external etcd

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -863,7 +863,7 @@ type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 command line example   | {{< code shell >}}
-sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
+sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}

--- a/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/cluster-sensu.md
@@ -354,19 +354,19 @@ etcd \
 Without these settings, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using your CA:
+To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
 
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./backend-1.pem \
 --etcd-key-file=./backend-1-key.pem \
---etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls='https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379' \
 --no-embed-etcd
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `etcd-client-urls` value must be a space-delimited list or a YAML array.
+**NOTE**: The etcd and sensu-backend certificates must share a CA, and the `etcd-client-urls` value must be a space-delimited list or a YAML array.
 {{% /notice %}}
 
 ## Migrate from embedded etcd to external etcd

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -892,7 +892,7 @@ type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 command line example   | {{< code shell >}}
-sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
+sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -354,19 +354,19 @@ etcd \
 Without these settings, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using your CA:
+To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
 
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./backend-1.pem \
 --etcd-key-file=./backend-1-key.pem \
---etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls='https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379' \
 --no-embed-etcd
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `etcd-client-urls` value must be a space-delimited list or a YAML array.
+**NOTE**: The etcd and sensu-backend certificates must share a CA, and the `etcd-client-urls` value must be a space-delimited list or a YAML array.
 {{% /notice %}}
 
 ## Migrate from embedded etcd to external etcd

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -938,7 +938,7 @@ type                    | List
 default                 | `http://127.0.0.1:2379`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_URLS`
 command line example   | {{< code shell >}}
-sensu-backend start --etcd-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
+sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -354,19 +354,19 @@ etcd \
 Without these settings, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the path to a client certificate created using your CA:
+To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
 
 {{< code shell >}}
 sensu-backend start \
 --etcd-trusted-ca-file=./ca.pem \
 --etcd-cert-file=./backend-1.pem \
 --etcd-key-file=./backend-1-key.pem \
---etcd-client-urls=https://10.0.0.1:2379,https://10.0.0.2:2379,https://10.0.0.3:2379 \
+--etcd-client-urls='https://10.0.0.1:2379 https://10.0.0.2:2379 https://10.0.0.3:2379' \
 --no-embed-etcd
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `etcd-client-urls` value must be a space-delimited list or a YAML array.
+**NOTE**: The etcd and sensu-backend certificates must share a CA, and the `etcd-client-urls` value must be a space-delimited list or a YAML array.
 {{% /notice %}}
 
 ## Migrate from embedded etcd to external etcd


### PR DESCRIPTION
## Description
In Run a Sensu cluster:
- Clarifies the etcd and backend certs must share a CA
- Corrects the syntax for the `etcd-client-urls` list

In the backend reference:
- Corrects the syntax for the `etcd-client-urls` list

## Motivation and Context
https://sumologic.slack.com/archives/D025XE6LWNM/p1626473454009100
