### PR TITLE
Add etcd-advertise-client-urls and example https value in Secure Sensu

### DIFF
--- a/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/secure-sensu.md
@@ -53,6 +53,7 @@ etcd-peer-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< code yml >}}
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
+etcd-advertise-client-urls: "https://localhost:2379"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 

--- a/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/secure-sensu.md
@@ -53,6 +53,7 @@ etcd-peer-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< code yml >}}
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
+etcd-advertise-client-urls: "https://localhost:2379"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/secure-sensu.md
@@ -53,6 +53,7 @@ etcd-peer-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< code yml >}}
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
+etcd-advertise-client-urls: "https://localhost:2379"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
@@ -53,6 +53,7 @@ etcd-peer-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< code yml >}}
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
+etcd-advertise-client-urls: "https://localhost:2379"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
@@ -53,6 +53,7 @@ etcd-peer-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< code yml >}}
 etcd-listen-client-urls: "https://localhost:2379"
 etcd-listen-peer-urls: "https://localhost:2380"
+etcd-advertise-client-urls: "https://localhost:2379"
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
 {{< /code >}}
 


### PR DESCRIPTION
## Description
Adds `etcd-advertise-client-urls` with https example value in Secure Sensu doc

## Motivation and Context
Discussion w/Anthony