### PR TITLE
Clarify event and metrics log backend sections describe config flags

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -379,6 +379,8 @@ Store Flags:
       --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
+For more information about log configuration flags, read [Event logging][65].
+
 ### General configuration flags
 
 {{% notice note %}}
@@ -1432,6 +1434,8 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
+Use these backend configuration flags to customize event logging:
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
@@ -1538,3 +1542,4 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [35]: ../../../operations/deploy-sensu/install-sensu/#architecture-overview
 [36]: #etcd-heartbeat-interval
 [37]: ../../../sensuctl/
+[65]: #event-logging

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -382,6 +382,8 @@ Store Flags:
       --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
+For more information about log configuration flags, read [Event logging][65].
+
 ### General configuration flags
 
 {{% notice note %}}
@@ -1459,6 +1461,8 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
+Use these backend configuration flags to customize event logging:
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file. 
@@ -1576,3 +1580,4 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [35]: ../../../operations/deploy-sensu/install-sensu/#architecture-overview
 [36]: #etcd-heartbeat-interval
 [37]: ../../../sensuctl/
+[65]: #event-logging

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -416,6 +416,8 @@ Store Flags:
       --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
+For more information about log configuration flags, read [Event logging][65].
+
 ### General configuration flags
 
 {{% notice note %}}
@@ -1562,6 +1564,8 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
+Use these backend configuration flags to customize event logging:
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file.
@@ -1699,3 +1703,4 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [38]: #configuration-via-environment-variables
 [60]: #backend-log-level
 [61]: #event-log-file
+[65]: #event-logging

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -521,6 +521,8 @@ Store Flags:
       --no-embed-etcd                             don't embed etcd, use external etcd instead
 {{< /code >}}
 
+For more information about log configuration flags, read [Event logging][65] and [Platform metrics logging][66].
+
 ### General configuration flags
 
 {{% notice note %}}
@@ -1662,6 +1664,8 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
+Use these backend configuration flags to customize event logging:
+
 | event-log-buffer-size |      |
 -----------------------|------
 description            | Buffer size of the event logger. Corresponds to the maximum number of events kept in memory in case the log file is temporarily unavailable or more events have been received than can be written to the log file.
@@ -1762,9 +1766,11 @@ Sensu automatically writes core platform metrics in [InfluxDB Line Protocol][62]
 You can use this file as an input source for your favorite data lake solution.
 
 Metrics logging is enabled by default but can be disabled with the disable-platform-metrics configuration flag.
-Sensu appends updated metrics at the interval you specify (default is every 60 seconds).
+Sensu appends updated metrics at the interval you specify with the platform-metrics-logging-interval configuration flag (default is every 60 seconds).
 
 To rotate the platform metrics log, use the same methods as for [event log rotation][63].
+
+Use these backend configuration flags to customize platform metrics logging:
 
 | disable-platform-metrics |      |
 -----------------------|------
@@ -1846,3 +1852,5 @@ platform-metrics-logging-interval: 60s{{< /code >}}
 [62]: https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
 [63]: #log-rotation
 [64]: ../../../sensuctl/#global-flags
+[65]: #event-logging
+[66]: #platform-metrics-logging


### PR DESCRIPTION
## Description
Adds links to help users find info about event and metrics logging flags for backed config. Also clarifies within the event logging and metrics logging sections that the tables describe config flags.

## Motivation and Context
Noticed when working on something else
