### PR TITLE
6.5.0: Env vars for username/password auth to external etcd

### DIFF
--- a/content/sensu-go/6.5/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/cluster-sensu.md
@@ -369,6 +369,23 @@ sensu-backend start \
 **NOTE**: The etcd and sensu-backend certificates must share a CA, and the `etcd-client-urls` value must be a space-delimited list or a YAML array.
 {{% /notice %}}
 
+### Authenticate with username and password for external etcd
+
+Managed database services (database-as-a-service, or DBaaS) often support external etcd authentication via username and password rather than client certificates.
+
+To use username and password authentication to connect to external etcd, add the `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` [environment variables][28] to the environment file.
+Replace `<your_username>` and `<your_password>` with the username and password you use for your external etcd provider:
+
+{{< code shell >}}
+SENSU_BACKEND_ETCD_CLIENT_USERNAME=<your_username>
+SENSU_BACKEND_ETCD_CLIENT_PASSWORD=<your_password>
+{{< /code >}}
+
+Read [Configuration via environment variables][28] to learn how to create and save environment variables.
+
+The `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` environment variables do not have corresponding configuration flags.
+To use username/passsword authentication for external etcd, you must configure these environment variables in the environment file.
+
 ## Migrate from embedded etcd to external etcd
 
 To migrate from embedded etcd to external etcd, first decide whether you need to migrate all of your etcd data or just your Sensu configurations.
@@ -427,3 +444,4 @@ To redeploy a cluster due to an issue like loss of quorum among cluster members,
 [25]: https://etcd.io/docs/v3.5/op-guide/recovery/#restoring-a-cluster
 [26]: ../../../sensuctl/back-up-recover/#restore-resources-from-backup
 [27]: #use-an-external-etcd-cluster
+[28]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables


### PR DESCRIPTION
## Description
Documents the new environment variables for using username and password to authenticate for external etcd, `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD`.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3397