### PR TITLE
Update agent and backend config flag lists

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -853,53 +853,53 @@ Usage:
   sensu-agent start [flags]
 
 Flags:
-      --allow-list string                     path to agent execution allow list configuration file
-      --annotations stringToString            entity annotations map (default [])
-      --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
-      --api-port int                          port the Sensu client HTTP API listens on (default 3031)
-      --assets-burst-limit int                asset fetch burst limit (default 100)
-      --assets-rate-limit float               maximum number of assets fetched per second
-      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
-      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
-      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
-      --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
-      --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
-      --cert-file string                      TLS certificate in PEM format
-  -c, --config-file string                    path to sensu-agent config file
-      --deregister                            ephemeral agent
-      --deregistration-handler string         deregistration handler that should process the entity deregistration event.
-      --detect-cloud-provider                 enable cloud provider detection mechanisms
-      --disable-assets                        disable check assets on this agent
-      --disable-api                           disable the Agent HTTP API
-      --disable-sockets                       disable the Agent TCP and UDP event sockets
-      --discover-processes                    indicates whether process discovery should be enabled
-      --events-burst-limit                    /events api burst limit
-      --events-rate-limit                     maximum number of events transmitted to the backend through the /events api
-  -h, --help                                  help for start
-      --insecure-skip-tls-verify              skip ssl verification
-      --keepalive-critical-timeout uint32     number of seconds until agent is considered dead by backend to create a critical event (default 0)
-      --keepalive-handlers string             comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
-      --keepalive-interval uint32             number of seconds to send between keepalive events (default 20)
-      --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
-      --key-file string                       TLS certificate key in PEM format
-      --labels stringToString                 entity labels map (default [])
-      --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "info")
-      --name string                           agent name (defaults to hostname) (default "my-hostname")
-      --namespace string                      agent namespace (default "default")
-      --password string                       agent password (default "P@ssw0rd!")
-      --redact string                         comma-delimited customized list of fields to redact
-      --require-fips                          indicates whether fips support should be required in openssl
-      --require-openssl                       indicates whether openssl should be required instead of go's built-in crypto
-      --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
-      --socket-port int                       port the Sensu client socket listens on (default 3030)
-      --statsd-disable                        disables the statsd listener and metrics server
-      --statsd-event-handlers strings         comma-delimited list of event handlers for statsd metrics
-      --statsd-flush-interval int             number of seconds between statsd flush (default 10)
-      --statsd-metrics-host string            address used for the statsd metrics server (default "127.0.0.1")
-      --statsd-metrics-port int               port used for the statsd metrics server (default 8125)
-      --subscriptions string                  comma-delimited list of agent subscriptions
-      --trusted-ca-file string                tls certificate authority
-      --user string                           agent user (default "agent")
+      --allow-list string                   path to agent execution allow list configuration file
+      --annotations stringToString          entity annotations map (default [])
+      --api-host string                     address to bind the Sensu client HTTP API to (default "127.0.0.1")
+      --api-port int                        port the Sensu client HTTP API listens on (default 3031)
+      --assets-burst-limit int              asset fetch burst limit (default 100)
+      --assets-rate-limit float             maximum number of assets fetched per second
+      --backend-handshake-timeout int       number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int      interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int       number of seconds the agent should wait for a response to a hearbeat (default 45)
+      --backend-url strings                 comma-delimited list of ws/wss URLs of Sensu backend servers. This flag can also be invoked multiple times (default [ws://127.0.0.1:8081])
+      --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-agent")
+      --cert-file string                    certificate for TLS authentication
+  -c, --config-file string                  path to sensu-agent config file (default "/etc/sensu/agent.yml")
+      --deregister                          ephemeral agent
+      --deregistration-handler string       deregistration handler that should process the entity deregistration event
+      --detect-cloud-provider               enable cloud provider detection
+      --disable-api                         disable the Agent HTTP API
+      --disable-assets                      disable check assets on this agent
+      --disable-sockets                     disable the Agent TCP and UDP event sockets
+      --discover-processes                  indicates whether process discovery should be enabled
+      --events-burst-limit int              /events api burst limit (default 10)
+      --events-rate-limit float             maximum number of events transmitted to the backend through the /events api
+  -h, --help                                help for start
+      --insecure-skip-tls-verify            skip TLS verification (not recommended!)
+      --keepalive-critical-timeout uint32   number of seconds until agent is considered dead by backend to create a critical event
+      --keepalive-handlers strings          comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
+      --keepalive-interval int              number of seconds to send between keepalive events (default 20)
+      --keepalive-warning-timeout uint32    number of seconds until agent is considered dead by backend to create a warning event (default 120)
+      --key-file string                     key for TLS authentication
+      --labels stringToString               entity labels map (default [])
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "info")
+      --name string                         agent name (defaults to hostname) (default "my_hostname")
+      --namespace string                    agent namespace (default "default")
+      --password string                     agent password (default "P@ssw0rd!")
+      --redact strings                      comma-delimited list of fields to redact, overwrites the default fields. This flag can also be invoked multiple times (default [password,passwd,pass,api_key,api_token,access_key,secret_key,private_key,secret])
+      --require-fips                        indicates whether fips support should be required in openssl
+      --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
+      --socket-host string                  address to bind the Sensu client socket to (default "127.0.0.1")
+      --socket-port int                     port the Sensu client socket listens on (default 3030)
+      --statsd-disable                      disables the statsd listener and metrics server
+      --statsd-event-handlers strings       comma-delimited list of event handlers for statsd metrics. This flag can also be invoked multiple times
+      --statsd-flush-interval int           number of seconds between statsd flush (default 10)
+      --statsd-metrics-host string          address used for the statsd metrics server (default "127.0.0.1")
+      --statsd-metrics-port int             port used for the statsd metrics server (default 8125)
+      --subscriptions strings               comma-delimited list of agent subscriptions. This flag can also be invoked multiple times
+      --trusted-ca-file string              TLS CA certificate bundle in PEM format
+      --user string                         agent user (default "agent")
 {{< /code >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/backend.md
@@ -316,14 +316,14 @@ General Flags:
       --agent-port int                      agent listener port (default 8081)
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --annotations stringToString          entity annotations map (default [])
-      --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
-      --api-request-limit                   maximum API request body size, in bytes (default 512000)
-      --api-url string                      URL of the API to connect to (default "http://localhost:8080")
+      --api-listen-address string           address to listen on for api traffic (default "[::]:8080")
+      --api-request-limit int               maximum API request body size, in bytes (default 512000)
+      --api-url string                      url of the api to connect to (default "http://localhost:8080")
       --assets-burst-limit int              asset fetch burst limit (default 100)
       --assets-rate-limit float             maximum number of assets fetched per second
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
-  -c, --config-file string                  path to sensu-backend config file
+  -c, --config-file string                  path to sensu-backend config file (default "/etc/sensu/backend.yml")
       --dashboard-cert-file string          dashboard TLS certificate in PEM format
       --dashboard-host string               dashboard listener host (default "[::]")
       --dashboard-key-file string           dashboard TLS certificate key in PEM format
@@ -336,48 +336,47 @@ General Flags:
       --eventd-workers int                  number of workers spawned for processing incoming events (default 100)
   -h, --help                                help for start
       --insecure-skip-tls-verify            skip TLS verification (not recommended!)
-      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs)
+      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JWTs
       --jwt-public-key-file string          path to the PEM-encoded public key to use to verify JWT signatures
       --keepalived-buffer-size int          number of incoming keepalives that can be buffered (default 100)
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
       --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
+      --metrics-refresh-interval string     Go duration value (e.g. 1h5m30s) that governs how often metrics are refreshed. (default "1m")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
-      --require-fips                        indicates whether fips support should be required in openssl
+      --require-fips                        indicates whether fips support should be required in openssl  
       --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format
 
 Store Flags:
-      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to the rest of the cluster (default [http://localhost:2379])
+      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to clients (default [http://localhost:2379])
       --etcd-cert-file string                      path to the client server TLS cert file
       --etcd-cipher-suites strings                 list of ciphers to use for etcd TLS configuration
-      --etcd-client-urls string                    client URLs to use when operating as an etcd client
       --etcd-client-cert-auth                      enable client cert authentication
-      --etcd-discovery                             use the dynamic cluster configuration method etcd
-discovery instead of the static `--initial-cluster method`
-      --etcd-discovery-srv                         use the dynamic cluster configuration method DNS SRV
-discovery instead of the static `--initial-cluster method`
+      --etcd-client-urls string                    client URLs to use when operating as an etcd client
+      --etcd-discovery string                      discovery URL used to bootstrap the cluster
+      --etcd-discovery-srv string                  DNS SRV record used to bootstrap the cluster
       --etcd-election-timeout uint                 time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself (default 1000)
       --etcd-heartbeat-interval uint               interval in ms with which the etcd leader will notify followers that it is still the leader (default 100)
       --etcd-initial-advertise-peer-urls strings   list of this member's peer URLs to advertise to the rest of the cluster (default [http://127.0.0.1:2380])
-      --etcd-initial-cluster string                initial cluster configuration for bootstrapping (default "default=http://127.0.0.1:2380")
-      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing"; default "new")
+      --etcd-initial-cluster string                initial cluster configuration for bootstrapping
+      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing") (default "new")
       --etcd-initial-cluster-token string          initial cluster token for the etcd cluster during bootstrap
       --etcd-key-file string                       path to the client server TLS key file
-      --etcd-listen-client-urls strings            list of URLs to listen on for client traffic (default [http://127.0.0.1:2379])
+      --etcd-listen-client-urls strings            list of etcd client URLs to listen on (default [http://127.0.0.1:2379])
       --etcd-listen-peer-urls strings              list of URLs to listen on for peer traffic (default [http://127.0.0.1:2380])
-      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution; default 1572864)
-      --etcd-name string                           human-readable name for this member (default "default")
+      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution) (default 1572864)
+      --etcd-name string                           name for this etcd node (default "default")
       --etcd-peer-cert-file string                 path to the peer server TLS cert file
       --etcd-peer-client-cert-auth                 enable peer client cert authentication
       --etcd-peer-key-file string                  path to the peer server TLS key file
       --etcd-peer-trusted-ca-file string           path to the peer server TLS trusted CA file
-      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution; default 4294967296)
+      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution) (default 4294967296)
       --etcd-trusted-ca-file string                path to the client server TLS trusted CA cert file
-      --no-embed-etcd                              don't embed etcd; use external etcd instead
+      --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
 ### General configuration flags
@@ -537,6 +536,19 @@ command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
+
+<a id="metrics-refresh-interval"></a>
+
+| metrics-refresh-interval |      |
+-------------|------
+description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.
+type         | String
+default      | `1m`
+environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
+command line example   | {{< code shell >}}
+sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+metrics-refresh-interval: "10s"{{< /code >}}
 
 | state-dir  |      |
 -------------|------

--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -390,7 +390,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 - ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153].
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -1654,3 +1654,4 @@ To get started with Sensu Go:
 [191]: /sensu-go/6.1/sensuctl/back-up-recover/
 [192]: /sensu-go/6.1/sensuctl/create-manage-resources/#sensuctl-prune
 [206]: /sensu-go/5.21/reference/backend/#log-rotation
+[224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -859,54 +859,54 @@ Usage:
   sensu-agent start [flags]
 
 Flags:
-      --agent-managed-entity                  manage this entity via the agent
-      --allow-list string                     path to agent execution allow list configuration file
-      --annotations stringToString            entity annotations map (default [])
-      --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
-      --api-port int                          port the Sensu client HTTP API listens on (default 3031)
-      --assets-burst-limit int                asset fetch burst limit (default 100)
-      --assets-rate-limit float               maximum number of assets fetched per second
-      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
-      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
-      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
-      --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
-      --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
-      --cert-file string                      TLS certificate in PEM format
-  -c, --config-file string                    path to sensu-agent config file
-      --deregister                            ephemeral agent
-      --deregistration-handler string         deregistration handler that should process the entity deregistration event.
-      --detect-cloud-provider                 enable cloud provider detection mechanisms
-      --disable-assets                        disable check assets on this agent
-      --disable-api                           disable the Agent HTTP API
-      --disable-sockets                       disable the Agent TCP and UDP event sockets
-      --discover-processes                    indicates whether process discovery should be enabled
-      --events-burst-limit                    /events api burst limit
-      --events-rate-limit                     maximum number of events transmitted to the backend through the /events api
-  -h, --help                                  help for start
-      --insecure-skip-tls-verify              skip ssl verification
-      --keepalive-critical-timeout uint32     number of seconds until agent is considered dead by backend to create a critical event (default 0)
-      --keepalive-handlers string             comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
-      --keepalive-interval uint32             number of seconds to send between keepalive events (default 20)
-      --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
-      --key-file string                       TLS certificate key in PEM format
-      --labels stringToString                 entity labels map (default [])
-      --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "info")
-      --name string                           agent name (defaults to hostname) (default "my-hostname")
-      --namespace string                      agent namespace (default "default")
-      --password string                       agent password (default "P@ssw0rd!")
-      --redact string                         comma-delimited customized list of fields to redact
-      --require-fips                          indicates whether fips support should be required in openssl
-      --require-openssl                       indicates whether openssl should be required instead of go's built-in crypto
-      --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
-      --socket-port int                       port the Sensu client socket listens on (default 3030)
-      --statsd-disable                        disables the statsd listener and metrics server
-      --statsd-event-handlers strings         comma-delimited list of event handlers for statsd metrics
-      --statsd-flush-interval int             number of seconds between statsd flush (default 10)
-      --statsd-metrics-host string            address used for the statsd metrics server (default "127.0.0.1")
-      --statsd-metrics-port int               port used for the statsd metrics server (default 8125)
-      --subscriptions string                  comma-delimited list of agent subscriptions
-      --trusted-ca-file string                tls certificate authority
-      --user string                           agent user (default "agent")
+      --agent-managed-entity                manage this entity via the agent
+      --allow-list string                   path to agent execution allow list configuration file
+      --annotations stringToString          entity annotations map (default [])
+      --api-host string                     address to bind the Sensu client HTTP API to (default "127.0.0.1")
+      --api-port int                        port the Sensu client HTTP API listens on (default 3031)
+      --assets-burst-limit int              asset fetch burst limit (default 100)
+      --assets-rate-limit float             maximum number of assets fetched per second
+      --backend-handshake-timeout int       number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int      interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int       number of seconds the agent should wait for a response to a hearbeat (default 45)
+      --backend-url strings                 comma-delimited list of ws/wss URLs of Sensu backend servers. This flag can also be invoked multiple times (default [ws://127.0.0.1:8081])
+      --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-agent")
+      --cert-file string                    certificate for TLS authentication
+  -c, --config-file string                  path to sensu-agent config file (default "/etc/sensu/agent.yml")
+      --deregister                          ephemeral agent
+      --deregistration-handler string       deregistration handler that should process the entity deregistration event
+      --detect-cloud-provider               enable cloud provider detection
+      --disable-api                         disable the Agent HTTP API
+      --disable-assets                      disable check assets on this agent
+      --disable-sockets                     disable the Agent TCP and UDP event sockets
+      --discover-processes                  indicates whether process discovery should be enabled
+      --events-burst-limit int              /events api burst limit (default 10)
+      --events-rate-limit float             maximum number of events transmitted to the backend through the /events api
+  -h, --help                                help for start
+      --insecure-skip-tls-verify            skip TLS verification (not recommended!)
+      --keepalive-critical-timeout uint32   number of seconds until agent is considered dead by backend to create a critical event
+      --keepalive-handlers strings          comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
+      --keepalive-interval int              number of seconds to send between keepalive events (default 20)
+      --keepalive-warning-timeout uint32    number of seconds until agent is considered dead by backend to create a warning event (default 120)
+      --key-file string                     key for TLS authentication
+      --labels stringToString               entity labels map (default [])
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "info")
+      --name string                         agent name (defaults to hostname) (default "my_hostname")
+      --namespace string                    agent namespace (default "default")
+      --password string                     agent password (default "P@ssw0rd!")
+      --redact strings                      comma-delimited list of fields to redact, overwrites the default fields. This flag can also be invoked multiple times (default [password,passwd,pass,api_key,api_token,access_key,secret_key,private_key,secret])
+      --require-fips                        indicates whether fips support should be required in openssl
+      --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
+      --socket-host string                  address to bind the Sensu client socket to (default "127.0.0.1")
+      --socket-port int                     port the Sensu client socket listens on (default 3030)
+      --statsd-disable                      disables the statsd listener and metrics server
+      --statsd-event-handlers strings       comma-delimited list of event handlers for statsd metrics. This flag can also be invoked multiple times
+      --statsd-flush-interval int           number of seconds between statsd flush (default 10)
+      --statsd-metrics-host string          address used for the statsd metrics server (default "127.0.0.1")
+      --statsd-metrics-port int             port used for the statsd metrics server (default 8125)
+      --subscriptions strings               comma-delimited list of agent subscriptions. This flag can also be invoked multiple times
+      --trusted-ca-file string              TLS CA certificate bundle in PEM format
+      --user string                         agent user (default "agent")
 {{< /code >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -316,14 +316,14 @@ General Flags:
       --agent-port int                      agent listener port (default 8081)
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --annotations stringToString          entity annotations map (default [])
-      --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
-      --api-request-limit                   maximum API request body size, in bytes (default 512000)
-      --api-url string                      URL of the API to connect to (default "http://localhost:8080")
+      --api-listen-address string           address to listen on for api traffic (default "[::]:8080")
+      --api-request-limit int               maximum API request body size, in bytes (default 512000)
+      --api-url string                      url of the api to connect to (default "http://localhost:8080")
       --assets-burst-limit int              asset fetch burst limit (default 100)
       --assets-rate-limit float             maximum number of assets fetched per second
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
-  -c, --config-file string                  path to sensu-backend config file
+  -c, --config-file string                  path to sensu-backend config file (default "/etc/sensu/backend.yml")
       --dashboard-cert-file string          dashboard TLS certificate in PEM format
       --dashboard-host string               dashboard listener host (default "[::]")
       --dashboard-key-file string           dashboard TLS certificate key in PEM format
@@ -336,48 +336,47 @@ General Flags:
       --eventd-workers int                  number of workers spawned for processing incoming events (default 100)
   -h, --help                                help for start
       --insecure-skip-tls-verify            skip TLS verification (not recommended!)
-      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs)
+      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JWTs
       --jwt-public-key-file string          path to the PEM-encoded public key to use to verify JWT signatures
       --keepalived-buffer-size int          number of incoming keepalives that can be buffered (default 100)
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
       --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
+      --metrics-refresh-interval string     Go duration value (e.g. 1h5m30s) that governs how often metrics are refreshed. (default "1m")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
-      --require-fips                        indicates whether fips support should be required in openssl
+      --require-fips                        indicates whether fips support should be required in openssl  
       --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format
 
 Store Flags:
-      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to the rest of the cluster (default [http://localhost:2379])
+      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to clients (default [http://localhost:2379])
       --etcd-cert-file string                      path to the client server TLS cert file
       --etcd-cipher-suites strings                 list of ciphers to use for etcd TLS configuration
-      --etcd-client-urls string                    client URLs to use when operating as an etcd client
       --etcd-client-cert-auth                      enable client cert authentication
-      --etcd-discovery                             use the dynamic cluster configuration method etcd
-discovery instead of the static `--initial-cluster method`
-      --etcd-discovery-srv                         use the dynamic cluster configuration method DNS SRV
-discovery instead of the static `--initial-cluster method`
+      --etcd-client-urls string                    client URLs to use when operating as an etcd client
+      --etcd-discovery string                      discovery URL used to bootstrap the cluster
+      --etcd-discovery-srv string                  DNS SRV record used to bootstrap the cluster
       --etcd-election-timeout uint                 time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself (default 1000)
       --etcd-heartbeat-interval uint               interval in ms with which the etcd leader will notify followers that it is still the leader (default 100)
       --etcd-initial-advertise-peer-urls strings   list of this member's peer URLs to advertise to the rest of the cluster (default [http://127.0.0.1:2380])
-      --etcd-initial-cluster string                initial cluster configuration for bootstrapping (default "default=http://127.0.0.1:2380")
-      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing"; default "new")
+      --etcd-initial-cluster string                initial cluster configuration for bootstrapping
+      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing") (default "new")
       --etcd-initial-cluster-token string          initial cluster token for the etcd cluster during bootstrap
       --etcd-key-file string                       path to the client server TLS key file
-      --etcd-listen-client-urls strings            list of URLs to listen on for client traffic (default [http://127.0.0.1:2379])
+      --etcd-listen-client-urls strings            list of etcd client URLs to listen on (default [http://127.0.0.1:2379])
       --etcd-listen-peer-urls strings              list of URLs to listen on for peer traffic (default [http://127.0.0.1:2380])
-      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution; default 1572864)
-      --etcd-name string                           human-readable name for this member (default "default")
+      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution) (default 1572864)
+      --etcd-name string                           name for this etcd node (default "default")
       --etcd-peer-cert-file string                 path to the peer server TLS cert file
       --etcd-peer-client-cert-auth                 enable peer client cert authentication
       --etcd-peer-key-file string                  path to the peer server TLS key file
       --etcd-peer-trusted-ca-file string           path to the peer server TLS trusted CA file
-      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution; default 4294967296)
+      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution) (default 4294967296)
       --etcd-trusted-ca-file string                path to the client server TLS trusted CA cert file
-      --no-embed-etcd                              don't embed etcd; use external etcd instead
+      --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
 ### General configuration flags
@@ -537,6 +536,19 @@ command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
+
+<a id="metrics-refresh-interval"></a>
+
+| metrics-refresh-interval |      |
+-------------|------
+description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.
+type         | String
+default      | `1m`
+environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
+command line example   | {{< code shell >}}
+sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+metrics-refresh-interval: "10s"{{< /code >}}
 
 | state-dir  |      |
 -------------|------

--- a/content/sensu-go/6.2/release-notes.md
+++ b/content/sensu-go/6.2/release-notes.md
@@ -537,7 +537,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 - ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153].
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -1814,3 +1814,4 @@ To get started with Sensu Go:
 [204]: /sensu-go/6.2/observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent
 [205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#configuration-via-flags
 [206]: /sensu-go/5.21/reference/backend/#log-rotation
+[224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -859,54 +859,54 @@ Usage:
   sensu-agent start [flags]
 
 Flags:
-      --agent-managed-entity                  manage this entity via the agent
-      --allow-list string                     path to agent execution allow list configuration file
-      --annotations stringToString            entity annotations map (default [])
-      --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
-      --api-port int                          port the Sensu client HTTP API listens on (default 3031)
-      --assets-burst-limit int                asset fetch burst limit (default 100)
-      --assets-rate-limit float               maximum number of assets fetched per second
-      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
-      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
-      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
-      --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
-      --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
-      --cert-file string                      TLS certificate in PEM format
-  -c, --config-file string                    path to sensu-agent config file
-      --deregister                            ephemeral agent
-      --deregistration-handler string         deregistration handler that should process the entity deregistration event.
-      --detect-cloud-provider                 enable cloud provider detection mechanisms
-      --disable-assets                        disable check assets on this agent
-      --disable-api                           disable the Agent HTTP API
-      --disable-sockets                       disable the Agent TCP and UDP event sockets
-      --discover-processes                    indicates whether process discovery should be enabled
-      --events-burst-limit                    /events api burst limit
-      --events-rate-limit                     maximum number of events transmitted to the backend through the /events api
-  -h, --help                                  help for start
-      --insecure-skip-tls-verify              skip ssl verification
-      --keepalive-critical-timeout uint32     number of seconds until agent is considered dead by backend to create a critical event (default 0)
-      --keepalive-handlers string             comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
-      --keepalive-interval uint32             number of seconds to send between keepalive events (default 20)
-      --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
-      --key-file string                       TLS certificate key in PEM format
-      --labels stringToString                 entity labels map (default [])
-      --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "info")
-      --name string                           agent name (defaults to hostname) (default "my-hostname")
-      --namespace string                      agent namespace (default "default")
-      --password string                       agent password (default "P@ssw0rd!")
-      --redact string                         comma-delimited customized list of fields to redact
-      --require-fips                          indicates whether fips support should be required in openssl
-      --require-openssl                       indicates whether openssl should be required instead of go's built-in crypto
-      --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
-      --socket-port int                       port the Sensu client socket listens on (default 3030)
-      --statsd-disable                        disables the statsd listener and metrics server
-      --statsd-event-handlers strings         comma-delimited list of event handlers for statsd metrics
-      --statsd-flush-interval int             number of seconds between statsd flush (default 10)
-      --statsd-metrics-host string            address used for the statsd metrics server (default "127.0.0.1")
-      --statsd-metrics-port int               port used for the statsd metrics server (default 8125)
-      --subscriptions string                  comma-delimited list of agent subscriptions
-      --trusted-ca-file string                tls certificate authority
-      --user string                           agent user (default "agent")
+      --agent-managed-entity                manage this entity via the agent
+      --allow-list string                   path to agent execution allow list configuration file
+      --annotations stringToString          entity annotations map (default [])
+      --api-host string                     address to bind the Sensu client HTTP API to (default "127.0.0.1")
+      --api-port int                        port the Sensu client HTTP API listens on (default 3031)
+      --assets-burst-limit int              asset fetch burst limit (default 100)
+      --assets-rate-limit float             maximum number of assets fetched per second
+      --backend-handshake-timeout int       number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int      interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int       number of seconds the agent should wait for a response to a hearbeat (default 45)
+      --backend-url strings                 comma-delimited list of ws/wss URLs of Sensu backend servers. This flag can also be invoked multiple times (default [ws://127.0.0.1:8081])
+      --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-agent")
+      --cert-file string                    certificate for TLS authentication
+  -c, --config-file string                  path to sensu-agent config file (default "/etc/sensu/agent.yml")
+      --deregister                          ephemeral agent
+      --deregistration-handler string       deregistration handler that should process the entity deregistration event
+      --detect-cloud-provider               enable cloud provider detection
+      --disable-api                         disable the Agent HTTP API
+      --disable-assets                      disable check assets on this agent
+      --disable-sockets                     disable the Agent TCP and UDP event sockets
+      --discover-processes                  indicates whether process discovery should be enabled
+      --events-burst-limit int              /events api burst limit (default 10)
+      --events-rate-limit float             maximum number of events transmitted to the backend through the /events api
+  -h, --help                                help for start
+      --insecure-skip-tls-verify            skip TLS verification (not recommended!)
+      --keepalive-critical-timeout uint32   number of seconds until agent is considered dead by backend to create a critical event
+      --keepalive-handlers strings          comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
+      --keepalive-interval int              number of seconds to send between keepalive events (default 20)
+      --keepalive-warning-timeout uint32    number of seconds until agent is considered dead by backend to create a warning event (default 120)
+      --key-file string                     key for TLS authentication
+      --labels stringToString               entity labels map (default [])
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "info")
+      --name string                         agent name (defaults to hostname) (default "my_hostname")
+      --namespace string                    agent namespace (default "default")
+      --password string                     agent password (default "P@ssw0rd!")
+      --redact strings                      comma-delimited list of fields to redact, overwrites the default fields. This flag can also be invoked multiple times (default [password,passwd,pass,api_key,api_token,access_key,secret_key,private_key,secret])
+      --require-fips                        indicates whether fips support should be required in openssl
+      --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
+      --socket-host string                  address to bind the Sensu client socket to (default "127.0.0.1")
+      --socket-port int                     port the Sensu client socket listens on (default 3030)
+      --statsd-disable                      disables the statsd listener and metrics server
+      --statsd-event-handlers strings       comma-delimited list of event handlers for statsd metrics. This flag can also be invoked multiple times
+      --statsd-flush-interval int           number of seconds between statsd flush (default 10)
+      --statsd-metrics-host string          address used for the statsd metrics server (default "127.0.0.1")
+      --statsd-metrics-port int             port used for the statsd metrics server (default 8125)
+      --subscriptions strings               comma-delimited list of agent subscriptions. This flag can also be invoked multiple times
+      --trusted-ca-file string              TLS CA certificate bundle in PEM format
+      --user string                         agent user (default "agent")
 {{< /code >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -318,14 +318,14 @@ General Flags:
       --agent-rate-limit int                agent connections maximum rate limit
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --annotations stringToString          entity annotations map (default [])
-      --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
-      --api-request-limit                   maximum API request body size, in bytes (default 512000)
-      --api-url string                      URL of the API to connect to (default "http://localhost:8080")
+      --api-listen-address string           address to listen on for api traffic (default "[::]:8080")
+      --api-request-limit int               maximum API request body size, in bytes (default 512000)
+      --api-url string                      url of the api to connect to (default "http://localhost:8080")
       --assets-burst-limit int              asset fetch burst limit (default 100)
       --assets-rate-limit float             maximum number of assets fetched per second
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
-  -c, --config-file string                  path to sensu-backend config file
+  -c, --config-file string                  path to sensu-backend config file (default "/etc/sensu/backend.yml")
       --dashboard-cert-file string          dashboard TLS certificate in PEM format
       --dashboard-host string               dashboard listener host (default "[::]")
       --dashboard-key-file string           dashboard TLS certificate key in PEM format
@@ -333,53 +333,53 @@ General Flags:
       --debug                               enable debugging and profiling features
       --deregistration-handler string       default deregistration handler
       --event-log-buffer-size int           buffer size of the event logger (default 100000)
+      --event-log-buffer-wait string        full buffer wait time (default "10ms")
       --event-log-file string               path to the event log file
       --eventd-buffer-size int              number of incoming events that can be buffered (default 100)
       --eventd-workers int                  number of workers spawned for processing incoming events (default 100)
   -h, --help                                help for start
       --insecure-skip-tls-verify            skip TLS verification (not recommended!)
-      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs)
+      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JWTs
       --jwt-public-key-file string          path to the PEM-encoded public key to use to verify JWT signatures
       --keepalived-buffer-size int          number of incoming keepalives that can be buffered (default 100)
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
       --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
+      --metrics-refresh-interval string     Go duration value (e.g. 1h5m30s) that governs how often metrics are refreshed. (default "1m")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
-      --require-fips                        indicates whether fips support should be required in openssl
+      --require-fips                        indicates whether fips support should be required in openssl  
       --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format
 
 Store Flags:
-      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to the rest of the cluster (default [http://localhost:2379])
+      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to clients (default [http://localhost:2379])
       --etcd-cert-file string                      path to the client server TLS cert file
       --etcd-cipher-suites strings                 list of ciphers to use for etcd TLS configuration
-      --etcd-client-urls string                    client URLs to use when operating as an etcd client
       --etcd-client-cert-auth                      enable client cert authentication
-      --etcd-discovery                             use the dynamic cluster configuration method etcd
-discovery instead of the static `--initial-cluster method`
-      --etcd-discovery-srv                         use the dynamic cluster configuration method DNS SRV
-discovery instead of the static `--initial-cluster method`
+      --etcd-client-urls string                    client URLs to use when operating as an etcd client
+      --etcd-discovery string                      discovery URL used to bootstrap the cluster
+      --etcd-discovery-srv string                  DNS SRV record used to bootstrap the cluster
       --etcd-election-timeout uint                 time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself (default 1000)
       --etcd-heartbeat-interval uint               interval in ms with which the etcd leader will notify followers that it is still the leader (default 100)
       --etcd-initial-advertise-peer-urls strings   list of this member's peer URLs to advertise to the rest of the cluster (default [http://127.0.0.1:2380])
-      --etcd-initial-cluster string                initial cluster configuration for bootstrapping (default "default=http://127.0.0.1:2380")
-      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing"; default "new")
+      --etcd-initial-cluster string                initial cluster configuration for bootstrapping
+      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing") (default "new")
       --etcd-initial-cluster-token string          initial cluster token for the etcd cluster during bootstrap
       --etcd-key-file string                       path to the client server TLS key file
-      --etcd-listen-client-urls strings            list of URLs to listen on for client traffic (default [http://127.0.0.1:2379])
+      --etcd-listen-client-urls strings            list of etcd client URLs to listen on (default [http://127.0.0.1:2379])
       --etcd-listen-peer-urls strings              list of URLs to listen on for peer traffic (default [http://127.0.0.1:2380])
-      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution; default 1572864)
-      --etcd-name string                           human-readable name for this member (default "default")
+      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution) (default 1572864)
+      --etcd-name string                           name for this etcd node (default "default")
       --etcd-peer-cert-file string                 path to the peer server TLS cert file
       --etcd-peer-client-cert-auth                 enable peer client cert authentication
       --etcd-peer-key-file string                  path to the peer server TLS key file
       --etcd-peer-trusted-ca-file string           path to the peer server TLS trusted CA file
-      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution; default 4294967296)
+      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution) (default 4294967296)
       --etcd-trusted-ca-file string                path to the client server TLS trusted CA cert file
-      --no-embed-etcd                              don't embed etcd; use external etcd instead
+      --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
 ### General configuration flags
@@ -539,6 +539,19 @@ command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
+
+<a id="metrics-refresh-interval"></a>
+
+| metrics-refresh-interval |      |
+-------------|------
+description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.
+type         | String
+default      | `1m`
+environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
+command line example   | {{< code shell >}}
+sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+metrics-refresh-interval: "10s"{{< /code >}}
 
 | state-dir  |      |
 -------------|------

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -570,7 +570,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 - ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153].
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -1856,3 +1856,4 @@ To get started with Sensu Go:
 [213]: /sensu-go/6.3/observability-pipeline/observe-entities/#service-entities
 [214]: /sensu-go/6.3/sensuctl/#global-flags
 [223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes
+[224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -859,54 +859,54 @@ Usage:
   sensu-agent start [flags]
 
 Flags:
-      --agent-managed-entity                  manage this entity via the agent
-      --allow-list string                     path to agent execution allow list configuration file
-      --annotations stringToString            entity annotations map (default [])
-      --api-host string                       address to bind the Sensu client HTTP API to (default "127.0.0.1")
-      --api-port int                          port the Sensu client HTTP API listens on (default 3031)
-      --assets-burst-limit int                asset fetch burst limit (default 100)
-      --assets-rate-limit float               maximum number of assets fetched per second
-      --backend-handshake-timeout int         number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
-      --backend-heartbeat-interval int        interval at which the agent should send heartbeats to the backend (default 30)
-      --backend-heartbeat-timeout int         number of seconds the agent should wait for a response to a hearbeat (default 45)
-      --backend-url strings                   ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times) (default [ws://127.0.0.1:8081])
-      --cache-dir string                      path to store cached data (default "/var/cache/sensu/sensu-agent")
-      --cert-file string                      TLS certificate in PEM format
-  -c, --config-file string                    path to sensu-agent config file
-      --deregister                            ephemeral agent
-      --deregistration-handler string         deregistration handler that should process the entity deregistration event.
-      --detect-cloud-provider                 enable cloud provider detection mechanisms
-      --disable-assets                        disable check assets on this agent
-      --disable-api                           disable the Agent HTTP API
-      --disable-sockets                       disable the Agent TCP and UDP event sockets
-      --discover-processes                    indicates whether process discovery should be enabled
-      --events-burst-limit                    /events api burst limit
-      --events-rate-limit                     maximum number of events transmitted to the backend through the /events api
-  -h, --help                                  help for start
-      --insecure-skip-tls-verify              skip ssl verification
-      --keepalive-critical-timeout uint32     number of seconds until agent is considered dead by backend to create a critical event (default 0)
-      --keepalive-handlers string             comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
-      --keepalive-interval uint32             number of seconds to send between keepalive events (default 20)
-      --keepalive-warning-timeout uint32      number of seconds until agent is considered dead by backend to create a warning event (default 120)
-      --key-file string                       TLS certificate key in PEM format
-      --labels stringToString                 entity labels map (default [])
-      --log-level string                      logging level [panic, fatal, error, warn, info, debug] (default "info")
-      --name string                           agent name (defaults to hostname) (default "my-hostname")
-      --namespace string                      agent namespace (default "default")
-      --password string                       agent password (default "P@ssw0rd!")
-      --redact string                         comma-delimited customized list of fields to redact
-      --require-fips                          indicates whether fips support should be required in openssl
-      --require-openssl                       indicates whether openssl should be required instead of go's built-in crypto
-      --socket-host string                    address to bind the Sensu client socket to (default "127.0.0.1")
-      --socket-port int                       port the Sensu client socket listens on (default 3030)
-      --statsd-disable                        disables the statsd listener and metrics server
-      --statsd-event-handlers strings         comma-delimited list of event handlers for statsd metrics
-      --statsd-flush-interval int             number of seconds between statsd flush (default 10)
-      --statsd-metrics-host string            address used for the statsd metrics server (default "127.0.0.1")
-      --statsd-metrics-port int               port used for the statsd metrics server (default 8125)
-      --subscriptions string                  comma-delimited list of agent subscriptions
-      --trusted-ca-file string                tls certificate authority
-      --user string                           agent user (default "agent")
+      --agent-managed-entity                manage this entity via the agent
+      --allow-list string                   path to agent execution allow list configuration file
+      --annotations stringToString          entity annotations map (default [])
+      --api-host string                     address to bind the Sensu client HTTP API to (default "127.0.0.1")
+      --api-port int                        port the Sensu client HTTP API listens on (default 3031)
+      --assets-burst-limit int              asset fetch burst limit (default 100)
+      --assets-rate-limit float             maximum number of assets fetched per second
+      --backend-handshake-timeout int       number of seconds the agent should wait when negotiating a new WebSocket connection (default 15)
+      --backend-heartbeat-interval int      interval at which the agent should send heartbeats to the backend (default 30)
+      --backend-heartbeat-timeout int       number of seconds the agent should wait for a response to a hearbeat (default 45)
+      --backend-url strings                 comma-delimited list of ws/wss URLs of Sensu backend servers. This flag can also be invoked multiple times (default [ws://127.0.0.1:8081])
+      --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-agent")
+      --cert-file string                    certificate for TLS authentication
+  -c, --config-file string                  path to sensu-agent config file (default "/etc/sensu/agent.yml")
+      --deregister                          ephemeral agent
+      --deregistration-handler string       deregistration handler that should process the entity deregistration event
+      --detect-cloud-provider               enable cloud provider detection
+      --disable-api                         disable the Agent HTTP API
+      --disable-assets                      disable check assets on this agent
+      --disable-sockets                     disable the Agent TCP and UDP event sockets
+      --discover-processes                  indicates whether process discovery should be enabled
+      --events-burst-limit int              /events api burst limit (default 10)
+      --events-rate-limit float             maximum number of events transmitted to the backend through the /events api
+  -h, --help                                help for start
+      --insecure-skip-tls-verify            skip TLS verification (not recommended!)
+      --keepalive-critical-timeout uint32   number of seconds until agent is considered dead by backend to create a critical event
+      --keepalive-handlers strings          comma-delimited list of keepalive handlers for this entity. This flag can also be invoked multiple times
+      --keepalive-interval int              number of seconds to send between keepalive events (default 20)
+      --keepalive-warning-timeout uint32    number of seconds until agent is considered dead by backend to create a warning event (default 120)
+      --key-file string                     key for TLS authentication
+      --labels stringToString               entity labels map (default [])
+      --log-level string                    logging level [panic, fatal, error, warn, info, debug] (default "info")
+      --name string                         agent name (defaults to hostname) (default "my_hostname")
+      --namespace string                    agent namespace (default "default")
+      --password string                     agent password (default "P@ssw0rd!")
+      --redact strings                      comma-delimited list of fields to redact, overwrites the default fields. This flag can also be invoked multiple times (default [password,passwd,pass,api_key,api_token,access_key,secret_key,private_key,secret])
+      --require-fips                        indicates whether fips support should be required in openssl
+      --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
+      --socket-host string                  address to bind the Sensu client socket to (default "127.0.0.1")
+      --socket-port int                     port the Sensu client socket listens on (default 3030)
+      --statsd-disable                      disables the statsd listener and metrics server
+      --statsd-event-handlers strings       comma-delimited list of event handlers for statsd metrics. This flag can also be invoked multiple times
+      --statsd-flush-interval int           number of seconds between statsd flush (default 10)
+      --statsd-metrics-host string          address used for the statsd metrics server (default "127.0.0.1")
+      --statsd-metrics-port int             port used for the statsd metrics server (default 8125)
+      --subscriptions strings               comma-delimited list of agent subscriptions. This flag can also be invoked multiple times
+      --trusted-ca-file string              TLS CA certificate bundle in PEM format
+      --user string                         agent user (default "agent")
 {{< /code >}}
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -350,69 +350,69 @@ General Flags:
       --agent-rate-limit int                agent connections maximum rate limit
       --agent-write-timeout int             timeout in seconds for agent writes (default 15)
       --annotations stringToString          entity annotations map (default [])
-      --api-listen-address string           address to listen on for API traffic (default "[::]:8080")
-      --api-request-limit                   maximum API request body size, in bytes (default 512000)
-      --api-url string                      URL of the API to connect to (default "http://localhost:8080")
+      --api-listen-address string           address to listen on for api traffic (default "[::]:8080")
+      --api-request-limit int               maximum API request body size, in bytes (default 512000)
+      --api-url string                      url of the api to connect to (default "http://localhost:8080")
       --assets-burst-limit int              asset fetch burst limit (default 100)
       --assets-rate-limit float             maximum number of assets fetched per second
       --cache-dir string                    path to store cached data (default "/var/cache/sensu/sensu-backend")
       --cert-file string                    TLS certificate in PEM format
-  -c, --config-file string                  path to sensu-backend config file
+  -c, --config-file string                  path to sensu-backend config file (default "/etc/sensu/backend.yml")
       --dashboard-cert-file string          dashboard TLS certificate in PEM format
       --dashboard-host string               dashboard listener host (default "[::]")
       --dashboard-key-file string           dashboard TLS certificate key in PEM format
       --dashboard-port int                  dashboard listener port (default 3000)
       --debug                               enable debugging and profiling features
       --deregistration-handler string       default deregistration handler
-      --etcd-log-level string               etcd logging level [panic, fatal, error, warn, info, debug]
       --event-log-buffer-size int           buffer size of the event logger (default 100000)
+      --event-log-buffer-wait string        full buffer wait time (default "10ms")
       --event-log-file string               path to the event log file
       --eventd-buffer-size int              number of incoming events that can be buffered (default 100)
       --eventd-workers int                  number of workers spawned for processing incoming events (default 100)
   -h, --help                                help for start
       --insecure-skip-tls-verify            skip TLS verification (not recommended!)
-      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JSON Web Tokens (JWTs)
+      --jwt-private-key-file string         path to the PEM-encoded private key to use to sign JWTs
       --jwt-public-key-file string          path to the PEM-encoded public key to use to verify JWT signatures
       --keepalived-buffer-size int          number of incoming keepalives that can be buffered (default 100)
       --keepalived-workers int              number of workers spawned for processing incoming keepalives (default 100)
       --key-file string                     TLS certificate key in PEM format
       --labels stringToString               entity labels map (default [])
       --log-level string                    logging level [panic, fatal, error, warn, info, debug, trace] (default "warn")
+      --metrics-refresh-interval string     Go duration value (e.g. 1h5m30s) that governs how often metrics are refreshed. (default "1m")
       --pipelined-buffer-size int           number of events to handle that can be buffered (default 100)
       --pipelined-workers int               number of workers spawned for handling events through the event pipeline (default 100)
-      --require-fips                        indicates whether fips support should be required in openssl
+      --require-fips                        indicates whether fips support should be required in openssl  
       --require-openssl                     indicates whether openssl should be required instead of go's built-in crypto
   -d, --state-dir string                    path to sensu state storage (default "/var/lib/sensu/sensu-backend")
       --trusted-ca-file string              TLS CA certificate bundle in PEM format
 
 Store Flags:
-      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to the rest of the cluster (default [http://localhost:2379])
+      --etcd-advertise-client-urls strings         list of this member's client URLs to advertise to clients (default [http://localhost:2379])
       --etcd-cert-file string                      path to the client server TLS cert file
       --etcd-cipher-suites strings                 list of ciphers to use for etcd TLS configuration
-      --etcd-client-urls string                    client URLs to use when operating as an etcd client
       --etcd-client-cert-auth                      enable client cert authentication
-      --etcd-discovery                             use the dynamic cluster configuration method etcd
-discovery instead of the static `--initial-cluster method`
-      --etcd-discovery-srv                         use the dynamic cluster configuration method DNS SRV
-discovery instead of the static `--initial-cluster method`
+      --etcd-client-urls string                    client URLs to use when operating as an etcd client
+      --etcd-discovery string                      discovery URL used to bootstrap the cluster
+      --etcd-discovery-srv string                  DNS SRV record used to bootstrap the cluster
       --etcd-election-timeout uint                 time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself (default 1000)
       --etcd-heartbeat-interval uint               interval in ms with which the etcd leader will notify followers that it is still the leader (default 100)
       --etcd-initial-advertise-peer-urls strings   list of this member's peer URLs to advertise to the rest of the cluster (default [http://127.0.0.1:2380])
-      --etcd-initial-cluster string                initial cluster configuration for bootstrapping (default "default=http://127.0.0.1:2380")
-      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing"; default "new")
+      --etcd-initial-cluster string                initial cluster configuration for bootstrapping
+      --etcd-initial-cluster-state string          initial cluster state ("new" or "existing") (default "new")
       --etcd-initial-cluster-token string          initial cluster token for the etcd cluster during bootstrap
       --etcd-key-file string                       path to the client server TLS key file
-      --etcd-listen-client-urls strings            list of URLs to listen on for client traffic (default [http://127.0.0.1:2379])
+      --etcd-listen-client-urls strings            list of etcd client URLs to listen on (default [http://127.0.0.1:2379])
       --etcd-listen-peer-urls strings              list of URLs to listen on for peer traffic (default [http://127.0.0.1:2380])
-      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution; default 1572864)
-      --etcd-name string                           human-readable name for this member (default "default")
+      --etcd-log-level string                      etcd logging level [panic, fatal, error, warn, info, debug]
+      --etcd-max-request-bytes uint                maximum etcd request size in bytes (use with caution) (default 1572864)
+      --etcd-name string                           name for this etcd node (default "default")
       --etcd-peer-cert-file string                 path to the peer server TLS cert file
       --etcd-peer-client-cert-auth                 enable peer client cert authentication
       --etcd-peer-key-file string                  path to the peer server TLS key file
       --etcd-peer-trusted-ca-file string           path to the peer server TLS trusted CA file
-      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution; default 4294967296)
+      --etcd-quota-backend-bytes int               maximum etcd database size in bytes (use with caution) (default 4294967296)
       --etcd-trusted-ca-file string                path to the client server TLS trusted CA cert file
-      --no-embed-etcd                              don't embed etcd; use external etcd instead
+      --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
 ### General configuration flags
@@ -542,17 +542,6 @@ sensu-backend start --deregistration-handler deregister{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
 
-| etcd-log-level  |      |
--------------|------
-description  | Logging level for the embedded etcd server: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`. Defaults to value provided for the [backend log level][37]. If the backend log level is set to `trace`, the etcd log level will be set to `debug` (`trace` is not a valid etcd log level).
-type         | String
-default      | [Backend log level][37] value (or `debug`, if the backend log level is set to `trace`)
-environment variable | `SENSU_BACKEND_ETCD_LOG_LEVEL`
-command line example   | {{< code shell >}}
-sensu-backend start --etcd-log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
-etcd-log-level: "debug"{{< /code >}}
-
 | labels     |      |
 -------------|------
 description  | Custom attributes to include with entity data for backend dynamic runtime assets (for example, handler and mutator dynamic runtime assets).{{% notice note %}}
@@ -585,6 +574,19 @@ command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
+
+<a id="metrics-refresh-interval"></a>
+
+| metrics-refresh-interval |      |
+-------------|------
+description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.
+type         | String
+default      | `1m`
+environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
+command line example   | {{< code shell >}}
+sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+metrics-refresh-interval: "10s"{{< /code >}}
 
 | state-dir  |      |
 -------------|------
@@ -1092,6 +1094,19 @@ etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
 {{< /code >}}
+
+<a id="etcd-log-level"></a>
+
+| etcd-log-level  |      |
+-------------|------
+description  | Logging level for the embedded etcd server: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`. Defaults to value provided for the [backend log level][37]. If the backend log level is set to `trace`, the etcd log level will be set to `debug` (`trace` is not a valid etcd log level).
+type         | String
+default      | [Backend log level][37] value (or `debug`, if the backend log level is set to `trace`)
+environment variable | `SENSU_BACKEND_ETCD_LOG_LEVEL`
+command line example   | {{< code shell >}}
+sensu-backend start --etcd-log-level debug{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+etcd-log-level: "debug"{{< /code >}}
 
 | etcd-name      |      |
 -----------------|------

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -610,7 +610,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 - ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153].
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -1897,10 +1897,11 @@ To get started with Sensu Go:
 [214]: /sensu-go/6.3/sensuctl/#global-flags
 [215]: /sensu-go/6.4/commercial/
 [216]: /sensu-go/6.4/platforms/#macos
-[217]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#general-configuration-flags
+[217]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#etcd-log-level
 [218]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#initialization-timeout-and-wait-flags
 [219]: https://etcd.io/docs/v3.5/metrics/etcd-metrics-latest.txt
 [220]: /sensu-go/6.4/web-ui/webconfig-reference/#sign-in-message
 [221]: /sensu-go/6.4/web-ui/webconfig-reference/#page-preferences-attributes
 [222]: /sensu-go/6.4/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
 [223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes
+[224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval


### PR DESCRIPTION
## Description
Align doc response and flag description tables with output for `sensu-agent start --help` and `sensu-backend start --help`

## Motivation and Context
Noticed some flags are not listed when working on something else