### PR TITLE
Revert "Redirect docs.uchiwa.io"

### DIFF
--- a/static.json
+++ b/static.json
@@ -7,10 +7,6 @@
             "url": "/sensu-core/latest/$1",
             "status": 301
         },
-        "~ docs.uchiwa.io/?$": {
-            "url": "/uchiwa/latest/",
-            "status": 301
-        },
         "~ ^/sensu-core/0.29/?((?<=\/).*)?$": {
             "url": "/sensu-core/latest/$1",
             "status": 301


### PR DESCRIPTION
Reverts sensu/sensu-docs#3308

As I suspected, adding a redirect in the docs static.json file does not work to redirect docs.uchiwa.io