### PR TITLE
Fix a capitalization error in InfluxDB guide

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -276,7 +276,7 @@ sensu-agent start --statsd-event-handlers influx-db
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled, metrics should start populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
-read [Troubleshoot Sensu][8] for log locations by platform.
+Read [Troubleshoot Sensu][8] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -276,7 +276,7 @@ sensu-agent start --statsd-event-handlers influx-db
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled, metrics should start populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
-read [Troubleshoot Sensu][8] for log locations by platform.
+Read [Troubleshoot Sensu][8] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -276,7 +276,7 @@ sensu-agent start --statsd-event-handlers influx-db
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled, metrics should start populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
-read [Troubleshoot Sensu][8] for log locations by platform.
+Read [Troubleshoot Sensu][8] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -284,7 +284,7 @@ sensu-agent start --statsd-event-handlers influx-db
 
 It might take a few moments after you assign the handler to the check or StatsD server for Sensu to receive the metrics, but after an event is handled, metrics should start populating InfluxDB.
 You can verify proper handler behavior with `sensu-backend` logs.
-read [Troubleshoot Sensu][8] for log locations by platform.
+Read [Troubleshoot Sensu][8] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"influx-db","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"pipelined executed event pipe
 handler","output":"","status":0`.


### PR DESCRIPTION
Fixes a capitalization typo in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/populate-metrics-influxdb/#validate-the-influxdb-handler