### PR TITLE
Update lists of namespaced and cluster-wide resources

### DIFF
--- a/content/sensu-go/6.1/operations/control-access/rbac.md
+++ b/content/sensu-go/6.1/operations/control-access/rbac.md
@@ -48,6 +48,7 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
 | `searches` | Saved [web UI][49] search queries |
+| `secrets` |[Secrets][48] (for example, username or password) |
 | `silenced` | [Silencing][14] resources within a namespace |
 
 ### Cluster-wide resource types
@@ -57,16 +58,17 @@ You can access cluster-wide resources only by cluster roles.
 
 | type | description |
 |---|---|
-| `authproviders` | [Authentication provider][32] configuration (commercial feature) |
-| `cluster` | Sensu clusters running multiple [Sensu backends][1] |
+| `apikeys` | [Persistent UUID][33] for authentication |
+| `authproviders` | [Authentication provider][32] configuration |
 | `clusterrolebindings` | Cluster-wide role assigners  |
 | `clusterroles` | Cluster-wide permission sets |
+| `clusters` | Sensu clusters running multiple [Sensu backends][1] |
+| `config` | Global configuration for [web UI display][21] |
 | `etcd-replicators` | [Mirror RBAC resource changes][40] to follower clusters |
 | `license` | Sensu [commercial license][37] |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `provider` | [PostgreSQL event store][47] provider |
 | `providers` | [Secrets providers][46] |
-| `secrets` |[Secrets][48] (for example, username or password) |
 | `users` | People or agents that interact with Sensu |
 
 ### Special resource types
@@ -2230,6 +2232,7 @@ spec:
 [18]: #cluster-wide-resource-types
 [19]: ../../../api/
 [20]: #default-users
+[21]: ../../../web-ui/webconfig-reference/
 [22]: ../../../observability-pipeline/observe-filter/filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -2241,6 +2244,7 @@ spec:
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
 [32]: ../sso/
+[33]: ../../../api/#authenticate-with-an-api-key
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -48,6 +48,7 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
 | `searches` | Saved [web UI][49] search queries |
+| `secrets` |[Secrets][48] (for example, username or password) |
 | `silenced` | [Silencing][14] resources within a namespace |
 
 ### Cluster-wide resource types
@@ -57,16 +58,17 @@ You can access cluster-wide resources only by cluster roles.
 
 | type | description |
 |---|---|
-| `authproviders` | [Authentication provider][32] configuration (commercial feature) |
-| `cluster` | Sensu clusters running multiple [Sensu backends][1] |
+| `apikeys` | [Persistent UUID][33] for authentication |
+| `authproviders` | [Authentication provider][32] configuration |
 | `clusterrolebindings` | Cluster-wide role assigners  |
 | `clusterroles` | Cluster-wide permission sets |
+| `clusters` | Sensu clusters running multiple [Sensu backends][1] |
+| `config` | Global configuration for [web UI display][21] |
 | `etcd-replicators` | [Mirror RBAC resource changes][40] to follower clusters |
 | `license` | Sensu [commercial license][37] |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `provider` | [PostgreSQL event store][47] provider |
 | `providers` | [Secrets providers][46] |
-| `secrets` |[Secrets][48] (for example, username or password) |
 | `users` | People or agents that interact with Sensu |
 
 ### Special resource types
@@ -2230,6 +2232,7 @@ spec:
 [18]: #cluster-wide-resource-types
 [19]: ../../../api/
 [20]: #default-users
+[21]: ../../../web-ui/webconfig-reference/
 [22]: ../../../observability-pipeline/observe-filter/filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -2241,6 +2244,7 @@ spec:
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
 [32]: ../sso/
+[33]: ../../../api/#authenticate-with-an-api-key
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
 [37]: ../../maintain-sensu/license/

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -47,7 +47,10 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `mutators` | [Mutator][11] resources within a namespace |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
+| `rule-templates` | [Resources applied to service components][38] for business service monitoring |
 | `searches` | Saved [web UI][49] search queries |
+| `secrets` |[Secrets][48] (for example, username or password) |
+| `service-components` | Resources that represent [elements in a business service][36] |
 | `silenced` | [Silencing][14] resources within a namespace |
 
 ### Cluster-wide resource types
@@ -57,16 +60,17 @@ You can access cluster-wide resources only by cluster roles.
 
 | type | description |
 |---|---|
-| `authproviders` | [Authentication provider][32] configuration (commercial feature) |
-| `cluster` | Sensu clusters running multiple [Sensu backends][1] |
+| `apikeys` | [Persistent UUID][33] for authentication |
+| `authproviders` | [Authentication provider][32] configuration |
 | `clusterrolebindings` | Cluster-wide role assigners  |
 | `clusterroles` | Cluster-wide permission sets |
+| `clusters` | Sensu clusters running multiple [Sensu backends][1] |
+| `config` | Global configuration for [web UI display][21] |
 | `etcd-replicators` | [Mirror RBAC resource changes][40] to follower clusters |
 | `license` | Sensu [commercial license][37] |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `provider` | [PostgreSQL event store][47] provider |
 | `providers` | [Secrets providers][46] |
-| `secrets` |[Secrets][48] (for example, username or password) |
 | `users` | People or agents that interact with Sensu |
 
 ### Special resource types
@@ -2230,6 +2234,7 @@ spec:
 [18]: #cluster-wide-resource-types
 [19]: ../../../api/
 [20]: #default-users
+[21]: ../../../web-ui/webconfig-reference/
 [22]: ../../../observability-pipeline/observe-filter/filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -2241,9 +2246,12 @@ spec:
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
 [32]: ../sso/
+[33]: ../../../api/#authenticate-with-an-api-key
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
+[36]: ../../../observability-pipeline/observe-schedule/service-components/
 [37]: ../../maintain-sensu/license/
+[38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
 [41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -47,7 +47,10 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `mutators` | [Mutator][11] resources within a namespace |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
+| `rule-templates` | [Resources applied to service components][38] for business service monitoring |
 | `searches` | Saved [web UI][49] search queries |
+| `secrets` |[Secrets][48] (for example, username or password) |
+| `service-components` | Resources that represent [elements in a business service][36] |
 | `silenced` | [Silencing][14] resources within a namespace |
 
 ### Cluster-wide resource types
@@ -57,16 +60,17 @@ You can access cluster-wide resources only by cluster roles.
 
 | type | description |
 |---|---|
-| `authproviders` | [Authentication provider][32] configuration (commercial feature) |
-| `cluster` | Sensu clusters running multiple [Sensu backends][1] |
+| `apikeys` | [Persistent UUID][33] for authentication |
+| `authproviders` | [Authentication provider][32] configuration |
 | `clusterrolebindings` | Cluster-wide role assigners  |
 | `clusterroles` | Cluster-wide permission sets |
+| `clusters` | Sensu clusters running multiple [Sensu backends][1] |
+| `config` | Global configuration for [web UI display][21] |
 | `etcd-replicators` | [Mirror RBAC resource changes][40] to follower clusters |
 | `license` | Sensu [commercial license][37] |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `provider` | [PostgreSQL event store][47] provider |
 | `providers` | [Secrets providers][46] |
-| `secrets` |[Secrets][48] (for example, username or password) |
 | `users` | People or agents that interact with Sensu |
 
 ### Special resource types
@@ -2230,6 +2234,7 @@ spec:
 [18]: #cluster-wide-resource-types
 [19]: ../../../api/
 [20]: #default-users
+[21]: ../../../web-ui/webconfig-reference/
 [22]: ../../../observability-pipeline/observe-filter/filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -2241,9 +2246,12 @@ spec:
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
 [32]: ../sso/
+[33]: ../../../api/#authenticate-with-an-api-key
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
+[36]: ../../../observability-pipeline/observe-schedule/service-components/
 [37]: ../../maintain-sensu/license/
+[38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
 [41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -45,10 +45,16 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
 | `mutators` | [Mutator][11] resources within a namespace |
+| `pipelines` | Resources composed of [event processing workflows][52] |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
+| `rule-templates` | [Resources applied to service components][38] for business service monitoring |
 | `searches` | Saved [web UI][49] search queries |
+| `secrets` |[Secrets][48] (for example, username or password) |
+| `service-components` | Resources that represent [elements in a business service][36] |
 | `silenced` | [Silencing][14] resources within a namespace |
+| `sumo-logic-metrics-handlers` | Persistent handlers for [transmitting metrics to Sumo Logic][43] |
+| `tcp-stream-handlers` | Persistent handlers for [sending events to TCP sockets][44] for remote storage |
 
 ### Cluster-wide resource types
 
@@ -57,16 +63,17 @@ You can access cluster-wide resources only by cluster roles.
 
 | type | description |
 |---|---|
-| `authproviders` | [Authentication provider][32] configuration (commercial feature) |
-| `cluster` | Sensu clusters running multiple [Sensu backends][1] |
+| `apikeys` | [Persistent UUID][33] for authentication |
+| `authproviders` | [Authentication provider][32] configuration |
 | `clusterrolebindings` | Cluster-wide role assigners  |
 | `clusterroles` | Cluster-wide permission sets |
+| `clusters` | Sensu clusters running multiple [Sensu backends][1] |
+| `config` | Global configuration for [web UI display][21] |
 | `etcd-replicators` | [Mirror RBAC resource changes][40] to follower clusters |
 | `license` | Sensu [commercial license][37] |
 | `namespaces` | Resource partitions within a Sensu instance |
 | `provider` | [PostgreSQL event store][47] provider |
 | `providers` | [Secrets providers][46] |
-| `secrets` |[Secrets][48] (for example, username or password) |
 | `users` | People or agents that interact with Sensu |
 
 ### Special resource types
@@ -2230,6 +2237,7 @@ spec:
 [18]: #cluster-wide-resource-types
 [19]: ../../../api/
 [20]: #default-users
+[21]: ../../../web-ui/webconfig-reference/
 [22]: ../../../observability-pipeline/observe-filter/filters/
 [23]: #role-bindings-and-cluster-role-bindings
 [24]: #role-and-cluster-role-specification
@@ -2241,13 +2249,18 @@ spec:
 [30]: #role-binding-and-cluster-role-binding-specification
 [31]: ../../../sensuctl/create-manage-resources/#create-resources
 [32]: ../sso/
+[33]: ../../../api/#authenticate-with-an-api-key
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
+[36]: ../../../observability-pipeline/observe-schedule/service-components/
 [37]: ../../maintain-sensu/license/
+[38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
 [41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
+[43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
+[44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
 [45]: ../../../sensuctl/#change-admin-users-password
 [46]: ../../manage-secrets/secrets-providers/
 [47]: ../../deploy-sensu/datastore/
@@ -2255,3 +2268,4 @@ spec:
 [49]: ../../../web-ui/search/#save-a-search
 [50]: ../../../sensuctl/#reset-a-user-password
 [51]: ../../../sensuctl/#generate-a-password-hash
+[52]: ../../../observability-pipeline/observe-process/pipelines/


### PR DESCRIPTION
## Description
Updates and completes the lists of namespaced and cluster-wide resources in all versions of https://docs.sensu.io/sensu-go/latest/operations/control-access/rbac/.

updates based on router info:
- https://github.com/sensu/sensu-go/tree/main/backend/apid/routers
- https://github.com/sensu/sensu-enterprise-go/tree/main/backend/apid/routers

## Motivation and Context
Noticed when working on 6.5.0 docs
