### PR TITLE
6.5.0: Upgrade agents to use pipelines

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -31,6 +31,10 @@ All the observability events that the check produces will be processed according
 Pipelines can replace [handler sets][1] and [handler stacks][2].
 We recommend migrating your existing handler sets and stacks to pipeline workflows.
 
+{{% notice note %}}
+**NOTE**: To use pipelines, [upgrade](../../../operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-650-from-any-previous-version) your agents to Sensu Go 6.5.0.
+{{% /notice %}}
+
 ## Pipeline example
 
 This example shows a pipeline resource definition that includes event filters, a mutator, and a handler:
@@ -836,6 +840,7 @@ api_version: core/v2
 [20]: ../tcp-stream-handlers/
 [21]: ../sumo-logic-metrics-handlers/
 [22]: ../
+[23]: ../../../operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-650-from-any-previous-version
 [24]: ../../observe-filter/filters/
 [25]: ../../../web-ui/search#search-for-labels
 [26]: ../../../operations/manage-secrets/secrets-management/

--- a/content/sensu-go/6.5/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/upgrade.md
@@ -72,6 +72,11 @@ sensuctl version
 For example, to debug an upgrade from 5.5.0 to 6.4.0, start with [Upgrade Sensu clusters from 5.7.0 or earlier to 5.8.0 or later](#upgrade-sensu-clusters-from-570-or-earlier-to-580-or-later).
 {{% /notice %}}
 
+## Upgrade to Sensu Go 6.5.0 from any previous version
+
+To use [pipelines][18], you must upgrade your Sensu agents to Sensu Go 6.5.0.
+Agents that are not upgraded to 6.5.0 will run checks, send observability events to the backend, and use the handlers that are defined in check [handlers arrays][17], but they will not run pipelines.
+
 ## Upgrade to Sensu Go 6.4.0 from any previous version
 
 In Sensu Go 6.4.0, we upgraded the embedded etcd version from 3.3.22 to 3.5.0.
@@ -244,3 +249,5 @@ sudo service sensu-backend restart
 [14]: #upgrade-sensu-clusters-from-570-or-earlier-to-580-or-later
 [15]: ../../../sensuctl/back-up-recover/
 [16]: ../../../release-notes/
+[17]: ../../../observability-pipeline/observe-schedule/checks#handlers-array
+[18]: ../../../observability-pipeline/observe-process/pipelines/


### PR DESCRIPTION
## Description
Adds a note in the pipelines reference doc about upgrading agents and a 6.5.0 section in the upgrade doc to warn that pipelines require agents upgraded to Sensu Go 6.5.0.

## Motivation and Context
https://sumologic.slack.com/archives/C024XK35Z3Q/p1632863776430000
