### PR TITLE
Convert glossary to concepts and terminology

### DIFF
--- a/content/sensu-go/6.1/learn/_index.md
+++ b/content/sensu-go/6.1/learn/_index.md
@@ -18,10 +18,9 @@ The Learn Sensu category includes tools to help you understand and start using S
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
-## Glossary
+## Concepts and terminology
 
-If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms and concepts.
-The glossary includes links to relevant reference documentation for more in-depth information.
+If you're new to Sensu, start with a basic review of Sensu [concepts and terminology][1], which includes definitions and links to relevant reference documentation for more in-depth information.
 
 To visualize how Sensu concepts work together in the observability pipeline, [take the tour][6] &mdash; follow the `Next` buttons on each page.
 
@@ -38,7 +37,7 @@ Follow the sandbox lessons to [build your first monitoring and observability wor
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
-[1]: glossary/
+[1]: concepts-terminology/
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/

--- a/content/sensu-go/6.1/learn/concepts-terminology.md
+++ b/content/sensu-go/6.1/learn/concepts-terminology.md
@@ -1,12 +1,12 @@
 ---
-title: "Glossary of Sensu terms"
-linkTitle: "Glossary"
-description: "Get familiar with Sensu terminology. Read our glossary to learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
+title: "Sensu concepts and terminology"
+linkTitle: "Concepts and Terminology"
+description: "Get familiar with Sensu concepts terminology. Learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
 weight: 10
-version: "6.3"
+version: "6.1"
 product: "Sensu Go"
 menu:
-  sensu-go-6.3:
+  sensu-go-6.1:
     parent: learn-sensu
 ---
 
@@ -98,10 +98,17 @@ Entries that allow you to suppress execution of event handlers on an ad-hoc basi
 Use silencing to schedule maintenance without being overloaded with alerts.
 [Read more about silencing][17].
 
+## Subscriptions
+Attributes used to indicate which entities will execute which checks.
+For Sensu to execute a check, the check definition must include a subscription that matches the subscription of at least one Sensu entity.
+Subscriptions allow you to configure check requests in a one-to-many model for entire groups or subgroups of entities rather than a traditional one-to-one mapping of configured hosts or observability checks.
+[Read more about subscriptions][22].
+
 ## Token
 A placeholder in a check definition that the agent replaces with local information before executing the check.
 Tokens let you fine-tune check attributes (like thresholds) on a per-entity level while reusing the check definition.
 [Read more about tokens][16].
+
 
 [1]: ../../observability-pipeline/observe-schedule/agent/
 [2]: ../../observability-pipeline/observe-schedule/backend/
@@ -121,3 +128,4 @@ Tokens let you fine-tune check attributes (like thresholds) on a per-entity leve
 [16]: ../../observability-pipeline/observe-schedule/tokens/
 [17]: ../../observability-pipeline/observe-process/silencing/
 [18]: ../../operations/control-access/rbac#resources
+[22]: ../../observability-pipeline/observe-schedule/subscriptions/

--- a/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.1/operations/maintain-sensu/migrate.md
@@ -54,7 +54,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-The [glossary][1] includes more information about new terminology in Sensu Go.
+Read [Sensu concepts and terminology][1] to learn more about new terms in Sensu Go.
 
 ## Architecture
 
@@ -506,7 +506,7 @@ When you're ready to sunset your Sensu Core instance, see the [platform][74] doc
 You may also want to re-install the `sensu-install` tool using the [`sensu-plugins-ruby` package][20].
 
 
-[1]: ../../../learn/glossary/
+[1]: ../../../learn/concepts-terminology/
 [2]: https://etcd.io/docs/latest/
 [3]: ../../../observability-pipeline/observe-schedule/backend/
 [4]: ../../../observability-pipeline/observe-schedule/agent/

--- a/content/sensu-go/6.2/learn/_index.md
+++ b/content/sensu-go/6.2/learn/_index.md
@@ -18,12 +18,12 @@ The Learn Sensu category includes tools to help you understand and start using S
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
-## Glossary
+## Concepts and terminology
 
-If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms and concepts.
-The glossary includes links to relevant reference documentation for more in-depth information.
+If you're new to Sensu, start with a basic review of Sensu [concepts and terminology][1], which includes definitions and links to relevant reference documentation for more in-depth information.
 
 To visualize how Sensu concepts work together in the observability pipeline, [take the tour][6] &mdash; follow the `Next` buttons on each page.
+
 ## Live demo
 
 Explore a [live demo][3] of the Sensu web UI: view the Entities page to see what Sensu is monitoring, the Events page to see the latest observability events, and the Checks page to see active service and metric checks.
@@ -37,7 +37,7 @@ Follow the sandbox lessons to [build your first monitoring and observability wor
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
-[1]: glossary/
+[1]: concepts-terminology/
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/

--- a/content/sensu-go/6.2/learn/concepts-terminology.md
+++ b/content/sensu-go/6.2/learn/concepts-terminology.md
@@ -1,12 +1,12 @@
 ---
-title: "Glossary of Sensu terms"
-linkTitle: "Glossary"
-description: "Get familiar with Sensu terminology. Read our glossary to learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
+title: "Sensu concepts and terminology"
+linkTitle: "Concepts and Terminology"
+description: "Get familiar with Sensu concepts terminology. Learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
 weight: 10
-version: "6.1"
+version: "6.2"
 product: "Sensu Go"
 menu:
-  sensu-go-6.1:
+  sensu-go-6.2:
     parent: learn-sensu
 ---
 
@@ -98,10 +98,17 @@ Entries that allow you to suppress execution of event handlers on an ad-hoc basi
 Use silencing to schedule maintenance without being overloaded with alerts.
 [Read more about silencing][17].
 
+## Subscriptions
+Attributes used to indicate which entities will execute which checks.
+For Sensu to execute a check, the check definition must include a subscription that matches the subscription of at least one Sensu entity.
+Subscriptions allow you to configure check requests in a one-to-many model for entire groups or subgroups of entities rather than a traditional one-to-one mapping of configured hosts or observability checks.
+[Read more about subscriptions][22].
+
 ## Token
 A placeholder in a check definition that the agent replaces with local information before executing the check.
 Tokens let you fine-tune check attributes (like thresholds) on a per-entity level while reusing the check definition.
 [Read more about tokens][16].
+
 
 [1]: ../../observability-pipeline/observe-schedule/agent/
 [2]: ../../observability-pipeline/observe-schedule/backend/
@@ -121,3 +128,4 @@ Tokens let you fine-tune check attributes (like thresholds) on a per-entity leve
 [16]: ../../observability-pipeline/observe-schedule/tokens/
 [17]: ../../observability-pipeline/observe-process/silencing/
 [18]: ../../operations/control-access/rbac#resources
+[22]: ../../observability-pipeline/observe-schedule/subscriptions/

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -54,7 +54,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-The [glossary][1] includes more information about new terminology in Sensu Go.
+Read [Sensu concepts and terminology][1] to learn more about new terms in Sensu Go.
 
 ## Architecture
 
@@ -506,7 +506,7 @@ When you're ready to sunset your Sensu Core instance, see the [platform][74] doc
 You may also want to re-install the `sensu-install` tool using the [`sensu-plugins-ruby` package][20].
 
 
-[1]: ../../../learn/glossary/
+[1]: ../../../learn/concepts-terminology/
 [2]: https://etcd.io/docs/latest/
 [3]: ../../../observability-pipeline/observe-schedule/backend/
 [4]: ../../../observability-pipeline/observe-schedule/agent/

--- a/content/sensu-go/6.3/learn/_index.md
+++ b/content/sensu-go/6.3/learn/_index.md
@@ -18,10 +18,9 @@ The Learn Sensu category includes tools to help you understand and start using S
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
-## Glossary
+## Concepts and terminology
 
-If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms and concepts.
-The glossary includes links to relevant reference documentation for more in-depth information.
+If you're new to Sensu, start with a basic review of Sensu [concepts and terminology][1], which includes definitions and links to relevant reference documentation for more in-depth information.
 
 To visualize how Sensu concepts work together in the observability pipeline, [take the tour][6] &mdash; follow the `Next` buttons on each page.
 
@@ -38,7 +37,7 @@ Follow the sandbox lessons to [build your first monitoring and observability wor
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
-[1]: glossary/
+[1]: concepts-terminology/
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/

--- a/content/sensu-go/6.3/learn/concepts-terminology.md
+++ b/content/sensu-go/6.3/learn/concepts-terminology.md
@@ -1,12 +1,12 @@
 ---
-title: "Glossary of Sensu terms"
-linkTitle: "Glossary"
-description: "Get familiar with Sensu terminology. Read our glossary to learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
+title: "Sensu concepts and terminology"
+linkTitle: "Concepts and Terminology"
+description: "Get familiar with Sensu concepts terminology. Learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
 weight: 10
-version: "6.2"
+version: "6.3"
 product: "Sensu Go"
 menu:
-  sensu-go-6.2:
+  sensu-go-6.3:
     parent: learn-sensu
 ---
 
@@ -30,6 +30,17 @@ The Sensu backend processes observation data (events) using filters, mutators, a
 It maintains configuration files, stores recent observation data, and schedules monitoring checks.
 You can interact with the backend using the API, command line, and web UI interfaces.
 [Read more about the Sensu backend][2].
+
+## Business service monitoring (BSM)
+A feature that provides high-level visibility into the current health of your business services.
+An example business service is a company website, which might require several individual elements to have OK status for the website to function (e.g. webservers, an inventory database, and a shopping cart).
+With business service monitoring (BSM), you could create a current status page for the company website that displays the website’s overall status at a glance.
+
+BSM requires two resources that work together to achieve top-down monitoring: service components and rule templates.
+Service components are the elements that make up your business services.
+Rule templates define the monitoring rules that produce events for service components based on customized evaluation expressions.
+
+[Read more about BSM][19], [rule templates][20], and [service components][21].
 
 ## Check
 A recurring check the agent runs to determine the state of a system component or collect metrics.
@@ -98,10 +109,17 @@ Entries that allow you to suppress execution of event handlers on an ad-hoc basi
 Use silencing to schedule maintenance without being overloaded with alerts.
 [Read more about silencing][17].
 
+## Subscriptions
+Attributes used to indicate which entities will execute which checks.
+For Sensu to execute a check, the check definition must include a subscription that matches the subscription of at least one Sensu entity.
+Subscriptions allow you to configure check requests in a one-to-many model for entire groups or subgroups of entities rather than a traditional one-to-one mapping of configured hosts or observability checks.
+[Read more about subscriptions][22].
+
 ## Token
 A placeholder in a check definition that the agent replaces with local information before executing the check.
 Tokens let you fine-tune check attributes (like thresholds) on a per-entity level while reusing the check definition.
 [Read more about tokens][16].
+
 
 [1]: ../../observability-pipeline/observe-schedule/agent/
 [2]: ../../observability-pipeline/observe-schedule/backend/
@@ -121,3 +139,7 @@ Tokens let you fine-tune check attributes (like thresholds) on a per-entity leve
 [16]: ../../observability-pipeline/observe-schedule/tokens/
 [17]: ../../observability-pipeline/observe-process/silencing/
 [18]: ../../operations/control-access/rbac#resources
+[19]: ../../observability-pipeline/observe-schedule/business-service-monitoring/
+[20]: ../../observability-pipeline/observe-schedule/rule-templates/
+[21]: ../../observability-pipeline/observe-schedule/service-components/
+[22]: ../../observability-pipeline/observe-schedule/subscriptions/

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -54,7 +54,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-The [glossary][1] includes more information about new terminology in Sensu Go.
+Read [Sensu concepts and terminology][1] to learn more about new terms in Sensu Go.
 
 ## Architecture
 
@@ -506,7 +506,7 @@ When you're ready to sunset your Sensu Core instance, see the [platform][74] doc
 You may also want to re-install the `sensu-install` tool using the [`sensu-plugins-ruby` package][20].
 
 
-[1]: ../../../learn/glossary/
+[1]: ../../../learn/concepts-terminology/
 [2]: https://etcd.io/docs/latest/
 [3]: ../../../observability-pipeline/observe-schedule/backend/
 [4]: ../../../observability-pipeline/observe-schedule/agent/

--- a/content/sensu-go/6.4/learn/_index.md
+++ b/content/sensu-go/6.4/learn/_index.md
@@ -18,10 +18,9 @@ The Learn Sensu category includes tools to help you understand and start using S
 To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
-## Glossary
+## Concepts and terminology
 
-If you're new to Sensu, start with a basic review of terminology in the [glossary][1] of definitions for common Sensu terms and concepts.
-The glossary includes links to relevant reference documentation for more in-depth information.
+If you're new to Sensu, start with a basic review of Sensu [concepts and terminology][1], which includes definitions and links to relevant reference documentation for more in-depth information.
 
 To visualize how Sensu concepts work together in the observability pipeline, [take the tour][6] &mdash; follow the `Next` buttons on each page.
 
@@ -38,7 +37,7 @@ Follow the sandbox lessons to [build your first monitoring and observability wor
 We also have a GitHub lesson that guides you through [deploying a Sensu cluster and example application into Kubernetes][7], plus a configuration that allows you to reuse Nagios-style monitoring checks to monitor the example application with a Sensu sidecar.
 
 
-[1]: glossary/
+[1]: concepts-terminology/
 [3]: demo/
 [4]: sandbox/
 [5]: learn-sensu-sandbox/

--- a/content/sensu-go/6.4/learn/concepts-terminology.md
+++ b/content/sensu-go/6.4/learn/concepts-terminology.md
@@ -1,7 +1,7 @@
 ---
-title: "Glossary of Sensu terms"
-linkTitle: "Glossary"
-description: "Get familiar with Sensu terminology. Read our glossary to learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
+title: "Sensu concepts and terminology"
+linkTitle: "Concepts and Terminology"
+description: "Get familiar with Sensu concepts terminology. Learn the definitions of common Sensu terms, including agent, asset, backend, check, event, and many more. Bonus: each term links to a corresponding guide!"
 weight: 10
 version: "6.4"
 product: "Sensu Go"
@@ -30,6 +30,17 @@ The Sensu backend processes observation data (events) using filters, mutators, a
 It maintains configuration files, stores recent observation data, and schedules monitoring checks.
 You can interact with the backend using the API, command line, and web UI interfaces.
 [Read more about the Sensu backend][2].
+
+## Business service monitoring (BSM)
+A feature that provides high-level visibility into the current health of your business services.
+An example business service is a company website, which might require several individual elements to have OK status for the website to function (e.g. webservers, an inventory database, and a shopping cart).
+With business service monitoring (BSM), you could create a current status page for the company website that displays the website’s overall status at a glance.
+
+BSM requires two resources that work together to achieve top-down monitoring: service components and rule templates.
+Service components are the elements that make up your business services.
+Rule templates define the monitoring rules that produce events for service components based on customized evaluation expressions.
+
+[Read more about BSM][19], [rule templates][20], and [service components][21].
 
 ## Check
 A recurring check the agent runs to determine the state of a system component or collect metrics.
@@ -98,10 +109,17 @@ Entries that allow you to suppress execution of event handlers on an ad-hoc basi
 Use silencing to schedule maintenance without being overloaded with alerts.
 [Read more about silencing][17].
 
+## Subscriptions
+Attributes used to indicate which entities will execute which checks.
+For Sensu to execute a check, the check definition must include a subscription that matches the subscription of at least one Sensu entity.
+Subscriptions allow you to configure check requests in a one-to-many model for entire groups or subgroups of entities rather than a traditional one-to-one mapping of configured hosts or observability checks.
+[Read more about subscriptions][22].
+
 ## Token
 A placeholder in a check definition that the agent replaces with local information before executing the check.
 Tokens let you fine-tune check attributes (like thresholds) on a per-entity level while reusing the check definition.
 [Read more about tokens][16].
+
 
 [1]: ../../observability-pipeline/observe-schedule/agent/
 [2]: ../../observability-pipeline/observe-schedule/backend/
@@ -121,3 +139,7 @@ Tokens let you fine-tune check attributes (like thresholds) on a per-entity leve
 [16]: ../../observability-pipeline/observe-schedule/tokens/
 [17]: ../../observability-pipeline/observe-process/silencing/
 [18]: ../../operations/control-access/rbac#resources
+[19]: ../../observability-pipeline/observe-schedule/business-service-monitoring/
+[20]: ../../observability-pipeline/observe-schedule/rule-templates/
+[21]: ../../observability-pipeline/observe-schedule/service-components/
+[22]: ../../observability-pipeline/observe-schedule/subscriptions/

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -54,7 +54,7 @@ This is a fundamental change in Sensu terminology from Sensu Core: the server is
 Clients are represented within Sensu Go as abstract entities that can describe a wider range of system components such as network gear, a web server, or a cloud resource.
 Entities include agent entities that run a Sensu agent and the familiar proxy entities.
 
-The [glossary][1] includes more information about new terminology in Sensu Go.
+Read [Sensu concepts and terminology][1] to learn more about new terms in Sensu Go.
 
 ## Architecture
 
@@ -506,7 +506,7 @@ When you're ready to sunset your Sensu Core instance, see the [platform][74] doc
 You may also want to re-install the `sensu-install` tool using the [`sensu-plugins-ruby` package][20].
 
 
-[1]: ../../../learn/glossary/
+[1]: ../../../learn/concepts-terminology/
 [2]: https://etcd.io/docs/latest/
 [3]: ../../../observability-pipeline/observe-schedule/backend/
 [4]: ../../../observability-pipeline/observe-schedule/agent/

--- a/static.json
+++ b/static.json
@@ -295,6 +295,14 @@
             "url": "/sensu-go/latest/api",
             "status": 301
         },
+        "~ ^/sensu-go/latest/learn/glossary/?$": {
+            "url": "/sensu-go/latest/learn/concepts-terminology",
+            "status": 301
+        },
+        "~ ^/sensu-go/6.[0-9]/?((?<=\/).*)?/learn/glossary/?$": {
+            "url": "/sensu-go/latest/learn/concepts-terminology",
+            "status": 301
+        },
         "~ ^/sensu-go/latest/learn/prometheus-metrics/?$": {
             "url": "/sensu-go/latest/observability-pipeline/observe-schedule/prometheus-metrics",
             "status": 301


### PR DESCRIPTION
## Description
Changes the glossary page title to "Concepts and terminology" and updates links and page references throughout.

Also adds BSM and subscriptions to the list of terms.

## Motivation and Context
Suggestion from Vikas
