### PR TITLE
Try uchiwa docs redirect again

### DIFF
--- a/static.json
+++ b/static.json
@@ -3,6 +3,10 @@
     "https_only": true,
     "error_page": "/404.html",
     "pattern_redirects": {
+        "~ docs.uchiwa.io/?((?<=\/).*)?$": {
+            "url": "docs.sensu.io/uchiwa/latest/",
+            "status": 301
+        },
         "~ ^/sensu-core/1.[0-9]/?((?<=\/).*)?$": {
             "url": "/sensu-core/latest/$1",
             "status": 301


### PR DESCRIPTION
## Description
Retrying https://github.com/sensu/sensu-docs/pull/3308 to redirect uchiwa.docs.io to docs.sensu.io/uchiwa/latest/, but this time with regex that Eric suggested.
