### PR TITLE
6.5.0: Document JavaScript mutators

### DIFF
--- a/content/sensu-go/6.5/api/mutators.md
+++ b/content/sensu-go/6.5/api/mutators.md
@@ -41,7 +41,9 @@ HTTP/1.1 200 OK
     "command": "example_mutator.go",
     "timeout": 0,
     "env_vars": [],
-    "runtime_assets": []
+    "runtime_assets": [],
+    "secrets": null,
+    "type": "pipe"
   }
 ]
 {{< /code >}}
@@ -69,7 +71,9 @@ output         | {{< code shell >}}
     "command": "example_mutator.go",
     "timeout": 0,
     "env_vars": [],
-    "runtime_assets": []
+    "runtime_assets": [],
+    "secrets": null,
+    "type": "pipe"
   }
 ]
 {{< /code >}}
@@ -97,7 +101,9 @@ curl -X POST \
   "command": "example_mutator.go",
   "timeout": 0,
   "env_vars": [],
-  "runtime_assets": []
+  "runtime_assets": [],
+  "secrets": null,
+  "type": "pipe"
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators
 
@@ -121,7 +127,9 @@ payload         | {{< code shell >}}
   "command": "example_mutator.go",
   "timeout": 0,
   "env_vars": [],
-  "runtime_assets": []
+  "runtime_assets": [],
+  "secrets": null,
+  "type": "pipe"
 }
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -151,7 +159,9 @@ HTTP/1.1 200 OK
   "command": "example_mutator.go",
   "timeout": 0,
   "env_vars": [],
-  "runtime_assets": []
+  "runtime_assets": [],
+  "secrets": null,
+  "type": "pipe"
 }
 {{< /code >}}
 
@@ -175,7 +185,9 @@ output               | {{< code json >}}
   "command": "example_mutator.go",
   "timeout": 0,
   "env_vars": [],
-  "runtime_assets": []
+  "runtime_assets": [],
+  "secrets": null,
+  "type": "pipe"
 }
 {{< /code >}}
 
@@ -202,7 +214,9 @@ curl -X PUT \
   "command": "example_mutator.go",
   "timeout": 0,
   "env_vars": [],
-  "runtime_assets": []
+  "runtime_assets": [],
+  "secrets": null,
+  "type": "pipe"
 }' \
 http://127.0.0.1:8080/api/core/v2/namespaces/default/mutators/example-mutator
 
@@ -226,7 +240,9 @@ payload         | {{< code shell >}}
   "command": "example_mutator.go",
   "timeout": 0,
   "env_vars": [],
-  "runtime_assets": []
+  "runtime_assets": [],
+  "secrets": null,
+  "type": "pipe"
 }
 {{< /code >}}
 response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 (Bad Request)</li><li>**Error**: 500 (Internal Server Error)</li></ul>

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -205,7 +205,7 @@ This allows `command` attributes to use “relative paths” for Sensu plugin co
 Mutators that use JavaScript are an efficient alternative to pipe mutators, which fork a process on each invocation.
 JavaScript mutators are evaluated by the [Otto JavaScript VM][19] as JavaScript programs, which enables greater mutator throughput at scale.
 
-JavaScript mutators do not require you to return any value &mdash; you can either also mutate the events that are passed to the mutator.
+JavaScript mutators do not require you to return any value &mdash; you can mutate the events that are passed to the mutator instead.
 However, if you do return a value with a JavaScript mutator, it must be a string.
 If a JavaScript mutator returns a non-string value (an array, object, integer, or Boolean), an error is recorded in the [Sensu backend log][20].
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -132,7 +132,7 @@ spec:
     "namespace": "default"
   },
   "spec": {
-    "eval": "return JSON.stringify({"some info": "is here"});",
+    "eval": "return JSON.stringify({\"some info\": \"is here\"});",
     "type": "javascript"
   }
 }
@@ -165,7 +165,7 @@ spec:
     "namespace": "default"
   },
   "spec": {
-    "eval": "event.check.labels["hello"] = "Sensu user";",
+    "eval": "event.check.labels[\"hello\"] = \"Sensu user\";",
     "type": "javascript"
   }
 }
@@ -586,7 +586,7 @@ eval: 'return JSON.stringify({"some stuff": "is here"});'
 {{< /code >}}
 {{< code json >}}
 {
-  "eval": "return JSON.stringify({"some stuff": "is here"});"
+  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
 }
 {{< /code >}}
 {{< /language-toggle >}}


### PR DESCRIPTION
## Description
Adds JavaScript mutator section and examples in mutator reference, along with `eval` and `type` attributes and description tables.

Also adds `type` attribute to examples in mutator API doc.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3266
