### PR TITLE
Clarify language around upgrading Sensu

### DIFF
--- a/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
@@ -15,6 +15,10 @@ To upgrade to the latest version of Sensu Go:
 
 1. [Install][1] the latest packages or Docker image.
 
+   {{% notice note %}}
+   **NOTE**: If you're upgrading a Sensu cluster, upgrade **all** of your Sensu backends before you run the `sensu-backend upgrade` command in step 5.
+{{% /notice %}}
+
 2. For systems that use `systemd`, run:
 {{< code shell >}}
 sudo systemctl daemon-reload

--- a/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
@@ -15,6 +15,10 @@ To upgrade to the latest version of Sensu Go:
 
 1. [Install][1] the latest packages or Docker image.
 
+   {{% notice note %}}
+   **NOTE**: If you're upgrading a Sensu cluster, upgrade **all** of your Sensu backends before you run the `sensu-backend upgrade` command in step 5.
+{{% /notice %}}
+
 2. For systems that use `systemd`, run:
 {{< code shell >}}
 sudo systemctl daemon-reload

--- a/content/sensu-go/6.5/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/upgrade.md
@@ -15,6 +15,10 @@ To upgrade to the latest version of Sensu Go:
 
 1. [Install][1] the latest packages or Docker image.
 
+   {{% notice note %}}
+   **NOTE**: If you're upgrading a Sensu cluster, upgrade **all** of your Sensu backends before you run the `sensu-backend upgrade` command in step 5.
+{{% /notice %}}
+
 2. For systems that use `systemd`, run:
 {{< code shell >}}
 sudo systemctl daemon-reload

--- a/content/sensu-go/6.6/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/upgrade.md
@@ -13,7 +13,11 @@ menu:
 
 To upgrade to the latest version of Sensu Go:
 
-1. [Install][1] the latest packages or Docker image.
+1. [Install or upgrade to][1] the latest packages or Docker image.
+
+   {{% notice note %}}
+   **NOTE**: If you're upgrading a Sensu cluster, you'll need upgrade ***all*** Sensu backends before running the command in step 5.
+{{% /notice %}}
 
 2. For systems that use `systemd`, run:
 {{< code shell >}}

--- a/content/sensu-go/6.6/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/upgrade.md
@@ -16,7 +16,7 @@ To upgrade to the latest version of Sensu Go:
 1. [Install or upgrade to][1] the latest packages or Docker image.
 
    {{% notice note %}}
-   **NOTE**: If you're upgrading a Sensu cluster, you'll need upgrade ***all*** Sensu backends before running the command in step 5.
+   **NOTE**: If you're upgrading a Sensu cluster, upgrade **all** of your Sensu backends before you run the `sensu-backend upgrade` command in step 5.
 {{% /notice %}}
 
 2. For systems that use `systemd`, run:


### PR DESCRIPTION
As part of a request in HS-27590, there needs to be some additional clarity in this document when it comes to performing a rolling upgrade. As it stands, the doc can be interpreted as if an operator should proceed through all steps first on a single backend, then upgrade the rest of the cluster members. The note I've added is an attempt to ensure that users know they should upgrade all backends before upgrading the database.
