### PR TITLE
Update link for Sumo Logic signup in Sensu Plus page

### DIFF
--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -181,7 +181,7 @@ Click a dashboard name to view your Sensu observability data.
 
 
 [1]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source
-[2]: https://www.sumologic.com/sign-up/
+[2]: https://www.sumologic.com/sign-up/?utm_source=sensudocs&utm_medium=sensuwebsite
 [3]: #create-a-handler-in-sensu
 [5]: ../observability-pipeline/observe-process/sumo-logic-metrics-handlers
 [6]: ../operations/manage-secrets/secrets/

--- a/content/sensu-go/6.6/sensu-plus.md
+++ b/content/sensu-go/6.6/sensu-plus.md
@@ -181,7 +181,7 @@ Click a dashboard name to view your Sensu observability data.
 
 
 [1]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source
-[2]: https://www.sumologic.com/sign-up/
+[2]: https://www.sumologic.com/sign-up/?utm_source=sensudocs&utm_medium=sensuwebsite
 [3]: #create-a-handler-in-sensu
 [5]: ../observability-pipeline/observe-process/sumo-logic-metrics-handlers
 [6]: ../operations/manage-secrets/secrets/


### PR DESCRIPTION
## Description
Updates the link for Sumo Logic signup in the Sensu Plus page so that we can keep track of how many people visit the link from that page.

## Motivation and Context
Received updated link from Iryna