### PR TITLE
Remove direct links to 5.21 pages on platforms page

### DIFF
--- a/content/sensu-go/6.1/platforms.md
+++ b/content/sensu-go/6.1/platforms.md
@@ -353,10 +353,10 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 
 [1]: #supported-packages
 [2]: #docker-images
-[3]: /sensu-go/5.21/commercial/
+[3]: ../commercial/
 [4]: #binary-only-distributions
-[5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
-[6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
+[5]: ../operations/deploy-sensu/install-sensu/
+[6]: ../operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads

--- a/content/sensu-go/6.2/platforms.md
+++ b/content/sensu-go/6.2/platforms.md
@@ -353,10 +353,10 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 
 [1]: #supported-packages
 [2]: #docker-images
-[3]: /sensu-go/5.21/commercial/
+[3]: ../commercial/
 [4]: #binary-only-distributions
-[5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
-[6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
+[5]: ../operations/deploy-sensu/install-sensu/
+[6]: ../operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads

--- a/content/sensu-go/6.3/platforms.md
+++ b/content/sensu-go/6.3/platforms.md
@@ -353,10 +353,10 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 
 [1]: #supported-packages
 [2]: #docker-images
-[3]: /sensu-go/5.21/commercial/
+[3]: ../commercial/
 [4]: #binary-only-distributions
-[5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
-[6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
+[5]: ../operations/deploy-sensu/install-sensu/
+[6]: ../operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads

--- a/content/sensu-go/6.4/platforms.md
+++ b/content/sensu-go/6.4/platforms.md
@@ -354,10 +354,10 @@ To build Sensu Go from source, see the [contributing guide on GitHub][16].
 
 [1]: #supported-packages
 [2]: #docker-images
-[3]: /sensu-go/5.21/commercial/
+[3]: ../commercial/
 [4]: #binary-only-distributions
-[5]: /sensu-go/5.21/operations/deploy-sensu/install-sensu/
-[6]: /sensu-go/5.21/operations/deploy-sensu/configuration-management/
+[5]: ../operations/deploy-sensu/install-sensu/
+[6]: ../operations/deploy-sensu/configuration-management/
 [7]: https://sensu.io/licenses
 [8]: https://packagecloud.io/sensu/stable/
 [9]: https://sensu.io/downloads


### PR DESCRIPTION
## Description
Updates three direct links to 5.21 pages to replace them with relative links for the current version in the Platforms page.

## Motivation and Context
Found when working on 6.4.1 release notes