### PR TITLE
Correct and update authentication for /apikeys POST and API response filtering examples

### DIFF
--- a/content/sensu-go/6.1/api/_index.md
+++ b/content/sensu-go/6.1/api/_index.md
@@ -145,7 +145,7 @@ The new access token should be included in the output:
 }
 {{< /code >}}
 
-### Generate an API token with sensuctl
+### Generate an API access token with sensuctl
 
 You can also generate an API access token using the sensuctl command line tool.
 The user credentials that you use to configure sensuctl determine your permissions to get, list, create, update, and delete resources with the Sensu API.
@@ -229,7 +229,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than via an environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -247,7 +247,7 @@ You can request a paginated response with the `limit` and `continue` query param
 The following request limits the response to a maximum of two objects:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response includes the available objects up to the specified limit.
@@ -289,7 +289,7 @@ To request the next two available users, use the `Sensu-Continue` token included
 
 {{< code shell >}}
 curl http://127.0.0.1:8080/api/core/v2/users?limit=2&continue=L2RlZmF1bU2Vuc3UtTWFjQ \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+-H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 If the response header does not include a `Sensu-Continue` token, there are no further objects to return.
@@ -477,7 +477,7 @@ Sensu's two _equality-based_ operators are `==` (equality) and `!=` (inequality)
 For example, to retrieve only checks with the label `type` and value `server`: 
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'labelSelector=type == "server"'
 {{< /code >}}
 
@@ -489,25 +489,25 @@ Include the `-G` flag so the request appends the query parameter data to the URL
 To retrieve checks that are not in the `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace != "production"'
 {{< /code >}}
 
 #### Set-based operators
 
-Sensu's two _set-based_ operators for lists of values are `in` and `notin`.
+Sensu's two *set-based* operators for lists of values are `in` and `notin`.
 
 For example, to retrieve checks with a `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that do not use the `slack` handler:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=slack notin check.handlers'
 {{< /code >}}
 
@@ -525,7 +525,7 @@ Sensu's _substring matching_ operator is `matches`.
 For example, to retrieve all checks whose name includes `linux`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.name matches "linux"'
 {{< /code >}}
 
@@ -534,14 +534,14 @@ For example, your webservers are named `webserver-1` through `webserver-25`, and
 In this case, you can use `matches` to retrieve all of your `webserver` entities:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=entity.name matches "webserver-"'
 {{< /code >}}
 
 Similarly, if you have entities labeled for different regions, you can use `matches` to find the entities that are labeled for the US (for example, `us-east-1`, `us-west-1`, and so on):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector:region matches "us"'
 {{< /code >}}
 
@@ -557,14 +557,14 @@ Use it to combine multiple statements separated with the logical operator in fie
 For example, the following cURL request retrieves checks that are not configured to be published **and** include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that are not published, include a `linux` subscription, and are in the `dev` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions && dev in check.namespace'
 {{< /code >}}
 
@@ -578,7 +578,7 @@ You can use field and label selectors in a single request.
 For example, to retrieve only checks that include a `linux` subscription *and* do not include a label for type `server`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions' \
 --data-urlencode 'labelSelector=type != "server"'
 {{< /code >}}
@@ -590,12 +590,12 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To use a label or field selector with string values that include special characters like hyphens and underscores, place the value in single or double quotes:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector=region == "us-west-1"'
 {{< /code >}}
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector="entity:i-0c1f8a116b84ea50c" in entity.subscriptions'
 {{< /code >}}
 
@@ -604,7 +604,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve checks that are in either the `dev` or `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace in [dev,production]'
 {{< /code >}}
 
@@ -613,14 +613,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve events for a specific check (`checkhttp`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=checkhttp in event.check.name'
 {{< /code >}}
 
 Similary, to retrieve only events for the `server` entity:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=server in event.entity.name'
 {{< /code >}}
 
@@ -630,7 +630,7 @@ Use the `event.check.status` field selector to retrieve events by severity.
 For example, to retrieve all events at `2` (CRITICAL) status:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.check.status == "2"'
 {{< /code >}}
 
@@ -639,7 +639,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve all incidents (all events whose status is not `0`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /code >}}
 
@@ -648,21 +648,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all checks that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 Similarly, to list all entities that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=linux in entity.subscriptions'
 {{< /code >}}
 
 To list all events for the `linux` subscription, use the `event.entity.subscriptions` field selector:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=linux in event.entity.subscriptions'
 {{< /code >}}
 
@@ -673,21 +673,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silenced resources for a particular namespace (in this example, the `default` namespace):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace == "default"'
 {{< /code >}}
 
 Likewise, to list all silenced resources *except* those in the `default` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace != "default"'
 {{< /code >}}
 
 To list all silenced events for all namespaces:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.is_silenced == true'
 {{< /code >}}
 
@@ -696,14 +696,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silences created by the user `alice`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator == "alice"'
 {{< /code >}}
 
 To list all silences that were not created by the `admin` user:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator != "admin"'
 {{< /code >}}
 
@@ -712,14 +712,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve silences with a specific subscription (in this example, `linux`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.subscription == "linux"'
 {{< /code >}}
 
 Another way to make the same request is:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=linux in silenced.subscription'
 {{< /code >}}
 
@@ -733,7 +733,7 @@ In other words, this filter retrieves **silences** with a particular subscriptio
 To list all silenced resources that expire only when a matching check resolves:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.expire_on_resolve == true'
 {{< /code >}}
 

--- a/content/sensu-go/6.1/api/apikeys.md
+++ b/content/sensu-go/6.1/api/apikeys.md
@@ -74,8 +74,9 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
-This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl).
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
+If you prefer, you can [create a new API key with sensuctl](../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.1/api/apikeys.md
+++ b/content/sensu-go/6.1/api/apikeys.md
@@ -71,11 +71,16 @@ The `/apikeys` API endpoint provides HTTP POST access to create a new API key.
 ### Example {#apikeys-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/apikeys` API endpoint to create a new API key.
-The request includes the API key definition in the request body and returns a successful HTTP `201 Created` response.
+The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
+
+{{% notice note %}}
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
--H "Authorization: Key $SENSU_API_KEY" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "admin"

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-email-alerts.md
@@ -217,7 +217,7 @@ In the final step, you will create an ad hoc event that you can trigger manually
 ## Create and trigger an ad hoc event
 
 To create an ad hoc event, first use `sensuctl env` to set up environment variables.
-The environment variables will provide the required credentials for the Sensu API:
+The environment variables will provide the required Sensu API access token credential for the Sensu API:
 
 {{< code shell >}}
 eval $(sensuctl env)

--- a/content/sensu-go/6.1/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.1/operations/control-access/use-apikeys.md
@@ -73,7 +73,7 @@ HTTP/1.1 200 OK
 **NOTE**: The API key resource is intentionally not compatible with [`sensuctl create`](../../../sensuctl/create-manage-resources/#create-resources).
 {{% /notice %}}
 
-To generate a new API key for the admin user:
+To use sensuctl to generate a new API key for the admin user, run:
 
 {{< code shell >}}
 sensuctl api-key grant admin

--- a/content/sensu-go/6.1/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/license.md
@@ -173,7 +173,7 @@ You can also see your current entity count and limit in the response headers for
 For example:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response headers will include your current entity count and limit:

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
@@ -130,11 +130,11 @@ You can use the [Secrets API][2] to create, view, and manage your secrets provid
 
 For example, to retrieve the list of secrets providers:
 
-{{< code shell >}}
+curl http://127.0.0.1:8080/api/core/v2/{{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
-{{< /code >}}
+-H "Authorization: Key $SENSU_API_KEY"
+{{< /code >}}namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
  
 ## Secrets providers specification
 

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
@@ -130,11 +130,11 @@ You can use the [Secrets API][2] to create, view, and manage your secrets provid
 
 For example, to retrieve the list of secrets providers:
 
-curl http://127.0.0.1:8080/api/core/v2/{{< code shell >}}
+{{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 -H "Authorization: Key $SENSU_API_KEY"
-{{< /code >}}namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
+{{< /code >}}
  
 ## Secrets providers specification
 

--- a/content/sensu-go/6.2/api/_index.md
+++ b/content/sensu-go/6.2/api/_index.md
@@ -145,7 +145,7 @@ The new access token should be included in the output:
 }
 {{< /code >}}
 
-### Generate an API token with sensuctl
+### Generate an API access token with sensuctl
 
 You can also generate an API access token using the sensuctl command line tool.
 The user credentials that you use to configure sensuctl determine your permissions to get, list, create, update, and delete resources with the Sensu API.
@@ -229,7 +229,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than via an environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -247,7 +247,7 @@ You can request a paginated response with the `limit` and `continue` query param
 The following request limits the response to a maximum of two objects:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response includes the available objects up to the specified limit.
@@ -289,7 +289,7 @@ To request the next two available users, use the `Sensu-Continue` token included
 
 {{< code shell >}}
 curl http://127.0.0.1:8080/api/core/v2/users?limit=2&continue=L2RlZmF1bU2Vuc3UtTWFjQ \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+-H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 If the response header does not include a `Sensu-Continue` token, there are no further objects to return.
@@ -477,7 +477,7 @@ Sensu's two _equality-based_ operators are `==` (equality) and `!=` (inequality)
 For example, to retrieve only checks with the label `type` and value `server`: 
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'labelSelector=type == "server"'
 {{< /code >}}
 
@@ -489,25 +489,25 @@ Include the `-G` flag so the request appends the query parameter data to the URL
 To retrieve checks that are not in the `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace != "production"'
 {{< /code >}}
 
 #### Set-based operators
 
-Sensu's two _set-based_ operators for lists of values are `in` and `notin`.
+Sensu's two *set-based* operators for lists of values are `in` and `notin`.
 
 For example, to retrieve checks with a `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that do not use the `slack` handler:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=slack notin check.handlers'
 {{< /code >}}
 
@@ -525,7 +525,7 @@ Sensu's _substring matching_ operator is `matches`.
 For example, to retrieve all checks whose name includes `linux`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.name matches "linux"'
 {{< /code >}}
 
@@ -534,14 +534,14 @@ For example, your webservers are named `webserver-1` through `webserver-25`, and
 In this case, you can use `matches` to retrieve all of your `webserver` entities:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=entity.name matches "webserver-"'
 {{< /code >}}
 
 Similarly, if you have entities labeled for different regions, you can use `matches` to find the entities that are labeled for the US (for example, `us-east-1`, `us-west-1`, and so on):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector:region matches "us"'
 {{< /code >}}
 
@@ -557,14 +557,14 @@ Use it to combine multiple statements separated with the logical operator in fie
 For example, the following cURL request retrieves checks that are not configured to be published **and** include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that are not published, include a `linux` subscription, and are in the `dev` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions && dev in check.namespace'
 {{< /code >}}
 
@@ -578,7 +578,7 @@ You can use field and label selectors in a single request.
 For example, to retrieve only checks that include a `linux` subscription *and* do not include a label for type `server`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions' \
 --data-urlencode 'labelSelector=type != "server"'
 {{< /code >}}
@@ -590,12 +590,12 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To use a label or field selector with string values that include special characters like hyphens and underscores, place the value in single or double quotes:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector=region == "us-west-1"'
 {{< /code >}}
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector="entity:i-0c1f8a116b84ea50c" in entity.subscriptions'
 {{< /code >}}
 
@@ -604,7 +604,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve checks that are in either the `dev` or `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace in [dev,production]'
 {{< /code >}}
 
@@ -613,14 +613,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve events for a specific check (`checkhttp`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=checkhttp in event.check.name'
 {{< /code >}}
 
 Similary, to retrieve only events for the `server` entity:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=server in event.entity.name'
 {{< /code >}}
 
@@ -630,7 +630,7 @@ Use the `event.check.status` field selector to retrieve events by severity.
 For example, to retrieve all events at `2` (CRITICAL) status:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.check.status == "2"'
 {{< /code >}}
 
@@ -639,7 +639,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve all incidents (all events whose status is not `0`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /code >}}
 
@@ -648,21 +648,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all checks that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 Similarly, to list all entities that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=linux in entity.subscriptions'
 {{< /code >}}
 
 To list all events for the `linux` subscription, use the `event.entity.subscriptions` field selector:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=linux in event.entity.subscriptions'
 {{< /code >}}
 
@@ -673,21 +673,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silenced resources for a particular namespace (in this example, the `default` namespace):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace == "default"'
 {{< /code >}}
 
 Likewise, to list all silenced resources *except* those in the `default` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace != "default"'
 {{< /code >}}
 
 To list all silenced events for all namespaces:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.is_silenced == true'
 {{< /code >}}
 
@@ -696,14 +696,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silences created by the user `alice`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator == "alice"'
 {{< /code >}}
 
 To list all silences that were not created by the `admin` user:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator != "admin"'
 {{< /code >}}
 
@@ -712,14 +712,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve silences with a specific subscription (in this example, `linux`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.subscription == "linux"'
 {{< /code >}}
 
 Another way to make the same request is:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=linux in silenced.subscription'
 {{< /code >}}
 
@@ -733,7 +733,7 @@ In other words, this filter retrieves **silences** with a particular subscriptio
 To list all silenced resources that expire only when a matching check resolves:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.expire_on_resolve == true'
 {{< /code >}}
 

--- a/content/sensu-go/6.2/api/apikeys.md
+++ b/content/sensu-go/6.2/api/apikeys.md
@@ -74,8 +74,9 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
-This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl).
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
+If you prefer, you can [create a new API key with sensuctl](../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.2/api/apikeys.md
+++ b/content/sensu-go/6.2/api/apikeys.md
@@ -71,11 +71,16 @@ The `/apikeys` API endpoint provides HTTP POST access to create a new API key.
 ### Example {#apikeys-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/apikeys` API endpoint to create a new API key.
-The request includes the API key definition in the request body and returns a successful HTTP `201 Created` response.
+The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
+
+{{% notice note %}}
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
--H "Authorization: Key $SENSU_API_KEY" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "admin"

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -217,7 +217,7 @@ In the final step, you will create an ad hoc event that you can trigger manually
 ## Create and trigger an ad hoc event
 
 To create an ad hoc event, first use `sensuctl env` to set up environment variables.
-The environment variables will provide the required credentials for the Sensu API:
+The environment variables will provide the required Sensu API access token credential for the Sensu API:
 
 {{< code shell >}}
 eval $(sensuctl env)

--- a/content/sensu-go/6.2/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.2/operations/control-access/use-apikeys.md
@@ -73,7 +73,7 @@ HTTP/1.1 200 OK
 **NOTE**: The API key resource is intentionally not compatible with [`sensuctl create`](../../../sensuctl/create-manage-resources/#create-resources).
 {{% /notice %}}
 
-To generate a new API key for the admin user:
+To use sensuctl to generate a new API key for the admin user, run:
 
 {{< code shell >}}
 sensuctl api-key grant admin

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -173,7 +173,7 @@ You can also see your current entity count and limit in the response headers for
 For example:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response headers will include your current entity count and limit:

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
@@ -130,11 +130,11 @@ You can use the [Secrets API][2] to create, view, and manage your secrets provid
 
 For example, to retrieve the list of secrets providers:
 
-{{< code shell >}}
+curl http://127.0.0.1:8080/api/core/v2/{{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
-{{< /code >}}
+-H "Authorization: Key $SENSU_API_KEY"
+{{< /code >}}namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
  
 ## Secrets providers specification
 

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
@@ -130,11 +130,11 @@ You can use the [Secrets API][2] to create, view, and manage your secrets provid
 
 For example, to retrieve the list of secrets providers:
 
-curl http://127.0.0.1:8080/api/core/v2/{{< code shell >}}
+{{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 -H "Authorization: Key $SENSU_API_KEY"
-{{< /code >}}namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
+{{< /code >}}
  
 ## Secrets providers specification
 

--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -145,7 +145,7 @@ The new access token should be included in the output:
 }
 {{< /code >}}
 
-### Generate an API token with sensuctl
+### Generate an API access token with sensuctl
 
 You can also generate an API access token using the sensuctl command line tool.
 The user credentials that you use to configure sensuctl determine your permissions to get, list, create, update, and delete resources with the Sensu API.
@@ -229,7 +229,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than via an environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -247,7 +247,7 @@ You can request a paginated response with the `limit` and `continue` query param
 The following request limits the response to a maximum of two objects:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response includes the available objects up to the specified limit.
@@ -289,7 +289,7 @@ To request the next two available users, use the `Sensu-Continue` token included
 
 {{< code shell >}}
 curl http://127.0.0.1:8080/api/core/v2/users?limit=2&continue=L2RlZmF1bU2Vuc3UtTWFjQ \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+-H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 If the response header does not include a `Sensu-Continue` token, there are no further objects to return.
@@ -477,7 +477,7 @@ Sensu's two _equality-based_ operators are `==` (equality) and `!=` (inequality)
 For example, to retrieve only checks with the label `type` and value `server`: 
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'labelSelector=type == "server"'
 {{< /code >}}
 
@@ -489,25 +489,25 @@ Include the `-G` flag so the request appends the query parameter data to the URL
 To retrieve checks that are not in the `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace != "production"'
 {{< /code >}}
 
 #### Set-based operators
 
-Sensu's two _set-based_ operators for lists of values are `in` and `notin`.
+Sensu's two *set-based* operators for lists of values are `in` and `notin`.
 
 For example, to retrieve checks with a `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that do not use the `slack` handler:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=slack notin check.handlers'
 {{< /code >}}
 
@@ -525,7 +525,7 @@ Sensu's _substring matching_ operator is `matches`.
 For example, to retrieve all checks whose name includes `linux`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.name matches "linux"'
 {{< /code >}}
 
@@ -534,14 +534,14 @@ For example, your webservers are named `webserver-1` through `webserver-25`, and
 In this case, you can use `matches` to retrieve all of your `webserver` entities:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=entity.name matches "webserver-"'
 {{< /code >}}
 
 Similarly, if you have entities labeled for different regions, you can use `matches` to find the entities that are labeled for the US (for example, `us-east-1`, `us-west-1`, and so on):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector:region matches "us"'
 {{< /code >}}
 
@@ -557,14 +557,14 @@ Use it to combine multiple statements separated with the logical operator in fie
 For example, the following cURL request retrieves checks that are not configured to be published **and** include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that are not published, include a `linux` subscription, and are in the `dev` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions && dev in check.namespace'
 {{< /code >}}
 
@@ -578,7 +578,7 @@ You can use field and label selectors in a single request.
 For example, to retrieve only checks that include a `linux` subscription *and* do not include a label for type `server`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions' \
 --data-urlencode 'labelSelector=type != "server"'
 {{< /code >}}
@@ -590,12 +590,12 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To use a label or field selector with string values that include special characters like hyphens and underscores, place the value in single or double quotes:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector=region == "us-west-1"'
 {{< /code >}}
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector="entity:i-0c1f8a116b84ea50c" in entity.subscriptions'
 {{< /code >}}
 
@@ -604,7 +604,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve checks that are in either the `dev` or `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace in [dev,production]'
 {{< /code >}}
 
@@ -613,14 +613,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve events for a specific check (`checkhttp`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=checkhttp in event.check.name'
 {{< /code >}}
 
 Similary, to retrieve only events for the `server` entity:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=server in event.entity.name'
 {{< /code >}}
 
@@ -630,7 +630,7 @@ Use the `event.check.status` field selector to retrieve events by severity.
 For example, to retrieve all events at `2` (CRITICAL) status:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.check.status == "2"'
 {{< /code >}}
 
@@ -639,7 +639,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve all incidents (all events whose status is not `0`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /code >}}
 
@@ -648,21 +648,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all checks that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 Similarly, to list all entities that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=linux in entity.subscriptions'
 {{< /code >}}
 
 To list all events for the `linux` subscription, use the `event.entity.subscriptions` field selector:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=linux in event.entity.subscriptions'
 {{< /code >}}
 
@@ -673,21 +673,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silenced resources for a particular namespace (in this example, the `default` namespace):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace == "default"'
 {{< /code >}}
 
 Likewise, to list all silenced resources *except* those in the `default` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace != "default"'
 {{< /code >}}
 
 To list all silenced events for all namespaces:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.is_silenced == true'
 {{< /code >}}
 
@@ -696,14 +696,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silences created by the user `alice`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator == "alice"'
 {{< /code >}}
 
 To list all silences that were not created by the `admin` user:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator != "admin"'
 {{< /code >}}
 
@@ -712,14 +712,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve silences with a specific subscription (in this example, `linux`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.subscription == "linux"'
 {{< /code >}}
 
 Another way to make the same request is:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=linux in silenced.subscription'
 {{< /code >}}
 
@@ -733,7 +733,7 @@ In other words, this filter retrieves **silences** with a particular subscriptio
 To list all silenced resources that expire only when a matching check resolves:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.expire_on_resolve == true'
 {{< /code >}}
 

--- a/content/sensu-go/6.3/api/apikeys.md
+++ b/content/sensu-go/6.3/api/apikeys.md
@@ -74,8 +74,9 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
-This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl).
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
+If you prefer, you can [create a new API key with sensuctl](../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.3/api/apikeys.md
+++ b/content/sensu-go/6.3/api/apikeys.md
@@ -71,11 +71,16 @@ The `/apikeys` API endpoint provides HTTP POST access to create a new API key.
 ### Example {#apikeys-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/apikeys` API endpoint to create a new API key.
-The request includes the API key definition in the request body and returns a successful HTTP `201 Created` response.
+The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
+
+{{% notice note %}}
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
--H "Authorization: Key $SENSU_API_KEY" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "admin"

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -217,7 +217,7 @@ In the final step, you will create an ad hoc event that you can trigger manually
 ## Create and trigger an ad hoc event
 
 To create an ad hoc event, first use `sensuctl env` to set up environment variables.
-The environment variables will provide the required credentials for the Sensu API:
+The environment variables will provide the required Sensu API access token credential for the Sensu API:
 
 {{< code shell >}}
 eval $(sensuctl env)

--- a/content/sensu-go/6.3/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.3/operations/control-access/use-apikeys.md
@@ -73,7 +73,7 @@ HTTP/1.1 200 OK
 **NOTE**: The API key resource is intentionally not compatible with [`sensuctl create`](../../../sensuctl/create-manage-resources/#create-resources).
 {{% /notice %}}
 
-To generate a new API key for the admin user:
+To use sensuctl to generate a new API key for the admin user, run:
 
 {{< code shell >}}
 sensuctl api-key grant admin

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -173,7 +173,7 @@ You can also see your current entity count and limit in the response headers for
 For example:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response headers will include your current entity count and limit:

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -130,11 +130,11 @@ You can use the [Secrets API][2] to create, view, and manage your secrets provid
 
 For example, to retrieve the list of secrets providers:
 
-{{< code shell >}}
+curl http://127.0.0.1:8080/api/core/v2/{{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
-{{< /code >}}
+-H "Authorization: Key $SENSU_API_KEY"
+{{< /code >}}namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
  
 ## Secrets providers specification
 

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -130,11 +130,11 @@ You can use the [Secrets API][2] to create, view, and manage your secrets provid
 
 For example, to retrieve the list of secrets providers:
 
-curl http://127.0.0.1:8080/api/core/v2/{{< code shell >}}
+{{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 -H "Authorization: Key $SENSU_API_KEY"
-{{< /code >}}namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
+{{< /code >}}
  
 ## Secrets providers specification
 

--- a/content/sensu-go/6.4/api/_index.md
+++ b/content/sensu-go/6.4/api/_index.md
@@ -145,7 +145,7 @@ The new access token should be included in the output:
 }
 {{< /code >}}
 
-### Generate an API token with sensuctl
+### Generate an API access token with sensuctl
 
 You can also generate an API access token using the sensuctl command line tool.
 The user credentials that you use to configure sensuctl determine your permissions to get, list, create, update, and delete resources with the Sensu API.
@@ -229,7 +229,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than via an environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -247,7 +247,7 @@ You can request a paginated response with the `limit` and `continue` query param
 The following request limits the response to a maximum of two objects:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/users?limit=2 -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response includes the available objects up to the specified limit.
@@ -289,7 +289,7 @@ To request the next two available users, use the `Sensu-Continue` token included
 
 {{< code shell >}}
 curl http://127.0.0.1:8080/api/core/v2/users?limit=2&continue=L2RlZmF1bU2Vuc3UtTWFjQ \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+-H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 If the response header does not include a `Sensu-Continue` token, there are no further objects to return.
@@ -477,7 +477,7 @@ Sensu's two _equality-based_ operators are `==` (equality) and `!=` (inequality)
 For example, to retrieve only checks with the label `type` and value `server`: 
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'labelSelector=type == "server"'
 {{< /code >}}
 
@@ -489,25 +489,25 @@ Include the `-G` flag so the request appends the query parameter data to the URL
 To retrieve checks that are not in the `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace != "production"'
 {{< /code >}}
 
 #### Set-based operators
 
-Sensu's two _set-based_ operators for lists of values are `in` and `notin`.
+Sensu's two *set-based* operators for lists of values are `in` and `notin`.
 
 For example, to retrieve checks with a `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that do not use the `slack` handler:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=slack notin check.handlers'
 {{< /code >}}
 
@@ -525,7 +525,7 @@ Sensu's _substring matching_ operator is `matches`.
 For example, to retrieve all checks whose name includes `linux`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.name matches "linux"'
 {{< /code >}}
 
@@ -534,14 +534,14 @@ For example, your webservers are named `webserver-1` through `webserver-25`, and
 In this case, you can use `matches` to retrieve all of your `webserver` entities:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=entity.name matches "webserver-"'
 {{< /code >}}
 
 Similarly, if you have entities labeled for different regions, you can use `matches` to find the entities that are labeled for the US (for example, `us-east-1`, `us-west-1`, and so on):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector:region matches "us"'
 {{< /code >}}
 
@@ -557,14 +557,14 @@ Use it to combine multiple statements separated with the logical operator in fie
 For example, the following cURL request retrieves checks that are not configured to be published **and** include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions'
 {{< /code >}}
 
 To retrieve checks that are not published, include a `linux` subscription, and are in the `dev` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.publish != true && linux in check.subscriptions && dev in check.namespace'
 {{< /code >}}
 
@@ -578,7 +578,7 @@ You can use field and label selectors in a single request.
 For example, to retrieve only checks that include a `linux` subscription *and* do not include a label for type `server`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions' \
 --data-urlencode 'labelSelector=type != "server"'
 {{< /code >}}
@@ -590,12 +590,12 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To use a label or field selector with string values that include special characters like hyphens and underscores, place the value in single or double quotes:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" -X GET http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'labelSelector=region == "us-west-1"'
 {{< /code >}}
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector="entity:i-0c1f8a116b84ea50c" in entity.subscriptions'
 {{< /code >}}
 
@@ -604,7 +604,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve checks that are in either the `dev` or `production` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=check.namespace in [dev,production]'
 {{< /code >}}
 
@@ -613,14 +613,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve events for a specific check (`checkhttp`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=checkhttp in event.check.name'
 {{< /code >}}
 
 Similary, to retrieve only events for the `server` entity:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=server in event.entity.name'
 {{< /code >}}
 
@@ -630,7 +630,7 @@ Use the `event.check.status` field selector to retrieve events by severity.
 For example, to retrieve all events at `2` (CRITICAL) status:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.check.status == "2"'
 {{< /code >}}
 
@@ -639,7 +639,7 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve all incidents (all events whose status is not `0`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.entity.status != "0"'
 {{< /code >}}
 
@@ -648,21 +648,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all checks that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/checks -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
 --data-urlencode 'fieldSelector=linux in check.subscriptions'
 {{< /code >}}
 
 Similarly, to list all entities that include the `linux` subscription:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/entities -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
 --data-urlencode 'fieldSelector=linux in entity.subscriptions'
 {{< /code >}}
 
 To list all events for the `linux` subscription, use the `event.entity.subscriptions` field selector:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=linux in event.entity.subscriptions'
 {{< /code >}}
 
@@ -673,21 +673,21 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silenced resources for a particular namespace (in this example, the `default` namespace):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace == "default"'
 {{< /code >}}
 
 Likewise, to list all silenced resources *except* those in the `default` namespace:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.namespace != "default"'
 {{< /code >}}
 
 To list all silenced events for all namespaces:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/events -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
 --data-urlencode 'fieldSelector=event.is_silenced == true'
 {{< /code >}}
 
@@ -696,14 +696,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To list all silences created by the user `alice`:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator == "alice"'
 {{< /code >}}
 
 To list all silences that were not created by the `admin` user:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.creator != "admin"'
 {{< /code >}}
 
@@ -712,14 +712,14 @@ curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/co
 To retrieve silences with a specific subscription (in this example, `linux`):
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.subscription == "linux"'
 {{< /code >}}
 
 Another way to make the same request is:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=linux in silenced.subscription'
 {{< /code >}}
 
@@ -733,7 +733,7 @@ In other words, this filter retrieves **silences** with a particular subscriptio
 To list all silenced resources that expire only when a matching check resolves:
 
 {{< code shell >}}
-curl -H "Authorization: Bearer $SENSU_ACCESS_TOKEN http://127.0.0.1:8080/api/core/v2/silenced -G \
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
 --data-urlencode 'fieldSelector=silenced.expire_on_resolve == true'
 {{< /code >}}
 

--- a/content/sensu-go/6.4/api/apikeys.md
+++ b/content/sensu-go/6.4/api/apikeys.md
@@ -74,8 +74,9 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
-This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl).
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
+If you prefer, you can [create a new API key with sensuctl](../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.4/api/apikeys.md
+++ b/content/sensu-go/6.4/api/apikeys.md
@@ -71,11 +71,16 @@ The `/apikeys` API endpoint provides HTTP POST access to create a new API key.
 ### Example {#apikeys-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/apikeys` API endpoint to create a new API key.
-The request includes the API key definition in the request body and returns a successful HTTP `201 Created` response.
+The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
+
+{{% notice note %}}
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../#authenticate-with-the-authentication-api) or [sensuctl](../#generate-an-api-access-token-with-sensuctl) .
+This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token. 
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
--H "Authorization: Key $SENSU_API_KEY" \
+-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "username": "admin"

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
@@ -217,7 +217,7 @@ In the final step, you will create an ad hoc event that you can trigger manually
 ## Create and trigger an ad hoc event
 
 To create an ad hoc event, first use `sensuctl env` to set up environment variables.
-The environment variables will provide the required credentials for the Sensu API:
+The environment variables will provide the required Sensu API access token credential for the Sensu API:
 
 {{< code shell >}}
 eval $(sensuctl env)

--- a/content/sensu-go/6.4/operations/control-access/use-apikeys.md
+++ b/content/sensu-go/6.4/operations/control-access/use-apikeys.md
@@ -73,7 +73,7 @@ HTTP/1.1 200 OK
 **NOTE**: The API key resource is intentionally not compatible with [`sensuctl create`](../../../sensuctl/create-manage-resources/#create-resources).
 {{% /notice %}}
 
-To generate a new API key for the admin user:
+To use sensuctl to generate a new API key for the admin user, run:
 
 {{< code shell >}}
 sensuctl api-key grant admin

--- a/content/sensu-go/6.4/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/license.md
@@ -173,7 +173,7 @@ You can also see your current entity count and limit in the response headers for
 For example:
 
 {{< code shell >}}
-curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+curl http://127.0.0.1:8080/api/core/v2/namespaces/default/entities -v -H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
 
 The response headers will include your current entity count and limit:

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
@@ -133,7 +133,7 @@ For example, to retrieve the list of secrets providers:
 {{< code shell >}}
 curl -X GET \
 http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
--H "Authorization: Bearer $SENSU_ACCESS_TOKEN"
+-H "Authorization: Key $SENSU_API_KEY"
 {{< /code >}}
  
 ## Secrets providers specification


### PR DESCRIPTION
## Description
- Updates the example for [/apikeys POST](https://docs.sensu.io/sensu-go/latest/api/apikeys/#create-a-new-api-key) to use authentication via access token. Otherwise, this example communicates that users need and API key to create and API key, which is confusing.
- Updates other examples throughout the docs to use `Authorization: Key $SENSU_API_KEY` rather than `Authorization: Bearer $SENSU_ACCESS_TOKEN`, particularly the [API response filtering](https://docs.sensu.io/sensu-go/latest/api/#equality-based-operators) examples

## Motivation and Context
https://sumologic.slack.com/archives/C024PCF29KR/p1628615672160800
