### PR TITLE
Add pipeline reference links at the ends of guides

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -61,9 +61,12 @@ Now that you know how to feed StatsD metrics into Sensu, check out these resourc
 
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
 * [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
+* [Pipeline reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
+
 
 [1]: https://github.com/statsd/statsd
 [2]: ../handlers/
 [3]: ../populate-metrics-influxdb/
 [4]: #configure-the-statsd-listener
 [5]: https://github.com/statsd/statsd
+[6]: ../pipelines/

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -449,6 +449,8 @@ If you add the debug handler and configure the `collect-metrics` check to use it
 Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
 For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
 
+Read the [pipeline reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+
 You can also learn to use Sensu to [collect Prometheus metrics][14].
 
 
@@ -466,3 +468,4 @@ You can also learn to use Sensu to [collect Prometheus metrics][14].
 [12]: ../../observe-events/events/#metrics-points
 [13]: ../../../operations/deploy-sensu/install-sensu/
 [14]: ../prometheus-metrics/
+[15]: ../../observe-process/pipelines/

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -522,6 +522,8 @@ Or, learn how to [monitor external resources with proxy checks and entities][5].
 
 You can also create a [handler][10] to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
 
+Read the [pipeline reference][16] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+
 
 [1]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage
 [2]: ../../../plugins/assets/
@@ -538,4 +540,5 @@ You can also create a [handler][10] to send alerts to [email][13], [PagerDuty][9
 [13]: ../../observe-process/send-email-alerts/
 [14]: https://bonsai.sensu.io/
 [15]: https://bonsai.sensu.io/assets/sensu/sensu-processes-check
+[16]: ../../observe-process/pipelines/
 [17]: ../../../sensuctl/


### PR DESCRIPTION
## Description
Adds a link to the pipeline reference at the end of three guides to add an alternative to handler config only:
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/monitor-server-resources/
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/collect-metrics-with-checks/
- https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/aggregate-metrics-statsd/

## Motivation and Context
Help with transition to pipelines
