### PR TITLE
6.5.0: Add processed_by attribute for events

### DIFF
--- a/content/sensu-go/6.5/api/events.md
+++ b/content/sensu-go/6.5/api/events.md
@@ -86,6 +86,7 @@ HTTP/1.1 200 OK
       },
       "secrets": null,
       "is_silenced": false,
+      "processed_by": "server1",
       "scheduler": "memory"
     },
     "entity": {
@@ -228,6 +229,7 @@ output         | {{< code shell >}}
       },
       "secrets": null,
       "is_silenced": false,
+      "processed_by": "server1",
       "scheduler": "memory"
     },
     "entity": {
@@ -455,6 +457,7 @@ HTTP/1.1 200 OK
       },
       "secrets": null,
       "is_silenced": false,
+      "processed_by": "server1",
       "scheduler": "memory"
     },
     "entity": {
@@ -585,6 +588,7 @@ HTTP/1.1 200 OK
       },
       "secrets": null,
       "is_silenced": false,
+      "processed_by": "server1",
       "scheduler": "etcd"
     },
     "entity": {
@@ -726,6 +730,7 @@ output               | {{< code json >}}
       },
       "secrets": null,
       "is_silenced": false,
+      "processed_by": "server1",
       "scheduler": "memory"
     },
     "entity": {
@@ -856,6 +861,7 @@ output               | {{< code json >}}
       },
       "secrets": null,
       "is_silenced": false,
+      "processed_by": "server1",
       "scheduler": "etcd"
     },
     "entity": {
@@ -992,6 +998,7 @@ HTTP/1.1 200 OK
     },
     "secrets": null,
     "is_silenced": false,
+    "processed_by": "server1",
     "scheduler": ""
   },
   "entity": {
@@ -1123,6 +1130,7 @@ output               | {{< code json >}}
     },
     "secrets": null,
     "is_silenced": false,
+    "processed_by": "server1",
     "scheduler": ""
   },
   "entity": {

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/_index.md
@@ -54,6 +54,7 @@ spec:
       status: 0
     interval: 10
     is_silenced: false
+    processed_by: sensu-go-sandbox
     issued: 1552506033
     last_ok: 1552506033
     low_flap_threshold: 0
@@ -166,6 +167,7 @@ spec:
       ],
       "interval": 10,
       "is_silenced": false,
+      "processed_by": "sensu-go-sandbox",
       "issued": 1552506033,
       "last_ok": 1552506033,
       "low_flap_threshold": 0,

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -69,6 +69,7 @@ spec:
       status: 0
     interval: 60
     is_silenced: false
+    processed_by: sensu-centos
     issued: 1617050501
     last_ok: 1617050501
     low_flap_threshold: 0
@@ -194,6 +195,7 @@ spec:
       ],
       "interval": 60,
       "is_silenced": false,
+      "processed_by": "sensu-centos",
       "issued": 1617050501,
       "last_ok": 1617050501,
       "low_flap_threshold": 0,
@@ -371,6 +373,7 @@ This is the format that events are in when Sensu sends them to handlers:
     },
     "secrets": null,
     "is_silenced": false,
+    "processed_by": "sensu-centos",
     "scheduler": "memory"
   },
   "entity": {
@@ -467,7 +470,7 @@ spec:
     entity_class: agent
     last_seen: 1552495139
     metadata:
-      name: sensu-go-sandbox
+      name: sensu-centos
       namespace: default
     redact:
     - password
@@ -634,6 +637,7 @@ spec:
       status: 0
     interval: 10
     is_silenced: false
+    processed_by: sensu-go-sandbox
     issued: 1552506033
     last_ok: 1552506033
     low_flap_threshold: 0
@@ -746,6 +750,7 @@ spec:
       ],
       "interval": 10,
       "is_silenced": false,
+      "processed_by": "sensu-go-sandbox",
       "issued": 1552506033,
       "last_ok": 1552506033,
       "low_flap_threshold": 0,
@@ -1094,6 +1099,7 @@ spec:
       status: 0
     interval: 10
     is_silenced: true
+    processed_by: sensu-go-sandbox
     issued: 1552506033
     last_ok: 1552506033
     low_flap_threshold: 0
@@ -1202,6 +1208,7 @@ spec:
       ],
       "interval": 10,
       "is_silenced": true,
+      "processed_by": "sensu-go-sandbox",
       "issued": 1552506033,
       "last_ok": 1552506033,
       "low_flap_threshold": 0,
@@ -1532,6 +1539,7 @@ check:
     status: 0
   interval: 10
   is_silenced: true
+  processed_by: sensu-go-sandbox
   issued: 1552506033
   last_ok: 1552506033
   low_flap_threshold: 0
@@ -1582,6 +1590,7 @@ check:
     ],
     "interval": 10,
     "is_silenced": true,
+    "processed_by": "sensu-go-sandbox",
     "issued": 1552506033,
     "last_ok": 1552506033,
     "low_flap_threshold": 0,
@@ -1843,6 +1852,24 @@ output: "sensu-go-sandbox.curl_timings.time_total 0.005
 {{< code json >}}
 {
   "output": "sensu-go-sandbox.curl_timings.time_total 0.005"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="processedby-attribute"></a>
+
+processed_by | |
+-------------|------
+description  | The name of the agent that processed the event. Useful for determining which agent processed an event executed by a [proxy check request][42] or a [POST request to the events API][41].
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+processed_by: sensu-go-sandbox
+{{< /code >}}
+{{< code json >}}
+{
+  "processed_by": "sensu-go-sandbox"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2117,3 +2144,5 @@ value: 0.005
 [38]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/flapping.html
 [39]: #flap-detection-algorithm
 [40]: ../../observe-filter/filters/#check-attributes-available-to-filters
+[41]: ../../observe-schedule/agent/#create-observability-events-using-the-agent-api
+[42]: ../../observe-schedule/checks/#proxy-checks

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -470,7 +470,7 @@ spec:
     entity_class: agent
     last_seen: 1552495139
     metadata:
-      name: sensu-centos
+      name: sensu-go-sandbox
       namespace: default
     redact:
     - password


### PR DESCRIPTION
## Description
For 6.5 docs:
- Updates event examples in https://docs.sensu.io/sensu-go/6.5/observability-pipeline/observe-events/ and https://docs.sensu.io/sensu-go/6.5/api/events/ to include the `processed_by` attribute
- Updates event examples in https://docs.sensu.io/sensu-go/6.5/observability-pipeline/observe-events/events/ to include the `processed_by` attribute and adds description table for the `processed_by` attribute in the check attributes of the event spec

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3265