### PR TITLE
Fix minor code formatting error in mutators reference

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-transform/mutators.md
@@ -104,7 +104,7 @@ spec:
 ## Commands
 
 Each Sensu mutator definition defines a command to be executed.
-Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu user`.
+Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu` user.
 Most mutator commands are provided by [Sensu plugins][4].
 
 Sensu mutator `command` attributes may include command line arguments for controlling the behavior of the `command` executable.

--- a/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
@@ -104,7 +104,7 @@ spec:
 ## Commands
 
 Each Sensu mutator definition defines a command to be executed.
-Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu user`.
+Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu` user.
 Most mutator commands are provided by [Sensu plugins][4].
 
 Sensu mutator `command` attributes may include command line arguments for controlling the behavior of the `command` executable.

--- a/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
@@ -104,7 +104,7 @@ spec:
 ## Commands
 
 Each Sensu mutator definition defines a command to be executed.
-Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu user`.
+Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu` user.
 Most mutator commands are provided by [Sensu plugins][4].
 
 Sensu mutator `command` attributes may include command line arguments for controlling the behavior of the `command` executable.

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
@@ -104,7 +104,7 @@ spec:
 ## Commands
 
 Each Sensu mutator definition defines a command to be executed.
-Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu user`.
+Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu` user.
 Most mutator commands are provided by [Sensu plugins][4].
 
 Sensu mutator `command` attributes may include command line arguments for controlling the behavior of the `command` executable.

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -104,7 +104,7 @@ spec:
 ## Commands
 
 Each Sensu mutator definition defines a command to be executed.
-Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu user`.
+Mutator commands are executable commands that will be executed on a Sensu backend, run as the `sensu` user.
 Most mutator commands are provided by [Sensu plugins][4].
 
 Sensu mutator `command` attributes may include command line arguments for controlling the behavior of the `command` executable.


### PR DESCRIPTION
## Description
In mutators reference, changes `sensu user` to `sensu` user

## Motivation and Context
Found when working on JS mutators doc for 6.5
