### PR TITLE
Change link from Core docs into Go docs for plugins info

### DIFF
--- a/content/sensu-core/1.9/_index.md
+++ b/content/sensu-core/1.9/_index.md
@@ -81,7 +81,7 @@ training, and other benefits, check out [Sensu Enterprise][14].
 [1]:  https://www.pagerduty.com
 [2]:  https://slack.com
 [3]:  https://github.com/sensu-plugins
-[4]:  /plugins/latest/reference/
+[4]:  installation/installing-plugins/
 [9]:  https://www.chef.io
 [10]: https://puppetlabs.com
 [11]: https://www.ansible.com

--- a/content/sensu-core/1.9/reference/plugins.md
+++ b/content/sensu-core/1.9/reference/plugins.md
@@ -17,10 +17,10 @@ health, or collect & analyze metrics), [Sensu handlers][2] (i.e. to send
 notifications or perform other actions based on [Sensu events][3]), or [Sensu
 mutators][3] (i.e. to modify [event data][4] prior to handling).
 
-For more about Sensu plugins, please refer to the [Plugins reference documentation][5].
+For more about Sensu plugins, please refer to [Installing & Managing Plugins][5].
 
 [1]:  ../checks
 [2]:  ../handlers
 [3]:  ../events#event-data
 [4]:  ../mutators
-[5]:  ../../../../plugins/latest/reference
+[5]:  ../../installation/installing-plugins/


### PR DESCRIPTION
## Description
Fixes a link in two pages of the Core docs that redirects to a page in the Sensu Go docset.

## Motivation and Context
ahrefs site audit
