### PR TITLE
Add BSM resources to describe-type list

### DIFF
--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -361,6 +361,8 @@ The response will list the names and other details for the supported resource ty
   secrets/v1.Provider                                  secrets/v1          Provider             false
   searches/v1.Search                                   searches/v1         Search               true
   web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  bsm/v1.RuleTemplate                                  bsm/v1              RuleTemplate         true        
+  bsm/v1.ServiceComponent                              bsm/v1              ServiceComponent     true  
   core/v2.Namespace              namespaces            core/v2             Namespace            false
   core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
   core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false

--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -361,6 +361,8 @@ The response will list the names and other details for the supported resource ty
   secrets/v1.Provider                                  secrets/v1          Provider             false
   searches/v1.Search                                   searches/v1         Search               true
   web/v1.GlobalConfig                                  web/v1              GlobalConfig         false
+  bsm/v1.RuleTemplate                                  bsm/v1              RuleTemplate         true        
+  bsm/v1.ServiceComponent                              bsm/v1              ServiceComponent     true  
   core/v2.Namespace              namespaces            core/v2             Namespace            false
   core/v2.ClusterRole            clusterroles          core/v2             ClusterRole          false
   core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding   false


### PR DESCRIPTION
## Description
Adds rule templates and service components to list of describe-type resources in sensuctl docs in 6.3 and 6.4 docs.

## Motivation and Context
Noticed when working on 6.5.0 docs