### PR TITLE
Fix formatting error in email alerts guide

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-process/send-email-alerts.md
@@ -87,7 +87,7 @@ To create the event filter, run:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -150,7 +150,7 @@ With your updates, create the handler using sensuctl:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -231,7 +231,7 @@ With the environment variables set, you can use the Sensu API to create your ad 
 {{% notice note %}}
 **NOTE**: The example events use the default namespace.
 If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
-{{% notice note %}}
+{{% /notice %}}
 
 This event outputs the message "Everything is OK.” when it occurs:
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -87,7 +87,7 @@ To create the event filter, run:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -150,7 +150,7 @@ With your updates, create the handler using sensuctl:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -231,7 +231,7 @@ With the environment variables set, you can use the Sensu API to create your ad 
 {{% notice note %}}
 **NOTE**: The example events use the default namespace.
 If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
-{{% notice note %}}
+{{% /notice %}}
 
 This event outputs the message "Everything is OK.” when it occurs:
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
@@ -87,7 +87,7 @@ To create the event filter, run:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -150,7 +150,7 @@ With your updates, create the handler using sensuctl:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -231,7 +231,7 @@ With the environment variables set, you can use the Sensu API to create your ad 
 {{% notice note %}}
 **NOTE**: The example events use the default namespace.
 If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
-{{% notice note %}}
+{{% /notice %}}
 
 This event outputs the message "Everything is OK.” when it occurs:
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -86,7 +86,7 @@ To create the event filter, run:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 type: EventFilter
@@ -149,7 +149,7 @@ With your updates, create the handler using sensuctl:
 
 {{< language-toggle >}}
 
-{{< code text "YML">}}
+{{< code text "YML" >}}
 cat << EOF | sensuctl create
 ---
 api_version: core/v2
@@ -230,7 +230,7 @@ With the environment variables set, you can use the Sensu API to create your ad 
 {{% notice note %}}
 **NOTE**: The example events use the default namespace.
 If you are using a different namespace, replace `default` in the event definitions and the API URLs with the name of the desired namespace.
-{{% notice note %}}
+{{% /notice %}}
 
 This event outputs the message "Everything is OK.” when it occurs:
 


### PR DESCRIPTION
## Description
Fixes a note formatting error in the email alerts guide that caused links to display improperly in the published page

## Motivation and Context
Page displays improperly with formatting error