### PR TITLE
Fix 'retrieve' typo in 6.3 and 6.4 BSM docs

### DIFF
--- a/content/sensu-go/6.1/release-notes.md
+++ b/content/sensu-go/6.1/release-notes.md
@@ -88,7 +88,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 - Fixed a bug that could cause a panic in the backend entity API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
-- When an asset artifact retrived by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
+- When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
 ## 6.1.3 release notes
 

--- a/content/sensu-go/6.2/release-notes.md
+++ b/content/sensu-go/6.2/release-notes.md
@@ -235,7 +235,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 - Fixed a bug that could cause a panic in the backend entity API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
-- When an asset artifact retrived by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
+- When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
 ## 6.1.3 release notes
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -155,7 +155,7 @@ For example, you might set the minimum threshold at 10 web servers with an OK st
 
 The `aggregate` rule template is useful in dynamic environments and environments with some tolerance for failure.
 
-To review the `aggregate` resource definition, retrive it with a GET request to the BSM API:
+To review the `aggregate` resource definition, retrieve it with a GET request to the BSM API:
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -268,7 +268,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 - Fixed a bug that could cause a panic in the backend entity API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
-- When an asset artifact retrived by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
+- When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
 ## 6.1.3 release notes
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -155,7 +155,7 @@ For example, you might set the minimum threshold at 10 web servers with an OK st
 
 The `aggregate` rule template is useful in dynamic environments and environments with some tolerance for failure.
 
-To review the `aggregate` resource definition, retrive it with a GET request to the BSM API:
+To review the `aggregate` resource definition, retrieve it with a GET request to the BSM API:
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -308,7 +308,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 - Fixed a bug that could cause a panic in the backend entity API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
-- When an asset artifact retrived by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
+- When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
 ## 6.1.3 release notes
 


### PR DESCRIPTION
## Description
BSM docs and release notes for 6.3 and 6.4 contain a typo "retrive" instead of "retrieve" -- this PR fixes it.

## Motivation and Context
Noticed when working on something else