### PR TITLE
6.6.0: Remove notes about 6.5.5 in backend reference

### DIFF
--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -457,7 +457,7 @@ General Flags:
       --api-listen-address string                 address to listen on for api traffic (default "[::]:8080")
       --api-request-limit int                     maximum API request body size, in bytes (default 512000)
       --api-url string                            url of the api to connect to (default "http://localhost:8080")
-      --api-write-timeout                         (available in Sensu Go 6.5.5) maximum duration before timing out writes of responses
+      --api-write-timeout                         maximum duration before timing out writes of responses
       --assets-burst-limit int                    asset fetch burst limit (default 100)
       --assets-rate-limit float                   maximum number of assets fetched per second
       --cache-dir string                          path to store cached data (default "/var/cache/sensu/sensu-backend")
@@ -467,7 +467,7 @@ General Flags:
       --dashboard-host string                     dashboard listener host (default "[::]")
       --dashboard-key-file string                 dashboard TLS certificate key in PEM format
       --dashboard-port int                        dashboard listener port (default 3000)
-      --dashboard-write-timeout                   (available in Sensu Go 6.5.5) maximum duration before timing out writes of responses
+      --dashboard-write-timeout                   maximum duration before timing out writes of responses
       --debug                                     enable debugging and profiling features
       --deregistration-handler string             default deregistration handler
       --disable-platform-metrics                  disable platform metrics logging
@@ -588,9 +588,7 @@ api-url: "http://localhost:8080"{{< /code >}}
 
 | api-write-timeout  |      |
 -------------|------
-description  | Maximum amount of time to wait before timing out on API HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).{{% notice note %}}
-**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.5.5 to use the api-write-timeout configuration flag.
-{{% /notice %}}
+description  | Maximum amount of time to wait before timing out on API HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).
 type         | String
 default      | `15s`
 environment variable | `SENSU_BACKEND_API_WRITE_TIMEOUT`
@@ -647,9 +645,7 @@ sensu-backend start -c /etc/sensu/backend.yml
 
 | dashboard-write-timeout  |      |
 -------------|------
-description  | Maximum amount of time to wait before timing out on web UI HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).{{% notice note %}}
-**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.5.5 to use the dashboard-write-timeout configuration flag.
-{{% /notice %}}
+description  | Maximum amount of time to wait before timing out on web UI HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).
 type         | String
 default      | `15s`
 environment variable | `SENSU_BACKEND_DASHBOARD_WRITE_TIMEOUT`


### PR DESCRIPTION
## Description
Removes the notes for the two timeout flags added in 6.5.5 from backend reference

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3496
