### PR TITLE
Fix broken link for 6.6.2 release notes in supported versions page

### DIFF
--- a/content/sensu-go/6.6/versions.md
+++ b/content/sensu-go/6.6/versions.md
@@ -180,4 +180,4 @@ This table lists the supported versions of Sensu Go with links to active documen
 [78]: https://docs.sensu.io/sensu-go/latest/release-notes/#655-release-notes
 [79]: https://docs.sensu.io/sensu-go/latest/release-notes/#660-release-notes
 [80]: https://docs.sensu.io/sensu-go/latest/release-notes/#661-release-notes
-[80]: https://docs.sensu.io/sensu-go/latest/release-notes/#662-release-notes
+[81]: https://docs.sensu.io/sensu-go/latest/release-notes/#662-release-notes


### PR DESCRIPTION
Fixes broken link to 6.6.2 release notes in 6.6 supported versions page