### PR TITLE
Explain that new streaming handler types are not valid for check handler arrays

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -763,7 +763,11 @@ subscriptions:
 
 |handlers    |      |
 -------------|------
-description  | Array of Sensu event handlers (names) to use for events created by the check. Each array item must be a string.
+description  | Array of Sensu event handlers (names) to use for events created by the check. Each array item must be a string. {{% notice note %}}
+**NOTE**: The names of [Sumo Logic metrics handlers](../../observe-process/sumo-logic-metrics-handlers/) and [TCP stream handlers](../../observe-process/tcp-stream-handlers/) are not valid values for the handlers array.
+Only [traditional handlers](../../observe-process/handlers/) are valid for the handlers array.<br><br>
+To use Sumo Logic metrics or TCP stream handlers, include them in a [pipeline](../../observe-process/pipelines/) workflow and reference the pipeline name in the check [pipelines array](#pipelines-attribute).
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -763,7 +763,11 @@ subscriptions:
 
 |handlers    |      |
 -------------|------
-description  | Array of Sensu event handlers (names) to use for events created by the check. Each array item must be a string.
+description  | Array of Sensu event handlers (names) to use for events created by the check. Each array item must be a string. {{% notice note %}}
+**NOTE**: The names of [Sumo Logic metrics handlers](../../observe-process/sumo-logic-metrics-handlers/) and [TCP stream handlers](../../observe-process/tcp-stream-handlers/) are not valid values for the handlers array.
+Only [traditional handlers](../../observe-process/handlers/) are valid for the handlers array.<br><br>
+To use Sumo Logic metrics or TCP stream handlers, include them in a [pipeline](../../observe-process/pipelines/) workflow and reference the pipeline name in the check [pipelines array](#pipelines-attribute).
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< language-toggle >}}


### PR DESCRIPTION
## Description
Adds a note in the check spec `handlers` description table to explain that users cannot reference a Sumo Logic metrics handler or TCP stream handler in a check `handlers` array.

## Motivation and Context
https://sumologic.slack.com/archives/C024XK35Z3Q/p1639507953119800
