### PR TITLE
6.3.0: Add description table for event-log-buffer-wait

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1426,6 +1426,17 @@ sensu-backend start --event-log-buffer-size 100000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
 
+| event-log-buffer-wait |      |
+-----------------------|------
+description            | Buffer wait time for the event logger. When the buffer is full, the event logger will wait for the specified time for the writer to consume events from the buffer.
+type                   | String
+default                | 10ms
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_WAIT`
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-buffer-wait 10ms{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+event-log-buffer-wait: 10ms{{< /code >}}
+
 | event-log-file |      |
 -----------------------|------
 description            | Path to the event log file. {{% notice warning %}}

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -97,6 +97,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 
 - ([Commercial feature][207]) Added [business service monitoring (BSM)][210] to provide high-level visibility into the current health of any number of business services, with a [built-in aggregate check rule template][211].
 - ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration flags.
+- ([Commercial feature][207]) Added the `event-log-buffer-wait` backend configuration flag, which allows you to specify how long the event logger will wait for the writer to consume events from the buffer when the buffer is full.
 - Added the entity class [service][213], which represents a business service for the business service monitoring (BSM) feature.
 
 **IMPROVEMENTS:**

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1519,7 +1519,7 @@ To write Sensu service logs to flat files on disk, read [Log Sensu services with
 
 | event-log-buffer-size |      |
 -----------------------|------
-description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
+description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file.
 type                   | Integer
 default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
@@ -1527,6 +1527,17 @@ command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-size 100000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
+
+| event-log-buffer-wait |      |
+-----------------------|------
+description            | Buffer wait time for the event logger. When the buffer is full, the event logger will wait for the specified time for the writer to consume events from the buffer.
+type                   | String
+default                | 10ms
+environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_WAIT`
+command line example   | {{< code shell >}}
+sensu-backend start --event-log-buffer-wait 10ms{{< /code >}}
+/etc/sensu/backend.yml example | {{< code shell >}}
+event-log-buffer-wait: 10ms{{< /code >}}
 
 | event-log-file |      |
 -----------------------|------

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -161,6 +161,7 @@ See the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 
 - ([Commercial feature][207]) Added [business service monitoring (BSM)][210] to provide high-level visibility into the current health of any number of business services, with a [built-in aggregate check rule template][211].
 - ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration flags.
+- ([Commercial feature][207]) Added the `event-log-buffer-wait` backend configuration flag, which allows you to specify how long the event logger will wait for the writer to consume events from the buffer when the buffer is full.
 - Added the entity class [service][213], which represents a business service for the business service monitoring (BSM) feature.
 
 **IMPROVEMENTS:**


### PR DESCRIPTION
## Description
Adds a description table for the event-log-buffer-wait flag in the backend reference for 6.3 and 6.4 docs

## Motivation and Context
6.3.0 release
