### PR TITLE
Remove namespace and empty labels and annotations from example resource definitions

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-entities/entities.md
@@ -39,10 +39,7 @@ This example shows the resource definition for an agent entity:
 type: Entity
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: webserver01
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -115,10 +112,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "webserver01"
   },
   "spec": {
     "entity_class": "agent",
@@ -266,8 +260,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
-  labels: null
 spec:
   deregister: false
   deregistration: {}
@@ -286,9 +278,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-docs",
-    "namespace": "default",
-    "labels": null
+    "name": "sensu-docs"
   },
   "spec": {
     "deregister": false,
@@ -368,7 +358,6 @@ metadata:
   labels:
     url: docs.sensu.io
   name: sensu-docs
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -388,7 +377,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/_index.md
@@ -38,7 +38,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -50,8 +49,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-filter/filters.md
@@ -47,7 +47,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: filter_minimum
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -59,8 +58,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_minimum",
-    "namespace": "default"
+    "name": "filter_minimum"
   },
   "spec": {
     "action": "allow",
@@ -109,7 +107,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: metrics-checks-only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -121,8 +118,7 @@ spec:
    "type": "EventFilter",
    "api_version": "core/v2",
    "metadata": {
-      "name": "metrics-checks-only",
-      "namespace": "default"
+      "name": "metrics-checks-only"
    },
    "spec": {
       "action": "allow",
@@ -146,7 +142,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: us-west-events
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -158,8 +153,7 @@ spec:
    "type": "EventFilter",
    "api_version": "core/v2",
    "metadata": {
-      "name": "us-west-events",
-      "namespace": "default"
+      "name": "us-west-events"
    },
    "spec": {
       "action": "allow",
@@ -205,7 +199,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -223,8 +216,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -287,8 +279,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -328,7 +319,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influx-db
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
@@ -348,8 +338,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influx-db",
-    "namespace": "default"
+    "name": "influx-db"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -826,10 +815,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: deny_if_failure_in_history
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -844,10 +830,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "deny_if_failure_in_history",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "deny_if_failure_in_history"
   },
   "spec": {
     "action": "deny",
@@ -873,7 +856,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -885,8 +867,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",
@@ -916,7 +897,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: not_production
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -928,8 +908,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "not_production",
-    "namespace": "default"
+    "name": "not_production"
   },
   "spec": {
     "action": "deny",
@@ -953,10 +932,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -969,10 +945,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "state_change_only",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -997,10 +970,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_60_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1014,10 +984,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_60_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_60_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1041,10 +1008,7 @@ This example will apply the same logic as the previous example but for checks wi
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_30_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1058,10 +1022,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_30_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_30_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1091,10 +1052,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: keepalive_timeouts
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1108,10 +1066,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "keepalive_timeouts",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "keepalive_timeouts"
   },
   "spec": {
     "action": "allow",
@@ -1139,10 +1094,7 @@ If evaluation returns false, the event will not be handled.
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: nine_to_fiver
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1156,10 +1108,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nine_to_fiver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "nine_to_fiver"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.2/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/silencing.md
@@ -46,10 +46,7 @@ This example shows a silencing resource definition that uses a per-entity subscr
 type: Silenced
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: entity:i-424242:*
-  namespace: default
 spec:
   begin: 1542671205
   check: null
@@ -65,10 +62,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:*",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:*"
   },
   "spec": {
     "expire": -1,
@@ -96,9 +90,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: entity:i-424242:check_ntp
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: entity:i-424242
   check: check_ntp
@@ -110,10 +101,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:check_ntp",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:check_ntp"
   },
   "spec": {
     "subscription": "entity:i-424242",
@@ -454,9 +442,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: appserver
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: appserver
 {{< /code >}}
@@ -466,10 +451,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver"
   },
   "spec": {
     "subscription": "appserver"
@@ -511,9 +493,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: appserver:mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: appserver
   check: mysql_status
@@ -524,10 +503,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver:mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver:mysql_status"
   },
   "spec": {
     "subscription": "appserver",
@@ -550,9 +526,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   check: mysql_status
 {{< /code >}}
@@ -562,10 +535,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "mysql_status"
   },
   "spec": {
     "check": "mysql_status"

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/_index.md
@@ -58,9 +58,7 @@ This check would run on any entities whose definitions also specify the `system`
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check-cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -92,9 +90,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "check-cpu",
-    "namespace": "default"
+    "name": "check-cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -518,7 +518,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: keepalive
-  namespace: default
 spec:
   handlers:
   - slack
@@ -530,8 +529,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "keepalive",
-    "namespace": "default"
+    "name": "keepalive"
   },
   "spec": {
     "type": "set",
@@ -1792,7 +1790,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   command: ping-github-api.sh $TEST_GITHUB_TOKEN
   handlers:
@@ -1808,8 +1805,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "command": "ping-github-api.sh $TEST_GITHUB_TOKEN",

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -1385,9 +1385,7 @@ The following handler will print the `TEST_VARIABLE` value set in your sensu-bac
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: print_test_var
-  namespace: default
 spec:
   command: echo $TEST_VARIABLE >> ./tmp/test.txt
   timeout: 0
@@ -1399,9 +1397,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "print_test_var",
-    "namespace": "default"
+    "name": "print_test_var"
   },
   "spec": {
     "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/checks.md
@@ -35,7 +35,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check_minimum
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -51,7 +50,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_minimum"
   },
   "spec": {
@@ -167,7 +165,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -183,8 +180,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_check",
-    "namespace": "default"
+    "name": "interval_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -224,7 +220,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   cron: '* * * * *'
@@ -240,8 +235,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "cron_check",
-    "namespace": "default"
+    "name": "cron_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -266,7 +260,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   check_hooks: null
   command: hi
@@ -296,8 +289,7 @@ spec:
    "type": "CheckConfig",
    "api_version": "core/v2",
    "metadata": {
-      "name": "cron_check",
-      "namespace": "default"
+      "name": "cron_check"
    },
    "spec": {
       "check_hooks": null,
@@ -343,7 +335,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ad_hoc_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -359,8 +350,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ad_hoc_check",
-    "namespace": "default"
+    "name": "ad_hoc_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -398,7 +388,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check
-  namespace: default
 spec:
   command: http_check.sh https://sensu.io
   handlers:
@@ -416,8 +405,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check",
-    "namespace": "default"
+    "name": "proxy_check"
   },
   "spec": {
     "command": "http_check.sh https://sensu.io",
@@ -457,7 +445,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check_proxy_requests
-  namespace: default
 spec:
   command: http_check.sh {{ .labels.url }}
   handlers:
@@ -477,8 +464,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check_proxy_requests",
-    "namespace": "default"
+    "name": "proxy_check_proxy_requests"
   },
   "spec": {
     "command": "http_check.sh {{ .labels.url }}",
@@ -1412,7 +1398,6 @@ metadata:
   labels:
     region: us-west-1
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: collect.sh
@@ -1449,7 +1434,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "collect-metrics",
-    "namespace": "default",
     "labels": {
       "region": "us-west-1"
     },
@@ -1513,7 +1497,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   check_hooks: null
   command: ping-github-api.sh $GITHUB_TOKEN
@@ -1527,8 +1510,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "check_hooks": null,
@@ -1559,7 +1541,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_test
-  namespace: default
 spec:
   command: powershell.exe -f c:\\users\\tester\\test.ps1
   subscriptions:
@@ -1575,8 +1556,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_test",
-    "namespace": "default"
+    "name": "interval_test"
   },
   "spec": {
     "command": "powershell.exe -f c:\\users\\tester\\test.ps1",

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Hooks Reference"
 reference_title: "Hooks"
 type: "reference"
 description: "Check hooks allow you to automate data collection that operators would typically perform by investigating observability alerts manually. Hooks help free up precious operator time. Read the reference doc to learn about hooks."
-weight: 60
+weight: 80
 version: "6.2"
 product: "Sensu Go"
 platformContent: false
@@ -30,10 +30,7 @@ This example demonstrates a check hook to capture the process tree when a proces
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   stdin: false
@@ -46,10 +43,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "process_tree",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",
@@ -426,10 +420,7 @@ You can use hooks for rudimentary auto-remediation tasks, such as starting a pro
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: restart_nginx
-  namespace: default
 spec:
   command: sudo systemctl start nginx
   stdin: false
@@ -441,10 +432,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "restart_nginx",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "restart_nginx"
   },
   "spec": {
     "command": "sudo systemctl start nginx",
@@ -471,11 +459,9 @@ You can create check hooks that use [token substitution][7] so you can fine-tune
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
   labels:
     foo: bar
   name: tokensub
-  namespace: default
 spec:
   command: tokensub {{ .labels.foo }}
   stdin: false
@@ -487,12 +473,10 @@ spec:
    "type": "HookConfig",
    "api_version": "core/v2",
    "metadata": {
-      "annotations": null,
       "labels": {
          "foo": "bar"
       },
-      "name": "tokensub",
-      "namespace": "default"
+      "name": "tokensub"
    },
    "spec": {
       "command": "tokensub {{ .labels.foo }}",

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/metrics.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect-system-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: system-check
@@ -73,8 +72,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "collect-system-metrics",
-    "namespace": "default"
+    "name": "collect-system-metrics"
   },
   "spec": {
     "check_hooks": null,
@@ -295,7 +293,6 @@ check:
     # HELP system_host_processes [GAUGE] Number of host processes
     # TYPE system_host_processes GAUGE
     system_host_processes{} 109 1635270399219
-
   state: passing
   status: 0
   total_state_change: 0

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/subscriptions.md
@@ -55,7 +55,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect_info
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -71,7 +70,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "collect_info"
   },
   "spec": {

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/tokens.md
@@ -4,7 +4,7 @@ linkTitle: "Tokens Reference"
 reference_title: "Tokens"
 type: "reference"
 description: "Tokens are placeholders in a check definition that the agent replaces with entity information before executing the check. You can use tokens to fine-tune check attributes (like alert thresholds) on a per-entity level while reusing check definitions. Read the reference doc to learn about tokens."
-weight: 80
+weight: 100
 version: "6.2"
 product: "Sensu Go"
 menu:
@@ -61,7 +61,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-disk-usage
-  namespace: default
 spec:
   check_hooks: []
   command: check-disk-usage -w {{index .labels "disk_warning" | default 80}} -c
@@ -93,8 +92,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-disk-usage",
-    "namespace": "default"
+    "name": "check-disk-usage"
   },
   "spec": {
     "check_hooks": [],
@@ -164,7 +162,6 @@ type: HookConfig
 api_version: core/v2
 metadata:
   name: disk_usage_details
-  namespace: default
 spec:
   command: du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default "/"}}  2>/dev/null
   runtime_assets: null
@@ -178,8 +175,7 @@ cat << EOF | sensuctl create
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "disk_usage_details",
-    "namespace": "default"
+    "name": "disk_usage_details"
   },
   "spec": {
     "command": "du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default \"/\"}}  2>/dev/null",

--- a/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.2/operations/control-access/create-limited-service-accounts.md
@@ -87,7 +87,6 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-delete
   namespace: default
 spec:
@@ -105,7 +104,6 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-delete",
     "namespace": "default"
   },
@@ -141,7 +139,6 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-service-delete
   namespace: default
 spec:
@@ -157,7 +154,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-service-delete",
     "namespace": "default"
   },
@@ -244,7 +240,6 @@ cat << EOF | sensuctl create
 type: Handler
 api_version: core/v2
 metadata:
-  namespace: default
   name: sensu-ec2-handler
 spec:
   type: pipe
@@ -275,7 +270,6 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "sensu-ec2-handler"
   },
   "spec": {

--- a/content/sensu-go/6.2/operations/control-access/rbac.md
+++ b/content/sensu-go/6.2/operations/control-access/rbac.md
@@ -423,7 +423,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: namespaced-resources-all-verbs
-  namespace: default
 spec:
   rules:
   - resources:
@@ -451,8 +450,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "namespaced-resources-all-verbs",
-    "namespace": "default"
+    "name": "namespaced-resources-all-verbs"
   },
   "spec": {
     "rules": [
@@ -999,7 +997,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: event-reader-binding
-  namespace: default
 spec:
   role_ref:
     name: event-reader
@@ -1014,8 +1011,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader-binding",
-    "namespace": "default"
+    "name": "event-reader-binding"
   },
   "spec": {
     "role_ref": {
@@ -1164,7 +1160,7 @@ You can use [sensuctl][2] to create a role binding that assigns a role:
 sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1173,9 +1169,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1192,9 +1186,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1223,7 +1215,7 @@ To create a role binding that assigns a cluster role:
 sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1232,9 +1224,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1251,9 +1241,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1282,7 +1270,7 @@ To create a cluster role binding:
 sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following cluster role binding resource definition:
+This command creates a cluster role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1291,7 +1279,6 @@ This command creates the following cluster role binding resource definition:
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
 spec:
   role_ref:
@@ -1309,7 +1296,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "NAME"
   },
   "spec": {
@@ -2582,7 +2568,6 @@ sensuctl cluster-role create silencing-script --verb get,list,create,update,dele
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script
 spec:
   rules:
@@ -2600,7 +2585,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script"
   },
   "spec": {
@@ -2637,7 +2621,6 @@ sensuctl role-binding create silencing-script-binding-team-1 --cluster-role sile
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script-binding-team-1
   namespace: team1
 spec:
@@ -2653,7 +2636,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script-binding-team-1",
     "namespace": "team1"
   },

--- a/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.2/operations/deploy-sensu/generate-certificates.md
@@ -327,7 +327,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: expired_certs
-  namespace: default
 spec:
   command: openssl x509 -noout -enddate -in <cert-name>.pem
   subscriptions:
@@ -340,8 +339,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
-    "name": "expired_certs"
+    "namespace": "default"
   },
   "spec": {
     "command": "openssl x509 -noout -enddate -in <cert-name>.pem",

--- a/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/migrate.md
@@ -358,9 +358,7 @@ Sensu Go hourly filter:
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -373,9 +371,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets.md
@@ -48,7 +48,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible-token
-  namespace: default
 spec:
   id: ANSIBLE_TOKEN
   provider: env
@@ -59,8 +58,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible-token",
-    "namespace": "default"
+    "name": "sensu-ansible-token"
   },
   "spec": {
     "id": "ANSIBLE_TOKEN",
@@ -81,7 +79,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible
-  namespace: default
 spec:
   id: 'secret/database#password'
   provider: vault
@@ -92,8 +89,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible",
-    "namespace": "default"
+    "name": "sensu-ansible"
   },
   "spec": {
     "id": "secret/database#password",

--- a/content/sensu-go/6.2/plugins/assets.md
+++ b/content/sensu-go/6.2/plugins/assets.md
@@ -41,7 +41,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_script
-  namespace: default
 spec:
   builds:
   - sha512: 4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b
@@ -53,8 +52,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_script",
-    "namespace": "default"
+    "name": "check_script"
   },
   "spec": {
     "builds": [
@@ -91,7 +89,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -132,7 +129,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -199,7 +195,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu_linux_amd64
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -222,7 +217,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu_linux_amd64",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -294,7 +288,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-prometheus-collector
-  namespace: default
 spec:
   builds:
   - url: https://assets.bonsai.sensu.io/ef812286f59de36a40e51178024b81c69666e1b7/sensu-prometheus-collector_1.1.6_linux_amd64.tar.gz
@@ -307,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_collector
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   interval: 10
@@ -326,8 +318,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-email-handler",
-    "namespace": "default"
+    "name": "sensu-email-handler"
   },
   "spec": {
     "builds": [
@@ -346,8 +337,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_collector",
-    "namespace": "default"
+    "name": "prometheus_collector"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",
@@ -465,7 +455,6 @@ To correctly capture exit status codes from PowerShell plugins distributed as dy
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: win-cpu-check
 spec:
   command: powershell.exe -ExecutionPolicy ByPass -f %{{assetPath "sensu-windows-powershell-checks"}}%\bin\check-windows-cpu-load.ps1 90 95
@@ -485,8 +474,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "win-cpu-check",
-    "namespace": "default"
+    "name": "win-cpu-check"
   },
   "spec": {
     "command": "powershell.exe -ExecutionPolicy ByPass -f %{{assetPath \"sensu-windows-powershell-checks\"}}%\\bin\\check-windows-cpu-load.ps1 90 95",

--- a/content/sensu-go/6.2/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.2/sensuctl/create-manage-resources.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: marketing-site
-  namespace: default
 spec:
   command: http-check -u https://sensu.io
   subscriptions:
@@ -53,7 +52,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -69,8 +67,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "marketing-site",
-    "namespace": "default"
+    "name": "marketing-site"
     },
   "spec": {
     "command": "http-check -u https://sensu.io",
@@ -83,8 +80,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.2/web-ui/searches-reference.md
+++ b/content/sensu-go/6.2/web-ui/searches-reference.md
@@ -35,7 +35,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: events-not-passing
-  namespace: default
 spec:
   parameters:
   - status:incident
@@ -50,8 +49,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "events-not-passing",
-    "namespace": "default"
+    "name": "events-not-passing"
   },
   "spec": {
     "parameters": [
@@ -79,7 +77,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: published-checks-linux-uswest
-  namespace: default
 spec:
   parameters:
   - published:true
@@ -93,8 +90,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "published-checks-linux-uswest",
-    "namespace": "default"
+    "name": "published-checks-linux-uswest"
   },
   "spec": {
     "parameters": [

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -39,10 +39,7 @@ This example shows the resource definition for an agent entity:
 type: Entity
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: webserver01
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -115,10 +112,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "webserver01"
   },
   "spec": {
     "entity_class": "agent",
@@ -261,8 +255,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
-  labels: null
 spec:
   deregister: false
   deregistration: {}
@@ -281,9 +273,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-docs",
-    "namespace": "default",
-    "labels": null
+    "name": "sensu-docs"
   },
   "spec": {
     "deregister": false,
@@ -358,9 +348,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"
@@ -414,7 +402,6 @@ metadata:
   labels:
     url: docs.sensu.io
   name: sensu-docs
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -434,7 +421,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }
@@ -517,9 +503,7 @@ To create a service entity with a `service_type` label using sensuctl `create`, 
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
   labels:
     service_type: datastore
 spec:
@@ -531,9 +515,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "postgresql",
-    "namespace": "default",
     "labels": {
       "service_type": "datastore"
     }

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/_index.md
@@ -38,7 +38,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -50,8 +49,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -47,7 +47,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: filter_minimum
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -59,8 +58,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_minimum",
-    "namespace": "default"
+    "name": "filter_minimum"
   },
   "spec": {
     "action": "allow",
@@ -109,7 +107,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: metrics-checks-only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -121,8 +118,7 @@ spec:
    "type": "EventFilter",
    "api_version": "core/v2",
    "metadata": {
-      "name": "metrics-checks-only",
-      "namespace": "default"
+      "name": "metrics-checks-only"
    },
    "spec": {
       "action": "allow",
@@ -146,7 +142,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: us-west-events
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -158,8 +153,7 @@ spec:
    "type": "EventFilter",
    "api_version": "core/v2",
    "metadata": {
-      "name": "us-west-events",
-      "namespace": "default"
+      "name": "us-west-events"
    },
    "spec": {
       "action": "allow",
@@ -205,7 +199,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -223,8 +216,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -268,7 +260,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -287,8 +278,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -328,7 +318,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influx-db
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
@@ -348,8 +337,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influx-db",
-    "namespace": "default"
+    "name": "influx-db"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -826,10 +814,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: deny_if_failure_in_history
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -844,10 +829,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "deny_if_failure_in_history",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "deny_if_failure_in_history"
   },
   "spec": {
     "action": "deny",
@@ -873,7 +855,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -885,8 +866,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",
@@ -916,7 +896,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: not_production
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -928,8 +907,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "not_production",
-    "namespace": "default"
+    "name": "not_production"
   },
   "spec": {
     "action": "deny",
@@ -953,10 +931,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -969,10 +944,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "state_change_only",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -997,10 +969,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_60_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1014,10 +983,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_60_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_60_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1041,10 +1007,7 @@ This example will apply the same logic as the previous example but for checks wi
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_30_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1058,10 +1021,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_30_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_30_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1091,10 +1051,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: keepalive_timeouts
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1108,10 +1065,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "keepalive_timeouts",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "keepalive_timeouts"
   },
   "spec": {
     "action": "allow",
@@ -1139,10 +1093,7 @@ If evaluation returns false, the event will not be handled.
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: nine_to_fiver
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1156,10 +1107,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nine_to_fiver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "nine_to_fiver"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/silencing.md
@@ -46,10 +46,7 @@ This example shows a silencing resource definition that uses a per-entity subscr
 type: Silenced
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: entity:i-424242:*
-  namespace: default
 spec:
   begin: 1542671205
   check: null
@@ -65,10 +62,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:*",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:*"
   },
   "spec": {
     "expire": -1,
@@ -96,9 +90,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: entity:i-424242:check_ntp
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: entity:i-424242
   check: check_ntp
@@ -110,10 +101,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:check_ntp",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:check_ntp"
   },
   "spec": {
     "subscription": "entity:i-424242",
@@ -453,10 +441,7 @@ Use this example to create a silencing entry for all checks with the `appserver`
 type: Silenced
 api_version: core/v2
 metadata:
-  name: appserver
-  namespace: default
-  labels: 
-  annotations: 
+  name: appserver 
 spec:
   subscription: appserver
 {{< /code >}}
@@ -466,10 +451,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver"
   },
   "spec": {
     "subscription": "appserver"
@@ -511,9 +493,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: appserver:mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: appserver
   check: mysql_status
@@ -524,10 +503,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver:mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver:mysql_status"
   },
   "spec": {
     "subscription": "appserver",
@@ -550,9 +526,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   check: mysql_status
 {{< /code >}}
@@ -562,10 +535,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "mysql_status"
   },
   "spec": {
     "check": "mysql_status"

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/_index.md
@@ -58,9 +58,7 @@ This check would run on any entities whose definitions also specify the `system`
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check-cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -92,9 +90,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "check-cpu",
-    "namespace": "default"
+    "name": "check-cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -518,7 +518,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: keepalive
-  namespace: default
 spec:
   handlers:
   - slack
@@ -530,8 +529,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "keepalive",
-    "namespace": "default"
+    "name": "keepalive"
   },
   "spec": {
     "type": "set",
@@ -1789,7 +1787,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   command: ping-github-api.sh $TEST_GITHUB_TOKEN
   handlers:
@@ -1805,8 +1802,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "command": "ping-github-api.sh $TEST_GITHUB_TOKEN",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1412,9 +1412,7 @@ The following handler will print the `TEST_VARIABLE` value set in your sensu-bac
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: print_test_var
-  namespace: default
 spec:
   command: echo $TEST_VARIABLE >> ./tmp/test.txt
   timeout: 0
@@ -1426,9 +1424,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "print_test_var",
-    "namespace": "default"
+    "name": "print_test_var"
   },
   "spec": {
     "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -61,8 +61,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: postgresql-1
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -89,9 +87,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "postgresql-1",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "postgresql-1"
   },
   "spec": {
     "cron": "",
@@ -138,8 +134,6 @@ type: RuleTemplate
 api_version: bsm/v1
 metadata:
   name: status-threshold
-  namespace: default
-  created_by: admin
 spec:
   description: Creates an event when the percentage of events with the given status exceed the given threshold
   arguments:
@@ -181,9 +175,7 @@ spec:
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "status-threshold",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "status-threshold"
   },
   "spec": {
     "description": "Creates an event when the percentage of events with the given status exceed the given threshold",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -35,7 +35,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check_minimum
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -51,7 +50,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_minimum"
   },
   "spec": {
@@ -167,7 +165,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -183,8 +180,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_check",
-    "namespace": "default"
+    "name": "interval_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -224,7 +220,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   cron: '* * * * *'
@@ -240,8 +235,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "cron_check",
-    "namespace": "default"
+    "name": "cron_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -266,7 +260,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   check_hooks: null
   command: hi
@@ -296,8 +289,7 @@ spec:
    "type": "CheckConfig",
    "api_version": "core/v2",
    "metadata": {
-      "name": "cron_check",
-      "namespace": "default"
+      "name": "cron_check"
    },
    "spec": {
       "check_hooks": null,
@@ -343,7 +335,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ad_hoc_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -359,8 +350,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ad_hoc_check",
-    "namespace": "default"
+    "name": "ad_hoc_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -398,7 +388,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check
-  namespace: default
 spec:
   command: http_check.sh https://sensu.io
   handlers:
@@ -416,8 +405,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check",
-    "namespace": "default"
+    "name": "proxy_check"
   },
   "spec": {
     "command": "http_check.sh https://sensu.io",
@@ -457,7 +445,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check_proxy_requests
-  namespace: default
 spec:
   command: http_check.sh {{ .labels.url }}
   handlers:
@@ -477,8 +464,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check_proxy_requests",
-    "namespace": "default"
+    "name": "proxy_check_proxy_requests"
   },
   "spec": {
     "command": "http_check.sh {{ .labels.url }}",
@@ -1412,7 +1398,6 @@ metadata:
   labels:
     region: us-west-1
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: collect.sh
@@ -1449,7 +1434,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "collect-metrics",
-    "namespace": "default",
     "labels": {
       "region": "us-west-1"
     },
@@ -1513,7 +1497,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   check_hooks: null
   command: ping-github-api.sh $GITHUB_TOKEN
@@ -1527,8 +1510,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "check_hooks": null,
@@ -1559,7 +1541,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_test
-  namespace: default
 spec:
   command: powershell.exe -f c:\\users\\tester\\test.ps1
   subscriptions:
@@ -1575,8 +1556,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_test",
-    "namespace": "default"
+    "name": "interval_test"
   },
   "spec": {
     "command": "powershell.exe -f c:\\users\\tester\\test.ps1",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
@@ -30,10 +30,7 @@ This example demonstrates a check hook to capture the process tree when a proces
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   stdin: false
@@ -46,10 +43,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "process_tree",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",
@@ -426,10 +420,7 @@ You can use hooks for rudimentary auto-remediation tasks, such as starting a pro
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: restart_nginx
-  namespace: default
 spec:
   command: sudo systemctl start nginx
   stdin: false
@@ -441,10 +432,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "restart_nginx",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "restart_nginx"
   },
   "spec": {
     "command": "sudo systemctl start nginx",
@@ -471,11 +459,9 @@ You can create check hooks that use [token substitution][7] so you can fine-tune
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
   labels:
     foo: bar
   name: tokensub
-  namespace: default
 spec:
   command: tokensub {{ .labels.foo }}
   stdin: false
@@ -487,12 +473,10 @@ spec:
    "type": "HookConfig",
    "api_version": "core/v2",
    "metadata": {
-      "annotations": null,
       "labels": {
          "foo": "bar"
       },
-      "name": "tokensub",
-      "namespace": "default"
+      "name": "tokensub"
    },
    "spec": {
       "command": "tokensub {{ .labels.foo }}",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect-system-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: system-check
@@ -73,8 +72,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "collect-system-metrics",
-    "namespace": "default"
+    "name": "collect-system-metrics"
   },
   "spec": {
     "check_hooks": null,
@@ -295,7 +293,6 @@ check:
     # HELP system_host_processes [GAUGE] Number of host processes
     # TYPE system_host_processes GAUGE
     system_host_processes{} 109 1635270399219
-
   state: passing
   status: 0
   total_state_change: 0

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -46,7 +46,6 @@ type: RuleTemplate
 api_version: bsm/v1
 metadata:
   name: status-threshold
-  namespace: default
 spec:
   description: Creates an event when the percentage of events with the given status exceed the given threshold
   arguments:
@@ -86,8 +85,7 @@ spec:
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "status-threshold",
-    "namespace": "default"
+    "name": "status-threshold"
   },
   "spec": {
     "description": "Creates an event when the percentage of events with the given status exceed the given threshold",
@@ -170,8 +168,7 @@ The response will include the complete `aggregate` rule template resource defini
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "aggregate",
-    "namespace": "default"
+    "name": "aggregate"
   },
   "spec": {
     "arguments": {
@@ -229,8 +226,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: web-app
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -257,9 +252,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "web-app",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "web-app"
   },
   "spec": {
     "cron": "",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
@@ -45,8 +45,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: postgresql-1
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -73,9 +71,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "postgresql-1",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "postgresql-1"
   },
   "spec": {
     "cron": "",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
@@ -55,7 +55,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect_info
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -71,7 +70,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "collect_info"
   },
   "spec": {

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -61,7 +61,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-disk-usage
-  namespace: default
 spec:
   check_hooks: []
   command: check-disk-usage -w {{index .labels "disk_warning" | default 80}} -c
@@ -93,8 +92,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-disk-usage",
-    "namespace": "default"
+    "name": "check-disk-usage"
   },
   "spec": {
     "check_hooks": [],
@@ -164,7 +162,6 @@ type: HookConfig
 api_version: core/v2
 metadata:
   name: disk_usage_details
-  namespace: default
 spec:
   command: du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default "/"}}  2>/dev/null
   runtime_assets: null
@@ -178,8 +175,7 @@ cat << EOF | sensuctl create
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "disk_usage_details",
-    "namespace": "default"
+    "name": "disk_usage_details"
   },
   "spec": {
     "command": "du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default \"/\"}}  2>/dev/null",

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -87,7 +87,6 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-delete
   namespace: default
 spec:
@@ -105,7 +104,6 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-delete",
     "namespace": "default"
   },
@@ -141,7 +139,6 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-service-delete
   namespace: default
 spec:
@@ -157,7 +154,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-service-delete",
     "namespace": "default"
   },
@@ -244,7 +240,6 @@ cat << EOF | sensuctl create
 type: Handler
 api_version: core/v2
 metadata:
-  namespace: default
   name: sensu-ec2-handler
 spec:
   type: pipe
@@ -275,7 +270,6 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "sensu-ec2-handler"
   },
   "spec": {

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -423,7 +423,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: namespaced-resources-all-verbs
-  namespace: default
 spec:
   rules:
   - resources:
@@ -451,8 +450,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "namespaced-resources-all-verbs",
-    "namespace": "default"
+    "name": "namespaced-resources-all-verbs"
   },
   "spec": {
     "rules": [
@@ -999,7 +997,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: event-reader-binding
-  namespace: default
 spec:
   role_ref:
     name: event-reader
@@ -1014,8 +1011,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader-binding",
-    "namespace": "default"
+    "name": "event-reader-binding"
   },
   "spec": {
     "role_ref": {
@@ -1164,7 +1160,7 @@ You can use [sensuctl][2] to create a role binding that assigns a role:
 sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1173,9 +1169,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1192,9 +1186,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1223,7 +1215,7 @@ To create a role binding that assigns a cluster role:
 sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1232,9 +1224,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1251,9 +1241,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1282,7 +1270,7 @@ To create a cluster role binding:
 sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following cluster role binding resource definition:
+This command creates a cluster role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1291,7 +1279,6 @@ This command creates the following cluster role binding resource definition:
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
 spec:
   role_ref:
@@ -1309,7 +1296,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "NAME"
   },
   "spec": {
@@ -2582,7 +2568,6 @@ sensuctl cluster-role create silencing-script --verb get,list,create,update,dele
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script
 spec:
   rules:
@@ -2600,7 +2585,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script"
   },
   "spec": {
@@ -2637,7 +2621,6 @@ sensuctl role-binding create silencing-script-binding-team-1 --cluster-role sile
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script-binding-team-1
   namespace: team1
 spec:
@@ -2653,7 +2636,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script-binding-team-1",
     "namespace": "team1"
   },

--- a/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/generate-certificates.md
@@ -327,7 +327,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: expired_certs
-  namespace: default
 spec:
   command: openssl x509 -noout -enddate -in <cert-name>.pem
   subscriptions:
@@ -340,8 +339,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
-    "name": "expired_certs"
+    "namespace": "default"
   },
   "spec": {
     "command": "openssl x509 -noout -enddate -in <cert-name>.pem",

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -358,9 +358,7 @@ Sensu Go hourly filter:
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -373,9 +371,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets.md
@@ -48,7 +48,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible-token
-  namespace: default
 spec:
   id: ANSIBLE_TOKEN
   provider: env
@@ -59,8 +58,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible-token",
-    "namespace": "default"
+    "name": "sensu-ansible-token"
   },
   "spec": {
     "id": "ANSIBLE_TOKEN",
@@ -81,7 +79,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible
-  namespace: default
 spec:
   id: 'secret/database#password'
   provider: vault
@@ -92,8 +89,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible",
-    "namespace": "default"
+    "name": "sensu-ansible"
   },
   "spec": {
     "id": "secret/database#password",

--- a/content/sensu-go/6.3/plugins/assets.md
+++ b/content/sensu-go/6.3/plugins/assets.md
@@ -41,7 +41,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_script
-  namespace: default
 spec:
   builds:
   - sha512: 4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b
@@ -53,8 +52,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_script",
-    "namespace": "default"
+    "name": "check_script"
   },
   "spec": {
     "builds": [
@@ -91,7 +89,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -132,7 +129,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -199,7 +195,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu_linux_amd64
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -222,7 +217,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu_linux_amd64",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -294,7 +288,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-prometheus-collector
-  namespace: default
 spec:
   builds:
   - url: https://assets.bonsai.sensu.io/ef812286f59de36a40e51178024b81c69666e1b7/sensu-prometheus-collector_1.1.6_linux_amd64.tar.gz
@@ -307,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_collector
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   interval: 10
@@ -465,7 +457,6 @@ To correctly capture exit status codes from PowerShell plugins distributed as dy
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: win-cpu-check
 spec:
   command: powershell.exe -ExecutionPolicy ByPass -f %{{assetPath "sensu-windows-powershell-checks"}}%\bin\check-windows-cpu-load.ps1 90 95
@@ -485,8 +476,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "win-cpu-check",
-    "namespace": "default"
+    "name": "win-cpu-check"
   },
   "spec": {
     "command": "powershell.exe -ExecutionPolicy ByPass -f %{{assetPath \"sensu-windows-powershell-checks\"}}%\\bin\\check-windows-cpu-load.ps1 90 95",

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: marketing-site
-  namespace: default
 spec:
   command: http-check -u https://sensu.io
   subscriptions:
@@ -53,7 +52,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -69,8 +67,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "marketing-site",
-    "namespace": "default"
+    "name": "marketing-site"
     },
   "spec": {
     "command": "http-check -u https://sensu.io",
@@ -83,8 +80,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.3/web-ui/searches-reference.md
+++ b/content/sensu-go/6.3/web-ui/searches-reference.md
@@ -35,7 +35,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: events-not-passing
-  namespace: default
 spec:
   parameters:
   - status:incident
@@ -50,8 +49,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "events-not-passing",
-    "namespace": "default"
+    "name": "events-not-passing"
   },
   "spec": {
     "parameters": [
@@ -79,7 +77,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: published-checks-linux-uswest
-  namespace: default
 spec:
   parameters:
   - published:true
@@ -93,8 +90,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "published-checks-linux-uswest",
-    "namespace": "default"
+    "name": "published-checks-linux-uswest"
   },
   "spec": {
     "parameters": [

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -39,10 +39,7 @@ This example shows the resource definition for an agent entity:
 type: Entity
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: webserver01
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -115,10 +112,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "webserver01"
   },
   "spec": {
     "entity_class": "agent",
@@ -261,8 +255,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
-  labels: null
 spec:
   deregister: false
   deregistration: {}
@@ -281,9 +273,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-docs",
-    "namespace": "default",
-    "labels": null
+    "name": "sensu-docs"
   },
   "spec": {
     "deregister": false,
@@ -346,9 +336,7 @@ This example shows the resource definition for a service entity:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -358,9 +346,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"
@@ -414,7 +400,6 @@ metadata:
   labels:
     url: docs.sensu.io
   name: sensu-docs
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -434,7 +419,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }
@@ -517,9 +501,7 @@ To create a service entity with a `service_type` label using sensuctl `create`, 
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
   labels:
     service_type: datastore
 spec:
@@ -531,9 +513,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "postgresql",
-    "namespace": "default",
     "labels": {
       "service_type": "datastore"
     }

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/_index.md
@@ -38,7 +38,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -50,8 +49,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -47,7 +47,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: filter_minimum
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -59,8 +58,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_minimum",
-    "namespace": "default"
+    "name": "filter_minimum"
   },
   "spec": {
     "action": "allow",
@@ -109,7 +107,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: metrics-checks-only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -121,8 +118,7 @@ spec:
    "type": "EventFilter",
    "api_version": "core/v2",
    "metadata": {
-      "name": "metrics-checks-only",
-      "namespace": "default"
+      "name": "metrics-checks-only"
    },
    "spec": {
       "action": "allow",
@@ -146,7 +142,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: us-west-events
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -158,8 +153,7 @@ spec:
    "type": "EventFilter",
    "api_version": "core/v2",
    "metadata": {
-      "name": "us-west-events",
-      "namespace": "default"
+      "name": "us-west-events"
    },
    "spec": {
       "action": "allow",
@@ -205,7 +199,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -223,8 +216,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -268,7 +260,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -287,8 +278,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -328,7 +318,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: influx-db
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
@@ -348,8 +337,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "influx-db",
-    "namespace": "default"
+    "name": "influx-db"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -826,10 +814,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: deny_if_failure_in_history
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -844,10 +829,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "deny_if_failure_in_history",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "deny_if_failure_in_history"
   },
   "spec": {
     "action": "deny",
@@ -873,7 +855,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -885,8 +866,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",
@@ -916,7 +896,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: not_production
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -928,8 +907,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "not_production",
-    "namespace": "default"
+    "name": "not_production"
   },
   "spec": {
     "action": "deny",
@@ -953,10 +931,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -969,10 +944,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "state_change_only",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -997,10 +969,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_60_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1014,10 +983,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_60_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_60_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1041,10 +1007,7 @@ This example will apply the same logic as the previous example but for checks wi
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_30_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1058,10 +1021,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_30_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_30_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1091,10 +1051,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: keepalive_timeouts
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1108,10 +1065,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "keepalive_timeouts",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "keepalive_timeouts"
   },
   "spec": {
     "action": "allow",
@@ -1139,10 +1093,7 @@ If evaluation returns false, the event will not be handled.
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: nine_to_fiver
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1156,10 +1107,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nine_to_fiver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "nine_to_fiver"
   },
   "spec": {
     "action": "allow",
@@ -1184,10 +1132,7 @@ For example, if office hours are 8:30 AM to 5:30 PM:
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: 830_to_530
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1202,10 +1147,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "830_to_530",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "830_to_530"
   },
   "spec": {
     "action": "allow",
@@ -1233,10 +1175,7 @@ In other words, this filter sets a 30-second time budget for event processing so
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: budget_30
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1249,10 +1188,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "budget_30",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "budget_30"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/silencing.md
@@ -46,10 +46,7 @@ This example shows a silencing resource definition that uses a per-entity subscr
 type: Silenced
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: entity:i-424242:*
-  namespace: default
 spec:
   begin: 1542671205
   check: null
@@ -65,10 +62,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:*",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:*"
   },
   "spec": {
     "expire": -1,
@@ -96,9 +90,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: entity:i-424242:check_ntp
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: entity:i-424242
   check: check_ntp
@@ -110,10 +101,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:check_ntp",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:check_ntp"
   },
   "spec": {
     "subscription": "entity:i-424242",
@@ -454,9 +442,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: appserver
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: appserver
 {{< /code >}}
@@ -466,10 +451,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver"
   },
   "spec": {
     "subscription": "appserver"
@@ -511,9 +493,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: appserver:mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: appserver
   check: mysql_status
@@ -524,10 +503,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver:mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver:mysql_status"
   },
   "spec": {
     "subscription": "appserver",
@@ -550,9 +526,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   check: mysql_status
 {{< /code >}}
@@ -562,10 +535,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "mysql_status"
   },
   "spec": {
     "check": "mysql_status"

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/_index.md
@@ -58,9 +58,7 @@ This check would run on any entities whose definitions also specify the `system`
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check-cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -92,9 +90,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "check-cpu",
-    "namespace": "default"
+    "name": "check-cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -518,7 +518,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: keepalive
-  namespace: default
 spec:
   handlers:
   - slack
@@ -530,8 +529,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "keepalive",
-    "namespace": "default"
+    "name": "keepalive"
   },
   "spec": {
     "type": "set",
@@ -1789,7 +1787,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   command: ping-github-api.sh $TEST_GITHUB_TOKEN
   handlers:
@@ -1805,8 +1802,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "command": "ping-github-api.sh $TEST_GITHUB_TOKEN",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1461,9 +1461,7 @@ The following handler will print the `TEST_VARIABLE` value set in your sensu-bac
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: print_test_var
-  namespace: default
 spec:
   command: echo $TEST_VARIABLE >> ./tmp/test.txt
   timeout: 0
@@ -1475,9 +1473,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "print_test_var",
-    "namespace": "default"
+    "name": "print_test_var"
   },
   "spec": {
     "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -61,8 +61,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: postgresql-1
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -89,9 +87,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "postgresql-1",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "postgresql-1"
   },
   "spec": {
     "cron": "",
@@ -138,8 +134,6 @@ type: RuleTemplate
 api_version: bsm/v1
 metadata:
   name: status-threshold
-  namespace: default
-  created_by: admin
 spec:
   description: Creates an event when the percentage of events with the given status exceed the given threshold
   arguments:
@@ -181,9 +175,7 @@ spec:
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "status-threshold",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "status-threshold"
   },
   "spec": {
     "description": "Creates an event when the percentage of events with the given status exceed the given threshold",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -35,7 +35,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check_minimum
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -51,7 +50,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_minimum"
   },
   "spec": {
@@ -167,7 +165,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -183,8 +180,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_check",
-    "namespace": "default"
+    "name": "interval_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -224,7 +220,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   cron: '* * * * *'
@@ -240,8 +235,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "cron_check",
-    "namespace": "default"
+    "name": "cron_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -255,7 +249,6 @@ spec:
 
 {{< /language-toggle >}}
 
-
 Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the `cron` attribute:
 
 {{< language-toggle >}}
@@ -266,7 +259,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   check_hooks: null
   command: hi
@@ -296,8 +288,7 @@ spec:
    "type": "CheckConfig",
    "api_version": "core/v2",
    "metadata": {
-      "name": "cron_check",
-      "namespace": "default"
+      "name": "cron_check"
    },
    "spec": {
       "check_hooks": null,
@@ -343,7 +334,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ad_hoc_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -359,8 +349,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ad_hoc_check",
-    "namespace": "default"
+    "name": "ad_hoc_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -398,7 +387,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check
-  namespace: default
 spec:
   command: http_check.sh https://sensu.io
   handlers:
@@ -416,8 +404,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check",
-    "namespace": "default"
+    "name": "proxy_check"
   },
   "spec": {
     "command": "http_check.sh https://sensu.io",
@@ -457,7 +444,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check_proxy_requests
-  namespace: default
 spec:
   command: http_check.sh {{ .labels.url }}
   handlers:
@@ -477,8 +463,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check_proxy_requests",
-    "namespace": "default"
+    "name": "proxy_check_proxy_requests"
   },
   "spec": {
     "command": "http_check.sh {{ .labels.url }}",
@@ -1412,7 +1397,6 @@ metadata:
   labels:
     region: us-west-1
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: collect.sh
@@ -1449,7 +1433,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "collect-metrics",
-    "namespace": "default",
     "labels": {
       "region": "us-west-1"
     },
@@ -1513,7 +1496,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   check_hooks: null
   command: ping-github-api.sh $GITHUB_TOKEN
@@ -1527,8 +1509,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "check_hooks": null,
@@ -1559,7 +1540,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_test
-  namespace: default
 spec:
   command: powershell.exe -f c:\\users\\tester\\test.ps1
   subscriptions:
@@ -1575,8 +1555,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_test",
-    "namespace": "default"
+    "name": "interval_test"
   },
   "spec": {
     "command": "powershell.exe -f c:\\users\\tester\\test.ps1",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
@@ -30,10 +30,7 @@ This example demonstrates a check hook to capture the process tree when a proces
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   stdin: false
@@ -46,10 +43,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "process_tree",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",
@@ -426,10 +420,7 @@ You can use hooks for rudimentary auto-remediation tasks, such as starting a pro
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: restart_nginx
-  namespace: default
 spec:
   command: sudo systemctl start nginx
   stdin: false
@@ -441,10 +432,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "restart_nginx",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "restart_nginx"
   },
   "spec": {
     "command": "sudo systemctl start nginx",
@@ -471,11 +459,9 @@ You can create check hooks that use [token substitution][7] so you can fine-tune
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
   labels:
     foo: bar
   name: tokensub
-  namespace: default
 spec:
   command: tokensub {{ .labels.foo }}
   stdin: false
@@ -487,12 +473,10 @@ spec:
    "type": "HookConfig",
    "api_version": "core/v2",
    "metadata": {
-      "annotations": null,
       "labels": {
          "foo": "bar"
       },
-      "name": "tokensub",
-      "namespace": "default"
+      "name": "tokensub"
    },
    "spec": {
       "command": "tokensub {{ .labels.foo }}",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect-system-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: system-check
@@ -73,8 +72,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "collect-system-metrics",
-    "namespace": "default"
+    "name": "collect-system-metrics"
   },
   "spec": {
     "check_hooks": null,
@@ -295,7 +293,6 @@ check:
     # HELP system_host_processes [GAUGE] Number of host processes
     # TYPE system_host_processes GAUGE
     system_host_processes{} 109 1635270399219
-
   state: passing
   status: 0
   total_state_change: 0

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -46,7 +46,6 @@ type: RuleTemplate
 api_version: bsm/v1
 metadata:
   name: status-threshold
-  namespace: default
 spec:
   description: Creates an event when the percentage of events with the given status exceed the given threshold
   arguments:
@@ -86,8 +85,7 @@ spec:
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "status-threshold",
-    "namespace": "default"
+    "name": "status-threshold"
   },
   "spec": {
     "description": "Creates an event when the percentage of events with the given status exceed the given threshold",
@@ -170,8 +168,7 @@ The response will include the complete `aggregate` rule template resource defini
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "aggregate",
-    "namespace": "default"
+    "name": "aggregate"
   },
   "spec": {
     "arguments": {
@@ -229,8 +226,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: web-app
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -257,9 +252,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "web-app",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "web-app"
   },
   "spec": {
     "cron": "",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -45,8 +45,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: postgresql-1
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -73,9 +71,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "postgresql-1",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "postgresql-1"
   },
   "spec": {
     "cron": "",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
@@ -55,7 +55,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect_info
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -71,7 +70,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "collect_info"
   },
   "spec": {

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -61,7 +61,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-disk-usage
-  namespace: default
 spec:
   check_hooks: []
   command: check-disk-usage -w {{index .labels "disk_warning" | default 80}} -c
@@ -93,8 +92,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-disk-usage",
-    "namespace": "default"
+    "name": "check-disk-usage"
   },
   "spec": {
     "check_hooks": [],
@@ -164,7 +162,6 @@ type: HookConfig
 api_version: core/v2
 metadata:
   name: disk_usage_details
-  namespace: default
 spec:
   command: du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default "/"}}  2>/dev/null
   runtime_assets: null
@@ -178,8 +175,7 @@ cat << EOF | sensuctl create
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "disk_usage_details",
-    "namespace": "default"
+    "name": "disk_usage_details"
   },
   "spec": {
     "command": "du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default \"/\"}}  2>/dev/null",

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -87,7 +87,6 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-delete
   namespace: default
 spec:
@@ -105,7 +104,6 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-delete",
     "namespace": "default"
   },
@@ -141,7 +139,6 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-service-delete
   namespace: default
 spec:
@@ -157,7 +154,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-service-delete",
     "namespace": "default"
   },
@@ -244,7 +240,6 @@ cat << EOF | sensuctl create
 type: Handler
 api_version: core/v2
 metadata:
-  namespace: default
   name: sensu-ec2-handler
 spec:
   type: pipe
@@ -275,7 +270,6 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "sensu-ec2-handler"
   },
   "spec": {

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -423,7 +423,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: namespaced-resources-all-verbs
-  namespace: default
 spec:
   rules:
   - resources:
@@ -451,8 +450,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "namespaced-resources-all-verbs",
-    "namespace": "default"
+    "name": "namespaced-resources-all-verbs"
   },
   "spec": {
     "rules": [
@@ -999,7 +997,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: event-reader-binding
-  namespace: default
 spec:
   role_ref:
     name: event-reader
@@ -1014,8 +1011,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader-binding",
-    "namespace": "default"
+    "name": "event-reader-binding"
   },
   "spec": {
     "role_ref": {
@@ -1164,7 +1160,7 @@ You can use [sensuctl][2] to create a role binding that assigns a role:
 sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1173,9 +1169,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1192,9 +1186,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1223,7 +1215,7 @@ To create a role binding that assigns a cluster role:
 sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1232,9 +1224,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1251,9 +1241,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1282,7 +1270,7 @@ To create a cluster role binding:
 sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following cluster role binding resource definition:
+This command creates a cluster role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1291,7 +1279,6 @@ This command creates the following cluster role binding resource definition:
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
 spec:
   role_ref:
@@ -1309,7 +1296,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "NAME"
   },
   "spec": {
@@ -2582,7 +2568,6 @@ sensuctl cluster-role create silencing-script --verb get,list,create,update,dele
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script
 spec:
   rules:
@@ -2600,7 +2585,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script"
   },
   "spec": {
@@ -2637,7 +2621,6 @@ sensuctl role-binding create silencing-script-binding-team-1 --cluster-role sile
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script-binding-team-1
   namespace: team1
 spec:
@@ -2653,7 +2636,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script-binding-team-1",
     "namespace": "team1"
   },

--- a/content/sensu-go/6.4/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/generate-certificates.md
@@ -327,7 +327,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: expired_certs
-  namespace: default
 spec:
   command: openssl x509 -noout -enddate -in <cert-name>.pem
   subscriptions:
@@ -340,8 +339,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
-    "name": "expired_certs"
+    "namespace": "default"
   },
   "spec": {
     "command": "openssl x509 -noout -enddate -in <cert-name>.pem",

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -358,9 +358,7 @@ Sensu Go hourly filter:
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -373,9 +371,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets.md
@@ -48,7 +48,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible-token
-  namespace: default
 spec:
   id: ANSIBLE_TOKEN
   provider: env
@@ -59,8 +58,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible-token",
-    "namespace": "default"
+    "name": "sensu-ansible-token"
   },
   "spec": {
     "id": "ANSIBLE_TOKEN",
@@ -81,7 +79,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible
-  namespace: default
 spec:
   id: 'secret/database#password'
   provider: vault
@@ -92,8 +89,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible",
-    "namespace": "default"
+    "name": "sensu-ansible"
   },
   "spec": {
     "id": "secret/database#password",

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -41,7 +41,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_script
-  namespace: default
 spec:
   builds:
   - sha512: 4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b
@@ -53,8 +52,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_script",
-    "namespace": "default"
+    "name": "check_script"
   },
   "spec": {
     "builds": [
@@ -91,7 +89,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -132,7 +129,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -199,7 +195,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu_linux_amd64
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -222,7 +217,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu_linux_amd64",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -294,7 +288,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-prometheus-collector
-  namespace: default
 spec:
   builds:
   - url: https://assets.bonsai.sensu.io/ef812286f59de36a40e51178024b81c69666e1b7/sensu-prometheus-collector_1.1.6_linux_amd64.tar.gz
@@ -307,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_collector
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   interval: 10
@@ -326,8 +318,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-email-handler",
-    "namespace": "default"
+    "name": "sensu-email-handler"
   },
   "spec": {
     "builds": [
@@ -346,8 +337,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_collector",
-    "namespace": "default"
+    "name": "prometheus_collector"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",
@@ -465,7 +455,6 @@ To correctly capture exit status codes from PowerShell plugins distributed as dy
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: win-cpu-check
 spec:
   command: powershell.exe -ExecutionPolicy ByPass -f %{{assetPath "sensu-windows-powershell-checks"}}%\bin\check-windows-cpu-load.ps1 90 95
@@ -485,8 +474,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "win-cpu-check",
-    "namespace": "default"
+    "name": "win-cpu-check"
   },
   "spec": {
     "command": "powershell.exe -ExecutionPolicy ByPass -f %{{assetPath \"sensu-windows-powershell-checks\"}}%\\bin\\check-windows-cpu-load.ps1 90 95",

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: marketing-site
-  namespace: default
 spec:
   command: http-check -u https://sensu.io
   subscriptions:
@@ -53,7 +52,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -69,8 +67,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "marketing-site",
-    "namespace": "default"
+    "name": "marketing-site"
     },
   "spec": {
     "command": "http-check -u https://sensu.io",
@@ -83,8 +80,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.4/web-ui/searches-reference.md
+++ b/content/sensu-go/6.4/web-ui/searches-reference.md
@@ -35,7 +35,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: events-not-passing
-  namespace: default
 spec:
   parameters:
   - status:incident
@@ -50,8 +49,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "events-not-passing",
-    "namespace": "default"
+    "name": "events-not-passing"
   },
   "spec": {
     "parameters": [
@@ -79,7 +77,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: published-checks-linux-uswest
-  namespace: default
 spec:
   parameters:
   - published:true
@@ -93,8 +90,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "published-checks-linux-uswest",
-    "namespace": "default"
+    "name": "published-checks-linux-uswest"
   },
   "spec": {
     "parameters": [

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -39,10 +39,7 @@ This example shows the resource definition for an agent entity:
 type: Entity
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: webserver01
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -115,10 +112,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "webserver01",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "webserver01"
   },
   "spec": {
     "entity_class": "agent",
@@ -261,8 +255,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: sensu-docs
-  namespace: default
-  labels: null
 spec:
   deregister: false
   deregistration: {}
@@ -281,9 +273,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-docs",
-    "namespace": "default",
-    "labels": null
+    "name": "sensu-docs"
   },
   "spec": {
     "deregister": false,
@@ -346,9 +336,7 @@ This example shows the resource definition for a service entity:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -358,9 +346,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"
@@ -414,7 +400,6 @@ metadata:
   labels:
     url: docs.sensu.io
   name: sensu-docs
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -434,7 +419,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "sensu-docs",
-    "namespace": "default",
     "labels": {
       "url": "docs.sensu.io"
     }
@@ -517,9 +501,7 @@ To create a service entity with a `service_type` label using sensuctl `create`, 
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
   labels:
     service_type: datastore
 spec:
@@ -531,9 +513,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "postgresql",
-    "namespace": "default",
     "labels": {
       "service_type": "datastore"
     }

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/_index.md
@@ -38,7 +38,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -50,8 +49,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -832,10 +832,7 @@ For instance, if you package underscore.js into a Sensu asset, you can use funct
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: deny_if_failure_in_history
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -850,10 +847,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "deny_if_failure_in_history",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "deny_if_failure_in_history"
   },
   "spec": {
     "action": "deny",
@@ -879,7 +873,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: production_filter
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -891,8 +884,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "production_filter",
-    "namespace": "default"
+    "name": "production_filter"
   },
   "spec": {
     "action": "allow",
@@ -922,7 +914,6 @@ type: EventFilter
 api_version: core/v2
 metadata:
   name: not_production
-  namespace: default
 spec:
   action: deny
   expressions:
@@ -934,8 +925,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "not_production",
-    "namespace": "default"
+    "name": "not_production"
   },
   "spec": {
     "action": "deny",
@@ -959,10 +949,7 @@ This example demonstrates how to use the `state_change_only` inclusive event fil
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: state_change_only
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -975,10 +962,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "state_change_only",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "state_change_only"
   },
   "spec": {
     "action": "allow",
@@ -1003,10 +987,7 @@ In this example, the `filter_interval_60_hourly` event filter will match event d
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_60_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1020,10 +1001,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_60_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_60_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1047,10 +1025,7 @@ This example will apply the same logic as the previous example but for checks wi
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: filter_interval_30_hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1064,10 +1039,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "filter_interval_30_hourly",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "filter_interval_30_hourly"
   },
   "spec": {
     "action": "allow",
@@ -1097,10 +1069,7 @@ If the annotation does not exist, the event filter uses 15 minutes for the alert
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: keepalive_timeouts
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1114,10 +1083,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "keepalive_timeouts",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "keepalive_timeouts"
   },
   "spec": {
     "action": "allow",
@@ -1145,10 +1111,7 @@ If evaluation returns false, the event will not be handled.
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: nine_to_fiver
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1162,10 +1125,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nine_to_fiver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "nine_to_fiver"
   },
   "spec": {
     "action": "allow",
@@ -1190,10 +1150,7 @@ For example, if office hours are 8:30 AM to 5:30 PM:
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: 830_to_530
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1208,10 +1165,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "830_to_530",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "830_to_530"
   },
   "spec": {
     "action": "allow",
@@ -1239,10 +1193,7 @@ In other words, this filter sets a 30-second time budget for event processing so
 type: EventFilter
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: budget_30
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -1255,10 +1206,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "name": "budget_30",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "budget_30"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -47,8 +47,6 @@ type: Pipeline
 api_version: core/v2
 metadata:
   name: incident_alerts
-  namespace: default
-  created_by: admin
 spec:
   workflows:
   - name: labeled_email_alerts
@@ -74,9 +72,7 @@ spec:
   "type": "Pipeline",
   "api_version": "core/v2",
   "metadata": {
-    "name": "incident_alerts",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "incident_alerts"
   },
   "spec": {
     "workflows": [
@@ -123,7 +119,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: incident_pipelines
-  namespace: default
 spec:
   command: collect.sh
   interval: 10
@@ -141,8 +136,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "incident_pipelines",
-    "namespace": "default"
+    "name": "incident_pipelines"
   },
   "spec": {
     "command": "collect.sh",
@@ -190,8 +184,6 @@ type: Pipeline
 api_version: core/v2
 metadata:
   name: incident_alerts
-  namespace: default
-  created_by: admin
 spec:
   workflows:
   - name: labeled_email_alerts
@@ -229,9 +221,7 @@ spec:
   "type": "Pipeline",
   "api_version": "core/v2",
   "metadata": {
-    "name": "incident_alerts",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "incident_alerts"
   },
   "spec": {
     "workflows": [

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/silencing.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/silencing.md
@@ -46,10 +46,7 @@ This example shows a silencing resource definition that uses a per-entity subscr
 type: Silenced
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: entity:i-424242:*
-  namespace: default
 spec:
   begin: 1542671205
   check: null
@@ -65,10 +62,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:*",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:*"
   },
   "spec": {
     "expire": -1,
@@ -96,9 +90,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: entity:i-424242:check_ntp
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: entity:i-424242
   check: check_ntp
@@ -110,10 +101,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "entity:i-424242:check_ntp",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "entity:i-424242:check_ntp"
   },
   "spec": {
     "subscription": "entity:i-424242",
@@ -454,9 +442,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: appserver
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   subscription: appserver
 {{< /code >}}
@@ -466,10 +451,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver"
   },
   "spec": {
     "subscription": "appserver"
@@ -510,10 +492,7 @@ To silence a check `mysql_status` that is running on Sensu entities with the sub
 type: Silenced
 api_version: core/v2
 metadata:
-  name: appserver:mysql_status
-  namespace: default
-  labels: 
-  annotations: 
+  name: appserver:mysql_status 
 spec:
   subscription: appserver
   check: mysql_status
@@ -524,10 +503,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "appserver:mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "appserver:mysql_status"
   },
   "spec": {
     "subscription": "appserver",
@@ -550,9 +526,6 @@ type: Silenced
 api_version: core/v2
 metadata:
   name: mysql_status
-  namespace: default
-  labels: 
-  annotations: 
 spec:
   check: mysql_status
 {{< /code >}}
@@ -562,10 +535,7 @@ spec:
   "type": "Silenced",
   "api_version": "core/v2",
   "metadata": {
-    "name": "mysql_status",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "mysql_status"
   },
   "spec": {
     "check": "mysql_status"

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
@@ -47,7 +47,6 @@ type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
   name: sumologic_http_log_metrics
-  namespace: default
 spec:
   url: "https://endpoint5.collection.us2.sumologic.com/receiver/v1/http/xxxxxxxx"
   max_connections: 10
@@ -59,8 +58,7 @@ spec:
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics",
-    "namespace": "default"
+    "name": "sumologic_http_log_metrics"
   },
   "spec": {
     "url": "https://endpoint5.collection.us2.sumologic.com/receiver/v1/http/xxxxxxxx",
@@ -82,7 +80,6 @@ type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
   name: sumologic_http_log_metrics
-  namespace: default
 spec:
   url: $SUMO_LOGIC_SOURCE_URL
   secrets:
@@ -97,8 +94,7 @@ spec:
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics",
-    "namespace": "default"
+    "name": "sumologic_http_log_metrics"
   },
   "spec": {
     "url": "$SUMO_LOGIC_SOURCE_URL",
@@ -135,8 +131,6 @@ type: Pipeline
 api_version: core/v2
 metadata:
   name: metrics_workflows
-  namespace: default
-  created_by: admin
 spec:
   workflows:
   - name: metrics_to_sumologic
@@ -155,9 +149,7 @@ spec:
   "type": "Pipeline",
   "api_version": "core/v2",
   "metadata": {
-    "name": "metrics_workflows",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "metrics_workflows"
   },
   "spec": {
     "workflows": [

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers.md
@@ -47,7 +47,6 @@ type: TCPStreamHandler
 api_version: pipeline/v1
 metadata:
   name: logstash
-  namespace: default
 spec:
   address: 127.0.0.1:4242
   tls_ca_cert_file: "/path/to/tls/ca.pem"
@@ -63,8 +62,7 @@ spec:
   "type": "TCPStreamHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "logstash",
-    "namespace": "default"
+    "name": "logstash"
   },
   "spec": {
     "address": "127.0.0.1:4242",
@@ -99,8 +97,6 @@ type: Pipeline
 api_version: core/v2
 metadata:
   name: tcp_logging_workflows
-  namespace: default
-  created_by: admin
 spec:
   workflows:
   - name: log_all_incidents
@@ -119,9 +115,7 @@ spec:
   "type": "Pipeline",
   "api_version": "core/v2",
   "metadata": {
-    "name": "tcp_logging_workflows",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "tcp_logging_workflows"
   },
   "spec": {
     "workflows": [

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/_index.md
@@ -58,9 +58,7 @@ This check would run on any entities whose definitions also specify the `system`
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check-cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -92,9 +90,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "check-cpu",
-    "namespace": "default"
+    "name": "check-cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -518,7 +518,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: keepalive
-  namespace: default
 spec:
   handlers:
   - slack
@@ -530,8 +529,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "keepalive",
-    "namespace": "default"
+    "name": "keepalive"
   },
   "spec": {
     "type": "set",
@@ -1833,7 +1831,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   command: ping-github-api.sh $TEST_GITHUB_TOKEN
   handlers:
@@ -1849,8 +1846,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "command": "ping-github-api.sh $TEST_GITHUB_TOKEN",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1566,9 +1566,7 @@ The following handler will print the `TEST_VARIABLE` value set in your sensu-bac
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: print_test_var
-  namespace: default
 spec:
   command: echo $TEST_VARIABLE >> ./tmp/test.txt
   timeout: 0
@@ -1580,9 +1578,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "print_test_var",
-    "namespace": "default"
+    "name": "print_test_var"
   },
   "spec": {
     "command": "echo $TEST_VARIABLE >> ./tmp/test.txt",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -61,8 +61,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: postgresql-1
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -89,9 +87,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "postgresql-1",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "postgresql-1"
   },
   "spec": {
     "cron": "",
@@ -138,8 +134,6 @@ type: RuleTemplate
 api_version: bsm/v1
 metadata:
   name: status-threshold
-  namespace: default
-  created_by: admin
 spec:
   description: Creates an event when the percentage of events with the given status exceed the given threshold
   arguments:
@@ -181,9 +175,7 @@ spec:
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "status-threshold",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "status-threshold"
   },
   "spec": {
     "description": "Creates an event when the percentage of events with the given status exceed the given threshold",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -35,7 +35,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check_minimum
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -51,7 +50,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "check_minimum"
   },
   "spec": {
@@ -167,7 +165,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -183,8 +180,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_check",
-    "namespace": "default"
+    "name": "interval_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -224,7 +220,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   cron: '* * * * *'
@@ -240,8 +235,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "cron_check",
-    "namespace": "default"
+    "name": "cron_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -255,7 +249,6 @@ spec:
 
 {{< /language-toggle >}}
 
-
 Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the `cron` attribute:
 
 {{< language-toggle >}}
@@ -266,7 +259,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: cron_check
-  namespace: default
 spec:
   check_hooks: null
   command: hi
@@ -296,8 +288,7 @@ spec:
    "type": "CheckConfig",
    "api_version": "core/v2",
    "metadata": {
-      "name": "cron_check",
-      "namespace": "default"
+      "name": "cron_check"
    },
    "spec": {
       "check_hooks": null,
@@ -343,7 +334,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ad_hoc_check
-  namespace: default
 spec:
   command: check-cpu.sh -w 75 -c 90
   handlers:
@@ -359,8 +349,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ad_hoc_check",
-    "namespace": "default"
+    "name": "ad_hoc_check"
   },
   "spec": {
     "command": "check-cpu.sh -w 75 -c 90",
@@ -398,7 +387,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check
-  namespace: default
 spec:
   command: http_check.sh https://sensu.io
   handlers:
@@ -416,8 +404,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check",
-    "namespace": "default"
+    "name": "proxy_check"
   },
   "spec": {
     "command": "http_check.sh https://sensu.io",
@@ -457,7 +444,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: proxy_check_proxy_requests
-  namespace: default
 spec:
   command: http_check.sh {{ .labels.url }}
   handlers:
@@ -477,8 +463,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "proxy_check_proxy_requests",
-    "namespace": "default"
+    "name": "proxy_check_proxy_requests"
   },
   "spec": {
     "command": "http_check.sh {{ .labels.url }}",
@@ -1503,7 +1488,6 @@ metadata:
   labels:
     region: us-west-1
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: collect.sh
@@ -1540,7 +1524,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "collect-metrics",
-    "namespace": "default",
     "labels": {
       "region": "us-west-1"
     },
@@ -1604,7 +1587,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: ping-github-api
-  namespace: default
 spec:
   check_hooks: null
   command: ping-github-api.sh $GITHUB_TOKEN
@@ -1618,8 +1600,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ping-github-api",
-    "namespace": "default"
+    "name": "ping-github-api"
   },
   "spec": {
     "check_hooks": null,
@@ -1650,7 +1631,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: interval_test
-  namespace: default
 spec:
   command: powershell.exe -f c:\\users\\tester\\test.ps1
   subscriptions:
@@ -1666,8 +1646,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "interval_test",
-    "namespace": "default"
+    "name": "interval_test"
   },
   "spec": {
     "command": "powershell.exe -f c:\\users\\tester\\test.ps1",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
@@ -30,10 +30,7 @@ This example demonstrates a check hook to capture the process tree when a proces
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   stdin: false
@@ -46,10 +43,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "process_tree",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",
@@ -430,10 +424,7 @@ You can use hooks for rudimentary auto-remediation tasks, such as starting a pro
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: restart_nginx
-  namespace: default
 spec:
   command: sudo systemctl start nginx
   stdin: false
@@ -445,10 +436,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "restart_nginx",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "restart_nginx"
   },
   "spec": {
     "command": "sudo systemctl start nginx",
@@ -475,11 +463,9 @@ You can create check hooks that use [token substitution][7] so you can fine-tune
 type: HookConfig
 api_version: core/v2
 metadata:
-  annotations: null
   labels:
     foo: bar
   name: tokensub
-  namespace: default
 spec:
   command: tokensub {{ .labels.foo }}
   stdin: false
@@ -491,12 +477,10 @@ spec:
    "type": "HookConfig",
    "api_version": "core/v2",
    "metadata": {
-      "annotations": null,
       "labels": {
          "foo": "bar"
       },
-      "name": "tokensub",
-      "namespace": "default"
+      "name": "tokensub"
    },
    "spec": {
       "command": "tokensub {{ .labels.foo }}",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect-system-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: system-check
@@ -73,8 +72,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "collect-system-metrics",
-    "namespace": "default"
+    "name": "collect-system-metrics"
   },
   "spec": {
     "check_hooks": null,
@@ -295,7 +293,6 @@ check:
     # HELP system_host_processes [GAUGE] Number of host processes
     # TYPE system_host_processes GAUGE
     system_host_processes{} 109 1635270399219
-
   state: passing
   status: 0
   total_state_change: 0

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
@@ -46,7 +46,6 @@ type: RuleTemplate
 api_version: bsm/v1
 metadata:
   name: status-threshold
-  namespace: default
 spec:
   description: Creates an event when the percentage of events with the given status exceed the given threshold
   arguments:
@@ -86,8 +85,7 @@ spec:
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "status-threshold",
-    "namespace": "default"
+    "name": "status-threshold"
   },
   "spec": {
     "description": "Creates an event when the percentage of events with the given status exceed the given threshold",
@@ -170,8 +168,7 @@ The response will include the complete `aggregate` rule template resource defini
   "type": "RuleTemplate",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "aggregate",
-    "namespace": "default"
+    "name": "aggregate"
   },
   "spec": {
     "arguments": {
@@ -229,8 +226,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: web-app
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -257,9 +252,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "web-app",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "web-app"
   },
   "spec": {
     "cron": "",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
@@ -45,8 +45,6 @@ type: ServiceComponent
 api_version: bsm/v1
 metadata:
   name: postgresql-1
-  namespace: default
-  created_by: admin
 spec:
   cron: ''
   handlers:
@@ -73,9 +71,7 @@ spec:
   "type": "ServiceComponent",
   "api_version": "bsm/v1",
   "metadata": {
-    "name": "postgresql-1",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "postgresql-1"
   },
   "spec": {
     "cron": "",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
@@ -55,7 +55,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: collect_info
-  namespace: default
 spec:
   command: collect.sh
   handlers:
@@ -71,8 +70,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
-    "name": "collect_info"
+    "namespace": "default"
   },
   "spec": {
     "command": "collect.sh",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -61,7 +61,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: check-disk-usage
-  namespace: default
 spec:
   check_hooks: []
   command: check-disk-usage -w {{index .labels "disk_warning" | default 80}} -c
@@ -93,8 +92,7 @@ cat << EOF | sensuctl create
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check-disk-usage",
-    "namespace": "default"
+    "name": "check-disk-usage"
   },
   "spec": {
     "check_hooks": [],
@@ -164,7 +162,6 @@ type: HookConfig
 api_version: core/v2
 metadata:
   name: disk_usage_details
-  namespace: default
 spec:
   command: du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default "/"}}  2>/dev/null
   runtime_assets: null
@@ -178,8 +175,7 @@ cat << EOF | sensuctl create
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "disk_usage_details",
-    "namespace": "default"
+    "name": "disk_usage_details"
   },
   "spec": {
     "command": "du -h --max-depth=1 -c {{index .labels "disk_usage_root" | default \"/\"}}  2>/dev/null",
@@ -240,7 +236,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-go-hello-world
-  namespace: default
 spec:
   builds:
   - sha512: 07665fda5b7c75e15e4322820aa7ddb791cc9338e38444e976e601bc7d7970592e806a7b88733690a238b7325437d31f85e98ae2fe47b008ca09c86530da9600
@@ -252,8 +247,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-go-hello-world",
-    "namespace": "default"
+    "name": "sensu-go-hello-world"
   },
   "spec": {
     "builds": [

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -87,7 +87,6 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-delete
   namespace: default
 spec:
@@ -105,7 +104,6 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-delete",
     "namespace": "default"
   },
@@ -141,7 +139,6 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ec2-service-delete
   namespace: default
 spec:
@@ -157,7 +154,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ec2-service-delete",
     "namespace": "default"
   },
@@ -244,7 +240,6 @@ cat << EOF | sensuctl create
 type: Handler
 api_version: core/v2
 metadata:
-  namespace: default
   name: sensu-ec2-handler
 spec:
   type: pipe
@@ -275,7 +270,6 @@ cat << EOF | sensuctl create
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "sensu-ec2-handler"
   },
   "spec": {

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -423,7 +423,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: namespaced-resources-all-verbs
-  namespace: default
 spec:
   rules:
   - resources:
@@ -451,8 +450,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "namespaced-resources-all-verbs",
-    "namespace": "default"
+    "name": "namespaced-resources-all-verbs"
   },
   "spec": {
     "rules": [
@@ -999,7 +997,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: event-reader-binding
-  namespace: default
 spec:
   role_ref:
     name: event-reader
@@ -1014,8 +1011,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "event-reader-binding",
-    "namespace": "default"
+    "name": "event-reader-binding"
   },
   "spec": {
     "role_ref": {
@@ -1164,7 +1160,7 @@ You can use [sensuctl][2] to create a role binding that assigns a role:
 sensuctl role-binding create NAME --role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1173,9 +1169,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1192,9 +1186,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1223,7 +1215,7 @@ To create a role binding that assigns a cluster role:
 sensuctl role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following role binding resource definition:
+This command creates a role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1232,9 +1224,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
-  namespace: default
 spec:
   role_ref:
     name: NAME
@@ -1251,9 +1241,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "NAME",
-    "namespace": "default"
+    "name": "NAME"
   },
   "spec": {
     "role_ref": {
@@ -1282,7 +1270,7 @@ To create a cluster role binding:
 sensuctl cluster-role-binding create NAME --cluster-role=NAME --user=username --group=groupname
 {{< /code >}}
 
-This command creates the following cluster role binding resource definition:
+This command creates a cluster role binding resource definition similar to the following:
 
 {{< language-toggle >}}
 
@@ -1291,7 +1279,6 @@ This command creates the following cluster role binding resource definition:
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: NAME
 spec:
   role_ref:
@@ -1309,7 +1296,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "NAME"
   },
   "spec": {
@@ -2582,7 +2568,6 @@ sensuctl cluster-role create silencing-script --verb get,list,create,update,dele
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script
 spec:
   rules:
@@ -2600,7 +2585,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script"
   },
   "spec": {
@@ -2637,7 +2621,6 @@ sensuctl role-binding create silencing-script-binding-team-1 --cluster-role sile
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: silencing-script-binding-team-1
   namespace: team1
 spec:
@@ -2653,7 +2636,6 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "silencing-script-binding-team-1",
     "namespace": "team1"
   },

--- a/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
@@ -327,7 +327,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: expired_certs
-  namespace: default
 spec:
   command: openssl x509 -noout -enddate -in <cert-name>.pem
   subscriptions:
@@ -340,7 +339,6 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "namespace": "default",
     "name": "expired_certs"
   },
   "spec": {

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -358,9 +358,7 @@ Sensu Go hourly filter:
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -373,9 +371,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets.md
@@ -48,7 +48,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible-token
-  namespace: default
 spec:
   id: ANSIBLE_TOKEN
   provider: env
@@ -59,8 +58,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible-token",
-    "namespace": "default"
+    "name": "sensu-ansible-token"
   },
   "spec": {
     "id": "ANSIBLE_TOKEN",
@@ -81,7 +79,6 @@ type: Secret
 api_version: secrets/v1
 metadata:
   name: sensu-ansible
-  namespace: default
 spec:
   id: 'secret/database#password'
   provider: vault
@@ -92,8 +89,7 @@ spec:
   "type": "Secret",
   "api_version": "secrets/v1",
   "metadata": {
-    "name": "sensu-ansible",
-    "namespace": "default"
+    "name": "sensu-ansible"
   },
   "spec": {
     "id": "secret/database#password",

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -41,7 +41,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_script
-  namespace: default
 spec:
   builds:
   - sha512: 4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b
@@ -53,8 +52,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_script",
-    "namespace": "default"
+    "name": "check_script"
   },
   "spec": {
     "builds": [
@@ -91,7 +89,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -132,7 +129,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -199,7 +195,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: check_cpu_linux_amd64
-  namespace: default
   labels:
     origin: bonsai
   annotations:
@@ -222,7 +217,6 @@ spec:
   "api_version": "core/v2",
   "metadata": {
     "name": "check_cpu_linux_amd64",
-    "namespace": "default",
     "labels": {
       "origin": "bonsai"
     },
@@ -294,7 +288,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-prometheus-collector
-  namespace: default
 spec:
   builds:
   - url: https://assets.bonsai.sensu.io/ef812286f59de36a40e51178024b81c69666e1b7/sensu-prometheus-collector_1.1.6_linux_amd64.tar.gz
@@ -307,7 +300,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_collector
-  namespace: default
 spec:
   command: "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up"
   interval: 10
@@ -326,8 +318,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-email-handler",
-    "namespace": "default"
+    "name": "sensu-email-handler"
   },
   "spec": {
     "builds": [
@@ -346,8 +337,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_collector",
-    "namespace": "default"
+    "name": "prometheus_collector"
   },
   "spec": {
     "command": "sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up",
@@ -465,7 +455,6 @@ To correctly capture exit status codes from PowerShell plugins distributed as dy
 type: CheckConfig
 api_version: core/v2
 metadata:
-  namespace: default
   name: win-cpu-check
 spec:
   command: powershell.exe -ExecutionPolicy ByPass -f %{{assetPath "sensu-windows-powershell-checks"}}%\bin\check-windows-cpu-load.ps1 90 95
@@ -485,8 +474,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "win-cpu-check",
-    "namespace": "default"
+    "name": "win-cpu-check"
   },
   "spec": {
     "command": "powershell.exe -ExecutionPolicy ByPass -f %{{assetPath \"sensu-windows-powershell-checks\"}}%\\bin\\check-windows-cpu-load.ps1 90 95",

--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -81,7 +81,6 @@ type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
   name: sumologic_http_log_metrics
-  namespace: default
 spec:
   url: "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx"
   max_connections: 10
@@ -93,8 +92,7 @@ spec:
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics",
-    "namespace": "default"
+    "name": "sumologic_http_log_metrics"
   },
   "spec": {
     "url": "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx",
@@ -117,7 +115,6 @@ type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
   name: sumologic_http_log_metrics
-  namespace: default
 spec:
   url: $SUMO_LOGIC_SOURCE_URL
   secrets:
@@ -132,8 +129,7 @@ spec:
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics",
-    "namespace": "default"
+    "name": "sumologic_http_log_metrics"
   },
   "spec": {
     "url": "$SUMO_LOGIC_SOURCE_URL",

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -40,7 +40,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: marketing-site
-  namespace: default
 spec:
   command: http-check -u https://sensu.io
   subscriptions:
@@ -53,7 +52,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -69,8 +67,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata" : {
-    "name": "marketing-site",
-    "namespace": "default"
+    "name": "marketing-site"
     },
   "spec": {
     "command": "http-check -u https://sensu.io",
@@ -83,8 +80,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.5/web-ui/searches-reference.md
+++ b/content/sensu-go/6.5/web-ui/searches-reference.md
@@ -35,7 +35,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: events-not-passing
-  namespace: default
 spec:
   parameters:
   - status:incident
@@ -50,8 +49,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "events-not-passing",
-    "namespace": "default"
+    "name": "events-not-passing"
   },
   "spec": {
     "parameters": [
@@ -79,7 +77,6 @@ type: Search
 api_version: searches/v1
 metadata:
   name: published-checks-linux-uswest
-  namespace: default
 spec:
   parameters:
   - published:true
@@ -93,8 +90,7 @@ spec:
   "type": "Search",
   "api_version": "searches/v1",
   "metadata": {
-    "name": "published-checks-linux-uswest",
-    "namespace": "default"
+    "name": "published-checks-linux-uswest"
   },
   "spec": {
     "parameters": [


### PR DESCRIPTION
## Description
Removes namespace and empty labels and annotations in resource definition examples throughout the docs.

## Motivation and Context
Make examples portable
