### PR TITLE
Add code required for intercom chat on sandbox page

### DIFF
--- a/content/sensu-go/6.1/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.1/learn/learn-sensu-sandbox.md
@@ -1,5 +1,6 @@
 ---
 title: "Learn Sensu Go"
+intercom: "sandbox"
 description: "Here’s everything you need to start learning Sensu Go, including how to set up the Sensu Go sandbox and your first three lesson plans. Learn how to create an observability event and event pipeline, as well as automate event production with the Sensu agent."
 version: "6.1"
 product: "Sensu Go"

--- a/content/sensu-go/6.2/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.2/learn/learn-sensu-sandbox.md
@@ -1,5 +1,6 @@
 ---
 title: "Learn Sensu Go"
+intercom: "sandbox"
 description: "Here’s everything you need to start learning Sensu Go, including how to set up the Sensu Go sandbox and your first three lesson plans. Learn how to create an observability event and event pipeline, as well as automate event production with the Sensu agent."
 version: "6.2"
 product: "Sensu Go"

--- a/content/sensu-go/6.3/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.3/learn/learn-sensu-sandbox.md
@@ -1,5 +1,6 @@
 ---
 title: "Learn Sensu Go"
+intercom: "sandbox"
 description: "Here’s everything you need to start learning Sensu Go, including how to set up the Sensu Go sandbox and your first three lesson plans. Learn how to create an observability event and event pipeline, as well as automate event production with the Sensu agent."
 version: "6.3"
 product: "Sensu Go"

--- a/content/sensu-go/6.4/learn/learn-sensu-sandbox.md
+++ b/content/sensu-go/6.4/learn/learn-sensu-sandbox.md
@@ -1,5 +1,6 @@
 ---
 title: "Learn Sensu Go"
+intercom: "sandbox"
 description: "Here’s everything you need to start learning Sensu Go, including how to set up the Sensu Go sandbox and your first three lesson plans. Learn how to create an observability event and event pipeline, as well as automate event production with the Sensu agent."
 version: "6.4"
 product: "Sensu Go"

--- a/layouts/shortcodes/intercomSandbox.html
+++ b/layouts/shortcodes/intercomSandbox.html
@@ -1,0 +1,7 @@
+<!-- Applies /js/intercomSandbox.js to pages with specified frontmatter type "intercom" and value "sandbox" -->
+{{ range (.Site.Pages.ByParam "intercom") }}
+	{{ if and (eq .Type "sandbox") }}
+  		<script type="text/javascript" src="/js/intercomSandbox.js"></script>
+	{{ end }}
+{{ end }}
+

--- a/static/js/intercomSandbox.js
+++ b/static/js/intercomSandbox.js
@@ -1,0 +1,43 @@
+/*
+ * code for intercom chat window for https://docs.sensu.io/sensu-go/x.x/learn/learn-sensu-sandbox/
+ */
+
+var APP_ID = "docs-sandbox-page";
+
+window.intercomSettings = {
+    app_id: APP_ID,
+};
+(function () {
+    var w = window;
+    var ic = w.Intercom;
+    if (typeof ic === "function") {
+        ic("reattach_activator");
+        ic("update", w.intercomSettings);
+    } else {
+        var d = document;
+        var i = function () {
+            i.c(arguments);
+        };
+        i.q = [];
+        i.c = function (args) {
+            i.q.push(args);
+        };
+        w.Intercom = i;
+        var l = function () {
+            var s = d.createElement("script");
+            s.type = "text/javascript";
+            s.async = true;
+            s.src = "https://widget.intercom.io/widget/" + APP_ID;
+            var x = d.getElementsByTagName("script")[0];
+            x.parentNode.insertBefore(s, x);
+        };
+        if (document.readyState === "complete") {
+            l();
+        } else if (w.attachEvent) {
+            w.attachEvent("onload", l);
+        } else {
+            w.addEventListener("load", l, false);
+        }
+    }
+})();
+

--- a/static/js/intercomSandbox.js
+++ b/static/js/intercomSandbox.js
@@ -2,7 +2,7 @@
  * code for intercom chat window for https://docs.sensu.io/sensu-go/x.x/learn/learn-sensu-sandbox/
  */
 
-var APP_ID = "docs-sandbox-page";
+var APP_ID = "docsSandboxPage";
 
 window.intercomSettings = {
     app_id: APP_ID,

--- a/static/js/intercomSandbox.js
+++ b/static/js/intercomSandbox.js
@@ -2,11 +2,11 @@
  * code for intercom chat window for https://docs.sensu.io/sensu-go/x.x/learn/learn-sensu-sandbox/
  */
 
-var APP_ID = "docsSandboxPage";
+var APP_ID = "abr73apk";
 
 window.intercomSettings = {
-    app_id: APP_ID,
-};
+    app_id: "abr73apk"
+  };
 (function () {
     var w = window;
     var ic = w.Intercom;
@@ -27,13 +27,11 @@ window.intercomSettings = {
             var s = d.createElement("script");
             s.type = "text/javascript";
             s.async = true;
-            s.src = "https://widget.intercom.io/widget/" + APP_ID;
+            s.src = "https://widget.intercom.io/widget/abr73apk";
             var x = d.getElementsByTagName("script")[0];
             x.parentNode.insertBefore(s, x);
         };
-        if (document.readyState === "complete") {
-            l();
-        } else if (w.attachEvent) {
+        if (w.attachEvent) {
             w.attachEvent("onload", l);
         } else {
             w.addEventListener("load", l, false);


### PR DESCRIPTION
## Description
Add frontmatter type "intercom" to [sandbox pages](https://docs.sensu.io/sensu-go/latest/learn/learn-sensu-sandbox/), plus the JS script to make it work and the shortcode to identify the pages to add the intercom chat window.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/1569