### PR TITLE
Remove default namespace from example resource definitions

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -91,7 +91,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-sensu-site
-  namespace: default
 spec:
   command: http-check --url https://sensu.io
   interval: 60
@@ -109,8 +108,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-sensu-site",
-    "namespace": "default"
+    "name": "check-sensu-site"
   },
   "spec": {
     "command": "http-check --url https://sensu.io",
@@ -233,7 +231,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
   labels:
     proxy_type: website
     url: https://docs.sensu.io
@@ -246,7 +243,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://docs.sensu.io"
@@ -266,7 +262,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: packagecloud-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://packagecloud.io
@@ -279,7 +274,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "packagecloud-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://packagecloud.io"
@@ -299,7 +293,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: github-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://github.com
@@ -312,7 +305,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "github-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://github.com"
@@ -376,7 +368,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-http
-  namespace: default
 spec:
   command: 'http-check --url {{ .labels.url }}'
   interval: 60
@@ -396,8 +387,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-http",
-    "namespace": "default"
+    "name": "check-http"
   },
   "spec": {
     "command": "http-check --url {{ .labels.url }}",

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -242,7 +242,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: fatigue_check
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -256,8 +255,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "fatigue_check",
-    "namespace": "default"
+    "name": "fatigue_check"
   },
   "spec": {
     "action": "allow",
@@ -302,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: linux-cpu-check
-  namespace: default
   annotations:
     fatigue_check/occurrences: '1'
     fatigue_check/interval: '3600'
@@ -336,7 +333,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "linux-cpu-check",
-    "namespace": "default",
     "annotations": {
       "fatigue_check/occurrences": "1",
       "fatigue_check/interval": "3600",

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/route-alerts.md
@@ -391,7 +391,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   handlers:
   - slack_ops
@@ -405,8 +404,7 @@ echo '{
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "handlers": [

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -96,7 +96,6 @@ metadata:
   annotations: null
   labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -113,8 +112,7 @@ cat << EOF | sensuctl create
   "metadata": {
     "annotations": null,
     "labels": null,
-    "name": "state_change_only",
-    "namespace": "default"
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -158,7 +156,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: email
 spec:
   type: pipe
@@ -179,7 +176,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "email"
   },
   "spec": {
@@ -231,6 +227,12 @@ efPxbRciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzkwMzY5NjQsImp0aSI6ImJiMmY0ODY
 {{< /code >}}
 
 With the environment variables set, you can use the Sensu API to create your ad hoc observability event.
+
+{{% notice note %}}
+**NOTE**: The example events use the default namespace.
+If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
+{{% notice note %}}
+
 This event outputs the message "Everything is OK.” when it occurs:
 
 {{< code shell >}}

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -233,7 +233,7 @@ The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: Handler
 api_version: core/v2

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -243,7 +243,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influxdb
-  namespace: default
 spec:
   command: "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu"
   timeout: 10
@@ -259,8 +258,7 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influxdb",
-    "namespace": "default"
+    "name": "influxdb"
   },
   "spec": {
     "command": "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu",
@@ -343,7 +341,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_metrics
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   handlers: []
@@ -366,8 +363,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-management.md
@@ -99,7 +99,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: SENSU_PAGERDUTY_KEY
   provider: env
@@ -112,8 +111,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "SENSU_PAGERDUTY_KEY",
@@ -345,7 +343,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: secret/pagerduty#key
   provider: vault
@@ -358,8 +355,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "secret/pagerduty#key",
@@ -407,7 +403,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: pagerduty
 spec:
   type: pipe
@@ -429,7 +424,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.2/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.2/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -105,7 +105,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_backend_health
 spec:
   command: http-json --url http://sensu-backend-beta:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -123,7 +122,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_backend_health
 spec:
   command: http-json --url http://sensu-backend-alpha:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -141,7 +139,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_backend_health"
   },
   "spec": {
@@ -164,7 +161,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_backend_health"
   },
   "spec": {
@@ -206,7 +202,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-beta:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -224,7 +219,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-alpha:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -242,7 +236,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_etcd_health"
   },
   "spec": {
@@ -265,7 +258,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_etcd_health"
   },
   "spec": {
@@ -356,7 +348,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-postgres-health
-  namespace: default
 spec:
   check_hooks: null
   command: http-json --url https://sensu.example.com:8080/health --query ".PostgresHealth[0].Healthy" --expression "== true"
@@ -387,8 +378,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-postgres-health",
-    "namespace": "default"
+    "name": "check-postgres-health"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.2/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.2/plugins/use-assets-to-install-plugins.md
@@ -71,7 +71,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: pagerduty-handler
-  namespace: default
   labels: {}
   annotations: {}
 spec:
@@ -88,7 +87,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "pagerduty-handler",
-    "namespace": "default",
     "labels": {
     },
     "annotations": {
@@ -145,7 +143,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler
   env_vars:
@@ -163,7 +160,6 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -91,7 +91,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-sensu-site
-  namespace: default
 spec:
   command: http-check --url https://sensu.io
   interval: 60
@@ -109,8 +108,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-sensu-site",
-    "namespace": "default"
+    "name": "check-sensu-site"
   },
   "spec": {
     "command": "http-check --url https://sensu.io",
@@ -233,7 +231,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
   labels:
     proxy_type: website
     url: https://docs.sensu.io
@@ -246,7 +243,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://docs.sensu.io"
@@ -266,7 +262,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: packagecloud-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://packagecloud.io
@@ -279,7 +274,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "packagecloud-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://packagecloud.io"
@@ -299,7 +293,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: github-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://github.com
@@ -312,7 +305,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "github-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://github.com"
@@ -376,7 +368,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-http
-  namespace: default
 spec:
   command: 'http-check --url {{ .labels.url }}'
   interval: 60
@@ -396,8 +387,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-http",
-    "namespace": "default"
+    "name": "check-http"
   },
   "spec": {
     "command": "http-check --url {{ .labels.url }}",

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -242,7 +242,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: fatigue_check
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -256,8 +255,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "fatigue_check",
-    "namespace": "default"
+    "name": "fatigue_check"
   },
   "spec": {
     "action": "allow",
@@ -302,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: linux-cpu-check
-  namespace: default
   annotations:
     fatigue_check/occurrences: '1'
     fatigue_check/interval: '3600'
@@ -336,7 +333,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "linux-cpu-check",
-    "namespace": "default",
     "annotations": {
       "fatigue_check/occurrences": "1",
       "fatigue_check/interval": "3600",

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -393,7 +393,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   handlers:
   - slack_ops
@@ -407,8 +406,7 @@ echo '{
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "handlers": [

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -96,7 +96,6 @@ metadata:
   annotations: null
   labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -113,8 +112,7 @@ cat << EOF | sensuctl create
   "metadata": {
     "annotations": null,
     "labels": null,
-    "name": "state_change_only",
-    "namespace": "default"
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -158,7 +156,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: email
 spec:
   type: pipe
@@ -179,7 +176,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "email"
   },
   "spec": {
@@ -231,6 +227,12 @@ efPxbRciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzkwMzY5NjQsImp0aSI6ImJiMmY0ODY
 {{< /code >}}
 
 With the environment variables set, you can use the Sensu API to create your ad hoc observability event.
+
+{{% notice note %}}
+**NOTE**: The example events use the default namespace.
+If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
+{{% notice note %}}
+
 This event outputs the message "Everything is OK.” when it occurs:
 
 {{< code shell >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -233,7 +233,7 @@ The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: Handler
 api_version: core/v2

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -243,7 +243,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influxdb
-  namespace: default
 spec:
   command: "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu"
   timeout: 10
@@ -259,8 +258,7 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influxdb",
-    "namespace": "default"
+    "name": "influxdb"
   },
   "spec": {
     "command": "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu",
@@ -343,7 +341,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_metrics
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   handlers: []
@@ -366,8 +363,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
@@ -99,7 +99,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: SENSU_PAGERDUTY_KEY
   provider: env
@@ -112,8 +111,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "SENSU_PAGERDUTY_KEY",
@@ -345,7 +343,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: secret/pagerduty#key
   provider: vault
@@ -358,8 +355,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "secret/pagerduty#key",
@@ -407,7 +403,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: pagerduty
 spec:
   type: pipe
@@ -429,7 +424,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -105,7 +105,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_backend_health
 spec:
   command: http-json --url http://sensu-backend-beta:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -123,7 +122,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_backend_health
 spec:
   command: http-json --url http://sensu-backend-alpha:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -141,7 +139,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_backend_health"
   },
   "spec": {
@@ -164,7 +161,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_backend_health"
   },
   "spec": {
@@ -206,7 +202,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-beta:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -224,7 +219,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-alpha:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -242,7 +236,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_etcd_health"
   },
   "spec": {
@@ -265,7 +258,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_etcd_health"
   },
   "spec": {
@@ -356,7 +348,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-postgres-health
-  namespace: default
 spec:
   check_hooks: null
   command: http-json --url https://sensu.example.com:8080/health --query ".PostgresHealth[0].Healthy" --expression "== true"
@@ -387,8 +378,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-postgres-health",
-    "namespace": "default"
+    "name": "check-postgres-health"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
@@ -71,7 +71,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: pagerduty-handler
-  namespace: default
   labels: {}
   annotations: {}
 spec:
@@ -88,7 +87,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "pagerduty-handler",
-    "namespace": "default",
     "labels": {
     },
     "annotations": {
@@ -145,7 +143,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler
   env_vars:
@@ -163,7 +160,6 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -91,7 +91,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-sensu-site
-  namespace: default
 spec:
   command: http-check --url https://sensu.io
   interval: 60
@@ -109,8 +108,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-sensu-site",
-    "namespace": "default"
+    "name": "check-sensu-site"
   },
   "spec": {
     "command": "http-check --url https://sensu.io",
@@ -233,7 +231,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
   labels:
     proxy_type: website
     url: https://docs.sensu.io
@@ -246,7 +243,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://docs.sensu.io"
@@ -266,7 +262,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: packagecloud-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://packagecloud.io
@@ -279,7 +274,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "packagecloud-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://packagecloud.io"
@@ -299,7 +293,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: github-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://github.com
@@ -312,7 +305,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "github-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://github.com"
@@ -376,7 +368,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-http
-  namespace: default
 spec:
   command: 'http-check --url {{ .labels.url }}'
   interval: 60
@@ -396,8 +387,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-http",
-    "namespace": "default"
+    "name": "check-http"
   },
   "spec": {
     "command": "http-check --url {{ .labels.url }}",

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -242,7 +242,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: fatigue_check
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -256,8 +255,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "fatigue_check",
-    "namespace": "default"
+    "name": "fatigue_check"
   },
   "spec": {
     "action": "allow",
@@ -302,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: linux-cpu-check
-  namespace: default
   annotations:
     fatigue_check/occurrences: '1'
     fatigue_check/interval: '3600'
@@ -336,7 +333,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "linux-cpu-check",
-    "namespace": "default",
     "annotations": {
       "fatigue_check/occurrences": "1",
       "fatigue_check/interval": "3600",

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -393,7 +393,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   handlers:
   - slack_ops
@@ -407,8 +406,7 @@ echo '{
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "handlers": [

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
@@ -96,7 +96,6 @@ metadata:
   annotations: null
   labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -113,8 +112,7 @@ cat << EOF | sensuctl create
   "metadata": {
     "annotations": null,
     "labels": null,
-    "name": "state_change_only",
-    "namespace": "default"
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -158,7 +156,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: email
 spec:
   type: pipe
@@ -179,7 +176,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "email"
   },
   "spec": {
@@ -231,6 +227,12 @@ efPxbRciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzkwMzY5NjQsImp0aSI6ImJiMmY0ODY
 {{< /code >}}
 
 With the environment variables set, you can use the Sensu API to create your ad hoc observability event.
+
+{{% notice note %}}
+**NOTE**: The example events use the default namespace.
+If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
+{{% notice note %}}
+
 This event outputs the message "Everything is OK.” when it occurs:
 
 {{< code shell >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -233,7 +233,7 @@ The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: Handler
 api_version: core/v2

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -243,7 +243,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influxdb
-  namespace: default
 spec:
   command: "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu"
   timeout: 10
@@ -259,8 +258,7 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influxdb",
-    "namespace": "default"
+    "name": "influxdb"
   },
   "spec": {
     "command": "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu",
@@ -343,7 +341,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_metrics
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   handlers: []
@@ -366,8 +363,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
@@ -99,7 +99,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: SENSU_PAGERDUTY_KEY
   provider: env
@@ -112,8 +111,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "SENSU_PAGERDUTY_KEY",
@@ -345,7 +343,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: secret/pagerduty#key
   provider: vault
@@ -358,8 +355,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "secret/pagerduty#key",
@@ -407,7 +403,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: pagerduty
 spec:
   type: pipe
@@ -429,7 +424,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -105,7 +105,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_backend_health
 spec:
   command: http-json --url http://sensu-backend-beta:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -123,7 +122,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_backend_health
 spec:
   command: http-json --url http://sensu-backend-alpha:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -141,7 +139,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_backend_health"
   },
   "spec": {
@@ -164,7 +161,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_backend_health"
   },
   "spec": {
@@ -206,7 +202,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-beta:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -224,7 +219,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-alpha:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -242,7 +236,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_etcd_health"
   },
   "spec": {
@@ -265,7 +258,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_etcd_health"
   },
   "spec": {
@@ -356,7 +348,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-postgres-health
-  namespace: default
 spec:
   check_hooks: null
   command: http-json --url https://sensu.example.com:8080/health --query ".PostgresHealth[0].Healthy" --expression "== true"
@@ -387,8 +378,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-postgres-health",
-    "namespace": "default"
+    "name": "check-postgres-health"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
@@ -71,7 +71,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: pagerduty-handler
-  namespace: default
   labels: {}
   annotations: {}
 spec:
@@ -88,7 +87,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "pagerduty-handler",
-    "namespace": "default",
     "labels": {
     },
     "annotations": {
@@ -145,7 +143,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler
   env_vars:
@@ -163,7 +160,6 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -91,7 +91,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-sensu-site
-  namespace: default
 spec:
   command: http-check --url https://sensu.io
   interval: 60
@@ -109,8 +108,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-sensu-site",
-    "namespace": "default"
+    "name": "check-sensu-site"
   },
   "spec": {
     "command": "http-check --url https://sensu.io",
@@ -233,7 +231,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
   labels:
     proxy_type: website
     url: https://docs.sensu.io
@@ -246,7 +243,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://docs.sensu.io"
@@ -266,7 +262,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: packagecloud-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://packagecloud.io
@@ -279,7 +274,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "packagecloud-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://packagecloud.io"
@@ -299,7 +293,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: github-site
-  namespace: default
   labels:
     proxy_type: website
     url: https://github.com
@@ -312,7 +305,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "github-site",
-    "namespace": "default",
     "labels": {
       "proxy_type": "website",
       "url": "https://github.com"
@@ -376,7 +368,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-http
-  namespace: default
 spec:
   command: 'http-check --url {{ .labels.url }}'
   interval: 60
@@ -396,8 +387,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-http",
-    "namespace": "default"
+    "name": "check-http"
   },
   "spec": {
     "command": "http-check --url {{ .labels.url }}",

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -246,7 +246,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: fatigue_check
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -260,8 +259,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "fatigue_check",
-    "namespace": "default"
+    "name": "fatigue_check"
   },
   "spec": {
     "action": "allow",
@@ -306,7 +304,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: linux-cpu-check
-  namespace: default
   annotations:
     fatigue_check/occurrences: '1'
     fatigue_check/interval: '3600'
@@ -340,7 +337,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "linux-cpu-check",
-    "namespace": "default",
     "annotations": {
       "fatigue_check/occurrences": "1",
       "fatigue_check/interval": "3600",

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -393,7 +393,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   handlers:
   - slack_ops
@@ -407,8 +406,7 @@ echo '{
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "handlers": [

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -96,7 +96,6 @@ metadata:
   annotations: null
   labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -113,8 +112,7 @@ cat << EOF | sensuctl create
   "metadata": {
     "annotations": null,
     "labels": null,
-    "name": "state_change_only",
-    "namespace": "default"
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -158,7 +156,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: email
 spec:
   type: pipe
@@ -179,7 +176,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "email"
   },
   "spec": {
@@ -231,6 +227,12 @@ efPxbRciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NzkwMzY5NjQsImp0aSI6ImJiMmY0ODY
 {{< /code >}}
 
 With the environment variables set, you can use the Sensu API to create your ad hoc observability event.
+
+{{% notice note %}}
+**NOTE**: The example events use the default namespace.
+If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
+{{% notice note %}}
+
 This event outputs the message "Everything is OK.” when it occurs:
 
 {{< code shell >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -237,7 +237,7 @@ The response will list the complete handler resource definition:
 
 {{< language-toggle >}}
 
-{{< code yaml >}}
+{{< code yml >}}
 ---
 type: Handler
 api_version: core/v2

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -243,7 +243,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influxdb
-  namespace: default
 spec:
   command: "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu"
   timeout: 10
@@ -259,8 +258,7 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influxdb",
-    "namespace": "default"
+    "name": "influxdb"
   },
   "spec": {
     "command": "sensu-influxdb-handler -a 'http://127.0.0.1:8086' -d sensu -u sensu -p sensu",
@@ -343,7 +341,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_metrics
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   handlers: []
@@ -366,8 +363,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -99,7 +99,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: SENSU_PAGERDUTY_KEY
   provider: env
@@ -112,8 +111,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "SENSU_PAGERDUTY_KEY",
@@ -345,7 +343,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: pagerduty_key
-  namespace: default
 spec:
   id: secret/pagerduty#key
   provider: vault
@@ -358,8 +355,7 @@ cat << EOF | sensuctl create
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "pagerduty_key",
-    "namespace": "default"
+    "name": "pagerduty_key"
   },
   "spec": {
     "id": "secret/pagerduty#key",
@@ -407,7 +403,6 @@ cat << EOF | sensuctl create
 api_version: core/v2
 type: Handler
 metadata:
-  namespace: default
   name: pagerduty
 spec:
   type: pipe
@@ -429,7 +424,6 @@ cat << EOF | sensuctl create
   "api_version": "core/v2",
   "type": "Handler",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {

--- a/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -105,7 +105,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_backend_health
 spec:
   command: http-json --url http://sensu-backend-beta:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -123,7 +122,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_backend_health
 spec:
   command: http-json --url http://sensu-backend-alpha:8080/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -141,7 +139,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_backend_health"
   },
   "spec": {
@@ -164,7 +161,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_backend_health"
   },
   "spec": {
@@ -206,7 +202,6 @@ Follow [Register dynamic runtime asset](#register-dynamic-runtime-asset) if you 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_beta_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-beta:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -224,7 +219,6 @@ spec:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: check_alpha_etcd_health
 spec:
   command: http-json --url http://sensu-etcd-alpha:2379/health --query ".ClusterHealth.[0].Healthy" --expression "== true"
@@ -242,7 +236,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_beta_etcd_health"
   },
   "spec": {
@@ -265,7 +258,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_alpha_etcd_health"
   },
   "spec": {
@@ -356,7 +348,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-postgres-health
-  namespace: default
 spec:
   check_hooks: null
   command: http-json --url https://sensu.example.com:8080/health --query ".PostgresHealth[0].Healthy" --expression "== true"
@@ -387,8 +378,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-postgres-health",
-    "namespace": "default"
+    "name": "check-postgres-health"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
@@ -71,7 +71,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: pagerduty-handler
-  namespace: default
   labels: {}
   annotations: {}
 spec:
@@ -88,7 +87,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "pagerduty-handler",
-    "namespace": "default",
     "labels": {
     },
     "annotations": {
@@ -145,7 +143,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler
   env_vars:
@@ -163,7 +160,6 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "pagerduty"
   },
   "spec": {


### PR DESCRIPTION
## Description
Removes namespace from examples meant to be used to create resources.

## Motivation and Context
Makes our examples portable for any user, who may be creating resources in a different namespace. h/t @jspaleta 
