### PR TITLE
Clarify PostgreSQL recommended settings

### DIFF
--- a/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/datastore.md
@@ -50,7 +50,7 @@ You can access event data stored in PostgreSQL using the same Sensu web UI, API,
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -84,6 +84,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][20] for information about setting parameters.
 
 ## Configure the PostgreSQL event store

--- a/content/sensu-go/6.1/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/scale-event-storage.md
@@ -43,7 +43,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -77,6 +77,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][2] for information about setting parameters.
 
 ## Configure Postgres

--- a/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/datastore.md
@@ -50,7 +50,7 @@ You can access event data stored in PostgreSQL using the same Sensu web UI, API,
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -84,6 +84,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][20] for information about setting parameters.
 
 ## Configure the PostgreSQL event store

--- a/content/sensu-go/6.2/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/scale-event-storage.md
@@ -43,7 +43,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -77,6 +77,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][2] for information about setting parameters.
 
 ## Configure Postgres

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -50,7 +50,7 @@ You can access event data stored in PostgreSQL using the same Sensu web UI, API,
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -84,6 +84,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][20] for information about setting parameters.
 
 ## Configure the PostgreSQL event store

--- a/content/sensu-go/6.3/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/scale-event-storage.md
@@ -43,7 +43,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -77,6 +77,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][2] for information about setting parameters.
 
 ## Configure Postgres

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -50,7 +50,7 @@ You can access event data stored in PostgreSQL using the same Sensu web UI, API,
 Sensu supports PostgreSQL 9.5 and later, including [Amazon Relational Database Service][3] (Amazon RDS) when configured with the PostgreSQL engine.
 See the [PostgreSQL docs][14] to install and configure PostgreSQL.
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -84,6 +84,7 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
 Read the [PostgreSQL parameters documentation][20] for information about setting parameters.
 
 ## Configure the PostgreSQL event store

--- a/content/sensu-go/6.4/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/scale-event-storage.md
@@ -43,7 +43,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 * Postgres user with permissions to the database (or administrative access to create such a user)
 * [Licensed Sensu Go backend][3]
 
-For optimal performance, use the following PostgreSQL configuration settings in your `postgresql.conf` file:
+For optimal performance, we recommend the following PostgreSQL configuration parameters and settings as a starting point for your `postgresql.conf` file:
 
 {{< code postgresql >}}
 max_connections = 200
@@ -77,7 +77,8 @@ autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.025
 {{< /code >}}
 
-Read the [PostgreSQL parameters documentation][2] for informmation about setting parameters.
+Adjust the parameters and settings as needed based on your hardware and the performance you observe.
+Read the [PostgreSQL parameters documentation][2] for information about setting parameters.
 
 ## Configure Postgres
 


### PR DESCRIPTION
## Description
Clarifies that the recommended settings in our PostgreSQL docs are intended as a starting point and should be adjusted based on hardware and performance.

## Motivation and Context
https://sumologic.slack.com/archives/C0254420A1Y/p1627659762001100?thread_ts=1627577716.197400&cid=C0254420A1Y