### PR TITLE
Add missing yaml separators in code examples

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -35,6 +35,7 @@ This example shows the resource definition for an agent entity:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Entity
 api_version: core/v2
 metadata:
@@ -260,6 +261,7 @@ This example shows the resource definition for a proxy entity:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Entity
 api_version: core/v2
 metadata:
@@ -435,6 +437,7 @@ sensuctl edit entity sensu-docs
 And update the metadata scope to include the `proxy_type` label:
 
 {{< code yml >}}
+---
 type: Entity
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/_index.md
@@ -34,6 +34,7 @@ Here's an example event that includes both status and metrics data:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-events/events.md
@@ -43,6 +43,7 @@ The following example shows the complete resource definition for a [status-only 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -453,6 +454,7 @@ This example shows the complete resource definition for a [metrics-only event][5
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -611,6 +613,7 @@ The following example resource definition for a [status and metrics event][19] c
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
@@ -42,6 +42,7 @@ This example shows the minimum required attributes for an event filter resource:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -199,6 +200,7 @@ To use the is_incident event filter, include `is_incident` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -261,6 +263,7 @@ To allow silencing for an event handler, add `not_silenced` to the handler confi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -320,6 +323,7 @@ To use the has_metrics event filter, include `has_metrics` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -818,6 +822,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -863,6 +868,7 @@ The following event filter allows handling for only events with a custom entity 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -905,6 +911,7 @@ If evaluation returns false, the event is handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -942,6 +949,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -985,6 +993,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1028,6 +1037,7 @@ This example will apply the same logic as the previous example but for checks wi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1077,6 +1087,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1124,6 +1135,7 @@ If evaluation returns false, the event will not be handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/handlers.md
@@ -176,6 +176,7 @@ You can list both of these handlers in a handler set to automate and streamline 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/plan-maintenance.md
@@ -50,6 +50,7 @@ This command creates the following silenced resource definition:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Silenced
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/subscriptions.md
@@ -50,6 +50,7 @@ For this agent to run a check, you must have at least one check with `linux` spe
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: CheckConfig
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/tokens.md
@@ -235,6 +235,7 @@ Token substitution allows you to host your dynamic runtime assets at different U
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Asset
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-transform/mutators.md
@@ -35,6 +35,7 @@ This example shows a mutator resource definition with the minimum required attri
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Mutator
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/use-federation.md
@@ -176,6 +176,7 @@ sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=v
     This command creates the following cluster role binding resource definition:
 {{< language-toggle >}}
 {{< code yml >}}
+---
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/license.md
@@ -138,6 +138,7 @@ In YAML and JSON formats, the entity count and limit are included as labels:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: LicenseFile
 api_version: licensing/v2
 metadata:

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -354,6 +354,7 @@ Sensu Go hourly filter:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.2/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.2/web-ui/webconfig-reference.md
@@ -36,6 +36,7 @@ In this web UI configuration example:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: GlobalConfig
 api_version: web/v1
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
@@ -34,6 +34,7 @@ Here's an example event that includes both status and metrics data:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -43,6 +43,7 @@ The following example shows the complete resource definition for a [status-only 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -453,6 +454,7 @@ This example shows the complete resource definition for a [metrics-only event][5
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -611,6 +613,7 @@ The following example resource definition for a [status and metrics event][19] c
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -42,6 +42,7 @@ This example shows the minimum required attributes for an event filter resource:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -199,6 +200,7 @@ To use the is_incident event filter, include `is_incident` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -261,6 +263,7 @@ To allow silencing for an event handler, add `not_silenced` to the handler confi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -320,6 +323,7 @@ To use the has_metrics event filter, include `has_metrics` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -818,6 +822,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -863,6 +868,7 @@ The following event filter allows handling for only events with a custom entity 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -905,6 +911,7 @@ If evaluation returns false, the event is handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -942,6 +949,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -985,6 +993,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1028,6 +1037,7 @@ This example will apply the same logic as the previous example but for checks wi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1077,6 +1087,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1124,6 +1135,7 @@ If evaluation returns false, the event will not be handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -176,6 +176,7 @@ You can list both of these handlers in a handler set to automate and streamline 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
@@ -50,6 +50,7 @@ This command creates the following silenced resource definition:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Silenced
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
@@ -50,6 +50,7 @@ For this agent to run a check, you must have at least one check with `linux` spe
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: CheckConfig
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -235,6 +235,7 @@ Token substitution allows you to host your dynamic runtime assets at different U
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Asset
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
@@ -35,6 +35,7 @@ This example shows a mutator resource definition with the minimum required attri
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Mutator
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -176,6 +176,7 @@ sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=v
     This command creates the following cluster role binding resource definition:
 {{< language-toggle >}}
 {{< code yml >}}
+---
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -138,6 +138,7 @@ In YAML and JSON formats, the entity count and limit are included as labels:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: LicenseFile
 api_version: licensing/v2
 metadata:

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -354,6 +354,7 @@ Sensu Go hourly filter:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.3/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.3/web-ui/webconfig-reference.md
@@ -36,6 +36,7 @@ In this web UI configuration example:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: GlobalConfig
 api_version: web/v1
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/_index.md
@@ -34,6 +34,7 @@ Here's an example event that includes both status and metrics data:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
@@ -43,6 +43,7 @@ The following example shows the complete resource definition for a [status-only 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -453,6 +454,7 @@ This example shows the complete resource definition for a [metrics-only event][5
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -611,6 +613,7 @@ The following example resource definition for a [status and metrics event][19] c
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -42,6 +42,7 @@ This example shows the minimum required attributes for an event filter resource:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -199,6 +200,7 @@ To use the is_incident event filter, include `is_incident` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -261,6 +263,7 @@ To allow silencing for an event handler, add `not_silenced` to the handler confi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -320,6 +323,7 @@ To use the has_metrics event filter, include `has_metrics` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -818,6 +822,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -863,6 +868,7 @@ The following event filter allows handling for only events with a custom entity 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -905,6 +911,7 @@ If evaluation returns false, the event is handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -942,6 +949,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -985,6 +993,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1028,6 +1037,7 @@ This example will apply the same logic as the previous example but for checks wi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1077,6 +1087,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1124,6 +1135,7 @@ If evaluation returns false, the event will not be handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1168,6 +1180,7 @@ For example, if office hours are 8:30 AM to 5:30 PM:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1216,6 +1229,7 @@ In other words, this filter sets a 30-second time budget for event processing so
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -176,6 +176,7 @@ You can list both of these handlers in a handler set to automate and streamline 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
@@ -50,6 +50,7 @@ This command creates the following silenced resource definition:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Silenced
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
@@ -50,6 +50,7 @@ For this agent to run a check, you must have at least one check with `linux` spe
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: CheckConfig
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -235,6 +235,7 @@ Token substitution allows you to host your dynamic runtime assets at different U
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Asset
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
@@ -35,6 +35,7 @@ This example shows a mutator resource definition with the minimum required attri
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Mutator
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -176,6 +176,7 @@ sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=v
     This command creates the following cluster role binding resource definition:
 {{< language-toggle >}}
 {{< code yml >}}
+---
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/license.md
@@ -138,6 +138,7 @@ In YAML and JSON formats, the entity count and limit are included as labels:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: LicenseFile
 api_version: licensing/v2
 metadata:

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -354,6 +354,7 @@ Sensu Go hourly filter:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.4/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.4/web-ui/webconfig-reference.md
@@ -39,6 +39,7 @@ In this web UI configuration example:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: GlobalConfig
 api_version: web/v1
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/_index.md
@@ -34,6 +34,7 @@ Here's an example event that includes both status and metrics data, retrieved wi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -43,6 +43,7 @@ The following example shows the complete resource definition for a [status-only 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -474,6 +475,7 @@ This example shows a complete [metrics-only event][5], retrieved with sensuctl e
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:
@@ -1491,6 +1493,7 @@ The following example resource definition for a [status and metrics event][19] c
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Event
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -42,6 +42,7 @@ This example shows the minimum required attributes for an event filter resource:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -199,6 +200,7 @@ To use the is_incident event filter, include `is_incident` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -261,6 +263,7 @@ To allow silencing for an event handler, add `not_silenced` to the handler confi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -320,6 +323,7 @@ To use the has_metrics event filter, include `has_metrics` in the handler config
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:
@@ -818,6 +822,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -863,6 +868,7 @@ The following event filter allows handling for only events with a custom entity 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -905,6 +911,7 @@ If evaluation returns false, the event is handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -942,6 +949,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -985,6 +993,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1028,6 +1037,7 @@ This example will apply the same logic as the previous example but for checks wi
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1077,6 +1087,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1124,6 +1135,7 @@ If evaluation returns false, the event will not be handled.
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1168,6 +1180,7 @@ For example, if office hours are 8:30 AM to 5:30 PM:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:
@@ -1216,6 +1229,7 @@ In other words, this filter sets a 30-second time budget for event processing so
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -176,6 +176,7 @@ You can list both of these handlers in a handler set to automate and streamline 
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Handler
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
@@ -50,6 +50,7 @@ This command creates the following silenced resource definition:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Silenced
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
@@ -50,6 +50,7 @@ For this agent to run a check, you must have at least one check with `linux` spe
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: CheckConfig
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -235,6 +235,7 @@ Token substitution allows you to host your dynamic runtime assets at different U
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Asset
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -30,6 +30,7 @@ This example shows a [pipe mutator][21] resource definition with the minimum req
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: Mutator
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -176,6 +176,7 @@ sensuctl cluster-role-binding create federation-viewer-readonly --cluster-role=v
     This command creates the following cluster role binding resource definition:
 {{< language-toggle >}}
 {{< code yml >}}
+---
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/license.md
@@ -138,6 +138,7 @@ In YAML and JSON formats, the entity count and limit are included as labels:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: LicenseFile
 api_version: licensing/v2
 metadata:

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -354,6 +354,7 @@ Sensu Go hourly filter:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: EventFilter
 api_version: core/v2
 metadata:

--- a/content/sensu-go/6.5/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.5/web-ui/webconfig-reference.md
@@ -39,6 +39,7 @@ In this web UI configuration example:
 {{< language-toggle >}}
 
 {{< code yml >}}
+---
 type: GlobalConfig
 api_version: web/v1
 metadata:


### PR DESCRIPTION
## Description
Adds yaml separators `---` where missing at the start of each yaml code example throughout the docs.

## Motivation and Context
Example standardization
