### PR TITLE
Add commercial features link element to docs.sensu.io

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -176,6 +176,11 @@
         </a>
       </div>
     </div>
+    <br>
+    <a class="colored colored--purple colored--rounded" href="./sensu-go/latest/commercial/">
+      <h3>Commercial Features</h3>
+      <p>Sensu Go offers commercial features designed for monitoring at scale.<br>All commercial features are available in the official Sensu Go distribution, and you can use them for free up to an entity limit of 100.</p>
+    </a>
     <div>
       <h2>Guides and examples</h2>
       <p>Step-by-step walkthroughs and workflows for specific observability tasks.</p>


### PR DESCRIPTION
## Description
Adds a linked element for https://docs.sensu.io/sensu-go/latest/commercial/ to the new docs.sensu.io landing page.

## Motivation and Context
Just think this page should be an option straight from the docs landing page.
