### PR TITLE
Add instructions for finding license expiration information

### DIFF
--- a/content/sensu-go/6.4/commercial.md
+++ b/content/sensu-go/6.4/commercial.md
@@ -82,6 +82,8 @@ Use sensuctl to view your license details at any time:
 sensuctl license info
 {{< /code >}}
 
+Users with permission to create or update licenses can also view license information in the Sensu [web UI][8] by pressing `CTRL .` to open the system information modal.
+
 These resources will help you get started with commercial features in Sensu Go:
 
 - [Set up and manage authentication providers][9]

--- a/content/sensu-go/6.4/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/license.md
@@ -189,7 +189,9 @@ Sensu-Entity-Limit: 100
 
 To view your commercial license expiration date, [log in to your Sensu account][1].
 
-If your license is within 30 days of expiration, Sensu issues regular warnings in the Sensu [backend logs][6].
+When your license is within 30 days of expiration, Sensu issues regular warnings in the Sensu [backend logs][6].
+Users with permission to create or update licenses can also view license expiration information in the web UI by pressing `CTRL .` to open the system information modal.
+
 If your license expires, you will still have access to [commercial features][5], but your entity limit will drop back down to the free limit of 100.
 
 ## Quick links

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -150,7 +150,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][215]) In the web UI, the system information modal now includes license expiration information, accessed via the `CTRL + .` keyboard shortcut, for users with the appropriate permissions.
+- ([Commercial feature][215]) In the web UI, the system information modal now includes license expiration information, accessed via the `CTRL .` keyboard shortcut, for users with the appropriate permissions.
 - ([Commercial feature][215]) Added [page-specific configuration][221] options and a custom [sign-in message attribute][220] for the web UI.
 - Added binary-only distribution for [macOS arm64][216].
 

--- a/content/sensu-go/6.4/web-ui/_index.md
+++ b/content/sensu-go/6.4/web-ui/_index.md
@@ -43,6 +43,11 @@ The access and refresh tokens are saved in your browser's local storage.
 The web UI complies with Sensu role-based access control (RBAC), so individual users can view information according to their access configurations.
 Read the [RBAC reference][3] for [default user credentials][4] and instructions for [creating new users][5].
 
+## View system information
+
+Press `CTRL .` in the web UI to open the system information modal and view information about your Sensu backend and etcd or PostgreSQL datastore.
+For users with permission to create or update licenses, the system information modal includes license expiration information.
+
 ## Use the implicit OR operator
 
 {{% notice commercial %}}

--- a/content/sensu-go/6.5/commercial.md
+++ b/content/sensu-go/6.5/commercial.md
@@ -83,6 +83,8 @@ Use sensuctl to view your license details at any time:
 sensuctl license info
 {{< /code >}}
 
+Users with permission to create or update licenses can also view license information in the Sensu [web UI][8] by pressing `CTRL .` to open the system information modal.
+
 These resources will help you get started with commercial features in Sensu Go:
 
 - [Set up and manage authentication providers][9]

--- a/content/sensu-go/6.5/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/license.md
@@ -189,7 +189,9 @@ Sensu-Entity-Limit: 100
 
 To view your commercial license expiration date, [log in to your Sensu account][1].
 
-If your license is within 30 days of expiration, Sensu issues regular warnings in the Sensu [backend logs][6].
+When your license is within 30 days of expiration, Sensu issues regular warnings in the Sensu [backend logs][6].
+Users with permission to create or update licenses can also view license expiration information in the web UI by pressing `CTRL .` to open the system information modal.
+
 If your license expires, you will still have access to [commercial features][5], but your entity limit will drop back down to the free limit of 100.
 
 ## Quick links

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -218,7 +218,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][215]) In the web UI, the system information modal now includes license expiration information, accessed via the `CTRL + .` keyboard shortcut, for users with the appropriate permissions.
+- ([Commercial feature][215]) In the web UI, the system information modal now includes license expiration information, accessed via the `CTRL .` keyboard shortcut, for users with the appropriate permissions.
 - ([Commercial feature][215]) Added [page-specific configuration][221] options and a custom [sign-in message attribute][220] for the web UI.
 - Added binary-only distribution for [macOS arm64][216].
 

--- a/content/sensu-go/6.5/web-ui/_index.md
+++ b/content/sensu-go/6.5/web-ui/_index.md
@@ -43,6 +43,11 @@ The access and refresh tokens are saved in your browser's local storage.
 The web UI complies with Sensu role-based access control (RBAC), so individual users can view information according to their access configurations.
 Read the [RBAC reference][3] for [default user credentials][4] and instructions for [creating new users][5].
 
+## View system information
+
+Press `CTRL .` in the web UI to open the system information modal and view information about your Sensu backend and etcd or PostgreSQL datastore.
+For users with permission to create or update licenses, the system information modal includes license expiration information.
+
 ## Use the implicit OR operator
 
 {{% notice commercial %}}


### PR DESCRIPTION
## Description
Adds instructions for finding license expiration information via the web UI in license reference and web UI index page. Also corrects the command in the release notes for 6.4 and 6.5 to remove the `+` (the command is `CTRL .` -- no + required).

## Motivation and Context
Discussion w/Sales in monthly sync
