### PR TITLE
Document overrides for agent and backend

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1800,6 +1800,49 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 **NOTE**: If you define the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, the agent WebSocket connection will also use the proxy URL you specify.
 {{% /notice %}}
 
+## Create overrides
+
+Sensu has default settings and limits for certain configuration attributes, like the default log level.
+Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
+
+You can create overrides in several ways:
+
+- **Recommended method**: environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Configuration settings in the agent.yml config file.
+- Command line arguments for `sensu-agent start`.
+
+{{% notice note %}}
+**NOTE**: We do not recommend editing the systemd unit file to create overrides.
+Overrides in the systemd unit file can be overwritten by future package upgrades.
+{{% /notice %}}
+
+Sensu applies the following precedence to override settings:
+
+1. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+2. Configuration in the agent.yml config file.
+3. Arguments passed to the Sensu agent via command line.
+
+For example, if you create overrides in all three places, the values in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` will take priority over values in the agent.yml config file and command line arguments.
+
+### Example override: Log level
+
+The default [log level][60] for the Sensu agent is `info`.
+To override the default and automatically apply a different log level for the agent, configure the agent log level environment variable with the desired level:
+
+{{< language-toggle >}}
+
+{{< code shell "Ubuntu/Debian" >}}
+$ echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-agent
+{{< /code >}}
+
+{{< code shell "RHEL/CentOS" >}}
+$ echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+After you restart the sensu-agent service, your settings will take effect.
+
 
 [1]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents
 [2]: ../backend/
@@ -1860,3 +1903,4 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
 [58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
 [59]: ../../../operations/control-access/#use-built-in-basic-authentication
+[60]: #log-level

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1807,27 +1807,34 @@ Depending on your environment and preferences, you may want to create overrides 
 
 You can create overrides in several ways:
 
-- **Recommended method**: environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Command line configuration flag arguments for `sensu-agent start`.
+- Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
 - Configuration settings in the agent.yml config file.
-- Command line arguments for `sensu-agent start`.
 
 {{% notice note %}}
 **NOTE**: We do not recommend editing the systemd unit file to create overrides.
-Overrides in the systemd unit file can be overwritten by future package upgrades.
+Future package upgrades can overwrite changes in the systemd unit file.
 {{% /notice %}}
 
 Sensu applies the following precedence to override settings:
 
-1. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
-2. Configuration in the agent.yml config file.
-3. Arguments passed to the Sensu agent via command line.
+1. Arguments passed to the Sensu agent via command line configuration flags.
+2. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+3. Configuration in the agent.yml config file.
 
-For example, if you create overrides in all three places, the values in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` will take priority over values in the agent.yml config file and command line arguments.
+For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` or the agent.yml config file.
 
 ### Example override: Log level
 
 The default [log level][60] for the Sensu agent is `info`.
-To override the default and automatically apply a different log level for the agent, configure the agent log level environment variable with the desired level:
+To override the default and automatically apply a different log level for the agent, add the `--log-level` command line configuration flag when you start the Sensu agent.
+For example, to specify `debug` as the log level:
+
+{{< code shell >}}
+sensu-agent start --log-level debug
+{{< /code >}}
+
+To configure an environment variable for the desired agent log level:
 
 {{< language-toggle >}}
 
@@ -1841,7 +1848,11 @@ $ echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
 
 {{< /language-toggle >}}
 
-After you restart the sensu-agent service, your settings will take effect.
+To configure the desired log level in the config file, add this line to agent.yml:
+
+{{< code shell >}}
+log-level: debug
+{{< /code >}}
 
 
 [1]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1434,6 +1434,51 @@ Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubu
 
 For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_BACKEND_TEST_VAR`.
 
+## Create overrides
+
+Sensu and various operating systems have default limits for certain configuration attributes, like the maximum number of open files.
+Depending on your environment, you may need to create overrides for both Sensu-specific and system limits.
+
+You can create overrides in several ways:
+
+- Recommended method: Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Configuration settings in the backend.yml config file.
+- Command line arguments for `sensu-backend start`.
+
+{{% notice warning %}}
+**WARNING**: Do not edit the systemd unit file to create overrides.
+{{% /notice %}}
+
+Sensu applies the following precedence to override settings:
+
+1. Environment variables in `/etc/default/sensu-backend`.
+2. Configuration in the backend.yml config file.
+3. Arguments passed to the Sensu backend via command line.
+
+For example, if you create overrides in all three places, the values in `/etc/default/sensu-backend` will take priority over values in the backend.yml config file and command line arguments.
+
+### Example: TODO (Sensu-specific limit)
+
+### Example: Maximum open files (system limit)
+
+For many Linux operating systems, the default limit for the maximum number of open files for a single process is 1024.
+Development and production environments often require a higher limit to allow more open files, like 65536, so you will need to override the default limit.
+
+To do this, create a [custom environment variable][38] named `SENSU_BACKEND_MAX_OPEN_FILES`:
+
+{{< language-toggle >}}
+
+{{< code shell "Ubuntu/Debian" >}}
+$ echo 'SENSU_BACKEND_MAX_OPEN_FILES=65536' | sudo tee -a /etc/default/sensu-backend
+{{< /code >}}
+
+{{< code shell "RHEL/CentOS" >}}
+$ echo 'SENSU_BACKEND_MAX_OPEN_FILES=65536' | sudo tee -a /etc/sysconfig/sensu-backend
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+
 ## Event logging
 
 {{% notice commercial %}}
@@ -1555,3 +1600,4 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [35]: ../../../operations/deploy-sensu/install-sensu/#architecture-overview
 [36]: #etcd-heartbeat-interval
 [37]: #backend-log-level
+[38]: #configuration-via-environment-variables

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1441,27 +1441,34 @@ Depending on your environment and preferences, you may want to create overrides 
 
 You can create overrides in several ways:
 
-- **Recommended method**: environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Command line configuration flag arguments for `sensu-backend start`.
+- Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
 - Configuration settings in the backend.yml config file.
-- Command line arguments for `sensu-backend start`.
 
 {{% notice note %}}
 **NOTE**: We do not recommend editing the systemd unit file to create overrides.
-Overrides in the systemd unit file can be overwritten by future package upgrades.
+Future package upgrades can overwrite changes in the systemd unit file.
 {{% /notice %}}
 
 Sensu applies the following precedence to override settings:
 
-1. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
-2. Configuration in the backend.yml config file.
-3. Arguments passed to the Sensu backend via command line.
+1. Arguments passed to the Sensu backend via command line configuration flags.
+2. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+3. Configuration in the backend.yml config file.
 
-For example, if you create overrides in all three places, the values in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` will take priority over values in the backend.yml config file and command line arguments.
+For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` or the backend.yml config file.
 
 ### Example override: Log level
 
-The default [log level][37] for the Sensu backend is `warn`.
-To override the default and automatically apply a different log level for the backend, configure the backend log level environment variable with the desired level:
+The default [log level][60] for the Sensu backend is `info`.
+To override the default and automatically apply a different log level for the backend, add the `--log-level` command line configuration flag when you start the Sensu backend.
+For example, to specify `debug` as the log level:
+
+{{< code shell >}}
+sensu-backend start --log-level debug
+{{< /code >}}
+
+To configure an environment variable for the desired backend log level:
 
 {{< language-toggle >}}
 
@@ -1475,7 +1482,11 @@ $ echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backen
 
 {{< /language-toggle >}}
 
-After you restart the sensu-backend service, your settings will take effect.
+To configure the desired log level in the config file, add this line to backend.yml:
+
+{{< code shell >}}
+log-level: debug
+{{< /code >}}
 
 ## Event logging
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1441,7 +1441,7 @@ Depending on your environment, you may need to create overrides for both Sensu-s
 
 You can create overrides in several ways:
 
-- Recommended method: Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Recommended method: environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
 - Configuration settings in the backend.yml config file.
 - Command line arguments for `sensu-backend start`.
 
@@ -1459,7 +1459,7 @@ For example, if you create overrides in all three places, the values in `/etc/de
 
 ### Example: TODO (Sensu-specific limit)
 
-### Example: Maximum open files (system limit)
+### Example: Max open files (system limit)
 
 For many Linux operating systems, the default limit for the maximum number of open files for a single process is 1024.
 Development and production environments often require a higher limit to allow more open files, like 65536, so you will need to override the default limit.
@@ -1477,7 +1477,6 @@ $ echo 'SENSU_BACKEND_MAX_OPEN_FILES=65536' | sudo tee -a /etc/sysconfig/sensu-b
 {{< /code >}}
 
 {{< /language-toggle >}}
-
 
 ## Event logging
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1436,7 +1436,7 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Create overrides
 
-Sensu and various operating systems have default limits for certain configuration attributes, like the maximum number of open files.
+Sensu and various operating systems have default settings and limits for certain configuration attributes, like the default access credentials and maximum number of open files.
 Depending on your environment, you may need to create overrides for both Sensu-specific and system limits.
 
 You can create overrides in several ways:
@@ -1457,14 +1457,15 @@ Sensu applies the following precedence to override settings:
 
 For example, if you create overrides in all three places, the values in `/etc/default/sensu-backend` will take priority over values in the backend.yml config file and command line arguments.
 
-### Example: TODO (Sensu-specific limit)
+### Example: TODO (Sensu-specific override)
 
-### Example: Max open files (system limit)
+
+### Example: Max open files
 
 For many Linux operating systems, the default limit for the maximum number of open files for a single process is 1024.
-Development and production environments often require a higher limit to allow more open files, like 65536, so you will need to override the default limit.
+Development and production environments often require a higher limit to allow more open files, so you will need to override the default limit.
 
-To do this, create a [custom environment variable][38] named `SENSU_BACKEND_MAX_OPEN_FILES`:
+To do this, create a [custom environment variable][38] named `SENSU_BACKEND_MAX_OPEN_FILES` and specify your desired max open files limit:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1436,48 +1436,46 @@ For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-bac
 
 ## Create overrides
 
-Sensu and various operating systems have default settings and limits for certain configuration attributes, like the default access credentials and maximum number of open files.
-Depending on your environment, you may need to create overrides for both Sensu-specific and system limits.
+Sensu has default settings and limits for certain configuration attributes, like the default log level.
+Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
 You can create overrides in several ways:
 
-- Recommended method: environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- **Recommended method**: environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
 - Configuration settings in the backend.yml config file.
 - Command line arguments for `sensu-backend start`.
 
-{{% notice warning %}}
-**WARNING**: Do not edit the systemd unit file to create overrides.
+{{% notice note %}}
+**NOTE**: We do not recommend editing the systemd unit file to create overrides.
+Overrides in the systemd unit file can be overwritten by future package upgrades.
 {{% /notice %}}
 
 Sensu applies the following precedence to override settings:
 
-1. Environment variables in `/etc/default/sensu-backend`.
+1. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
 2. Configuration in the backend.yml config file.
 3. Arguments passed to the Sensu backend via command line.
 
-For example, if you create overrides in all three places, the values in `/etc/default/sensu-backend` will take priority over values in the backend.yml config file and command line arguments.
+For example, if you create overrides in all three places, the values in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` will take priority over values in the backend.yml config file and command line arguments.
 
-### Example: TODO (Sensu-specific override)
+### Example override: Log level
 
-
-### Example: Max open files
-
-For many Linux operating systems, the default limit for the maximum number of open files for a single process is 1024.
-Development and production environments often require a higher limit to allow more open files, so you will need to override the default limit.
-
-To do this, create a [custom environment variable][38] named `SENSU_BACKEND_MAX_OPEN_FILES` and specify your desired max open files limit:
+The default [log level][37] for the Sensu backend is `warn`.
+To override the default and automatically apply a different log level for the backend, configure the backend log level environment variable with the desired level:
 
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-$ echo 'SENSU_BACKEND_MAX_OPEN_FILES=65536' | sudo tee -a /etc/default/sensu-backend
+$ echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-$ echo 'SENSU_BACKEND_MAX_OPEN_FILES=65536' | sudo tee -a /etc/sysconfig/sensu-backend
+$ echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+After you restart the sensu-backend service, your settings will take effect.
 
 ## Event logging
 

--- a/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
@@ -768,7 +768,7 @@ To maximize Sensu Go performance, we recommend that you:
 
 ### Symptoms of poor performance
 
-At the default "warn" log level, you may see messages like these from your Sensu backend:
+At the Sensu backend's default "warn" log level, you may see messages like these from your backend:
 
 {{< code json >}}
 {"component":"etcd","level":"warning","msg":"read-only range request \"key:\\\"/sensu.io/handlers/default/keepalive\\\" limit:1 \" with result \"range_response_count:0 size:6\" took too long (169.767546ms) to execute","pkg":"etcdserver","time":"..."}


### PR DESCRIPTION
## Description
In the agent and backend reference, documents how to create Sensu-specific and system limit overrides using environment variables, configuration file settings, and command line arguments, with examples.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3248
