### PR TITLE
Add note about mutator type in mutator spec

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -565,7 +565,8 @@ eval: 'return JSON.stringify({"some stuff": "is here"});'
 
 type         | 
 -------------|------ 
-description  | Mutator type. 
+description  | Mutator type.{{% notice note %}}**NOTE**: Make sure to specify the type is `javascript` when you create a JavaScript mutator. If you do not specify the type, Sensu uses `pipe` as the default, expects a command attribute in the mutator definition, and ignores any eval attribute you provide.
+{{% /notice %}}
 required     | false
 type         | String
 default      | `pipe`


### PR DESCRIPTION
## Description
Adds a note about specifying the mutator type if creating a JavaScript mutator.

## Motivation and Context
https://sumologic.slack.com/archives/C024XK35Z3Q/p1634915300067900
