### PR TITLE
Remove instructor-led workshop link

### DIFF
--- a/content/sensu-go/6.1/get-started.md
+++ b/content/sensu-go/6.1/get-started.md
@@ -38,7 +38,6 @@ We recommend these resources for learning more about Sensu:
 
 {{% notice protip %}}
 **PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Explore monitoring at scale with Sensu Go

--- a/content/sensu-go/6.1/learn/_index.md
+++ b/content/sensu-go/6.1/learn/_index.md
@@ -15,7 +15,6 @@ The Learn Sensu category includes tools to help you understand and start using S
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Concepts and terminology

--- a/content/sensu-go/6.1/next-steps.md
+++ b/content/sensu-go/6.1/next-steps.md
@@ -36,8 +36,7 @@ Element | Description
 Event list | Events are observation data that represent the state of an entity at a point in time. Observation data in events include check status or metric results (or both), the executing agent, and a timestamp. The `sensuctl event list` command retrieves the most recent events for each check you’re running.
 
 {{% notice protip %}}
-**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
+**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 {{% /notice %}}
 
 ### Examine a resource definition

--- a/content/sensu-go/6.2/get-started.md
+++ b/content/sensu-go/6.2/get-started.md
@@ -38,7 +38,6 @@ We recommend these resources for learning more about Sensu:
 
 {{% notice protip %}}
 **PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Explore monitoring at scale with Sensu Go

--- a/content/sensu-go/6.2/learn/_index.md
+++ b/content/sensu-go/6.2/learn/_index.md
@@ -15,7 +15,6 @@ The Learn Sensu category includes tools to help you understand and start using S
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Concepts and terminology

--- a/content/sensu-go/6.2/next-steps.md
+++ b/content/sensu-go/6.2/next-steps.md
@@ -36,8 +36,7 @@ Element | Description
 Event list | Events are observation data that represent the state of an entity at a point in time. Observation data in events include check status or metric results (or both), the executing agent, and a timestamp. The `sensuctl event list` command retrieves the most recent events for each check you’re running.
 
 {{% notice protip %}}
-**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
+**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 {{% /notice %}}
 
 ### Examine a resource definition

--- a/content/sensu-go/6.3/get-started.md
+++ b/content/sensu-go/6.3/get-started.md
@@ -38,7 +38,6 @@ We recommend these resources for learning more about Sensu:
 
 {{% notice protip %}}
 **PRO TIP**: In addition to the resources listed on this page, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Explore monitoring at scale with Sensu Go

--- a/content/sensu-go/6.3/learn/_index.md
+++ b/content/sensu-go/6.3/learn/_index.md
@@ -15,7 +15,6 @@ The Learn Sensu category includes tools to help you understand and start using S
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Concepts and terminology

--- a/content/sensu-go/6.3/next-steps.md
+++ b/content/sensu-go/6.3/next-steps.md
@@ -36,8 +36,7 @@ Element | Description
 Event list | Events are observation data that represent the state of an entity at a point in time. Observation data in events include check status or metric results (or both), the executing agent, and a timestamp. The `sensuctl event list` command retrieves the most recent events for each check you’re running.
 
 {{% notice protip %}}
-**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
+**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 {{% /notice %}}
 
 ### Examine a resource definition

--- a/content/sensu-go/6.4/get-started.md
+++ b/content/sensu-go/6.4/get-started.md
@@ -38,7 +38,6 @@ We recommend these resources for learning more about Sensu:
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Explore monitoring at scale with Sensu Go

--- a/content/sensu-go/6.4/learn/_index.md
+++ b/content/sensu-go/6.4/learn/_index.md
@@ -15,7 +15,6 @@ The Learn Sensu category includes tools to help you understand and start using S
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Concepts and terminology

--- a/content/sensu-go/6.4/next-steps.md
+++ b/content/sensu-go/6.4/next-steps.md
@@ -36,8 +36,7 @@ Element | Description
 Event list | Events are observation data that represent the state of an entity at a point in time. Observation data in events include check status or metric results (or both), the executing agent, and a timestamp. The `sensuctl event list` command retrieves the most recent events for each check you’re running.
 
 {{% notice protip %}}
-**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
+**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 {{% /notice %}}
 
 ### Examine a resource definition

--- a/content/sensu-go/6.5/get-started.md
+++ b/content/sensu-go/6.5/get-started.md
@@ -38,7 +38,6 @@ We recommend these resources for learning more about Sensu:
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Explore monitoring at scale with Sensu Go

--- a/content/sensu-go/6.5/learn/_index.md
+++ b/content/sensu-go/6.5/learn/_index.md
@@ -15,7 +15,6 @@ The Learn Sensu category includes tools to help you understand and start using S
 
 {{% notice protip %}}
 **PRO TIP**: In addition to these learning resources, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
 {{% /notice %}}
 
 ## Concepts and terminology

--- a/content/sensu-go/6.5/next-steps.md
+++ b/content/sensu-go/6.5/next-steps.md
@@ -36,8 +36,7 @@ Element | Description
 Event list | Events are observation data that represent the state of an entity at a point in time. Observation data in events include check status or metric results (or both), the executing agent, and a timestamp. The `sensuctl event list` command retrieves the most recent events for each check you’re running.
 
 {{% notice protip %}}
-**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://github.com/sensu/sensu-go-workshop).
-To register for an interactive instructor-led session, visit the [Sensu Go Workshop registration page](https://sensu.io/sensu-go-workshop).
+**PRO TIP**: If you're not familiar with these concepts, try the [self-guided Sensu Go Workshop](https://sensu.io/resources?type=workshop).
 {{% /notice %}}
 
 ### Examine a resource definition


### PR DESCRIPTION
## Description
Removes links to instructor-led workshops until the sensu.io landing page is reworked.

## Motivation and Context
Discussed during DA - Customer sync
