### PR TITLE
Fix incorrect link to mTLS info in Secure Sensu

### DIFF
--- a/content/sensu-go/6.2/commercial.md
+++ b/content/sensu-go/6.2/commercial.md
@@ -108,7 +108,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [18]: ../operations/maintain-sensu/license/
 [19]: ../observability-pipeline/observe-filter/filters#build-event-filter-expressions-with-javascript-execution-functions
 [20]: ../operations/deploy-sensu/use-federation/	
-[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[21]: ../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [24]: ../plugins/supported-integrations/
 [25]: #commercial-features-in-sensu-go

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/agent.md
@@ -1902,5 +1902,5 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
-[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[58]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [59]: ../../../operations/control-access/#use-built-in-basic-authentication

--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/backend.md
@@ -1531,7 +1531,7 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [28]: ../subscriptions/
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly
 [30]: https://en.m.wikipedia.org/wiki/WebSocket
-[31]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[31]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [32]: ../../../operations/deploy-sensu/generate-certificates/
 [33]: ../../../operations/deploy-sensu/secure-sensu/
 [34]: ../agent/#username-and-password-authentication

--- a/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.2/operations/maintain-sensu/troubleshoot.md
@@ -803,7 +803,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
-[3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[3]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-management.md
@@ -29,8 +29,7 @@ Secrets are configured via [secrets resources][8].
 A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
 
 This guide only covers the handler use case, but you can use secrets management in handler, mutator, and check execution.
-When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via mutually authenticated transport layer security (mTLS)-encrypted WebSockets.
-Read more about [enabling mTLS][15].
+When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via [mutually authenticated transport layer security (mTLS)-encrypted WebSockets][15].
 
 The secret included in your Sensu handler will be exposed to Sensu services at runtime as an environment variable.
 Sensu only exposes secrets to Sensu services like environment variables and automatically redacts secrets from all logs, the API, and the web UI.
@@ -470,7 +469,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [12]: https://www.vaultproject.io/docs/concepts/lease.html#lease-durations-and-renewal
 [13]: ../../../api/secrets#providers-provider-put
 [14]: ../../../api/secrets#secrets-secret-put
-[15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets-providers.md
@@ -497,7 +497,7 @@ burst: 100
 [10]: https://www.vaultproject.io/docs/auth/token/
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../secrets-management/

--- a/content/sensu-go/6.2/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.2/operations/manage-secrets/secrets.md
@@ -319,4 +319,4 @@ provider: vault
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication

--- a/content/sensu-go/6.3/commercial.md
+++ b/content/sensu-go/6.3/commercial.md
@@ -110,7 +110,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [18]: ../operations/maintain-sensu/license/
 [19]: ../observability-pipeline/observe-filter/filters#build-event-filter-expressions-with-javascript-execution-functions
 [20]: ../operations/deploy-sensu/use-federation/	
-[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[21]: ../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/supported-integrations/

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -1899,5 +1899,5 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
-[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[58]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [59]: ../../../operations/control-access/#use-built-in-basic-authentication

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -1569,7 +1569,7 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [28]: ../subscriptions/
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly
 [30]: https://en.m.wikipedia.org/wiki/WebSocket
-[31]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[31]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [32]: ../../../operations/deploy-sensu/generate-certificates/
 [33]: ../../../operations/deploy-sensu/secure-sensu/
 [34]: ../agent/#username-and-password-authentication

--- a/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/troubleshoot.md
@@ -803,7 +803,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
-[3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[3]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
@@ -29,8 +29,7 @@ Secrets are configured via [secrets resources][8].
 A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
 
 This guide only covers the handler use case, but you can use secrets management in handler, mutator, and check execution.
-When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via mutually authenticated transport layer security (mTLS)-encrypted WebSockets.
-Read more about [enabling mTLS][15].
+When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via [mutually authenticated transport layer security (mTLS)-encrypted WebSockets][15].
 
 The secret included in your Sensu handler will be exposed to Sensu services at runtime as an environment variable.
 Sensu only exposes secrets to Sensu services like environment variables and automatically redacts secrets from all logs, the API, and the web UI.
@@ -470,7 +469,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [12]: https://www.vaultproject.io/docs/concepts/lease.html#lease-durations-and-renewal
 [13]: ../../../api/secrets#providers-provider-put
 [14]: ../../../api/secrets#secrets-secret-put
-[15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -497,7 +497,7 @@ burst: 100
 [10]: https://www.vaultproject.io/docs/auth/token/
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../secrets-management/

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets.md
@@ -319,4 +319,4 @@ provider: vault
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication

--- a/content/sensu-go/6.4/commercial.md
+++ b/content/sensu-go/6.4/commercial.md
@@ -113,7 +113,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [18]: ../operations/maintain-sensu/license/
 [19]: ../observability-pipeline/observe-filter/filters#build-event-filter-expressions-with-javascript-execution-functions
 [20]: ../operations/deploy-sensu/use-federation/	
-[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[21]: ../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/supported-integrations/

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1954,6 +1954,6 @@ log-level: debug
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
-[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[58]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [59]: ../../../operations/control-access/#use-built-in-basic-authentication
 [60]: #log-level

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1689,7 +1689,7 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [28]: ../subscriptions/
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly
 [30]: https://en.m.wikipedia.org/wiki/WebSocket
-[31]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[31]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [32]: ../../../operations/deploy-sensu/generate-certificates/
 [33]: ../../../operations/deploy-sensu/secure-sensu/
 [34]: ../agent/#username-and-password-authentication

--- a/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/troubleshoot.md
@@ -816,7 +816,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
-[3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[3]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
@@ -29,8 +29,7 @@ Secrets are configured via [secrets resources][8].
 A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
 
 This guide only covers the handler use case, but you can use secrets management in handler, mutator, and check execution.
-When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via mutually authenticated transport layer security (mTLS)-encrypted WebSockets.
-Read more about [enabling mTLS][15].
+When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via [mutually authenticated transport layer security (mTLS)-encrypted WebSockets][15].
 
 The secret included in your Sensu handler will be exposed to Sensu services at runtime as an environment variable.
 Sensu only exposes secrets to Sensu services like environment variables and automatically redacts secrets from all logs, the API, and the web UI.
@@ -470,7 +469,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [12]: https://www.vaultproject.io/docs/concepts/lease.html#lease-durations-and-renewal
 [13]: ../../../api/secrets#providers-provider-put
 [14]: ../../../api/secrets#secrets-secret-put
-[15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
@@ -497,7 +497,7 @@ burst: 100
 [10]: https://www.vaultproject.io/docs/auth/token/
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../secrets-management/

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets.md
@@ -319,4 +319,4 @@ provider: vault
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication

--- a/content/sensu-go/6.5/commercial.md
+++ b/content/sensu-go/6.5/commercial.md
@@ -114,7 +114,7 @@ These resources will help you get started with commercial features in Sensu Go:
 [18]: ../operations/maintain-sensu/license/
 [19]: ../observability-pipeline/observe-filter/filters#build-event-filter-expressions-with-javascript-execution-functions
 [20]: ../operations/deploy-sensu/use-federation/	
-[21]: ../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[21]: ../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [22]: ../operations/manage-secrets/secrets-management/
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/supported-integrations/

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1998,7 +1998,7 @@ log-level: debug
 [55]: ../../../commercial/
 [56]: #allow-list
 [57]: ../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events
-[58]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[58]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [59]: ../../../operations/control-access/#use-built-in-basic-authentication
 [60]: #log-level
 [61]: #retry-min

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1834,7 +1834,7 @@ platform-metrics-logging-interval: 60s{{< /code >}}
 [28]: ../subscriptions/
 [29]: https://unix.stackexchange.com/questions/29574/how-can-i-set-up-logrotate-to-rotate-logs-hourly
 [30]: https://en.m.wikipedia.org/wiki/WebSocket
-[31]: ../../../operations/deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[31]: ../../../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [32]: ../../../operations/deploy-sensu/generate-certificates/
 [33]: ../../../operations/deploy-sensu/secure-sensu/
 [34]: ../agent/#username-and-password-authentication

--- a/content/sensu-go/6.5/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/troubleshoot.md
@@ -816,7 +816,7 @@ The backend will stop listening on those ports when the etcd database is unavail
 
 [1]: ../../../observability-pipeline/observe-schedule/agent#operation
 [2]: ../../../platforms/#windows
-[3]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[3]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [4]: https://etcd.io/docs/latest/op-guide/security/
 [5]: ../../../observability-pipeline/observe-schedule/agent/#restart-the-service
 [6]: ../../../observability-pipeline/observe-schedule/agent#events-post

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -29,8 +29,7 @@ Secrets are configured via [secrets resources][8].
 A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
 
 This guide only covers the handler use case, but you can use secrets management in handler, mutator, and check execution.
-When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via mutually authenticated transport layer security (mTLS)-encrypted WebSockets.
-Read more about [enabling mTLS][15].
+When a check configuration references a secret, the Sensu backend will only transmit the check's execution requests to agents that are connected via [mutually authenticated transport layer security (mTLS)-encrypted WebSockets][15].
 
 The secret included in your Sensu handler will be exposed to Sensu services at runtime as an environment variable.
 Sensu only exposes secrets to Sensu services like environment variables and automatically redacts secrets from all logs, the API, and the web UI.
@@ -530,7 +529,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [12]: https://www.vaultproject.io/docs/concepts/lease.html#lease-durations-and-renewal
 [13]: ../../../api/secrets#providers-provider-put
 [14]: ../../../api/secrets#secrets-secret-put
-[15]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
 [21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
@@ -497,7 +497,7 @@ burst: 100
 [10]: https://www.vaultproject.io/docs/auth/token/
 [11]: https://www.vaultproject.io/api/auth/cert/index.html
 [12]: #client-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [14]: https://www.vaultproject.io/docs/secrets/kv
 [15]: https://www.vaultproject.io/api/auth/cert/index.html#parameters-7
 [16]: ../secrets-management/

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets.md
@@ -319,4 +319,4 @@ provider: vault
 [10]: https://learn.hashicorp.com/vault/getting-started/dev-server
 [11]: ../secrets-management/
 [12]: #metadata-attributes
-[13]: ../../deploy-sensu/secure-sensu/#sensu-agent-mtls-authentication
+[13]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication


### PR DESCRIPTION
## Description
Fixes the mTLS link throughout the docs so that it points to the correct section in Secure Sensu.

## Motivation and Context
Found when working on something else
