### PR TITLE
Update links to InfluxDB docs

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/checks.md
@@ -1614,7 +1614,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [45]: #cron-scheduling
 [46]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [47]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[48]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/metrics.md
@@ -696,7 +696,7 @@ The event specification describes [metrics attributes in events][5].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-graphite-handler
 [13]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [14]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[15]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[15]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
@@ -1640,7 +1640,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [45]: #cron-scheduling
 [46]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [47]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[48]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -696,7 +696,7 @@ The event specification describes [metrics attributes in events][5].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-graphite-handler
 [13]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [14]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[15]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[15]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -1640,7 +1640,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [45]: #cron-scheduling
 [46]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [47]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[48]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -696,7 +696,7 @@ The event specification describes [metrics attributes in events][5].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-graphite-handler
 [13]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [14]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[15]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[15]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -1640,7 +1640,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [45]: #cron-scheduling
 [46]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [47]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[48]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -696,7 +696,7 @@ The event specification describes [metrics attributes in events][5].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-graphite-handler
 [13]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [14]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[15]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[15]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -1640,7 +1640,7 @@ The dynamic runtime asset reference includes an [example check definition that u
 [45]: #cron-scheduling
 [46]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [47]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[48]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[48]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [49]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [50]: ../../observe-events/events/#metrics-attribute
 [51]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -696,7 +696,7 @@ The event specification describes [metrics attributes in events][5].
 [12]: https://bonsai.sensu.io/assets/sensu/sensu-go-graphite-handler
 [13]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/perfdata.html
 [14]: https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-[15]: https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_tutorial/#measurement
+[15]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [16]: http://opentsdb.net/docs/build/html/user_guide/writing/index.html#data-specification
 [17]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [18]: ../../../plugins/supported-integrations/#time-series-and-long-term-event-storage


### PR DESCRIPTION
## Description
Updates links to InfluxDB docs to use v1.9 rather than 1.4 and remove the #measurement anchor

## Motivation and Context
Noticed when working on something else