### PR TITLE
Replace ruby examples in check, handler, and mutator attributes

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -648,12 +648,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-handler
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-handler"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
@@ -934,12 +934,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-check
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-check"
   ]
 }
 {{< /code >}}
@@ -1062,13 +1062,13 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 - CHECK_HOST=my.host.internal
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0",
+    "APP_VERSION=2.5.0",
     "CHECK_HOST=my.host.internal"
   ]
 }

--- a/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
@@ -400,12 +400,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0"
+    "APP_VERSION=2.5.0"
   ]
 }
 {{< /code >}}
@@ -419,12 +419,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-mutator
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-mutator"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -648,12 +648,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-handler
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-handler"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -934,12 +934,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-check
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-check"
   ]
 }
 {{< /code >}}
@@ -1062,13 +1062,13 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 - CHECK_HOST=my.host.internal
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0",
+    "APP_VERSION=2.5.0",
     "CHECK_HOST=my.host.internal"
   ]
 }

--- a/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
@@ -400,12 +400,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0"
+    "APP_VERSION=2.5.0"
   ]
 }
 {{< /code >}}
@@ -419,12 +419,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-mutator
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-mutator"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -648,12 +648,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-handler
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-handler"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -934,12 +934,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-check
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-check"
   ]
 }
 {{< /code >}}
@@ -1062,13 +1062,13 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 - CHECK_HOST=my.host.internal
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0",
+    "APP_VERSION=2.5.0",
     "CHECK_HOST=my.host.internal"
   ]
 }

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
@@ -400,12 +400,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0"
+    "APP_VERSION=2.5.0"
   ]
 }
 {{< /code >}}
@@ -419,12 +419,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-mutator
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-mutator"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -648,12 +648,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-handler
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-handler"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -945,12 +945,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-check
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-check"
   ]
 }
 {{< /code >}}
@@ -1100,13 +1100,13 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 - CHECK_HOST=my.host.internal
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0",
+    "APP_VERSION=2.5.0",
     "CHECK_HOST=my.host.internal"
   ]
 }

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -484,12 +484,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 env_vars:
-- RUBY_VERSION=2.5.0
+- APP_VERSION=2.5.0
 {{< /code >}}
 {{< code json >}}
 {
   "env_vars": [
-    "RUBY_VERSION=2.5.0"
+    "APP_VERSION=2.5.0"
   ]
 }
 {{< /code >}}
@@ -503,12 +503,12 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- ruby-2.5.0
+- metric-mutator
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "ruby-2.5.0"
+    "metric-mutator"
   ]
 }
 {{< /code >}}


### PR DESCRIPTION
## Description
Removes ruby examples in check, handler, and mutator attribute description tables
