### PR TITLE
Fix heading level format for sensuctl subcommands

### DIFF
--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -335,7 +335,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][1]
 
-## Subcommands
+### Subcommands
 
 Sensuctl provides a standard set of list, info, and delete operations for most resource types.
 
@@ -400,7 +400,7 @@ For example, the following command returns the same output as `sensuctl event li
 sensuctl event list --chunk-size 500
 {{< /code >}}
 
-#### sensuctl check
+### sensuctl check
 
 In addition to the [standard subcommands][23], the `sensuctl check execute` command executes a check on demand, given the check name:
 
@@ -420,7 +420,7 @@ You can also use the `--subscriptions` flag to override the subscriptions in the
 sensuctl check execute check-cpu --subscriptions demo,webserver
 {{< /code >}}
 
-#### sensuctl cluster
+### sensuctl cluster
 
 The `sensuctl cluster` command lets you manage a Sensu cluster using the following subcommands:
 
@@ -445,7 +445,7 @@ To see the health of your Sensu cluster:
 sensuctl cluster health
 {{< /code >}}
 
-#### sensuctl event
+### sensuctl event
 
 In addition to the [standard subcommands][23], you can use `sensuctl event resolve` to manually resolve events:
 
@@ -459,15 +459,15 @@ For example, the following command manually resolves an event created by the ent
 sensuctl event resolve webserver1 check-http
 {{< /code >}}
 
-#### sensuctl namespace
+### sensuctl namespace
 
 See the [namespaces reference][21] for information about using access control with namespaces.
 
-#### sensuctl user
+### sensuctl user
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
-#### sensuctl prune
+### sensuctl prune
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
@@ -488,7 +488,7 @@ The pruning operation always follows the role-based access control (RBAC) permis
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
 In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
-##### Supported resource types
+#### Supported resource types
 
 {{% notice note %}}
 **NOTE**: In Sensu 6.1.0, `sensuctl prune` does not work with hooks.
@@ -536,7 +536,7 @@ The response will list all supported `sensuctl prune` resource types:
 **NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
-##### sensuctl prune flags
+#### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
 The following table describes the command-specific flags.
@@ -552,7 +552,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune usage
+#### sensuctl prune usage
 
 {{< code shell >}}
 sensuctl prune <resource_type>,<resource_type>... -f <file_or_url> [-r] ... ] --<namespace> <flags>

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -345,7 +345,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][1]
 
-## Subcommands
+### Subcommands
 
 Sensuctl provides a standard set of list, info, and delete operations for most resource types.
 
@@ -410,7 +410,7 @@ For example, the following command returns the same output as `sensuctl event li
 sensuctl event list --chunk-size 500
 {{< /code >}}
 
-#### sensuctl check
+### sensuctl check
 
 In addition to the [standard subcommands][23], the `sensuctl check execute` command executes a check on demand, given the check name:
 
@@ -430,7 +430,7 @@ You can also use the `--subscriptions` flag to override the subscriptions in the
 sensuctl check execute check-cpu --subscriptions demo,webserver
 {{< /code >}}
 
-#### sensuctl cluster
+### sensuctl cluster
 
 The `sensuctl cluster` command lets you manage a Sensu cluster using the following subcommands:
 
@@ -455,7 +455,7 @@ To see the health of your Sensu cluster:
 sensuctl cluster health
 {{< /code >}}
 
-#### sensuctl event
+### sensuctl event
 
 In addition to the [standard subcommands][23], you can use `sensuctl event resolve` to manually resolve events:
 
@@ -469,15 +469,15 @@ For example, the following command manually resolves an event created by the ent
 sensuctl event resolve webserver1 check-http
 {{< /code >}}
 
-#### sensuctl namespace
+### sensuctl namespace
 
 See the [namespaces reference][21] for information about using access control with namespaces.
 
-#### sensuctl user
+### sensuctl user
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
-#### sensuctl prune
+### sensuctl prune
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
@@ -498,7 +498,7 @@ The pruning operation always follows the role-based access control (RBAC) permis
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
 In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
-##### Supported resource types
+#### Supported resource types
 
 To retrieve the supported `sensuctl prune` resource types, run:
 
@@ -543,7 +543,7 @@ The response will list all supported `sensuctl prune` resource types:
 **NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
-##### sensuctl prune flags
+#### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
 The following table describes the command-specific flags.
@@ -560,7 +560,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune usage
+#### sensuctl prune usage
 
 {{< code shell >}}
 sensuctl prune <resource_type>,<resource_type>... -f <file_or_url> [-r] ... ] --<namespace> <flags>

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -345,7 +345,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][1]
 
-## Subcommands
+### Subcommands
 
 Sensuctl provides a standard set of list, info, and delete operations for most resource types.
 
@@ -410,7 +410,7 @@ For example, the following command returns the same output as `sensuctl event li
 sensuctl event list --chunk-size 500
 {{< /code >}}
 
-#### sensuctl check
+### sensuctl check
 
 In addition to the [standard subcommands][23], the `sensuctl check execute` command executes a check on demand, given the check name:
 
@@ -430,7 +430,7 @@ You can also use the `--subscriptions` flag to override the subscriptions in the
 sensuctl check execute check-cpu --subscriptions demo,webserver
 {{< /code >}}
 
-#### sensuctl cluster
+### sensuctl cluster
 
 The `sensuctl cluster` command lets you manage a Sensu cluster using the following subcommands:
 
@@ -455,7 +455,7 @@ To see the health of your Sensu cluster:
 sensuctl cluster health
 {{< /code >}}
 
-#### sensuctl event
+### sensuctl event
 
 In addition to the [standard subcommands][23], you can use `sensuctl event resolve` to manually resolve events:
 
@@ -469,15 +469,15 @@ For example, the following command manually resolves an event created by the ent
 sensuctl event resolve webserver1 check-http
 {{< /code >}}
 
-#### sensuctl namespace
+### sensuctl namespace
 
 See the [namespaces reference][21] for information about using access control with namespaces.
 
-#### sensuctl user
+### sensuctl user
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
-#### sensuctl prune
+### sensuctl prune
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
@@ -498,7 +498,7 @@ The pruning operation always follows the role-based access control (RBAC) permis
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
 In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
-##### Supported resource types
+#### Supported resource types
 
 To retrieve the supported `sensuctl prune` resource types, run:
 
@@ -545,7 +545,7 @@ The response will list all supported `sensuctl prune` resource types:
 **NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
-##### sensuctl prune flags
+#### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
 The following table describes the command-specific flags.
@@ -562,7 +562,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune usage
+#### sensuctl prune usage
 
 {{< code shell >}}
 sensuctl prune <resource_type>,<resource_type>... -f <file_or_url> [-r] ... ] --<namespace> <flags>

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -345,7 +345,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][1]
 
-## Subcommands
+### Subcommands
 
 Sensuctl provides a standard set of list, info, and delete operations for most resource types.
 
@@ -410,7 +410,7 @@ For example, the following command returns the same output as `sensuctl event li
 sensuctl event list --chunk-size 500
 {{< /code >}}
 
-#### sensuctl check
+### sensuctl check
 
 In addition to the [standard subcommands][23], the `sensuctl check execute` command executes a check on demand, given the check name:
 
@@ -430,7 +430,7 @@ You can also use the `--subscriptions` flag to override the subscriptions in the
 sensuctl check execute check-cpu --subscriptions demo,webserver
 {{< /code >}}
 
-#### sensuctl cluster
+### sensuctl cluster
 
 The `sensuctl cluster` command lets you manage a Sensu cluster using the following subcommands:
 
@@ -455,7 +455,7 @@ To see the health of your Sensu cluster:
 sensuctl cluster health
 {{< /code >}}
 
-#### sensuctl event
+### sensuctl event
 
 In addition to the [standard subcommands][23], you can use `sensuctl event resolve` to manually resolve events:
 
@@ -469,15 +469,15 @@ For example, the following command manually resolves an event created by the ent
 sensuctl event resolve webserver1 check-http
 {{< /code >}}
 
-#### sensuctl namespace
+### sensuctl namespace
 
 See the [namespaces reference][21] for information about using access control with namespaces.
 
-#### sensuctl user
+### sensuctl user
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
-#### sensuctl prune
+### sensuctl prune
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
@@ -498,7 +498,7 @@ The pruning operation always follows the role-based access control (RBAC) permis
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
 In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
-##### Supported resource types
+#### Supported resource types
 
 To retrieve the supported `sensuctl prune` resource types, run:
 
@@ -545,7 +545,7 @@ The response will list all supported `sensuctl prune` resource types:
 **NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
-##### sensuctl prune flags
+#### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
 The following table describes the command-specific flags.
@@ -562,7 +562,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune usage
+#### sensuctl prune usage
 
 {{< code shell >}}
 sensuctl prune <resource_type>,<resource_type>... -f <file_or_url> [-r] ... ] --<namespace> <flags>

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -345,7 +345,7 @@ Sensuctl provides the following commands to manage Sensu resources.
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][1]
 
-## Subcommands
+### Subcommands
 
 Sensuctl provides a standard set of list, info, and delete operations for most resource types.
 
@@ -410,7 +410,7 @@ For example, the following command returns the same output as `sensuctl event li
 sensuctl event list --chunk-size 500
 {{< /code >}}
 
-#### sensuctl check
+### sensuctl check
 
 In addition to the [standard subcommands][23], the `sensuctl check execute` command executes a check on demand, given the check name:
 
@@ -430,7 +430,7 @@ You can also use the `--subscriptions` flag to override the subscriptions in the
 sensuctl check execute check-cpu --subscriptions demo,webserver
 {{< /code >}}
 
-#### sensuctl cluster
+### sensuctl cluster
 
 The `sensuctl cluster` command lets you manage a Sensu cluster using the following subcommands:
 
@@ -455,7 +455,7 @@ To see the health of your Sensu cluster:
 sensuctl cluster health
 {{< /code >}}
 
-#### sensuctl event
+### sensuctl event
 
 In addition to the [standard subcommands][23], you can use `sensuctl event resolve` to manually resolve events:
 
@@ -469,15 +469,15 @@ For example, the following command manually resolves an event created by the ent
 sensuctl event resolve webserver1 check-http
 {{< /code >}}
 
-#### sensuctl namespace
+### sensuctl namespace
 
 See the [namespaces reference][21] for information about using access control with namespaces.
 
-#### sensuctl user
+### sensuctl user
 
 See the [RBAC reference][22] for information about local user management with sensuctl.
 
-#### sensuctl prune
+### sensuctl prune
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access sensuctl pruning in the packaged Sensu Go distribution.
@@ -498,7 +498,7 @@ The pruning operation always follows the role-based access control (RBAC) permis
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
 In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
-##### Supported resource types
+#### Supported resource types
 
 To retrieve the supported `sensuctl prune` resource types, run:
 
@@ -545,7 +545,7 @@ The response will list all supported `sensuctl prune` resource types:
 **NOTE**: Short names are only supported for `core/v2` resources.
 {{% /notice %}}
 
-##### sensuctl prune flags
+#### sensuctl prune flags
 
 Run `sensuctl prune -h` to view command-specific and global flags.
 The following table describes the command-specific flags.
@@ -562,7 +562,7 @@ The following table describes the command-specific flags.
 `-r` or `--recursive` | Prune command will follow subdirectories.
 `-u` or `--users` | Prunes only resources that were created by the specified users (comma-separated strings). Defaults to the currently configured sensuctl user.
 
-##### sensuctl prune usage
+#### sensuctl prune usage
 
 {{< code shell >}}
 sensuctl prune <resource_type>,<resource_type>... -f <file_or_url> [-r] ... ] --<namespace> <flags>


### PR DESCRIPTION
## Description
Fixes the heading levels throughout the sensuctl subcommands and subsequent sections

## Motivation and Context
Noticed when working on something else
