### PR TITLE
Replace wget command with curl -O alternative

### DIFF
--- a/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.2/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -418,7 +418,7 @@ sensu-centos   prometheus_metrics   up,instance=localhost:9090,job=prometheus va
 Download the Grafana dashboard configuration file from the Sensu docs:
 
 {{< code shell >}}
-wget https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
+curl -O https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
 {{< /code >}}
 
 Using the downloaded file, add the dashboard to Grafana with an API call:

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -418,7 +418,7 @@ sensu-centos   prometheus_metrics   up,instance=localhost:9090,job=prometheus va
 Download the Grafana dashboard configuration file from the Sensu docs:
 
 {{< code shell >}}
-wget https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
+curl -O https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
 {{< /code >}}
 
 Using the downloaded file, add the dashboard to Grafana with an API call:

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -418,7 +418,7 @@ sensu-centos   prometheus_metrics   up,instance=localhost:9090,job=prometheus va
 Download the Grafana dashboard configuration file from the Sensu docs:
 
 {{< code shell >}}
-wget https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
+curl -O https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
 {{< /code >}}
 
 Using the downloaded file, add the dashboard to Grafana with an API call:

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -418,7 +418,7 @@ sensu-centos   prometheus_metrics   up,instance=localhost:9090,job=prometheus va
 Download the Grafana dashboard configuration file from the Sensu docs:
 
 {{< code shell >}}
-wget https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
+curl -O https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
 {{< /code >}}
 
 Using the downloaded file, add the dashboard to Grafana with an API call:

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -418,7 +418,7 @@ sensu-centos   prometheus_metrics   up,instance=localhost:9090,job=prometheus va
 Download the Grafana dashboard configuration file from the Sensu docs:
 
 {{< code shell >}}
-wget https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
+curl -O https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json
 {{< /code >}}
 
 Using the downloaded file, add the dashboard to Grafana with an API call:


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/prometheus-metrics/#configure-a-dashboard-in-grafana, replaces first command:
`wget https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json`

with:
`curl -O https://docs.sensu.io/sensu-go/latest/files/up_or_down_dashboard.json`

The wget version results in a certificate error that is invalid (the docs.sensu.io cert is not expired).

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3440
