### PR TITLE
Remove rb examples

### DIFF
--- a/content/sensu-go/6.1/api/events.md
+++ b/content/sensu-go/6.1/api/events.md
@@ -37,15 +37,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -178,15 +177,14 @@ output         | {{< code shell >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -404,15 +402,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -673,15 +670,14 @@ output               | {{< code json >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -946,15 +942,14 @@ HTTP/1.1 200 OK
 
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"
@@ -1076,15 +1071,14 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-events/events.md
@@ -50,7 +50,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.rb -w 75 -c 90
+    command: check-cpu-usage -w 75 -c 90
     duration: 5.058211427
     env_vars: null
     executed: 1617050501
@@ -85,8 +85,7 @@ spec:
     publish: true
     round_robin: false
     runtime_assets:
-    - cpu-checks-plugins
-    - sensu-ruby-runtime
+    - check-cpu-usage
     scheduler: memory
     secrets: null
     state: passing
@@ -163,7 +162,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "duration": 5.058211427,
       "env_vars": null,
       "executed": 1617050501,
@@ -209,8 +208,7 @@ spec:
       "publish": true,
       "round_robin": false,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "scheduler": "memory",
       "secrets": null,
@@ -308,15 +306,14 @@ This is the format that events are in when Sensu sends them to handlers:
 {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-filter/route-alerts.md
@@ -571,7 +571,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -584,8 +584,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -609,7 +608,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -623,8 +622,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-process/send-slack-alerts.md
@@ -192,7 +192,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -205,8 +205,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -227,7 +226,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -241,8 +240,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/_index.md
@@ -63,7 +63,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -76,8 +76,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -99,7 +98,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -113,8 +112,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -449,7 +449,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  "command": "check-http.rb -u https://sensuapp.org"
+  command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/agent.md
@@ -449,7 +449,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  command": "http-check --url https://sensu.io"
+  "command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.1/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -63,7 +63,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `cpu-checks-plugins` and `nagiosfoundation` dynamic runtime assets:
+The response should list the `check-cpu-usage` and `nagiosfoundation` dynamic runtime assets:
 
 {{< code shell >}}
         Name                                           URL                                      Hash    

--- a/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.1/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.1/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.1/operations/monitoring-as-code/_index.md
@@ -105,7 +105,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -118,8 +118,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -140,7 +139,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -154,8 +153,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.1/plugins/plugins.md
+++ b/content/sensu-go/6.1/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "check-http.rb -u https://sensuapp.org"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.1/plugins/plugins.md
+++ b/content/sensu-go/6.1/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.1/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.1/sensuctl/create-manage-resources.md
@@ -37,7 +37,7 @@ metadata:
   name: marketing-site
   namespace: default
 spec:
-  command: check-http.rb -u https://sensu.io
+  command: http-check -u https://sensu.io
   subscriptions:
   - demo
   interval: 15
@@ -68,7 +68,7 @@ spec:
     "namespace": "default"
     },
   "spec": {
-    "command": "check-http.rb -u https://sensu.io",
+    "command": "http-check -u https://sensu.io",
     "subscriptions": ["demo"],
     "interval": 15,
     "handlers": ["slack"]

--- a/content/sensu-go/6.2/api/events.md
+++ b/content/sensu-go/6.2/api/events.md
@@ -37,15 +37,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -179,15 +178,14 @@ output         | {{< code shell >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -406,15 +404,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -677,15 +674,14 @@ output               | {{< code json >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -952,15 +948,14 @@ HTTP/1.1 200 OK
 
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"
@@ -1083,15 +1078,14 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -50,7 +50,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.rb -w 75 -c 90
+    command: check-cpu-usage -w 75 -c 90
     duration: 5.058211427
     env_vars: null
     executed: 1617050501
@@ -85,8 +85,7 @@ spec:
     publish: true
     round_robin: false
     runtime_assets:
-    - cpu-checks-plugins
-    - sensu-ruby-runtime
+    - check-cpu-usage
     scheduler: memory
     secrets: null
     state: passing
@@ -164,7 +163,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "duration": 5.058211427,
       "env_vars": null,
       "executed": 1617050501,
@@ -210,8 +209,7 @@ spec:
       "publish": true,
       "round_robin": false,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "scheduler": "memory",
       "secrets": null,
@@ -310,15 +308,14 @@ This is the format that events are in when Sensu sends them to handlers:
 {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
@@ -571,7 +571,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -584,8 +584,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -609,7 +608,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -623,8 +622,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-slack-alerts.md
@@ -192,7 +192,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -205,8 +205,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -227,7 +226,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -241,8 +240,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/_index.md
@@ -63,7 +63,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -76,8 +76,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -99,7 +98,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -113,8 +112,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  "command": "check-http.rb -u https://sensuapp.org"
+  command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  command": "http-check --url https://sensu.io"
+  "command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -63,7 +63,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `cpu-checks-plugins` and `nagiosfoundation` dynamic runtime assets:
+The response should list the `check-cpu-usage` and `nagiosfoundation` dynamic runtime assets:
 
 {{< code shell >}}
         Name                                           URL                                      Hash    

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.2/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.2/operations/monitoring-as-code/_index.md
@@ -105,7 +105,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -118,8 +118,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -140,7 +139,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -154,8 +153,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.2/plugins/plugins.md
+++ b/content/sensu-go/6.2/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "check-http.rb -u https://sensuapp.org"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.2/plugins/plugins.md
+++ b/content/sensu-go/6.2/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -42,7 +42,7 @@ metadata:
   name: marketing-site
   namespace: default
 spec:
-  command: check-http.rb -u https://sensu.io
+  command: http-check -u https://sensu.io
   subscriptions:
   - demo
   interval: 15
@@ -73,7 +73,7 @@ spec:
     "namespace": "default"
     },
   "spec": {
-    "command": "check-http.rb -u https://sensu.io",
+    "command": "http-check -u https://sensu.io",
     "subscriptions": ["demo"],
     "interval": 15,
     "handlers": ["slack"]

--- a/content/sensu-go/6.3/api/events.md
+++ b/content/sensu-go/6.3/api/events.md
@@ -37,15 +37,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -179,15 +178,14 @@ output         | {{< code shell >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -406,15 +404,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -677,15 +674,14 @@ output               | {{< code json >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -952,15 +948,14 @@ HTTP/1.1 200 OK
 
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"
@@ -1083,15 +1078,14 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -50,7 +50,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.rb -w 75 -c 90
+    command: check-cpu-usage -w 75 -c 90
     duration: 5.058211427
     env_vars: null
     executed: 1617050501
@@ -85,8 +85,7 @@ spec:
     publish: true
     round_robin: false
     runtime_assets:
-    - cpu-checks-plugins
-    - sensu-ruby-runtime
+    - check-cpu-usage
     scheduler: memory
     secrets: null
     state: passing
@@ -164,7 +163,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "duration": 5.058211427,
       "env_vars": null,
       "executed": 1617050501,
@@ -210,8 +209,7 @@ spec:
       "publish": true,
       "round_robin": false,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "scheduler": "memory",
       "secrets": null,
@@ -310,15 +308,14 @@ This is the format that events are in when Sensu sends them to handlers:
 {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -571,7 +571,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -584,8 +584,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -609,7 +608,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -623,8 +622,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -192,7 +192,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -205,8 +205,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -227,7 +226,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -241,8 +240,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/_index.md
@@ -63,7 +63,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -76,8 +76,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -99,7 +98,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -113,8 +112,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  "command": "check-http.rb -u https://sensuapp.org"
+  command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  command": "http-check --url https://sensu.io"
+  "command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -63,7 +63,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `cpu-checks-plugins` and `nagiosfoundation` dynamic runtime assets:
+The response should list the `check-cpu-usage` and `nagiosfoundation` dynamic runtime assets:
 
 {{< code shell >}}
         Name                                           URL                                      Hash    

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.3/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.3/operations/monitoring-as-code/_index.md
@@ -105,7 +105,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -118,8 +118,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -140,7 +139,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -154,8 +153,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.3/plugins/plugins.md
+++ b/content/sensu-go/6.3/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "check-http.rb -u https://sensuapp.org"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.3/plugins/plugins.md
+++ b/content/sensu-go/6.3/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -42,7 +42,7 @@ metadata:
   name: marketing-site
   namespace: default
 spec:
-  command: check-http.rb -u https://sensu.io
+  command: http-check -u https://sensu.io
   subscriptions:
   - demo
   interval: 15
@@ -73,7 +73,7 @@ spec:
     "namespace": "default"
     },
   "spec": {
-    "command": "check-http.rb -u https://sensu.io",
+    "command": "http-check -u https://sensu.io",
     "subscriptions": ["demo"],
     "interval": 15,
     "handlers": ["slack"]

--- a/content/sensu-go/6.4/api/events.md
+++ b/content/sensu-go/6.4/api/events.md
@@ -37,15 +37,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -179,15 +178,14 @@ output         | {{< code shell >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -406,15 +404,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -677,15 +674,14 @@ output               | {{< code json >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -952,15 +948,14 @@ HTTP/1.1 200 OK
 
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"
@@ -1083,15 +1078,14 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
@@ -50,7 +50,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.rb -w 75 -c 90
+    command: check-cpu-usage -w 75 -c 90
     duration: 5.058211427
     env_vars: null
     executed: 1617050501
@@ -85,8 +85,7 @@ spec:
     publish: true
     round_robin: false
     runtime_assets:
-    - cpu-checks-plugins
-    - sensu-ruby-runtime
+    - check-cpu-usage
     scheduler: memory
     secrets: null
     state: passing
@@ -164,7 +163,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "duration": 5.058211427,
       "env_vars": null,
       "executed": 1617050501,
@@ -210,8 +209,7 @@ spec:
       "publish": true,
       "round_robin": false,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "scheduler": "memory",
       "secrets": null,
@@ -310,15 +308,14 @@ This is the format that events are in when Sensu sends them to handlers:
 {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -571,7 +571,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -584,8 +584,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -609,7 +608,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -623,8 +622,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
@@ -192,7 +192,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -205,8 +205,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -227,7 +226,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -241,8 +240,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/_index.md
@@ -63,7 +63,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -76,8 +76,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -99,7 +98,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -113,8 +112,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  "command": "check-http.rb -u https://sensuapp.org"
+  command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  command": "http-check --url https://sensu.io"
+  "command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -63,7 +63,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `cpu-checks-plugins` and `nagiosfoundation` dynamic runtime assets:
+The response should list the `check-cpu-usage` and `nagiosfoundation` dynamic runtime assets:
 
 {{< code shell >}}
         Name                                           URL                                      Hash    

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.4/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.4/operations/monitoring-as-code/_index.md
@@ -105,7 +105,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -118,8 +118,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -140,7 +139,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -154,8 +153,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.4/plugins/plugins.md
+++ b/content/sensu-go/6.4/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "check-http.rb -u https://sensuapp.org"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.4/plugins/plugins.md
+++ b/content/sensu-go/6.4/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -42,7 +42,7 @@ metadata:
   name: marketing-site
   namespace: default
 spec:
-  command: check-http.rb -u https://sensu.io
+  command: http-check -u https://sensu.io
   subscriptions:
   - demo
   interval: 15
@@ -73,7 +73,7 @@ spec:
     "namespace": "default"
     },
   "spec": {
-    "command": "check-http.rb -u https://sensu.io",
+    "command": "http-check -u https://sensu.io",
     "subscriptions": ["demo"],
     "interval": 15,
     "handlers": ["slack"]

--- a/content/sensu-go/6.5/api/events.md
+++ b/content/sensu-go/6.5/api/events.md
@@ -37,15 +37,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -187,15 +186,14 @@ output         | {{< code shell >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -422,15 +420,14 @@ HTTP/1.1 200 OK
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -709,15 +706,14 @@ output               | {{< code json >}}
 [
   {
     "check": {
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "handlers": [],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
       "publish": true,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "subscriptions": [
         "system"
@@ -1000,15 +996,14 @@ HTTP/1.1 200 OK
 
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"
@@ -1139,15 +1134,14 @@ response codes       | <ul><li>**Success**: 200 (OK)</li><li> **Missing**: 404 (
 output               | {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -50,7 +50,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: check-cpu.rb -w 75 -c 90
+    command: check-cpu-usage -w 75 -c 90
     duration: 5.058211427
     env_vars: null
     executed: 1617050501
@@ -86,8 +86,7 @@ spec:
     publish: true
     round_robin: false
     runtime_assets:
-    - cpu-checks-plugins
-    - sensu-ruby-runtime
+    - check-cpu-usage
     scheduler: memory
     secrets: null
     state: passing
@@ -169,7 +168,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "check-cpu.rb -w 75 -c 90",
+      "command": "check-cpu-usage -w 75 -c 90",
       "duration": 5.058211427,
       "env_vars": null,
       "executed": 1617050501,
@@ -216,8 +215,7 @@ spec:
       "publish": true,
       "round_robin": false,
       "runtime_assets": [
-        "cpu-checks-plugins",
-        "sensu-ruby-runtime"
+        "check-cpu-usage"
       ],
       "scheduler": "memory",
       "secrets": null,
@@ -323,15 +321,14 @@ This is the format that events are in when Sensu sends them to handlers:
 {{< code json >}}
 {
   "check": {
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "handlers": [],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
     "publish": true,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "subscriptions": [
       "system"

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -571,7 +571,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -584,8 +584,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -609,7 +608,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -623,8 +622,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -196,7 +196,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -209,8 +209,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -231,7 +230,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -245,8 +244,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/_index.md
@@ -63,7 +63,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -76,8 +76,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -99,7 +98,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -113,8 +112,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  "command": "check-http.rb -u https://sensuapp.org"
+  command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -453,7 +453,7 @@ description  | Command executed to produce the event. Use the `command` attribut
 required     | false
 type         | String
 example      | {{< code json >}}{
-  command": "http-check --url https://sensu.io"
+  "command": "http-check --url https://sensu.io"
 }{{< /code >}}
 
 interval     | 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -63,7 +63,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `cpu-checks-plugins` and `nagiosfoundation` dynamic runtime assets:
+The response should list the `check-cpu-usage` and `nagiosfoundation` dynamic runtime assets:
 
 {{< code shell >}}
         Name                                           URL                                      Hash    

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -73,8 +73,8 @@ If you don't have existing infrastructure for issuing certificates, read [Genera
 
 This prerequisite extends to configuring the following Sensu backend etcd parameters:
 
-| Backend property             | Note |
-|------------------------------|------|
+| Backend property             | Description |
+|------------------------------|-------------|
 | `etcd-cert-file`             | Path to certificate used for TLS on etcd client/peer communications (for example, `/etc/sensu/tls/backend-1.pem`.  |
 | `etcd-key-file`              | Path to key corresponding with `etcd-cert-file` certificate (for example, `/etc/sensu/tls/backend-1-key.pem`. |
 | `etcd-trusted-ca-file`       | Path to CA certificate chain file (for example, `/etc/sensu/tls/ca.pem`. This CA certificate chain must be usable to validate certificates for all backends in the federation. |

--- a/content/sensu-go/6.5/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.5/operations/monitoring-as-code/_index.md
@@ -105,7 +105,7 @@ metadata:
   namespace: default
 spec:
   check_hooks: null
-  command: check-cpu.rb -w 75 -c 90
+  command: check-cpu-usage -w 75 -c 90
   env_vars: null
   handlers:
   - slack
@@ -118,8 +118,7 @@ spec:
   publish: true
   round_robin: false
   runtime_assets:
-  - cpu-checks-plugins
-  - sensu-ruby-runtime
+  - check-cpu-usage
   secrets: null
   stdin: false
   subdue: null
@@ -140,7 +139,7 @@ spec:
   },
   "spec": {
     "check_hooks": null,
-    "command": "check-cpu.rb -w 75 -c 90",
+    "command": "check-cpu-usage -w 75 -c 90",
     "env_vars": null,
     "handlers": [
       "slack"
@@ -154,8 +153,7 @@ spec:
     "publish": true,
     "round_robin": false,
     "runtime_assets": [
-      "cpu-checks-plugins",
-      "sensu-ruby-runtime"
+      "check-cpu-usage"
     ],
     "secrets": null,
     "stdin": false,

--- a/content/sensu-go/6.5/plugins/plugins.md
+++ b/content/sensu-go/6.5/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "check-http.rb -u https://sensuapp.org"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.5/plugins/plugins.md
+++ b/content/sensu-go/6.5/plugins/plugins.md
@@ -41,7 +41,7 @@ Plugins must be executable files that are discoverable on the Sensu system (that
 {{% notice note %}}
 **NOTE**: By default, Sensu installer packages will modify the system `$PATH` for the Sensu processes to include `/etc/sensu/plugins`.
 As a result, executable scripts (for example, plugins) located in `/etc/sensu/plugins` will be valid commands.
-This allows command attributes to use relative paths for Sensu plugin commands, such as `command": "http-check --url https://sensu.io"`.
+This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
 ## Go plugin example

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -42,7 +42,7 @@ metadata:
   name: marketing-site
   namespace: default
 spec:
-  command: check-http.rb -u https://sensu.io
+  command: http-check -u https://sensu.io
   subscriptions:
   - demo
   interval: 15
@@ -73,7 +73,7 @@ spec:
     "namespace": "default"
     },
   "spec": {
-    "command": "check-http.rb -u https://sensu.io",
+    "command": "http-check -u https://sensu.io",
     "subscriptions": ["demo"],
     "interval": 15,
     "handlers": ["slack"]


### PR DESCRIPTION
## Description
Removes .rb command examples

## Motivation and Context
More work on removing Ruby-based plugin examples in the docs