### PR TITLE
Remove html line breaks in route alerts

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
@@ -85,9 +85,9 @@ You'll use these functions to create event filters that represent the three acti
 
 | event filter name | expression | description
 | --- | --- | --- |
-| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity<br> or check label `contacts: ops`
-| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
-| `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
+| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity or check label `contacts: ops`
+| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity or check label `contacts: dev`
+| `contact_fallback` | `no_contacts(event)` | Allow events without an entity or check `contacts` label
 
 Use sensuctl to create the three event filters:
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -85,9 +85,9 @@ You'll use these functions to create event filters that represent the three acti
 
 | event filter name | expression | description
 | --- | --- | --- |
-| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity<br> or check label `contacts: ops`
-| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
-| `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
+| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity or check label `contacts: ops`
+| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity or check label `contacts: dev`
+| `contact_fallback` | `no_contacts(event)` | Allow events without an entity or check `contacts` label
 
 Use sensuctl to create the three event filters:
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -85,9 +85,9 @@ You'll use these functions to create event filters that represent the three acti
 
 | event filter name | expression | description
 | --- | --- | --- |
-| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity<br> or check label `contacts: ops`
-| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
-| `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
+| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity or check label `contacts: ops`
+| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity or check label `contacts: dev`
+| `contact_fallback` | `no_contacts(event)` | Allow events without an entity or check `contacts` label
 
 Use sensuctl to create the three event filters:
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -85,9 +85,9 @@ You'll use these functions to create event filters that represent the three acti
 
 | event filter name | expression | description
 | --- | --- | --- |
-| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity<br> or check label `contacts: ops`
-| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity<br> or check label `contacts: dev`
-| `contact_fallback` | `no_contacts(event)` | Allow events without an entity<br> or check `contacts` label
+| `contact_ops` | `has_contact(event, "ops")` | Allow events with the entity or check label `contacts: ops`
+| `contact_dev` | `has_contact(event, "dev")` | Allow events with the entity or check label `contacts: dev`
+| `contact_fallback` | `no_contacts(event)` | Allow events without an entity or check `contacts` label
 
 Use sensuctl to create the three event filters:
 


### PR DESCRIPTION
## Description
Removes html line breaks in table in Route alerts guide

## Motivation and Context
Noticed when working on something else in this doc