### PR TITLE
Update link used for LDAP etc on commercial features page

### DIFF
--- a/content/sensu-go/6.1/commercial.md
+++ b/content/sensu-go/6.1/commercial.md
@@ -96,7 +96,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [6]: ../web-ui/search/
 [7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
-[9]: ../operations/control-access/
+[9]: ../operations/control-access/sso/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4/
 [12]: ../operations/deploy-sensu/datastore#scale-event-storage

--- a/content/sensu-go/6.2/commercial.md
+++ b/content/sensu-go/6.2/commercial.md
@@ -96,7 +96,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [6]: ../web-ui/search/
 [7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
-[9]: ../operations/control-access/
+[9]: ../operations/control-access/sso/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4/
 [12]: ../operations/deploy-sensu/datastore#scale-event-storage

--- a/content/sensu-go/6.3/commercial.md
+++ b/content/sensu-go/6.3/commercial.md
@@ -98,7 +98,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [6]: ../web-ui/search/
 [7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
-[9]: ../operations/control-access/
+[9]: ../operations/control-access/sso/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4/
 [12]: ../operations/deploy-sensu/datastore#scale-event-storage

--- a/content/sensu-go/6.4/commercial.md
+++ b/content/sensu-go/6.4/commercial.md
@@ -99,7 +99,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [6]: ../web-ui/search/
 [7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
-[9]: ../operations/control-access/
+[9]: ../operations/control-access/sso/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4/
 [12]: ../operations/deploy-sensu/datastore#scale-event-storage

--- a/content/sensu-go/6.5/commercial.md
+++ b/content/sensu-go/6.5/commercial.md
@@ -99,7 +99,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [6]: ../web-ui/search/
 [7]: https://sensu.io/blog/one-year-of-sensu-go/
 [8]: ../web-ui/
-[9]: ../operations/control-access/
+[9]: ../operations/control-access/sso/
 [10]: ../observability-pipeline/observe-schedule/backend#event-logging
 [11]: https://bonsai.sensu.io/assets?tiers%5B%5D=4/
 [12]: ../operations/deploy-sensu/datastore#scale-event-storage


### PR DESCRIPTION
## Description
Updates link used for LDAP etc on commercial features page from https://docs.sensu.io/sensu-go/latest/operations/control-access/ to https://docs.sensu.io/sensu-go/latest/operations/control-access/sso/.

## Motivation and Context
Noticed when working on 6.5.0 docs