### PR TITLE
Redirect docs.uchiwa.io

### DIFF
--- a/static.json
+++ b/static.json
@@ -7,6 +7,10 @@
             "url": "/sensu-core/latest/$1",
             "status": 301
         },
+        "~ docs.uchiwa.io/?$": {
+            "url": "/uchiwa/latest/",
+            "status": 301
+        },
         "~ ^/sensu-core/0.29/?((?<=\/).*)?$": {
             "url": "/sensu-core/latest/$1",
             "status": 301


### PR DESCRIPTION
## Description
Redirects docs.uchiwa.io to docs.sensu.io/uchiwa/latest/ using static.json

## Motivation and Context
Redirect testing for https://github.com/sensu/sensu-docs/issues/2829