### PR TITLE
Add missing hyphen in silences GIF link

### DIFF
--- a/content/sensu-go/6.6/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.6/web-ui/view-manage-resources.md
@@ -83,7 +83,7 @@ The top row of the silences list includes options for filtering and sorting sile
 
 Click `+ NEW` to open a modal window and create silences for individual events, by check or subscription name, or by entity:
 
-{{< figure src="/images/silences-modal-6-6-0.gif" alt="Create a new silence in the modal window" link="/images/silences-modal6-6-0.gif" target="_blank" >}}
+{{< figure src="/images/silences-modal-6-6-0.gif" alt="Create a new silence in the modal window" link="/images/silences-modal-6-6-0.gif" target="_blank" >}}
 
 You can also silence individual checks and entities from their detail pages in the web UI.
 


### PR DESCRIPTION
## Description
Adds a missing hyphen in the link for the second gif under https://docs.sensu.io/sensu-go/latest/web-ui/view-manage-resources/#manage-silences

## Motivation and Context
Ahrefs audit finding
