### PR TITLE
Remove duplicate stop command for Windows agent

### DIFF
--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -661,7 +661,6 @@ sudo service sensu-agent restart
 **Windows**
 
 {{< code text >}}
-sc.exe stop SensuAgent
 sc.exe start SensuAgent
 {{< /code >}}
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -665,7 +665,6 @@ sudo service sensu-agent restart
 **Windows**
 
 {{< code text >}}
-sc.exe stop SensuAgent
 sc.exe start SensuAgent
 {{< /code >}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -665,7 +665,6 @@ sudo service sensu-agent restart
 **Windows**
 
 {{< code text >}}
-sc.exe stop SensuAgent
 sc.exe start SensuAgent
 {{< /code >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -665,7 +665,6 @@ sudo service sensu-agent restart
 **Windows**
 
 {{< code text >}}
-sc.exe stop SensuAgent
 sc.exe start SensuAgent
 {{< /code >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -665,7 +665,6 @@ sudo service sensu-agent restart
 **Windows**
 
 {{< code text >}}
-sc.exe stop SensuAgent
 sc.exe start SensuAgent
 {{< /code >}}
 


### PR DESCRIPTION
## Description
Removes the duplicate Windows stop command in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#restart-the-service

## Motivation and Context
Noticed when reviewing a skunkworks PR
