### PR TITLE
Fix heading level for pipelines object in events spec

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -2478,7 +2478,7 @@ created_by: "admin"
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### Pipelines attributes
+### Pipelines attributes
 
 type         | 
 -------------|------

--- a/content/sensu-go/6.6/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-events/events.md
@@ -2478,7 +2478,7 @@ created_by: "admin"
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### Pipelines attributes
+### Pipelines attributes
 
 type         | 
 -------------|------


### PR DESCRIPTION
## Description
Fixes heading level for pipelines attributes to h3 in specification tables in events reference

## Motivation and Context
Noticed when working on something else
