### PR TITLE
Fix command explanation that should say handler

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -229,7 +229,7 @@ sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
-The response will list the complete check resource definition:
+The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -1,4 +1,4 @@
----
+ ---
 title: "Send PagerDuty alerts with Sensu"
 linkTitle: "Send PagerDuty Alerts"
 guide_title: "Send PagerDuty alerts with Sensu"
@@ -229,7 +229,7 @@ sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
-The response will list the complete check resource definition:
+The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -229,7 +229,7 @@ sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
-The response will list the complete check resource definition:
+The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -229,7 +229,7 @@ sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
-The response will list the complete check resource definition:
+The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -229,7 +229,7 @@ sensuctl handler info pagerduty --format wrapped-json
 {{< /code >}}
 {{< /language-toggle >}}
 
-The response will list the complete check resource definition:
+The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 


### PR DESCRIPTION
## Description
Fixes a sensuctl command explanation that previously said it would retrieve a check rather than a handler (handler is correct)

## Motivation and Context
Noticed when working on something else
