### PR TITLE
Add note about Common Name in certs for Sensu Go 6.4.0 and later versions

### DIFF
--- a/content/sensu-go/6.4/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/deployment-architecture.md
@@ -56,7 +56,13 @@ Therefore, we recommend planning for encryption before initiating a clustered Se
 
 As described in [Secure Sensu][6], the backend uses a shared certificate and key for web UI and agent communications.
 You can secure communications with etcd using the same certificate and key.
-The certificate's common name or subject alternate names must include the network interfaces and DNS names that will point to those systems.
+The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
+
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/generate-certificates.md
@@ -133,6 +133,12 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (for example, `backend-1.example.com`), and an unqualified name (for example, `backend-1`):
 
 Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |

--- a/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
@@ -22,6 +22,12 @@ It also describes agent mutual transport layer security (mTLS) authentication, w
 Before you can secure Sensu, you must [generate the certificates][12] you will need.
 After you generate certificates, follow this reference to secure Sensu for production.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 ## Secure etcd peer communication
 
 {{% notice warning %}}

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -64,6 +64,12 @@ Because federation depends on communication with multiple disparate clusters, wo
 To ensure that cluster members can validate each other, certificates for each cluster member should include the IP addresses or hostnames specified in the values of sensu-backend `etcd-advertise-client-urls`, `etcd-advertise-peer-urls`, and `etcd-initial-advertise-peer-urls` parameters.
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 To continue with this guide, make sure you have the required TLS credentials in place:
 
 * A PEM-formatted X.509 certificate and corresponding private key copied to each cluster member.

--- a/content/sensu-go/6.5/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/deployment-architecture.md
@@ -56,7 +56,13 @@ Therefore, we recommend planning for encryption before initiating a clustered Se
 
 As described in [Secure Sensu][6], the backend uses a shared certificate and key for web UI and agent communications.
 You can secure communications with etcd using the same certificate and key.
-The certificate's common name or subject alternate names must include the network interfaces and DNS names that will point to those systems.
+The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
+
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
@@ -133,6 +133,12 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (for example, `backend-1.example.com`), and an unqualified name (for example, `backend-1`):
 
 Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |

--- a/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
@@ -22,6 +22,12 @@ It also describes agent mutual transport layer security (mTLS) authentication, w
 Before you can secure Sensu, you must [generate the certificates][12] you will need.
 After you generate certificates, follow this reference to secure Sensu for production.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 ## Secure etcd peer communication
 
 {{% notice warning %}}

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -64,6 +64,12 @@ Because federation depends on communication with multiple disparate clusters, wo
 To ensure that cluster members can validate each other, certificates for each cluster member should include the IP addresses or hostnames specified in the values of sensu-backend `etcd-advertise-client-urls`, `etcd-advertise-peer-urls`, and `etcd-initial-advertise-peer-urls` parameters.
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 To continue with this guide, make sure you have the required TLS credentials in place:
 
 * A PEM-formatted X.509 certificate and corresponding private key copied to each cluster member.

--- a/content/sensu-go/6.6/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/deployment-architecture.md
@@ -56,7 +56,13 @@ Therefore, we recommend planning for encryption before initiating a clustered Se
 
 As described in [Secure Sensu][6], the backend uses a shared certificate and key for web UI and agent communications.
 You can secure communications with etcd using the same certificate and key.
-The certificate's common name or subject alternate names must include the network interfaces and DNS names that will point to those systems.
+The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
+
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
@@ -133,6 +133,12 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 This guide assumes a scenario with three backend members that are reachable via a `10.0.0.x` IP address, a fully qualified name (for example, `backend-1.example.com`), and an unqualified name (for example, `backend-1`):
 
 Unqualified<br>name | IP address | Fully qualified<br>domain name<br>(FQDN) | Additional<br>names |

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
@@ -22,6 +22,12 @@ It also describes agent mutual transport layer security (mTLS) authentication, w
 Before you can secure Sensu, you must [generate the certificates][12] you will need.
 After you generate certificates, follow this reference to secure Sensu for production.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 ## Secure etcd peer communication
 
 {{% notice warning %}}

--- a/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
@@ -64,6 +64,12 @@ Because federation depends on communication with multiple disparate clusters, wo
 To ensure that cluster members can validate each other, certificates for each cluster member should include the IP addresses or hostnames specified in the values of sensu-backend `etcd-advertise-client-urls`, `etcd-advertise-peer-urls`, and `etcd-initial-advertise-peer-urls` parameters.
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
+{{% notice note %}}
+**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
+As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+{{% /notice %}}
+
 To continue with this guide, make sure you have the required TLS credentials in place:
 
 * A PEM-formatted X.509 certificate and corresponding private key copied to each cluster member.


### PR DESCRIPTION
## Description
Adds information about Common Name deprecation in Go from [troubleshooting](https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/troubleshoot/#commonname-deprecation-in-go-115) to several pages in the 6.4+ docs:
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/deployment-architecture/
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/generate-certificates/
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/
- https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/use-federation/

## Motivation and Context
https://sumologic.slack.com/archives/C024PCF29KR/p1638285052201900