### PR TITLE
Add note about adjusting expiry duration in cert signing

### DIFF
--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -106,6 +106,9 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 {{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
+{{% notice note %}}
+**NOTE**: We suggest a 6-month expiry duration for security, but you can use any duration you prefer when you define the `expiry` attribute value in the signing parameters.
+{{% /notice %}}
 
 <a id="copy-ca-pem"></a>
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -106,6 +106,9 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 {{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
+{{% notice note %}}
+**NOTE**: We suggest a 6-month expiry duration for security, but you can use any duration you prefer when you define the `expiry` attribute value in the signing parameters.
+{{% /notice %}}
 
 <a id="copy-ca-pem"></a>
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/generate-certificates.md
@@ -106,6 +106,9 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 {{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
+{{% notice note %}}
+**NOTE**: We suggest a 6-month expiry duration for security, but you can use any duration you prefer when you define the `expiry` attribute value in the signing parameters.
+{{% /notice %}}
 
 <a id="copy-ca-pem"></a>
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
@@ -106,6 +106,9 @@ echo '{"CN":"Sensu Test CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -
 {{< code shell >}}
 echo '{"signing":{"default":{"expiry":"17520h","usages":["signing","key encipherment","client auth"]},"profiles":{"backend":{"usages":["signing","key encipherment","server auth","client auth"],"expiry":"4320h"},"agent":{"usages":["signing","key encipherment","client auth"],"expiry":"4320h"}}}}' > ca-config.json
 {{< /code >}}
+{{% notice note %}}
+**NOTE**: We suggest a 6-month expiry duration for security, but you can use any duration you prefer when you define the `expiry` attribute value in the signing parameters.
+{{% /notice %}}
 
 <a id="copy-ca-pem"></a>
 


### PR DESCRIPTION
## Description
Adds a note about adjusting the expiry duration as desired when defining signing parameters for certs in step 4 under https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/generate-certificates/#create-a-certificate-authority-ca

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3474
