### PR TITLE
Add RBAC examples with multiple rules

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -635,7 +635,7 @@ agent-port: 8081{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -688,7 +688,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -729,7 +729,7 @@ require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
 ------------------|------
-description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/tokens.md
@@ -301,7 +301,7 @@ Access nested Sensu [entity attributes][3] with dot notation (for example, `syst
 
 If an attribute is not provided by the [entity][3], a token's default value will be substituted.
 Token default values are separated by a pipe character and the word "default" (`| default`).
-Use token default values to provide a fallback value for entities that are missing a specified token attribute.
+Use token default values to provide a fallback value for entities that are missing a specified token attribute.
 
 For example, `{{.labels.url | default "https://sensu.io"}}` would be replaced with a custom label called `url`.
 If no such attribute called `url` is included in the entity definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.

--- a/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.2/operations/control-access/create-read-only-user.md
@@ -16,7 +16,7 @@ menu:
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.
 Use RBAC rules to achieve **multitenancy** so different projects and teams can share a Sensu instance. 
 
-Sensu RBAC helps different teams and projects share a Sensu instance.
+Sensu RBAC helps different teams and projects share a Sensu instance.
 RBAC allows you to manage users and their access to resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -2309,7 +2309,11 @@ spec:
 {{< /language-toggle >}}
 
 Create as many rules as you need in the role or cluster role.
-In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+For example, you can configure a role or cluster role that includes one rule for each verb, with each rule listing only the resources that verb should apply to.
+
+Here's another example that includes three rules.
+Each rule specifies different access permissions for the resource types listed in the rule.
+In addition, the user group would have no access at all for the two resources that are not listed: API keys and licences.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -12,7 +12,7 @@ menu:
     parent: control-access
 ---
 
-Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
 - **Roles** create sets of permissions (for example, get and delete) tied to resource types.
@@ -45,11 +45,16 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
 | `mutators` | [Mutator][11] resources within a namespace |
+| `pipelines` | Resources composed of [event processing workflows][52] |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
+| `rule-templates` | [Resources applied to service components][38] for business service monitoring |
 | `searches` | Saved [web UI][49] search queries |
 | `secrets` |[Secrets][48] (for example, username or password) |
+| `service-components` | Resources that represent [elements in a business service][36] |
 | `silenced` | [Silencing][14] resources within a namespace |
+| `sumo-logic-metrics-handlers` | Persistent handlers for [transmitting metrics to Sumo Logic][43] |
+| `tcp-stream-handlers` | Persistent handlers for [sending events to TCP sockets][44] for remote storage |
 
 ### Cluster-wide resource types
 
@@ -103,7 +108,7 @@ spec:
   groups:
   - ops
   - dev
-  password: USER_PASSWORD
+  password: user_password
   password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
   username: alice
 {{< /code >}}
@@ -115,7 +120,7 @@ spec:
   "metadata": {},
   "spec": {
     "username": "alice",
-    "password": "USER_PASSWORD",
+    "password": "user_password",
     "password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm",
     "disabled": false,
     "groups": ["ops", "dev"]
@@ -272,11 +277,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-password: USER_PASSWORD
+password: user_password
 {{< /code >}}
 {{< code json >}}
 {
-  "password": "USER_PASSWORD"
+  "password": "user_password"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -421,8 +426,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -453,12 +457,26 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -497,8 +515,7 @@ metadata:
   name: all-resources-all-verbs
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -535,14 +552,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -573,13 +609,13 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
+| `system:pipeline` | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
 | `cluster-admin` | `ClusterRole` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `admin`         | `ClusterRole` | Full access to all [resource types][4]. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `edit`          | `ClusterRole` | Read and write access to most resources except roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `view`          | `ClusterRole` | Read-only permission to most [resource types][4] with the exception of roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `system:agent`  | `ClusterRole` | Used internally by Sensu agents. You can configure an agent's user credentials using the [`user` and `password` agent configuration flags][41]. |
-| `system:user`  | `ClusterRole` | Get and update permissions for local resources for the current user. |
+| `system:user`   | `ClusterRole` | Get and update permissions for local resources for the current user. |
 
 ### Manage roles and cluster roles
 
@@ -630,7 +666,7 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
-This command creates the following role resource definition:
+This command creates the following role resource definition, which provides get, list, create, update, and delete permissions for all resources in the production namespace:
 
 {{< language-toggle >}}
 
@@ -644,8 +680,7 @@ metadata:
   namespace: production
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - '*'
     verbs:
     - get
@@ -667,7 +702,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "*"
         ],
@@ -762,8 +796,7 @@ metadata:
   name: global-event-reader
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - events
     verbs:
     - get
@@ -781,7 +814,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "events"
         ],
@@ -1085,7 +1117,7 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
+| `system:pipeline` | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
 | `cluster-admin` | `ClusterRoleBinding` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `system:agent` | `ClusterRoleBinding` | Full access to all events. Used internally by Sensu agents. |
 | `system:user` | `ClusterRoleBinding` | Get and update permissions for local resources for the current user. |
@@ -1448,21 +1480,20 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
-    - checks
-    - hooks
-    - filters
-    - events
-    - filters
-    - mutators
-    - handlers
-    verbs:
-    - get
-    - list
-    - create
-    - update
-    - delete
+    - resources:
+      - checks
+      - hooks
+      - filters
+      - events
+      - filters
+      - mutators
+      - handlers
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
 {{< /code >}}
 
 {{< code json >}}
@@ -1476,9 +1507,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1545,8 +1589,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - checks
     - hooks
     - filters
@@ -1573,9 +1616,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1648,6 +1704,7 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
 {{< /code >}}
 
 {{< code json >}}
@@ -1657,7 +1714,8 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password"
   }
 }
 {{< /code >}}
@@ -1675,8 +1733,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1708,12 +1765,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1786,6 +1858,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
+  groups:
+  - ops
 {{< /code >}}
 
 {{< code json >}}
@@ -1795,7 +1870,11 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1813,8 +1892,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1846,12 +1924,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1928,9 +2021,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
   groups:
   - ops
-
 {{< /code >}}
 
 {{< code json >}}
@@ -1941,7 +2034,10 @@ spec:
   "spec": {
     "disabled": false,
     "username": "alice",
-    "groups": ["ops"]
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1958,8 +2054,7 @@ metadata:
   name: default-admin
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1996,14 +2091,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -2039,6 +2153,354 @@ spec:
   "spec": {
     "role_ref": {
       "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign different permissions for different resource types
+
+You can assign different permissions for different resource types in a role or cluster role definition.
+To do this, you'll still create at least one user assigned to a group, a role or cluster role, and a role binding or cluster role binding.
+However, in this case, the role or cluster role will include more than one rule.
+
+For example, you may want users in a testing group to be able to get and list all resource types but create, update, and delete only silenced entries across all namespaces.
+Create a user `alice` assigned to the group `ops_testing`, a cluster role `manage_silences` with two rules (one for all resources and one just for silences), and a cluster role binding `ops_testing_manage_silences`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops_testing
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops_testing"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: manage_silences
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - '*'
+  - verbs:
+    - create
+    - update
+    - delete
+    resources:
+    - silenced
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "manage_silences"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "*"
+        ]
+      },
+      {
+        "verbs": [
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "silenced"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_testing_manage_silences
+spec:
+  role_ref:
+    name: manage_silences
+    type: ClusterRole
+  subjects:
+  - name: ops_testing
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_testing_manage_silences"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "manage_silences",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops_testing",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Create as many rules as you need in the role or cluster role.
+In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: ops_access
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - entities
+    - events
+    - rolebindings
+    - roles
+    - clusterrolebindings
+    - clusterroles
+    - config
+    - users
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    resources:
+    - assets
+    - checks
+    - filters
+    - handlers
+    - hooks
+    - mutators
+    - pipelines
+    - rule-templates
+    - searches
+    - secrets
+    - service-components
+    - silenced
+    - sumo-logic-metrics-handlers
+    - tcp-stream-handlers
+    - clusters
+    - etcd-replicators
+    - providers
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    resources:
+    - authproviders
+    - namespaces
+    - provider
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "entities",
+          "events",
+          "rolebindings",
+          "roles",
+          "clusterrolebindings",
+          "clusterroles",
+          "config",
+          "users"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rule-templates",
+          "searches",
+          "secrets",
+          "service-components",
+          "silenced",
+          "sumo-logic-metrics-handlers",
+          "tcp-stream-handlers",
+          "clusters",
+          "etcd-replicators",
+          "providers"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update"
+        ],
+        "resources": [
+          "authproviders",
+          "namespaces",
+          "provider"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_access_assignment
+spec:
+  role_ref:
+    name: ops_access
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access_assignment"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "ops_access",
       "type": "ClusterRole"
     },
     "subjects": [
@@ -2120,8 +2582,7 @@ metadata:
   name: silencing-script
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - silenced
     verbs:
     - get
@@ -2141,7 +2602,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "silenced"
         ],
@@ -2247,11 +2707,15 @@ spec:
 [33]: ../../../api/#authenticate-with-an-api-key
 [34]: ../#use-built-in-basic-authentication
 [35]: https://en.wikipedia.org/wiki/Bcrypt
+[36]: ../../../observability-pipeline/observe-schedule/service-components/
 [37]: ../../maintain-sensu/license/
+[38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
 [41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
+[43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
+[44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
 [45]: ../../../sensuctl/#change-admin-users-password
 [46]: ../../manage-secrets/secrets-providers/
 [47]: ../../deploy-sensu/datastore/
@@ -2259,3 +2723,4 @@ spec:
 [49]: ../../../web-ui/search/#save-a-search
 [50]: ../../../sensuctl/#reset-a-user-password
 [51]: ../../../sensuctl/#generate-a-password-hash
+[52]: ../../../observability-pipeline/observe-process/pipelines/

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -330,7 +330,7 @@ Subjects:
 ## Register clusters
 
 Clusters must be registered to become visible in the web UI.
-Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
+Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
 
 {{% notice note %}}
 **NOTE**: Individual cluster resources may list the API URLs for a single stand-alone backend or multiple backends that are members of the same etcd cluster.

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets.md
@@ -237,7 +237,7 @@ name: sensu-ansible-token
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][9] that the secret belongs to.
+description  | [Sensu RBAC namespace][9] that the secret belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -664,7 +664,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -717,7 +717,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -758,7 +758,7 @@ require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
 ------------------|------
-description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -447,7 +447,7 @@ name: status-threshold
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
@@ -255,7 +255,7 @@ name: postgresql-1
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -301,7 +301,7 @@ Access nested Sensu [entity attributes][3] with dot notation (for example, `syst
 
 If an attribute is not provided by the [entity][3], a token's default value will be substituted.
 Token default values are separated by a pipe character and the word "default" (`| default`).
-Use token default values to provide a fallback value for entities that are missing a specified token attribute.
+Use token default values to provide a fallback value for entities that are missing a specified token attribute.
 
 For example, `{{.labels.url | default "https://sensu.io"}}` would be replaced with a custom label called `url`.
 If no such attribute called `url` is included in the entity definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.

--- a/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
@@ -16,7 +16,7 @@ menu:
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.
 Use RBAC rules to achieve **multitenancy** so different projects and teams can share a Sensu instance. 
 
-Sensu RBAC helps different teams and projects share a Sensu instance.
+Sensu RBAC helps different teams and projects share a Sensu instance.
 RBAC allows you to manage users and their access to resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -2309,7 +2309,11 @@ spec:
 {{< /language-toggle >}}
 
 Create as many rules as you need in the role or cluster role.
-In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+For example, you can configure a role or cluster role that includes one rule for each verb, with each rule listing only the resources that verb should apply to.
+
+Here's another example that includes three rules.
+Each rule specifies different access permissions for the resource types listed in the rule.
+In addition, the user group would have no access at all for the two resources that are not listed: API keys and licences.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -12,7 +12,7 @@ menu:
     parent: control-access
 ---
 
-Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
 - **Roles** create sets of permissions (for example, get and delete) tied to resource types.
@@ -45,6 +45,7 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
 | `mutators` | [Mutator][11] resources within a namespace |
+| `pipelines` | Resources composed of [event processing workflows][52] |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
 | `rule-templates` | [Resources applied to service components][38] for business service monitoring |
@@ -52,6 +53,8 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `secrets` |[Secrets][48] (for example, username or password) |
 | `service-components` | Resources that represent [elements in a business service][36] |
 | `silenced` | [Silencing][14] resources within a namespace |
+| `sumo-logic-metrics-handlers` | Persistent handlers for [transmitting metrics to Sumo Logic][43] |
+| `tcp-stream-handlers` | Persistent handlers for [sending events to TCP sockets][44] for remote storage |
 
 ### Cluster-wide resource types
 
@@ -105,7 +108,7 @@ spec:
   groups:
   - ops
   - dev
-  password: USER_PASSWORD
+  password: user_password
   password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
   username: alice
 {{< /code >}}
@@ -117,7 +120,7 @@ spec:
   "metadata": {},
   "spec": {
     "username": "alice",
-    "password": "USER_PASSWORD",
+    "password": "user_password",
     "password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm",
     "disabled": false,
     "groups": ["ops", "dev"]
@@ -274,11 +277,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-password: USER_PASSWORD
+password: user_password
 {{< /code >}}
 {{< code json >}}
 {
-  "password": "USER_PASSWORD"
+  "password": "user_password"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -423,8 +426,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -455,12 +457,26 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -499,8 +515,7 @@ metadata:
   name: all-resources-all-verbs
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -537,14 +552,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -575,13 +609,13 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
+| `system:pipeline` | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
 | `cluster-admin` | `ClusterRole` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `admin`         | `ClusterRole` | Full access to all [resource types][4]. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `edit`          | `ClusterRole` | Read and write access to most resources except roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `view`          | `ClusterRole` | Read-only permission to most [resource types][4] with the exception of roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `system:agent`  | `ClusterRole` | Used internally by Sensu agents. You can configure an agent's user credentials using the [`user` and `password` agent configuration flags][41]. |
-| `system:user`  | `ClusterRole` | Get and update permissions for local resources for the current user. |
+| `system:user`   | `ClusterRole` | Get and update permissions for local resources for the current user. |
 
 ### Manage roles and cluster roles
 
@@ -632,7 +666,7 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
-This command creates the following role resource definition:
+This command creates the following role resource definition, which provides get, list, create, update, and delete permissions for all resources in the production namespace:
 
 {{< language-toggle >}}
 
@@ -646,8 +680,7 @@ metadata:
   namespace: production
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - '*'
     verbs:
     - get
@@ -669,7 +702,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "*"
         ],
@@ -764,8 +796,7 @@ metadata:
   name: global-event-reader
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - events
     verbs:
     - get
@@ -783,7 +814,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "events"
         ],
@@ -1087,7 +1117,7 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
+| `system:pipeline` | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
 | `cluster-admin` | `ClusterRoleBinding` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `system:agent` | `ClusterRoleBinding` | Full access to all events. Used internally by Sensu agents. |
 | `system:user` | `ClusterRoleBinding` | Get and update permissions for local resources for the current user. |
@@ -1450,21 +1480,20 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
-    - checks
-    - hooks
-    - filters
-    - events
-    - filters
-    - mutators
-    - handlers
-    verbs:
-    - get
-    - list
-    - create
-    - update
-    - delete
+    - resources:
+      - checks
+      - hooks
+      - filters
+      - events
+      - filters
+      - mutators
+      - handlers
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
 {{< /code >}}
 
 {{< code json >}}
@@ -1478,9 +1507,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1547,8 +1589,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - checks
     - hooks
     - filters
@@ -1575,9 +1616,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1650,6 +1704,7 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
 {{< /code >}}
 
 {{< code json >}}
@@ -1659,7 +1714,8 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password"
   }
 }
 {{< /code >}}
@@ -1677,8 +1733,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1710,12 +1765,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1788,6 +1858,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
+  groups:
+  - ops
 {{< /code >}}
 
 {{< code json >}}
@@ -1797,7 +1870,11 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1815,8 +1892,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1848,12 +1924,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1930,9 +2021,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
   groups:
   - ops
-
 {{< /code >}}
 
 {{< code json >}}
@@ -1943,7 +2034,10 @@ spec:
   "spec": {
     "disabled": false,
     "username": "alice",
-    "groups": ["ops"]
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1960,8 +2054,7 @@ metadata:
   name: default-admin
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1998,14 +2091,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -2041,6 +2153,354 @@ spec:
   "spec": {
     "role_ref": {
       "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign different permissions for different resource types
+
+You can assign different permissions for different resource types in a role or cluster role definition.
+To do this, you'll still create at least one user assigned to a group, a role or cluster role, and a role binding or cluster role binding.
+However, in this case, the role or cluster role will include more than one rule.
+
+For example, you may want users in a testing group to be able to get and list all resource types but create, update, and delete only silenced entries across all namespaces.
+Create a user `alice` assigned to the group `ops_testing`, a cluster role `manage_silences` with two rules (one for all resources and one just for silences), and a cluster role binding `ops_testing_manage_silences`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops_testing
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops_testing"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: manage_silences
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - '*'
+  - verbs:
+    - create
+    - update
+    - delete
+    resources:
+    - silenced
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "manage_silences"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "*"
+        ]
+      },
+      {
+        "verbs": [
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "silenced"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_testing_manage_silences
+spec:
+  role_ref:
+    name: manage_silences
+    type: ClusterRole
+  subjects:
+  - name: ops_testing
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_testing_manage_silences"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "manage_silences",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops_testing",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Create as many rules as you need in the role or cluster role.
+In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: ops_access
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - entities
+    - events
+    - rolebindings
+    - roles
+    - clusterrolebindings
+    - clusterroles
+    - config
+    - users
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    resources:
+    - assets
+    - checks
+    - filters
+    - handlers
+    - hooks
+    - mutators
+    - pipelines
+    - rule-templates
+    - searches
+    - secrets
+    - service-components
+    - silenced
+    - sumo-logic-metrics-handlers
+    - tcp-stream-handlers
+    - clusters
+    - etcd-replicators
+    - providers
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    resources:
+    - authproviders
+    - namespaces
+    - provider
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "entities",
+          "events",
+          "rolebindings",
+          "roles",
+          "clusterrolebindings",
+          "clusterroles",
+          "config",
+          "users"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rule-templates",
+          "searches",
+          "secrets",
+          "service-components",
+          "silenced",
+          "sumo-logic-metrics-handlers",
+          "tcp-stream-handlers",
+          "clusters",
+          "etcd-replicators",
+          "providers"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update"
+        ],
+        "resources": [
+          "authproviders",
+          "namespaces",
+          "provider"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_access_assignment
+spec:
+  role_ref:
+    name: ops_access
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access_assignment"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "ops_access",
       "type": "ClusterRole"
     },
     "subjects": [
@@ -2122,8 +2582,7 @@ metadata:
   name: silencing-script
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - silenced
     verbs:
     - get
@@ -2143,7 +2602,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "silenced"
         ],
@@ -2256,6 +2714,8 @@ spec:
 [40]: ../../deploy-sensu/etcdreplicators/
 [41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
+[43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
+[44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
 [45]: ../../../sensuctl/#change-admin-users-password
 [46]: ../../manage-secrets/secrets-providers/
 [47]: ../../deploy-sensu/datastore/
@@ -2263,3 +2723,4 @@ spec:
 [49]: ../../../web-ui/search/#save-a-search
 [50]: ../../../sensuctl/#reset-a-user-password
 [51]: ../../../sensuctl/#generate-a-password-hash
+[52]: ../../../observability-pipeline/observe-process/pipelines/

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -330,7 +330,7 @@ Subjects:
 ## Register clusters
 
 Clusters must be registered to become visible in the web UI.
-Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
+Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
 
 {{% notice note %}}
 **NOTE**: Individual cluster resources may list the API URLs for a single stand-alone backend or multiple backends that are members of the same etcd cluster.

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets.md
@@ -237,7 +237,7 @@ name: sensu-ansible-token
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][9] that the secret belongs to.
+description  | [Sensu RBAC namespace][9] that the secret belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -700,7 +700,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -753,7 +753,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -794,7 +794,7 @@ require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
 ------------------|------
-description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -447,7 +447,7 @@ name: status-threshold
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -255,7 +255,7 @@ name: postgresql-1
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -301,7 +301,7 @@ Access nested Sensu [entity attributes][3] with dot notation (for example, `syst
 
 If an attribute is not provided by the [entity][3], a token's default value will be substituted.
 Token default values are separated by a pipe character and the word "default" (`| default`).
-Use token default values to provide a fallback value for entities that are missing a specified token attribute.
+Use token default values to provide a fallback value for entities that are missing a specified token attribute.
 
 For example, `{{.labels.url | default "https://sensu.io"}}` would be replaced with a custom label called `url`.
 If no such attribute called `url` is included in the entity definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.

--- a/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
@@ -16,7 +16,7 @@ menu:
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.
 Use RBAC rules to achieve **multitenancy** so different projects and teams can share a Sensu instance. 
 
-Sensu RBAC helps different teams and projects share a Sensu instance.
+Sensu RBAC helps different teams and projects share a Sensu instance.
 RBAC allows you to manage users and their access to resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -2309,7 +2309,11 @@ spec:
 {{< /language-toggle >}}
 
 Create as many rules as you need in the role or cluster role.
-In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+For example, you can configure a role or cluster role that includes one rule for each verb, with each rule listing only the resources that verb should apply to.
+
+Here's another example that includes three rules.
+Each rule specifies different access permissions for the resource types listed in the rule.
+In addition, the user group would have no access at all for the two resources that are not listed: API keys and licences.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -12,7 +12,7 @@ menu:
     parent: control-access
 ---
 
-Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
 - **Roles** create sets of permissions (for example, get and delete) tied to resource types.
@@ -45,6 +45,7 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `handlers` | [Handler][9] resources within a namespace |
 | `hooks` | [Hook][10] resources within a namespace |
 | `mutators` | [Mutator][11] resources within a namespace |
+| `pipelines` | Resources composed of [event processing workflows][52] |
 | `rolebindings` | Namespace-specific role assigners |
 | `roles` | Namespace-specific permission sets |
 | `rule-templates` | [Resources applied to service components][38] for business service monitoring |
@@ -52,6 +53,8 @@ You can access namespaced resources by [roles and cluster roles][13].
 | `secrets` |[Secrets][48] (for example, username or password) |
 | `service-components` | Resources that represent [elements in a business service][36] |
 | `silenced` | [Silencing][14] resources within a namespace |
+| `sumo-logic-metrics-handlers` | Persistent handlers for [transmitting metrics to Sumo Logic][43] |
+| `tcp-stream-handlers` | Persistent handlers for [sending events to TCP sockets][44] for remote storage |
 
 ### Cluster-wide resource types
 
@@ -105,7 +108,7 @@ spec:
   groups:
   - ops
   - dev
-  password: USER_PASSWORD
+  password: user_password
   password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
   username: alice
 {{< /code >}}
@@ -117,7 +120,7 @@ spec:
   "metadata": {},
   "spec": {
     "username": "alice",
-    "password": "USER_PASSWORD",
+    "password": "user_password",
     "password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm",
     "disabled": false,
     "groups": ["ops", "dev"]
@@ -274,11 +277,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-password: USER_PASSWORD
+password: user_password
 {{< /code >}}
 {{< code json >}}
 {
-  "password": "USER_PASSWORD"
+  "password": "user_password"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -423,8 +426,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -455,12 +457,26 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -499,8 +515,7 @@ metadata:
   name: all-resources-all-verbs
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -537,14 +552,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -575,13 +609,13 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
+| `system:pipeline` | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
 | `cluster-admin` | `ClusterRole` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `admin`         | `ClusterRole` | Full access to all [resource types][4]. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `edit`          | `ClusterRole` | Read and write access to most resources except roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `view`          | `ClusterRole` | Read-only permission to most [resource types][4] with the exception of roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `system:agent`  | `ClusterRole` | Used internally by Sensu agents. You can configure an agent's user credentials using the [`user` and `password` agent configuration flags][41]. |
-| `system:user`  | `ClusterRole` | Get and update permissions for local resources for the current user. |
+| `system:user`   | `ClusterRole` | Get and update permissions for local resources for the current user. |
 
 ### Manage roles and cluster roles
 
@@ -632,7 +666,7 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
-This command creates the following role resource definition:
+This command creates the following role resource definition, which provides get, list, create, update, and delete permissions for all resources in the production namespace:
 
 {{< language-toggle >}}
 
@@ -646,8 +680,7 @@ metadata:
   namespace: production
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - '*'
     verbs:
     - get
@@ -669,7 +702,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "*"
         ],
@@ -764,8 +796,7 @@ metadata:
   name: global-event-reader
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - events
     verbs:
     - get
@@ -783,7 +814,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "events"
         ],
@@ -1087,7 +1117,7 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
+| `system:pipeline` | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
 | `cluster-admin` | `ClusterRoleBinding` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `system:agent` | `ClusterRoleBinding` | Full access to all events. Used internally by Sensu agents. |
 | `system:user` | `ClusterRoleBinding` | Get and update permissions for local resources for the current user. |
@@ -1450,21 +1480,20 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
-    - checks
-    - hooks
-    - filters
-    - events
-    - filters
-    - mutators
-    - handlers
-    verbs:
-    - get
-    - list
-    - create
-    - update
-    - delete
+    - resources:
+      - checks
+      - hooks
+      - filters
+      - events
+      - filters
+      - mutators
+      - handlers
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
 {{< /code >}}
 
 {{< code json >}}
@@ -1478,9 +1507,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1547,8 +1589,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - checks
     - hooks
     - filters
@@ -1575,9 +1616,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1650,6 +1704,7 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
 {{< /code >}}
 
 {{< code json >}}
@@ -1659,7 +1714,8 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password"
   }
 }
 {{< /code >}}
@@ -1677,8 +1733,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1710,12 +1765,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1788,6 +1858,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
+  groups:
+  - ops
 {{< /code >}}
 
 {{< code json >}}
@@ -1797,7 +1870,11 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1815,8 +1892,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1848,12 +1924,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1930,9 +2021,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
   groups:
   - ops
-
 {{< /code >}}
 
 {{< code json >}}
@@ -1943,7 +2034,10 @@ spec:
   "spec": {
     "disabled": false,
     "username": "alice",
-    "groups": ["ops"]
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1960,8 +2054,7 @@ metadata:
   name: default-admin
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1998,14 +2091,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -2041,6 +2153,354 @@ spec:
   "spec": {
     "role_ref": {
       "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign different permissions for different resource types
+
+You can assign different permissions for different resource types in a role or cluster role definition.
+To do this, you'll still create at least one user assigned to a group, a role or cluster role, and a role binding or cluster role binding.
+However, in this case, the role or cluster role will include more than one rule.
+
+For example, you may want users in a testing group to be able to get and list all resource types but create, update, and delete only silenced entries across all namespaces.
+Create a user `alice` assigned to the group `ops_testing`, a cluster role `manage_silences` with two rules (one for all resources and one just for silences), and a cluster role binding `ops_testing_manage_silences`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops_testing
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops_testing"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: manage_silences
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - '*'
+  - verbs:
+    - create
+    - update
+    - delete
+    resources:
+    - silenced
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "manage_silences"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "*"
+        ]
+      },
+      {
+        "verbs": [
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "silenced"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_testing_manage_silences
+spec:
+  role_ref:
+    name: manage_silences
+    type: ClusterRole
+  subjects:
+  - name: ops_testing
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_testing_manage_silences"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "manage_silences",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops_testing",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Create as many rules as you need in the role or cluster role.
+In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: ops_access
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - entities
+    - events
+    - rolebindings
+    - roles
+    - clusterrolebindings
+    - clusterroles
+    - config
+    - users
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    resources:
+    - assets
+    - checks
+    - filters
+    - handlers
+    - hooks
+    - mutators
+    - pipelines
+    - rule-templates
+    - searches
+    - secrets
+    - service-components
+    - silenced
+    - sumo-logic-metrics-handlers
+    - tcp-stream-handlers
+    - clusters
+    - etcd-replicators
+    - providers
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    resources:
+    - authproviders
+    - namespaces
+    - provider
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "entities",
+          "events",
+          "rolebindings",
+          "roles",
+          "clusterrolebindings",
+          "clusterroles",
+          "config",
+          "users"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rule-templates",
+          "searches",
+          "secrets",
+          "service-components",
+          "silenced",
+          "sumo-logic-metrics-handlers",
+          "tcp-stream-handlers",
+          "clusters",
+          "etcd-replicators",
+          "providers"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update"
+        ],
+        "resources": [
+          "authproviders",
+          "namespaces",
+          "provider"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_access_assignment
+spec:
+  role_ref:
+    name: ops_access
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access_assignment"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "ops_access",
       "type": "ClusterRole"
     },
     "subjects": [
@@ -2122,8 +2582,7 @@ metadata:
   name: silencing-script
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - silenced
     verbs:
     - get
@@ -2143,7 +2602,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "silenced"
         ],
@@ -2256,6 +2714,8 @@ spec:
 [40]: ../../deploy-sensu/etcdreplicators/
 [41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
+[43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
+[44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
 [45]: ../../../sensuctl/#change-admin-users-password
 [46]: ../../manage-secrets/secrets-providers/
 [47]: ../../deploy-sensu/datastore/
@@ -2263,3 +2723,4 @@ spec:
 [49]: ../../../web-ui/search/#save-a-search
 [50]: ../../../sensuctl/#reset-a-user-password
 [51]: ../../../sensuctl/#generate-a-password-hash
+[52]: ../../../observability-pipeline/observe-process/pipelines/

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -330,7 +330,7 @@ Subjects:
 ## Register clusters
 
 Clusters must be registered to become visible in the web UI.
-Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
+Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
 
 {{% notice note %}}
 **NOTE**: Individual cluster resources may list the API URLs for a single stand-alone backend or multiple backends that are members of the same etcd cluster.

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets.md
@@ -237,7 +237,7 @@ name: sensu-ansible-token
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][9] that the secret belongs to.
+description  | [Sensu RBAC namespace][9] that the secret belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -805,7 +805,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -858,7 +858,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -899,7 +899,7 @@ require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
 ------------------|------
-description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description       | Path to the primary backend CA file. Specifies a fallback SSL/TLS certificate authority in PEM format used for etcd client (mutual TLS) communication if the `etcd-trusted-ca-file` is not used. This CA file is used in communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type              | String
 default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
@@ -447,7 +447,7 @@ name: status-threshold
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
@@ -255,7 +255,7 @@ name: postgresql-1
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -301,7 +301,7 @@ Access nested Sensu [entity attributes][3] with dot notation (for example, `syst
 
 If an attribute is not provided by the [entity][3], a token's default value will be substituted.
 Token default values are separated by a pipe character and the word "default" (`| default`).
-Use token default values to provide a fallback value for entities that are missing a specified token attribute.
+Use token default values to provide a fallback value for entities that are missing a specified token attribute.
 
 For example, `{{.labels.url | default "https://sensu.io"}}` would be replaced with a custom label called `url`.
 If no such attribute called `url` is included in the entity definition, the default (or fallback) value of `https://sensu.io` will be used to substitute the token.

--- a/content/sensu-go/6.5/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.5/operations/control-access/create-read-only-user.md
@@ -16,7 +16,7 @@ menu:
 Role-based access control (RBAC) allows you to exercise fine-grained control over how Sensu users interact with Sensu resources.
 Use RBAC rules to achieve **multitenancy** so different projects and teams can share a Sensu instance. 
 
-Sensu RBAC helps different teams and projects share a Sensu instance.
+Sensu RBAC helps different teams and projects share a Sensu instance.
 RBAC allows you to manage users and their access to resources based on **namespaces**, **groups**, **roles**, and **bindings**.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including RBAC resources like users and roles.

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -12,7 +12,7 @@ menu:
     parent: control-access
 ---
 
-Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
+Sensu's role-based access control (RBAC) helps different teams and projects share a Sensu instance.
 RBAC allows you to specify actions users are allowed to take against resources, within [namespaces][12] or across all namespaces, based on roles bound to the user or to one or more groups the user is a member of.
 
 - **Roles** create sets of permissions (for example, get and delete) tied to resource types.
@@ -108,7 +108,7 @@ spec:
   groups:
   - ops
   - dev
-  password: USER_PASSWORD
+  password: user_password
   password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
   username: alice
 {{< /code >}}
@@ -120,7 +120,7 @@ spec:
   "metadata": {},
   "spec": {
     "username": "alice",
-    "password": "USER_PASSWORD",
+    "password": "user_password",
     "password_hash": "$5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm",
     "disabled": false,
     "groups": ["ops", "dev"]
@@ -277,11 +277,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-password: USER_PASSWORD
+password: user_password
 {{< /code >}}
 {{< code json >}}
 {
-  "password": "USER_PASSWORD"
+  "password": "user_password"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -426,8 +426,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -458,12 +457,26 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -502,8 +515,7 @@ metadata:
   name: all-resources-all-verbs
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -540,14 +552,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -578,13 +609,13 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
+| `system:pipeline` | `Role` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be assigned to Sensu users. |
 | `cluster-admin` | `ClusterRole` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `admin`         | `ClusterRole` | Full access to all [resource types][4]. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `edit`          | `ClusterRole` | Read and write access to most resources except roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `view`          | `ClusterRole` | Read-only permission to most [resource types][4] with the exception of roles and role bindings. You can apply this cluster role within a namespace by using a role binding (not a cluster role binding). |
 | `system:agent`  | `ClusterRole` | Used internally by Sensu agents. You can configure an agent's user credentials using the [`user` and `password` agent configuration flags][41]. |
-| `system:user`  | `ClusterRole` | Get and update permissions for local resources for the current user. |
+| `system:user`   | `ClusterRole` | Get and update permissions for local resources for the current user. |
 
 ### Manage roles and cluster roles
 
@@ -635,7 +666,7 @@ For example, the following command creates an admin role restricted to the produ
 sensuctl role create prod-admin --verb='get,list,create,update,delete' --resource='*' --namespace production
 {{< /code >}}
 
-This command creates the following role resource definition:
+This command creates the following role resource definition, which provides get, list, create, update, and delete permissions for all resources in the production namespace:
 
 {{< language-toggle >}}
 
@@ -649,8 +680,7 @@ metadata:
   namespace: production
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - '*'
     verbs:
     - get
@@ -672,7 +702,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "*"
         ],
@@ -767,8 +796,7 @@ metadata:
   name: global-event-reader
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - events
     verbs:
     - get
@@ -786,7 +814,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "events"
         ],
@@ -1090,7 +1117,7 @@ Every [Sensu backend][1] includes:
 
 | role name       | type          | description |
 | --------------- | ------------- | ----------- |
-| `system:pipeline`  | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
+| `system:pipeline` | `RoleBinding` | Facility that allows the EventFilter engine to load events from Sensu's event store. `system:pipeline` is an implementation detail and should not be applied to Sensu users. |
 | `cluster-admin` | `ClusterRoleBinding` | Full access to all [resource types][4] across namespaces, including access to [cluster-wide resource types][18]. |
 | `system:agent` | `ClusterRoleBinding` | Full access to all events. Used internally by Sensu agents. |
 | `system:user` | `ClusterRoleBinding` | Get and update permissions for local resources for the current user. |
@@ -1453,21 +1480,20 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
-    - checks
-    - hooks
-    - filters
-    - events
-    - filters
-    - mutators
-    - handlers
-    verbs:
-    - get
-    - list
-    - create
-    - update
-    - delete
+    - resources:
+      - checks
+      - hooks
+      - filters
+      - events
+      - filters
+      - mutators
+      - handlers
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
 {{< /code >}}
 
 {{< code json >}}
@@ -1481,9 +1507,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1550,8 +1589,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - checks
     - hooks
     - filters
@@ -1578,9 +1616,22 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
-        "resources": ["checks", "hooks", "filters", "events", "filters", "mutators", "handlers"],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "resources": [
+          "checks",
+          "hooks",
+          "filters",
+          "events",
+          "filters",
+          "mutators",
+          "handlers"
+        ],
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1653,6 +1704,7 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
 {{< /code >}}
 
 {{< code json >}}
@@ -1662,7 +1714,8 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password"
   }
 }
 {{< /code >}}
@@ -1680,8 +1733,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1713,12 +1765,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1791,6 +1858,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
+  groups:
+  - ops
 {{< /code >}}
 
 {{< code json >}}
@@ -1800,7 +1870,11 @@ spec:
   "metadata": {},
   "spec": {
     "disabled": false,
-    "username": "alice"
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1818,8 +1892,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -1851,12 +1924,27 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "searches", "silenced"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "searches",
+          "silenced"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -1933,9 +2021,9 @@ metadata: {}
 spec:
   disabled: false
   username: alice
+  password: user_password
   groups:
   - ops
-
 {{< /code >}}
 
 {{< code json >}}
@@ -1946,7 +2034,10 @@ spec:
   "spec": {
     "disabled": false,
     "username": "alice",
-    "groups": ["ops"]
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
   }
 }
 {{< /code >}}
@@ -1963,8 +2054,7 @@ metadata:
   name: default-admin
 spec:
   rules:
-  - resource_names: []
-    resources:
+  - resources:
     - assets
     - checks
     - entities
@@ -2001,14 +2091,33 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": [],
         "resources": [
-          "assets", "checks", "entities", "events", "filters", "handlers",
-          "hooks", "mutators", "rolebindings", "roles", "silenced",
-          "cluster", "clusterrolebindings", "clusterroles",
-          "namespaces", "users", "authproviders", "license"
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "rolebindings",
+          "roles",
+          "silenced",
+          "cluster",
+          "clusterrolebindings",
+          "clusterroles",
+          "namespaces",
+          "users",
+          "authproviders",
+          "license"
         ],
-        "verbs": ["get", "list", "create", "update", "delete"]
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ]
       }
     ]
   }
@@ -2044,6 +2153,354 @@ spec:
   "spec": {
     "role_ref": {
       "name": "default-admin",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Assign different permissions for different resource types
+
+You can assign different permissions for different resource types in a role or cluster role definition.
+To do this, you'll still create at least one user assigned to a group, a role or cluster role, and a role binding or cluster role binding.
+However, in this case, the role or cluster role will include more than one rule.
+
+For example, you may want users in a testing group to be able to get and list all resource types but create, update, and delete only silenced entries across all namespaces.
+Create a user `alice` assigned to the group `ops_testing`, a cluster role `manage_silences` with two rules (one for all resources and one just for silences), and a cluster role binding `ops_testing_manage_silences`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops_testing
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops_testing"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: manage_silences
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - '*'
+  - verbs:
+    - create
+    - update
+    - delete
+    resources:
+    - silenced
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "manage_silences"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "*"
+        ]
+      },
+      {
+        "verbs": [
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "silenced"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_testing_manage_silences
+spec:
+  role_ref:
+    name: manage_silences
+    type: ClusterRole
+  subjects:
+  - name: ops_testing
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_testing_manage_silences"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "manage_silences",
+      "type": "ClusterRole"
+    },
+    "subjects": [
+      {
+        "name": "ops_testing",
+        "type": "Group"
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Create as many rules as you need in the role or cluster role.
+In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: User
+api_version: core/v2
+metadata: {}
+spec:
+  disabled: false
+  username: alice
+  password: user_password
+  groups:
+  - ops
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "User",
+  "api_version": "core/v2",
+  "metadata": {},
+  "spec": {
+    "disabled": false,
+    "username": "alice",
+    "password": "user_password",
+    "groups": [
+      "ops"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRole
+api_version: core/v2
+metadata:
+  name: ops_access
+spec:
+  rules:
+  - verbs:
+    - get
+    - list
+    resources:
+    - entities
+    - events
+    - rolebindings
+    - roles
+    - clusterrolebindings
+    - clusterroles
+    - config
+    - users
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    resources:
+    - assets
+    - checks
+    - filters
+    - handlers
+    - hooks
+    - mutators
+    - pipelines
+    - rule-templates
+    - searches
+    - secrets
+    - service-components
+    - silenced
+    - sumo-logic-metrics-handlers
+    - tcp-stream-handlers
+    - clusters
+    - etcd-replicators
+    - providers
+  - verbs:
+    - get
+    - list
+    - create
+    - update
+    resources:
+    - authproviders
+    - namespaces
+    - provider
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRole",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access"
+  },
+  "spec": {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "entities",
+          "events",
+          "rolebindings",
+          "roles",
+          "clusterrolebindings",
+          "clusterroles",
+          "config",
+          "users"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rule-templates",
+          "searches",
+          "secrets",
+          "service-components",
+          "silenced",
+          "sumo-logic-metrics-handlers",
+          "tcp-stream-handlers",
+          "clusters",
+          "etcd-replicators",
+          "providers"
+        ]
+      },
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update"
+        ],
+        "resources": [
+          "authproviders",
+          "namespaces",
+          "provider"
+        ]
+      }
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: ClusterRoleBinding
+api_version: core/v2
+metadata:
+  name: ops_access_assignment
+spec:
+  role_ref:
+    name: ops_access
+    type: ClusterRole
+  subjects:
+  - name: ops
+    type: Group
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "ClusterRoleBinding",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "ops_access_assignment"
+  },
+  "spec": {
+    "role_ref": {
+      "name": "ops_access",
       "type": "ClusterRole"
     },
     "subjects": [
@@ -2125,8 +2582,7 @@ metadata:
   name: silencing-script
 spec:
   rules:
-  - resource_names: null
-    resources:
+  - resources:
     - silenced
     verbs:
     - get
@@ -2146,7 +2602,6 @@ spec:
   "spec": {
     "rules": [
       {
-        "resource_names": null,
         "resources": [
           "silenced"
         ],

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -2309,7 +2309,11 @@ spec:
 {{< /language-toggle >}}
 
 Create as many rules as you need in the role or cluster role.
-In this example, all users in the `ops` group would have different permissions for three sets of resource types, as well as no access at all for the two resources that are not listed: API keys and licences.
+For example, you can configure a role or cluster role that includes one rule for each verb, with each rule listing only the resources that verb should apply to.
+
+Here's another example that includes three rules.
+Each rule specifies different access permissions for the resource types listed in the rule.
+In addition, the user group would have no access at all for the two resources that are not listed: API keys and licences.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -330,7 +330,7 @@ Subjects:
 ## Register clusters
 
 Clusters must be registered to become visible in the web UI.
-Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
+Each registered cluster must have a name and a list of one or more cluster member URLs corresponding to the backend REST API.
 
 {{% notice note %}}
 **NOTE**: Individual cluster resources may list the API URLs for a single stand-alone backend or multiple backends that are members of the same etcd cluster.

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets.md
@@ -237,7 +237,7 @@ name: sensu-ansible-token
 
 namespace    |      |
 -------------|------
-description  | [Sensu RBAC namespace][9] that the secret belongs to.
+description  | [Sensu RBAC namespace][9] that the secret belongs to.
 required     | true
 type         | String
 example      | {{< language-toggle >}}


### PR DESCRIPTION
## Description
Adds RBAC examples showing how to configure roles and cluster roles that provide different permissions for different resources.

Also removes an odd character, `<0xa0>`, that was inserted in some docs in place of a regular space.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3410