### PR TITLE
Change table header from Note to Description in federation guide

### DIFF
--- a/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/use-federation/#configure-backends-for-tls a table header "Note" should be "Description" instead

## Motivation and Context
Noticed when working on something else
