### PR TITLE
6.6.0: Update etcd heartbeat interval and election timeout defaults

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -434,8 +434,8 @@ Store Flags:
       --etcd-client-urls string                    client URLs to use when operating as an etcd client
       --etcd-discovery string                      discovery URL used to bootstrap the cluster
       --etcd-discovery-srv string                  DNS SRV record used to bootstrap the cluster
-      --etcd-election-timeout uint                 time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself (default 1000)
-      --etcd-heartbeat-interval uint               interval in ms with which the etcd leader will notify followers that it is still the leader (default 100)
+      --etcd-election-timeout uint                 time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself (default 5000)
+      --etcd-heartbeat-interval uint               interval in ms with which the etcd leader will notify followers that it is still the leader (default 500)
       --etcd-initial-advertise-peer-urls strings   list of this member's peer URLs to advertise to the rest of the cluster (default [http://127.0.0.1:2380])
       --etcd-initial-cluster string                initial cluster configuration for bootstrapping
       --etcd-initial-cluster-state string          initial cluster state ("new" or "existing") (default "new")
@@ -1256,12 +1256,12 @@ description            | Time that a follower node will go without hearing a hea
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
-default                | `1000`
+default                | `5000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 command line example   | {{< code shell >}}
-sensu-backend start --etcd-election-timeout 1000{{< /code >}}
+sensu-backend start --etcd-election-timeout 5000{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-etcd-election-timeout: 1000{{< /code >}}
+etcd-election-timeout: 5000{{< /code >}}
 
 <a id="etcd-heartbeat-interval"></a>
 
@@ -1273,12 +1273,12 @@ description            | Interval at which the etcd leader will notify followers
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | Integer
-default                | `100`
+default                | `500`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
-sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
+sensu-backend start --etcd-heartbeat-interval 500{{< /code >}}
 /etc/sensu/backend.yml example | {{< code shell >}}
-etcd-heartbeat-interval: 100{{< /code >}}
+etcd-heartbeat-interval: 500{{< /code >}}
 
 | etcd-max-request-bytes |      |
 -----------------------|------


### PR DESCRIPTION
## Description
Updates default values for etcd-heartbeat-interval and etcd-election-timeout backend config flags.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3269