### PR TITLE
Correct statement about downloading assets from Bonsai

### DIFF
--- a/content/sensu-go/6.1/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.1/plugins/use-assets-to-install-plugins.md
@@ -49,7 +49,7 @@ If you do not specify a version to install, Sensu automatically installs the lat
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
 
-You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
+You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to download the asset definition for your Sensu backend platform and architecture.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/6.2/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.2/plugins/use-assets-to-install-plugins.md
@@ -49,7 +49,7 @@ If you do not specify a version to install, Sensu automatically installs the lat
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
 
-You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
+You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to download the asset definition for your Sensu backend platform and architecture.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
@@ -49,7 +49,7 @@ If you do not specify a version to install, Sensu automatically installs the lat
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
 
-You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
+You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to download the asset definition for your Sensu backend platform and architecture.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.

--- a/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
@@ -49,7 +49,7 @@ If you do not specify a version to install, Sensu automatically installs the lat
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `pagerduty-handler`.
 
-You can also click the Download button on the asset page in [Bonsai][7] to download the asset definition for your Sensu backend platform and architecture.
+You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to download the asset definition for your Sensu backend platform and architecture.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.


### PR DESCRIPTION
## Description
In Use assets to install plugins, corrects the instruction to click "download" button -- instead users can visit the Release Assets tab to download a specific build.

## Motivation and Context
Discovered when working on something else