### PR TITLE
Remove all remaining examples with Ruby plugins or commands

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/_index.md
@@ -41,7 +41,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: /opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u "http://localhost"
+    command: metrics-curl -u "http://localhost"
     duration: 0.060790838
     env_vars: null
     executed: 1552506033
@@ -148,7 +148,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "command": "metrics-curl -u \"http://localhost\"",
       "duration": 0.060790838,
       "env_vars": null,
       "executed": 1552506033,

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
@@ -41,7 +41,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: /opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u "http://localhost"
+    command: metrics-curl -u "http://localhost"
     duration: 0.060790838
     env_vars: null
     executed: 1552506033
@@ -148,7 +148,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "command": "metrics-curl -u \"http://localhost\"",
       "duration": 0.060790838,
       "env_vars": null,
       "executed": 1552506033,

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/_index.md
@@ -41,7 +41,7 @@ metadata:
 spec:
   check:
     check_hooks: null
-    command: /opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u "http://localhost"
+    command: metrics-curl -u "http://localhost"
     duration: 0.060790838
     env_vars: null
     executed: 1552506033
@@ -148,7 +148,7 @@ spec:
   "spec": {
     "check": {
       "check_hooks": null,
-      "command": "/opt/sensu-plugins-ruby/embedded/bin/metrics-curl.rb -u \"http://localhost\"",
+      "command": "metrics-curl -u \"http://localhost\"",
       "duration": 0.060790838,
       "env_vars": null,
       "executed": 1552506033,


### PR DESCRIPTION
## Description
Removes the last few command examples that use a Ruby plugin path

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2919
