### PR TITLE
Fix links to EC2 integration page on Sensu Go docs homepage

### DIFF
--- a/content/sensu-go/6.1/_index.md
+++ b/content/sensu-go/6.1/_index.md
@@ -99,7 +99,7 @@ Sensu is a comprehensive monitoring and observability solution for enterprises, 
 [32]: plugins/supported-integrations/influxdb/
 [33]: plugins/supported-integrations/ansible/
 [34]: plugins/supported-integrations/sumologic/
-[35]: plugins/supported-integrations/ec2/
+[35]: plugins/supported-integrations/aws-ec2/
 [36]: plugins/supported-integrations/rundeck/
 [37]: plugins/supported-integrations/saltstack/
 [38]: plugins/supported-integrations/

--- a/content/sensu-go/6.2/_index.md
+++ b/content/sensu-go/6.2/_index.md
@@ -99,7 +99,7 @@ Sensu is a comprehensive monitoring and observability solution for enterprises, 
 [32]: plugins/supported-integrations/influxdb/
 [33]: plugins/supported-integrations/ansible/
 [34]: plugins/supported-integrations/sumologic/
-[35]: plugins/supported-integrations/ec2/
+[35]: plugins/supported-integrations/aws-ec2/
 [36]: plugins/supported-integrations/rundeck/
 [37]: plugins/supported-integrations/saltstack/
 [38]: plugins/supported-integrations/

--- a/content/sensu-go/6.3/_index.md
+++ b/content/sensu-go/6.3/_index.md
@@ -99,7 +99,7 @@ Sensu is a comprehensive monitoring and observability solution for enterprises, 
 [32]: plugins/supported-integrations/influxdb/
 [33]: plugins/supported-integrations/ansible/
 [34]: plugins/supported-integrations/sumologic/
-[35]: plugins/supported-integrations/ec2/
+[35]: plugins/supported-integrations/aws-ec2/
 [36]: plugins/supported-integrations/rundeck/
 [37]: plugins/supported-integrations/saltstack/
 [38]: plugins/supported-integrations/

--- a/content/sensu-go/6.4/_index.md
+++ b/content/sensu-go/6.4/_index.md
@@ -99,7 +99,7 @@ Sensu is a comprehensive monitoring and observability solution for enterprises, 
 [32]: plugins/supported-integrations/influxdb/
 [33]: plugins/supported-integrations/ansible/
 [34]: plugins/supported-integrations/sumologic/
-[35]: plugins/supported-integrations/ec2/
+[35]: plugins/supported-integrations/aws-ec2/
 [36]: plugins/supported-integrations/rundeck/
 [37]: plugins/supported-integrations/saltstack/
 [38]: plugins/supported-integrations/


### PR DESCRIPTION
## Description
Fixes incorrect link to EC2 integrations page at https://docs.sensu.io/sensu-go/latest/

## Motivation and Context
Ahrefs site audit