### PR TITLE
Update http-checks plugin version in Monitor Sensu with Sensu

### DIFF
--- a/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -42,14 +42,14 @@ This asset includes the `http-json` plugin, which your checks will rely on.
 To register the http-checks dynamic runtime asset, `sensu/http-checks`, run:
 
 {{< code shell >}}
-sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
+sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 {{< /code >}}
 
 The response will confirm that the asset was added:
 
 {{< code shell >}}
-fetching bonsai asset: sensu/http-checks:0.4.0
-added asset: sensu/http-checks:0.4.0
+fetching bonsai asset: sensu/http-checks:0.5.0
+added asset: sensu/http-checks:0.5.0
 
 You have successfully added the Sensu asset resource, but the asset will not get downloaded until
 it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
@@ -69,12 +69,12 @@ The response should list the `http-checks` dynamic runtime asset:
 {{< code shell >}}
      Name                                       URL                                    Hash    
 ────────────── ───────────────────────────────────────────────────────────────────── ──────────
-  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.4.0_windows_amd64.tar.gz   52ae075  
-  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.4.0_darwin_amd64.tar.gz    72d0f15  
-  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.4.0_linux_armv7.tar.gz     ef18587  
-  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.4.0_linux_arm64.tar.gz     3504ddf  
-  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.4.0_linux_386.tar.gz       60b8883  
-  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.4.0_linux_amd64.tar.gz     1db73a8 
+  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.5.0_linux_armv7.tar.gz     b28f8c3  
+  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.5.0_linux_arm64.tar.gz     7308f9c  
+  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.5.0_linux_386.tar.gz       6457583  
+  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.5.0_windows_amd64.tar.gz   b936ca0  
+  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.5.0_darwin_amd64.tar.gz    38e6cb8  
+  http-checks   //assets.bonsai.sensu.io/.../http-checks_0.5.0_linux_amd64.tar.gz     bc5fc3b 
 {{< /code >}}
 
 Because plugins are published for multiple platforms, including Linux and Windows, the output will include multiple entries for each of the dynamic runtime assets.


### PR DESCRIPTION
## Description
Updates the http-checks plugin version to 0.5.0 in Monitor Sensu with Sensu.

## Motivation and Context
Plugin update merged last week: https://github.com/sensu/http-checks/pull/15
