### PR TITLE
Fix URL error in Sensu Plus example

### DIFF
--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -83,7 +83,7 @@ metadata:
   name: sumologic_http_log_metrics
   namespace: default
 spec:
-  url: "https://https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx"
+  url: "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx"
   max_connections: 10
   timeout: 10s
 {{< /code >}}
@@ -97,7 +97,7 @@ spec:
     "namespace": "default"
   },
   "spec": {
-    "url": "https://https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx",
+    "url": "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx",
     "max_connections": 10,
     "timeout": "10s"
   }


### PR DESCRIPTION
## Description
Fixes `https://https://` in Sensu Plus handler example at https://docs.sensu.io/sensu-go/latest/sensu-plus/#create-a-handler-in-sensu

## Motivation and Context
h/t @mgibson323 
