### PR TITLE
Fix broken links at the top of the pipelines reference

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -17,7 +17,7 @@ menu:
 **IMPORTANT**: The pipeline resources described on this page are different from the handler resources you can create with the [pipeline API](../../../api/pipeline/).<br><br>
 The [pipeline API](../../../api/pipeline/) does not create pipeline resources.
 Instead, it allows you to create handlers that can **only** be used in pipeline resources.
-Read the [Sumo Logic metrics handlers reference](../../observability-pipeline/observe-process/sumo-logic-metrics-handlers) and [TCP stream handlers reference](../../observability-pipeline/observe-process/tcp-stream-handlers) for more information.
+Read the [Sumo Logic metrics handlers reference](../sumo-logic-metrics-handlers) and [TCP stream handlers reference](../tcp-stream-handlers) for more information.
 {{% /notice %}}
 
 Sensu executes pipelines during the **[process][22]** stage of the [observability pipeline][29].


### PR DESCRIPTION
## Description
Fixes two broken links to streaming handlers reference pages in the note at the top of the pipelines reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3424
