### PR TITLE
Add Sensu Plus to docs.sensu.io landing page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -150,9 +150,6 @@
       <h2>Sensu at enterprise scale</h2>
       <p>Monitor tens of thousands of nodes and process 100M+ events per hour. Scale for complex and distributed infrastructures and high-volume event storage.</p>
       <div class="info-grid info-grid--comfy">
-        <a class="colored colored--purple colored--rounded" href="./sensu-go/latest/operations/deploy-sensu/deployment-architecture/">
-          <p>Deployment architecture</p>
-        </a>
         <a class="colored colored--purple colored--rounded" href="./sensu-go/latest/operations/deploy-sensu/generate-certificates/">
           <p>Certificates and security</p>
         </a>
@@ -161,6 +158,9 @@
         </a>
         <a class="colored colored--purple colored--rounded" href="./sensu-go/latest/operations/deploy-sensu/scale-event-storage/">
           <p>Enterprise datastore</p>
+        </a>
+        <a class="colored colored--purple colored--rounded" href="./sensu-go/latest/sensu-plus/">
+          <p>Sensu Plus</p>
         </a>
         <a class="colored colored--purple colored--rounded" href="./sensu-go/latest/operations/manage-secrets/secrets-management/">
           <p>Secrets management</p>
@@ -215,7 +215,7 @@
       <h2>Learn Sensu</h2>
       <p>Start using Sensu and discover what you can do. Get hands-on and use our fully featured product for free up to 100 entities.</p>
       <div class="info-grid info-grid--comfy">
-        <a class="colored colored--white colored--rounded" href="https://sensu.io/resources?type=workshop">
+        <a class="colored colored--white colored--rounded" href="https://github.com/sensu/sensu-go-workshop#sensu-go-workshop">
           <p>Take the self-guided Sensu Go workshop</p>
         </a>
         <a class="colored colored--white colored--rounded" href="./sensu-go/latest/observability-pipeline/">


### PR DESCRIPTION
## Description
Adds Sensu Plus button and link under "Sensu at enterprise scale" heading on docs.sensu.io landing page. Also removes Deployment architecture from the same section and changes the link to the self-guided workshop.

## Motivation and Context
Noticed it's not already there
