### PR TITLE
Fix sensuctl example for filtering by field selectors

### DIFF
--- a/content/sensu-go/6.1/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.1/sensuctl/filter-responses.md
@@ -95,7 +95,7 @@ sensuctl event list --field-selector 'event.check.status == "2"'
 To retrieve all entities whose name includes the substring `webserver`:
 
 {{< code shell >}}
-sensuctl entity list --fieldSelector 'entity.name matches "webserver"'
+sensuctl entity list --field-selector 'entity.name matches "webserver"'
 {{< /code >}}
 
 ### Use the logical AND operator

--- a/content/sensu-go/6.2/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.2/sensuctl/filter-responses.md
@@ -95,7 +95,7 @@ sensuctl event list --field-selector 'event.check.status == "2"'
 To retrieve all entities whose name includes the substring `webserver`:
 
 {{< code shell >}}
-sensuctl entity list --fieldSelector 'entity.name matches "webserver"'
+sensuctl entity list --field-selector 'entity.name matches "webserver"'
 {{< /code >}}
 
 ### Use the logical AND operator

--- a/content/sensu-go/6.3/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.3/sensuctl/filter-responses.md
@@ -95,7 +95,7 @@ sensuctl event list --field-selector 'event.check.status == "2"'
 To retrieve all entities whose name includes the substring `webserver`:
 
 {{< code shell >}}
-sensuctl entity list --fieldSelector 'entity.name matches "webserver"'
+sensuctl entity list --field-selector 'entity.name matches "webserver"'
 {{< /code >}}
 
 ### Use the logical AND operator

--- a/content/sensu-go/6.4/sensuctl/filter-responses.md
+++ b/content/sensu-go/6.4/sensuctl/filter-responses.md
@@ -95,7 +95,7 @@ sensuctl event list --field-selector 'event.check.status == "2"'
 To retrieve all entities whose name includes the substring `webserver`:
 
 {{< code shell >}}
-sensuctl entity list --fieldSelector 'entity.name matches "webserver"'
+sensuctl entity list --field-selector 'entity.name matches "webserver"'
 {{< /code >}}
 
 ### Use the logical AND operator


### PR DESCRIPTION
## Description
Fixes the third example under https://docs.sensu.io/sensu-go/latest/sensuctl/filter-responses/#filter-responses-with-field-selectors, which used `--fieldSelector` instead of `--field-selector`.

## Motivation and Context
h/t to @lspxxv for finding this mistake!
