### PR TITLE
Fix GET used in PUT description in handler API doc

### DIFF
--- a/content/sensu-go/6.1/api/handlers.md
+++ b/content/sensu-go/6.1/api/handlers.md
@@ -258,7 +258,7 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
 
 ### Example {#handlershandler-put-example}
 

--- a/content/sensu-go/6.2/api/handlers.md
+++ b/content/sensu-go/6.2/api/handlers.md
@@ -258,7 +258,7 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
 
 ### Example {#handlershandler-put-example}
 

--- a/content/sensu-go/6.3/api/handlers.md
+++ b/content/sensu-go/6.3/api/handlers.md
@@ -258,7 +258,7 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
 
 ### Example {#handlershandler-put-example}
 

--- a/content/sensu-go/6.4/api/handlers.md
+++ b/content/sensu-go/6.4/api/handlers.md
@@ -258,7 +258,7 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
 
 ### Example {#handlershandler-put-example}
 

--- a/content/sensu-go/6.5/api/handlers.md
+++ b/content/sensu-go/6.5/api/handlers.md
@@ -258,7 +258,7 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
 
 ### Example {#handlershandler-put-example}
 


### PR DESCRIPTION
## Description
The PUT description for the handlers API doc says GET -- this fixes it to say PUT instead.

## Motivation and Context
Found when working on pipelines API doc