### PR TITLE
Remove 6.4.1 and 6.4.2 notes in 6.5 doc set

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1154,7 +1154,7 @@ name: "agent-01"{{< /code >}}
 --------------|------
 description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type          | String
-default       | `info` in Sensu Go 6.4.0<br>`warn` in Sensu Go 6.4.1
+default       | `warn`
 environment variable | `SENSU_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-agent start --log-level debug{{< /code >}}
@@ -1826,7 +1826,7 @@ For example, if you create overrides using all three methods, the command line c
 
 ### Example override: Log level
 
-The default [log level][60] for the Sensu agent is `info` in Sensu Go 6.4.0 and `warn` in Sensu Go 6.4.1.
+The default [log level][60] for the Sensu agent is `warn`.
 
 To override the default and automatically apply a different log level for the agent, add the `--log-level` command line configuration flag when you start the Sensu agent.
 For example, to specify `debug` as the log level:

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1558,9 +1558,7 @@ event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 
 | event-log-parallel-encoders |      |
 -----------------------|------
-description            | Indicates whether Sensu should use parallel JSON encoders for event logging. If `true`, Sensu sets the number of JSON encoder workers to 50% of the total number of cores, with a minimum of 2 (for example, 6 JSON encoders on a 12-core machine). Otherwise, Sensu uses the default setting, which is a single JSON encoding worker.<br><br>The `event-log-parallel-encoders` setting will not take effect unless you also specify a path to the event log file with the [`event-log-file`][61] configuration attribute.{{% notice note %}}
-**NOTE**: The `event-log-parallel-encoders` configuration attribute is available in [Sensu Go 6.4.2](../../../release-notes/#642-release-notes).
-{{% /notice %}}
+description            | Indicates whether Sensu should use parallel JSON encoders for event logging. If `true`, Sensu sets the number of JSON encoder workers to 50% of the total number of cores, with a minimum of 2 (for example, 6 JSON encoders on a 12-core machine). Otherwise, Sensu uses the default setting, which is a single JSON encoding worker.<br><br>The `event-log-parallel-encoders` setting will not take effect unless you also specify a path to the event log file with the [`event-log-file`][61] configuration attribute.
 type                   | Boolean
 default                | false
 environment variable   | `SENSU_BACKEND_EVENT_LOG_PARALLEL_ENCODERS`


### PR DESCRIPTION
## Description
Removes 6.4.x-specific notes in the 6.5 doc set

## Motivation and Context
6.4.x version-specific notes are not needed in 6.5 docs
