### PR TITLE
Add handler and check examples using env vars in backend and agent references

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -1700,12 +1700,13 @@ sudo touch /etc/sysconfig/sensu-agent
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables that control Sensu agent configuration begin with `SENSU_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the flag `api-host` is `SENSU_API_HOST`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
 
@@ -1744,7 +1745,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 #### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the `SENSU_LABELS` and `SENSU_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
@@ -1779,7 +1780,56 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file, it will be available to use in your check configurations as `$SENSU_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check configurations as `$TEST_VARIABLE`.
+The following check will print the `TEST_VARIABLE` value set in your sensu-agent file in `/tmp/test.txt` if the first command (`check-cpu-usage -w 75 -c 90`) is executed successfully:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check_cpu
+  namespace: default
+spec:
+  command: check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt
+  handlers:
+  - slack
+  interval: 10
+  publish: true
+  subscriptions:
+  - system
+  runtime_assets:
+  - check-cpu-usage
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "handlers": [
+      "slack"
+    ],
+    "interval": 10,
+    "publish": true,
+    "subscriptions": [
+      "system"
+    ],
+    "runtime_assets": [
+      "check-cpu-usage"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Use environment variables to specify an HTTP proxy for agent use
 

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -1294,12 +1294,13 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
+All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
+     For example, the environment variable for the configuration flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1338,18 +1339,18 @@ They are listed in the [configuration flag description tables](#general-configur
 
 ### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the `SENSU_BACKEND_LABELS` and `SENSU_BACKEND_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the label and annotation environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1359,11 +1360,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1372,7 +1373,48 @@ echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https:
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_BACKEND_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
+The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Handler
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: print_test_var
+  namespace: default
+spec:
+  command: echo $TEST_VARIABLE >> ./tmp/test.txt
+  timeout: 0
+  type: pipe
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "print_test_var",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "timeout": 0,
+    "type": "pipe"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: We recommend using secrets with the `Env` provider to expose secrets from environment variables on your Sensu backend nodes rather than using environment variables directly in your handler commands.
+Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
+{{% /notice %}}
 
 ## Event logging
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -1697,12 +1697,13 @@ sudo touch /etc/sysconfig/sensu-agent
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables that control Sensu agent configuration begin with `SENSU_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the flag `api-host` is `SENSU_API_HOST`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
 
@@ -1741,7 +1742,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 #### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the `SENSU_LABELS` and `SENSU_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
@@ -1776,7 +1777,56 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file, it will be available to use in your check configurations as `$SENSU_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check configurations as `$TEST_VARIABLE`.
+The following check will print the `TEST_VARIABLE` value set in your sensu-agent file in `/tmp/test.txt` if the first command (`check-cpu-usage -w 75 -c 90`) is executed successfully:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check_cpu
+  namespace: default
+spec:
+  command: check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt
+  handlers:
+  - slack
+  interval: 10
+  publish: true
+  subscriptions:
+  - system
+  runtime_assets:
+  - check-cpu-usage
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "handlers": [
+      "slack"
+    ],
+    "interval": 10,
+    "publish": true,
+    "subscriptions": [
+      "system"
+    ],
+    "runtime_assets": [
+      "check-cpu-usage"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Use environment variables to specify an HTTP proxy for agent use
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1321,12 +1321,13 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
+All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
+     For example, the environment variable for the configuration flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1365,18 +1366,18 @@ They are listed in the [configuration flag description tables](#general-configur
 
 ### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the `SENSU_BACKEND_LABELS` and `SENSU_BACKEND_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the label and annotation environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1386,11 +1387,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1399,7 +1400,48 @@ echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https:
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_BACKEND_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
+The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Handler
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: print_test_var
+  namespace: default
+spec:
+  command: echo $TEST_VARIABLE >> ./tmp/test.txt
+  timeout: 0
+  type: pipe
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "print_test_var",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "timeout": 0,
+    "type": "pipe"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: We recommend using secrets with the `Env` provider to expose secrets from environment variables on your Sensu backend nodes rather than using environment variables directly in your handler commands.
+Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
+{{% /notice %}}
 
 ## Event logging
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1697,12 +1697,13 @@ sudo touch /etc/sysconfig/sensu-agent
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables that control Sensu agent configuration begin with `SENSU_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the flag `api-host` is `SENSU_API_HOST`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
 
@@ -1741,7 +1742,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 #### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the `SENSU_LABELS` and `SENSU_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
@@ -1776,7 +1777,56 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file, it will be available to use in your check configurations as `$SENSU_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check configurations as `$TEST_VARIABLE`.
+The following check will print the `TEST_VARIABLE` value set in your sensu-agent file in `/tmp/test.txt` if the first command (`check-cpu-usage -w 75 -c 90`) is executed successfully:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check_cpu
+  namespace: default
+spec:
+  command: check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt
+  handlers:
+  - slack
+  interval: 10
+  publish: true
+  subscriptions:
+  - system
+  runtime_assets:
+  - check-cpu-usage
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "handlers": [
+      "slack"
+    ],
+    "interval": 10,
+    "publish": true,
+    "subscriptions": [
+      "system"
+    ],
+    "runtime_assets": [
+      "check-cpu-usage"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Use environment variables to specify an HTTP proxy for agent use
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1370,12 +1370,13 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
+All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
+     For example, the environment variable for the configuration flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1414,18 +1415,18 @@ They are listed in the [configuration flag description tables](#general-configur
 
 ### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the `SENSU_BACKEND_LABELS` and `SENSU_BACKEND_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the label and annotation environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1435,11 +1436,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1448,7 +1449,48 @@ echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https:
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_BACKEND_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
+The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Handler
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: print_test_var
+  namespace: default
+spec:
+  command: echo $TEST_VARIABLE >> ./tmp/test.txt
+  timeout: 0
+  type: pipe
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "print_test_var",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "timeout": 0,
+    "type": "pipe"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: We recommend using secrets with the `Env` provider to expose secrets from environment variables on your Sensu backend nodes rather than using environment variables directly in your handler commands.
+Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
+{{% /notice %}}
 
 ## Create overrides
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1741,12 +1741,13 @@ sudo touch /etc/sysconfig/sensu-agent
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu configuration begin with `SENSU_`.
+All environment variables that control Sensu agent configuration begin with `SENSU_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the flag `api-host` is `SENSU_API_HOST`.
 
-     For a custom test variable, the environment variable name might be `SENSU_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
 
@@ -1785,7 +1786,7 @@ They are listed in the [configuration flag description tables](#general-configur
 
 #### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the `SENSU_LABELS` and `SENSU_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your check and plugin configurations, you must use a specific format when you create the environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
@@ -1820,7 +1821,56 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
-For example, if you create a `SENSU_TEST_VAR` variable in your sensu-agent file, it will be available to use in your check configurations as `$SENSU_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check configurations as `$TEST_VARIABLE`.
+The following check will print the `TEST_VARIABLE` value set in your sensu-agent file in `/tmp/test.txt` if the first command (`check-cpu-usage -w 75 -c 90`) is executed successfully:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: check_cpu
+  namespace: default
+spec:
+  command: check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt
+  handlers:
+  - slack
+  interval: 10
+  publish: true
+  subscriptions:
+  - system
+  runtime_assets:
+  - check-cpu-usage
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "CheckConfig",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "check_cpu",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "check-cpu-usage -w 75 -c 90 && echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "handlers": [
+      "slack"
+    ],
+    "interval": 10,
+    "publish": true,
+    "subscriptions": [
+      "system"
+    ],
+    "runtime_assets": [
+      "check-cpu-usage"
+    ]
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Use environment variables to specify an HTTP proxy for agent use
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1475,12 +1475,13 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables controlling Sensu backend configuration begin with `SENSU_BACKEND_`.
+All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
      To rename a configuration flag you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
-     For example, the environment variable for the flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
+     For example, the environment variable for the configuration flag `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom test variable, the environment variable name might be `SENSU_BACKEND_TEST_VAR`.
+     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+     For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
 
@@ -1519,18 +1520,18 @@ They are listed in the [configuration flag description tables](#general-configur
 
 ### Format for label and annotation environment variables
 
-To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the `SENSU_BACKEND_LABELS` and `SENSU_BACKEND_ANNOTATIONS` environment variables.
+To use labels and annotations as environment variables in your handler configurations, you must use a specific format when you create the label and annotation environment variables.
 
 For example, to create the labels `"region": "us-east-1"` and `"type": "website"` as an environment variable:
 
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1540,11 +1541,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 {{< language-toggle >}}
 
 {{< code shell "Ubuntu/Debian" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
-echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
+echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -1553,7 +1554,48 @@ echo 'SENSU_BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https:
 
 Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
 
-For example, if you create a `SENSU_BACKEND_TEST_VAR` variable in your sensu-backend file, it will be available to use in your handler configurations as `$SENSU_BACKEND_TEST_VAR`.
+For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
+The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
+
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+type: Handler
+api_version: core/v2
+metadata:
+  created_by: admin
+  name: print_test_var
+  namespace: default
+spec:
+  command: echo $TEST_VARIABLE >> ./tmp/test.txt
+  timeout: 0
+  type: pipe
+{{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Handler",
+  "api_version": "core/v2",
+  "metadata": {
+    "created_by": "admin",
+    "name": "print_test_var",
+    "namespace": "default"
+  },
+  "spec": {
+    "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",
+    "timeout": 0,
+    "type": "pipe"
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: We recommend using secrets with the `Env` provider to expose secrets from environment variables on your Sensu backend nodes rather than using environment variables directly in your handler commands.
+Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
+{{% /notice %}}
 
 ## Create overrides
 


### PR DESCRIPTION
## Description
In the agent and backend references:
- Corrects naming convention requirements for custom environment variables.
- Adds an example check (agent) and handler (backend) with commands that include a custom environment variable.

In the backend reference, adds a note to recommend using secrets to expose custom env vars rather than using them directly in commands.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3405
