### PR TITLE
Specify Vault provider spec.client.version options

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
@@ -492,7 +492,7 @@ type         |
 description  | Handler type.
 required     | true
 type         | String
-allowed values | `pipe`, `tcp`, `udp` & `set`
+allowed values | `pipe`, `tcp`, `udp`, and `set`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 type: pipe

--- a/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.1/operations/manage-secrets/secrets-providers.md
@@ -436,6 +436,7 @@ version      |
 description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
+allowed values | `v1` and `v2`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 version: v1

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -492,7 +492,7 @@ type         |
 description  | Handler type.
 required     | true
 type         | String
-allowed values | `pipe`, `tcp`, `udp` & `set`
+allowed values | `pipe`, `tcp`, `udp`, and `set`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 type: pipe

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
@@ -436,6 +436,7 @@ version      |
 description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
+allowed values | `v1` and `v2`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 version: v1

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -492,7 +492,7 @@ type         |
 description  | Handler type.
 required     | true
 type         | String
-allowed values | `pipe`, `tcp`, `udp` & `set`
+allowed values | `pipe`, `tcp`, `udp`, and `set`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 type: pipe

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -436,6 +436,7 @@ version      |
 description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
+allowed values | `v1` and `v2`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 version: v1

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -492,7 +492,7 @@ type         |
 description  | Handler type.
 required     | true
 type         | String
-allowed values | `pipe`, `tcp`, `udp` & `set`
+allowed values | `pipe`, `tcp`, `udp`, and `set`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 type: pipe

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
@@ -436,6 +436,7 @@ version      |
 description  | HashiCorp Vault [key/value store version][14].
 required     | true
 type         | String
+allowed values | `v1` and `v2`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 version: v1


### PR DESCRIPTION
## Description
Adds allowed values `v1` and `v2` for Vault secrets provider in https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets-providers/#client-attributes

Also eliminates an ampersand in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/#spec-attributes

## Motivation and Context
https://sumologic.slack.com/archives/C0257A32C30/p1628879018017400