### PR TITLE
Fix typos in handlers and etcd replicators docs

### DIFF
--- a/content/sensu-go/6.1/api/handlers.md
+++ b/content/sensu-go/6.1/api/handlers.md
@@ -189,7 +189,7 @@ response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 
 
 ## Get a specific handler {#handlershandler-get}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler name.
 
 ### Example {#handlershandler-get-example}
 
@@ -258,11 +258,11 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler name.
 
 ### Example {#handlershandler-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-dbdevelopment_filter`.
+In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-db`.
 The request returns a successful HTTP `201 Created` response.
 
 {{< code shell >}}

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/handlers.md
@@ -3,7 +3,7 @@ title: "Handlers reference"
 linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
-description: "Handlers are actions the Sensu backend executes on events, allowing you to created automated monitoring workflows. Read the reference doc to learn about handlers."
+description: "Handlers are actions the Sensu backend executes on events, allowing you to create automated monitoring workflows. Read the reference doc to learn about handlers."
 weight: 10
 version: "6.1"
 product: "Sensu Go"

--- a/content/sensu-go/6.1/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/etcdreplicators.md
@@ -398,7 +398,7 @@ created_by: admin
 
 ca_cert      |      |
 -------------|------
-description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
+description  | Path to the PEM-format CA certificate to use for TLS client authentication.
 required     | true if `insecure: false` (the default configuration). If `insecure: true`, `ca_cert` is not required.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.2/api/handlers.md
+++ b/content/sensu-go/6.2/api/handlers.md
@@ -189,7 +189,7 @@ response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 
 
 ## Get a specific handler {#handlershandler-get}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler name.
 
 ### Example {#handlershandler-get-example}
 
@@ -258,11 +258,11 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler name.
 
 ### Example {#handlershandler-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-dbdevelopment_filter`.
+In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-db`.
 The request returns a successful HTTP `201 Created` response.
 
 {{< code shell >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -3,7 +3,7 @@ title: "Handlers reference"
 linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
-description: "Handlers are actions the Sensu backend executes on events, allowing you to created automated monitoring workflows. Read the reference doc to learn about handlers."
+description: "Handlers are actions the Sensu backend executes on events, allowing you to create automated monitoring workflows. Read the reference doc to learn about handlers."
 weight: 10
 version: "6.2"
 product: "Sensu Go"

--- a/content/sensu-go/6.2/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/etcdreplicators.md
@@ -398,7 +398,7 @@ created_by: admin
 
 ca_cert      |      |
 -------------|------
-description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
+description  | Path to the PEM-format CA certificate to use for TLS client authentication.
 required     | true if `insecure: false` (the default configuration). If `insecure: true`, `ca_cert` is not required.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/api/handlers.md
+++ b/content/sensu-go/6.3/api/handlers.md
@@ -189,7 +189,7 @@ response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 
 
 ## Get a specific handler {#handlershandler-get}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler name.
 
 ### Example {#handlershandler-get-example}
 
@@ -258,11 +258,11 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler name.
 
 ### Example {#handlershandler-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-dbdevelopment_filter`.
+In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-db`.
 The request returns a successful HTTP `201 Created` response.
 
 {{< code shell >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -3,7 +3,7 @@ title: "Handlers reference"
 linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
-description: "Handlers are actions the Sensu backend executes on events, allowing you to created automated monitoring workflows. Read the reference doc to learn about handlers."
+description: "Handlers are actions the Sensu backend executes on events, allowing you to create automated monitoring workflows. Read the reference doc to learn about handlers."
 weight: 10
 version: "6.3"
 product: "Sensu Go"

--- a/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
@@ -398,7 +398,7 @@ created_by: admin
 
 ca_cert      |      |
 -------------|------
-description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
+description  | Path to the PEM-format CA certificate to use for TLS client authentication.
 required     | true if `insecure: false` (the default configuration). If `insecure: true`, `ca_cert` is not required.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/api/handlers.md
+++ b/content/sensu-go/6.4/api/handlers.md
@@ -189,7 +189,7 @@ response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 
 
 ## Get a specific handler {#handlershandler-get}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler name.
 
 ### Example {#handlershandler-get-example}
 
@@ -258,11 +258,11 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler name.
 
 ### Example {#handlershandler-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-dbdevelopment_filter`.
+In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-db`.
 The request returns a successful HTTP `201 Created` response.
 
 {{< code shell >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -3,7 +3,7 @@ title: "Handlers reference"
 linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
-description: "Handlers are actions the Sensu backend executes on events, allowing you to created automated monitoring workflows. Read the reference doc to learn about handlers."
+description: "Handlers are actions the Sensu backend executes on events, allowing you to create automated monitoring workflows. Read the reference doc to learn about handlers."
 weight: 10
 version: "6.4"
 product: "Sensu Go"

--- a/content/sensu-go/6.4/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/etcdreplicators.md
@@ -398,7 +398,7 @@ created_by: admin
 
 ca_cert      |      |
 -------------|------
-description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
+description  | Path to the PEM-format CA certificate to use for TLS client authentication.
 required     | true if `insecure: false` (the default configuration). If `insecure: true`, `ca_cert` is not required.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/api/handlers.md
+++ b/content/sensu-go/6.5/api/handlers.md
@@ -189,7 +189,7 @@ response codes  | <ul><li>**Success**: 201 (Created)</li><li>**Malformed**: 400 
 
 ## Get a specific handler {#handlershandler-get}
 
-The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP GET access to [handler data][1] for specific `:handler` definitions, by handler name.
 
 ### Example {#handlershandler-get-example}
 
@@ -258,11 +258,11 @@ output               | {{< code json >}}
 
 ## Create or update a handler {#handlershandler-put}
 
-The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler `name`.
+The `/handlers/:handler` API endpoint provides HTTP PUT access to create or update a specific `:handler` definition, by handler name.
 
 ### Example {#handlershandler-put-example}
 
-In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-dbdevelopment_filter`.
+In the following example, an HTTP PUT request is submitted to the `/handlers/:handler` API endpoint to create the handler `influx-db`.
 The request returns a successful HTTP `201 Created` response.
 
 {{< code shell >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -3,7 +3,7 @@ title: "Handlers reference"
 linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
-description: "Handlers are actions the Sensu backend executes on events, allowing you to created automated monitoring workflows. Read the reference doc to learn about handlers."
+description: "Handlers are actions the Sensu backend executes on events, allowing you to create automated monitoring workflows. Read the reference doc to learn about handlers."
 weight: 10
 version: "6.5"
 product: "Sensu Go"

--- a/content/sensu-go/6.5/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/etcdreplicators.md
@@ -398,7 +398,7 @@ created_by: admin
 
 ca_cert      |      |
 -------------|------
-description  | Path to an the PEM-format CA certificate to use for TLS client authentication.
+description  | Path to the PEM-format CA certificate to use for TLS client authentication.
 required     | true if `insecure: false` (the default configuration). If `insecure: true`, `ca_cert` is not required.
 type         | String
 example      | {{< language-toggle >}}


### PR DESCRIPTION
## Description
Fixes typos in handler and etcd replicators references as well as handlers API doc.

## Motivation and Context
Found while working on 6.5.0 docs
