### PR TITLE
Update sensuctl create/manage to remove filters from handler definitions

### DIFF
--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -350,39 +350,39 @@ sensuctl describe-type all
 The response will list the names and other details for the supported resource types:
 
 {{< code shell >}}
-      Fully Qualified Name           Short Name           API Version             Type            Namespaced  
- ────────────────────────────── ───────────────────── ─────────────────── ─────────────────────  ──────────── 
-  authentication/v2.Provider                           authentication/v2   Provider                 false
-  licensing/v2.LicenseFile                             licensing/v2        LicenseFile              false
-  store/v1.PostgresConfig                              store/v1            PostgresConfig           false
-  federation/v1.Cluster                                federation/v1       Cluster                  false
-  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator           false
-  secrets/v1.Secret                                    secrets/v1          Secret                   true
-  secrets/v1.Provider                                  secrets/v1          Provider                 false
-  searches/v1.Search                                   searches/v1         Search                   true
-  web/v1.GlobalConfig                                  web/v1              GlobalConfig             false
-  bsm/v1.RuleTemplate                                  bsm/v1              RuleTemplate             true        
-  bsm/v1.ServiceComponent                              bsm/v1              ServiceComponent         true       
-  pipeline/v1.SumoLogicMetricsHandler                  pipeline/v1         SumoLogicMetricsHandler  true        
-  pipeline/v1.TCPStreamHandler                         pipeline/v1         TCPStreamHandler         true        
-  core/v2.Namespace              namespaces            core/v2             Namespace                false
-  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole              false
-  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding       false
-  core/v2.User                   users                 core/v2             User                     false
-  core/v2.APIKey                 apikeys               core/v2             APIKey                   false
-  core/v2.TessenConfig           tessen                core/v2             TessenConfig             false
-  core/v2.Asset                  assets                core/v2             Asset                    true
-  core/v2.CheckConfig            checks                core/v2             CheckConfig              true
-  core/v2.Entity                 entities              core/v2             Entity                   true
-  core/v2.Event                  events                core/v2             Event                    true
-  core/v2.EventFilter            filters               core/v2             EventFilter              true
-  core/v2.Handler                handlers              core/v2             Handler                  true
-  core/v2.HookConfig             hooks                 core/v2             HookConfig               true
-  core/v2.Mutator                mutators              core/v2             Mutator                  true
-  core/v2.Role                   roles                 core/v2             Role                     true
-  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding              true
-  core/v2.Silenced               silenced              core/v2             Silenced                 true  
-  core/v2.Pipeline               pipelines             core/v2             Pipeline                 true
+         Fully Qualified Name               Short Name           API Version               Type             Namespaced  
+────────────────────────────────────── ───────────────────── ─────────────────── ───────────────────────── ─────────────
+  authentication/v2.Provider                                  authentication/v2   Provider                  false
+  licensing/v2.LicenseFile                                    licensing/v2        LicenseFile               false
+  store/v1.PostgresConfig                                     store/v1            PostgresConfig            false
+  federation/v1.EtcdReplicator                                federation/v1       EtcdReplicator            false
+  federation/v1.Cluster                                       federation/v1       Cluster                   false
+  secrets/v1.Secret                                           secrets/v1          Secret                    true
+  secrets/v1.Provider                                         secrets/v1          Provider                  false
+  searches/v1.Search                                          searches/v1         Search                    true
+  web/v1.GlobalConfig                                         web/v1              GlobalConfig              false
+  bsm/v1.RuleTemplate                                         bsm/v1              RuleTemplate              true
+  bsm/v1.ServiceComponent                                     bsm/v1              ServiceComponent          true
+  pipeline/v1.SumoLogicMetricsHandler                         pipeline/v1         SumoLogicMetricsHandler   true
+  pipeline/v1.TCPStreamHandler                                pipeline/v1         TCPStreamHandler          true
+  core/v2.Namespace                     namespaces            core/v2             Namespace                 false
+  core/v2.ClusterRole                   clusterroles          core/v2             ClusterRole               false
+  core/v2.ClusterRoleBinding            clusterrolebindings   core/v2             ClusterRoleBinding        false
+  core/v2.User                          users                 core/v2             User                      false
+  core/v2.APIKey                        apikeys               core/v2             APIKey                    false
+  core/v2.TessenConfig                  tessen                core/v2             TessenConfig              false
+  core/v2.Asset                         assets                core/v2             Asset                     true
+  core/v2.CheckConfig                   checks                core/v2             CheckConfig               true
+  core/v2.Entity                        entities              core/v2             Entity                    true
+  core/v2.Event                         events                core/v2             Event                     true
+  core/v2.EventFilter                   filters               core/v2             EventFilter               true
+  core/v2.Handler                       handlers              core/v2             Handler                   true
+  core/v2.HookConfig                    hooks                 core/v2             HookConfig                true
+  core/v2.Mutator                       mutators              core/v2             Mutator                   true
+  core/v2.Pipeline                      pipelines             core/v2             Pipeline                  true
+  core/v2.Role                          roles                 core/v2             Role                      true
+  core/v2.RoleBinding                   rolebindings          core/v2             RoleBinding               true
+  core/v2.Silenced                      silenced              core/v2             Silenced                  true 
 {{< /code >}}
 
 You can also list specific resource types by fully qualified name or short name:

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -56,9 +56,6 @@ spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
   - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
-  filters:
-  - is_incident
-  - not_silenced
   type: pipe
 {{< /code >}}
 
@@ -87,13 +84,6 @@ spec:
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     ],
-    "filters": [
-      "is_incident",
-      "not_silenced"
-    ],
-    "handlers": [],
-    "runtime_assets": [],
-    "timeout": 0,
     "type": "pipe"
   }
 }
@@ -507,39 +497,39 @@ sensuctl describe-type all
 The response will list all supported `sensuctl prune` resource types:
 
 {{< code shell >}}
-      Fully Qualified Name           Short Name           API Version             Type             Namespaced  
- ────────────────────────────── ───────────────────── ─────────────────── ─────────────────────── ──────────── 
-  authentication/v2.Provider                           authentication/v2   Provider                 false       
-  licensing/v2.LicenseFile                             licensing/v2        LicenseFile              false       
-  store/v1.PostgresConfig                              store/v1            PostgresConfig           false       
-  federation/v1.EtcdReplicator                         federation/v1       EtcdReplicator           false       
-  federation/v1.Cluster                                federation/v1       Cluster                  false       
-  secrets/v1.Secret                                    secrets/v1          Secret                   true        
-  secrets/v1.Provider                                  secrets/v1          Provider                 false       
-  searches/v1.Search                                   searches/v1         Search                   true        
-  web/v1.GlobalConfig                                  web/v1              GlobalConfig             false       
-  bsm/v1.RuleTemplate                                  bsm/v1              RuleTemplate             true        
-  bsm/v1.ServiceComponent                              bsm/v1              ServiceComponent         true        
-  pipeline/v1.SumoLogicMetricsHandler                  pipeline/v1         SumoLogicMetricsHandler  true        
-  pipeline/v1.TCPStreamHandler                         pipeline/v1         TCPStreamHandler         true        
-  core/v2.Namespace              namespaces            core/v2             Namespace                false       
-  core/v2.ClusterRole            clusterroles          core/v2             ClusterRole              false       
-  core/v2.ClusterRoleBinding     clusterrolebindings   core/v2             ClusterRoleBinding       false       
-  core/v2.User                   users                 core/v2             User                     false       
-  core/v2.APIKey                 apikeys               core/v2             APIKey                   false       
-  core/v2.TessenConfig           tessen                core/v2             TessenConfig             false       
-  core/v2.Asset                  assets                core/v2             Asset                    true        
-  core/v2.CheckConfig            checks                core/v2             CheckConfig              true        
-  core/v2.Entity                 entities              core/v2             Entity                   true        
-  core/v2.Event                  events                core/v2             Event                    true        
-  core/v2.EventFilter            filters               core/v2             EventFilter              true        
-  core/v2.Handler                handlers              core/v2             Handler                  true        
-  core/v2.HookConfig             hooks                 core/v2             HookConfig               true        
-  core/v2.Mutator                mutators              core/v2             Mutator                  true        
-  core/v2.Role                   roles                 core/v2             Role                     true        
-  core/v2.RoleBinding            rolebindings          core/v2             RoleBinding              true        
-  core/v2.Silenced               silenced              core/v2             Silenced                 true        
-  core/v2.Pipeline               pipelines             core/v2             Pipeline                 true 
+         Fully Qualified Name               Short Name           API Version               Type             Namespaced  
+────────────────────────────────────── ───────────────────── ─────────────────── ───────────────────────── ─────────────
+  authentication/v2.Provider                                  authentication/v2   Provider                  false
+  licensing/v2.LicenseFile                                    licensing/v2        LicenseFile               false
+  store/v1.PostgresConfig                                     store/v1            PostgresConfig            false
+  federation/v1.EtcdReplicator                                federation/v1       EtcdReplicator            false
+  federation/v1.Cluster                                       federation/v1       Cluster                   false
+  secrets/v1.Secret                                           secrets/v1          Secret                    true
+  secrets/v1.Provider                                         secrets/v1          Provider                  false
+  searches/v1.Search                                          searches/v1         Search                    true
+  web/v1.GlobalConfig                                         web/v1              GlobalConfig              false
+  bsm/v1.RuleTemplate                                         bsm/v1              RuleTemplate              true
+  bsm/v1.ServiceComponent                                     bsm/v1              ServiceComponent          true
+  pipeline/v1.SumoLogicMetricsHandler                         pipeline/v1         SumoLogicMetricsHandler   true
+  pipeline/v1.TCPStreamHandler                                pipeline/v1         TCPStreamHandler          true
+  core/v2.Namespace                     namespaces            core/v2             Namespace                 false
+  core/v2.ClusterRole                   clusterroles          core/v2             ClusterRole               false
+  core/v2.ClusterRoleBinding            clusterrolebindings   core/v2             ClusterRoleBinding        false
+  core/v2.User                          users                 core/v2             User                      false
+  core/v2.APIKey                        apikeys               core/v2             APIKey                    false
+  core/v2.TessenConfig                  tessen                core/v2             TessenConfig              false
+  core/v2.Asset                         assets                core/v2             Asset                     true
+  core/v2.CheckConfig                   checks                core/v2             CheckConfig               true
+  core/v2.Entity                        entities              core/v2             Entity                    true
+  core/v2.Event                         events                core/v2             Event                     true
+  core/v2.EventFilter                   filters               core/v2             EventFilter               true
+  core/v2.Handler                       handlers              core/v2             Handler                   true
+  core/v2.HookConfig                    hooks                 core/v2             HookConfig                true
+  core/v2.Mutator                       mutators              core/v2             Mutator                   true
+  core/v2.Pipeline                      pipelines             core/v2             Pipeline                  true
+  core/v2.Role                          roles                 core/v2             Role                      true
+  core/v2.RoleBinding                   rolebindings          core/v2             RoleBinding               true
+  core/v2.Silenced                      silenced              core/v2             Silenced                  true 
 {{< /code >}}
 
 {{% notice note %}}


### PR DESCRIPTION
## Description
Updates handler definitions in https://docs.sensu.io/sensu-go/6.5/sensuctl/create-manage-resources/ to remove filters. Also updates sensuctl describe-type all response (in both sensuctl docs that include it).

## Motivation and Context
Support transition to pipelines