### PR TITLE
Change link to workshops

### DIFF
--- a/content/sensu-go/6.1/get-started.md
+++ b/content/sensu-go/6.1/get-started.md
@@ -37,7 +37,7 @@ We recommend these resources for learning more about Sensu:
 - Join the [Sensu Community Forum on Discourse][8]
 
 {{% notice protip %}}
-**PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.1/learn/_index.md
+++ b/content/sensu-go/6.1/learn/_index.md
@@ -14,7 +14,7 @@ menu:
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
 {{% notice protip %}}
-**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/get-started.md
+++ b/content/sensu-go/6.2/get-started.md
@@ -37,7 +37,7 @@ We recommend these resources for learning more about Sensu:
 - Join the [Sensu Community Forum on Discourse][8]
 
 {{% notice protip %}}
-**PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.2/learn/_index.md
+++ b/content/sensu-go/6.2/learn/_index.md
@@ -14,7 +14,7 @@ menu:
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
 {{% notice protip %}}
-**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/get-started.md
+++ b/content/sensu-go/6.3/get-started.md
@@ -37,7 +37,7 @@ We recommend these resources for learning more about Sensu:
 - Join the [Sensu Community Forum on Discourse][8]
 
 {{% notice protip %}}
-**PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/learn/_index.md
+++ b/content/sensu-go/6.3/learn/_index.md
@@ -14,7 +14,7 @@ menu:
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
 {{% notice protip %}}
-**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/get-started.md
+++ b/content/sensu-go/6.4/get-started.md
@@ -37,7 +37,7 @@ We recommend these resources for learning more about Sensu:
 - Join the [Sensu Community Forum on Discourse][8]
 
 {{% notice protip %}}
-**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/learn/_index.md
+++ b/content/sensu-go/6.4/learn/_index.md
@@ -14,7 +14,7 @@ menu:
 The Learn Sensu category includes tools to help you understand and start using Sensu, the industry-leading observability pipeline for multi-cloud monitoring, consolidating monitoring tools, and filling observability gaps at scale.
 
 {{% notice protip %}}
-**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
+**PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 


### PR DESCRIPTION
## Description
Changes link to self-guided workshop to use https://sensu.io/resources?type=workshop instead of the GitHub repo

## Motivation and Context
Resources page now neatly lists workshop lessons and the lesson pages themselves look nicer than the readmes
