### PR TITLE
Add entity limit warning information to entity and license docs

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/_index.md
@@ -195,7 +195,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
-Use sensuctl or the license API to [view your overall entity count and limit][5].
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+You can also use sensuctl or the license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -19,6 +19,8 @@ Sensu uses [agent entities][31] and [proxy entities][32].
 Sensu's free entity limit is 100 entities.
 All [commercial features][9] are available for free in the packaged Sensu Go distribution for up to 100 entities.
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
+
+Learn more about entity limits in the [license reference][29].
 Read [the announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
@@ -1614,7 +1616,7 @@ cpu_percent: 0.12639
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
-[29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
+[29]: ../../../operations/maintain-sensu/license/#entity-limit
 [30]: ../../../web-ui/search/
 [31]: ../#agent-entities
 [32]: ../#proxy-entities

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -83,6 +83,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+
 ### View entity count and entity limit
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
@@ -243,7 +243,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
-Use sensuctl or the license API to [view your overall entity count and limit][5].
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+You can also use sensuctl or the license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -19,6 +19,8 @@ Sensu uses [agent entities][31], [proxy entities][32], and [service entities][40
 Sensu's free entity limit is 100 entities.
 All [commercial features][9] are available for free in the packaged Sensu Go distribution for up to 100 entities.
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
+
+Learn more about entity limits in the [license reference][29].
 Read [the announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
@@ -1741,7 +1743,7 @@ cpu_percent: 0.12639
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
-[29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
+[29]: ../../../operations/maintain-sensu/license/#entity-limit
 [30]: ../../../web-ui/search/
 [31]: ../#agent-entities
 [32]: ../#proxy-entities

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -83,6 +83,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+
 ### View entity count and entity limit
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
@@ -243,7 +243,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
-Use sensuctl or the license API to [view your overall entity count and limit][5].
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+You can also use sensuctl or the license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -19,6 +19,8 @@ Sensu uses [agent entities][31], [proxy entities][32], and [service entities][40
 Sensu's free entity limit is 100 entities.
 All [commercial features][9] are available for free in the packaged Sensu Go distribution for up to 100 entities.
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
+
+Learn more about entity limits in the [license reference][29].
 Read [the announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
@@ -1741,7 +1743,7 @@ cpu_percent: 0.12639
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
-[29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
+[29]: ../../../operations/maintain-sensu/license/#entity-limit
 [30]: ../../../web-ui/search/
 [31]: ../#agent-entities
 [32]: ../#proxy-entities

--- a/content/sensu-go/6.4/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/license.md
@@ -83,6 +83,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+
 ### View entity count and entity limit
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
@@ -243,7 +243,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
-Use sensuctl or the license API to [view your overall entity count and limit][5].
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+You can also use sensuctl or the license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -19,6 +19,8 @@ Sensu uses [agent entities][31], [proxy entities][32], and [service entities][40
 Sensu's free entity limit is 100 entities.
 All [commercial features][9] are available for free in the packaged Sensu Go distribution for up to 100 entities.
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
+
+Learn more about entity limits in the [license reference][29].
 Read [the announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
@@ -1741,7 +1743,7 @@ cpu_percent: 0.12639
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag
 [26]: #processes-attributes
 [28]: https://man7.org/linux/man-pages/man1/top.1.html
-[29]: ../../../operations/maintain-sensu/license/#view-entity-count-and-entity-limit
+[29]: ../../../operations/maintain-sensu/license/#entity-limit
 [30]: ../../../web-ui/search/
 [31]: ../#agent-entities
 [32]: ../#proxy-entities

--- a/content/sensu-go/6.5/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/license.md
@@ -83,6 +83,8 @@ For example, if your license has an entity limit of 10,000 and an agent entity c
 At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
+If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
+
 ### View entity count and entity limit
 
 Your current entity count and entity limit are included in the `sensuctl license info` response.


### PR DESCRIPTION
## Description
Adds information about entity limit and entity class limit warnings in entity index, entity reference, and license reference docs.

## Motivation and Context
Discussion in sales sync
