### PR TITLE
Deprecate agent-burst-limit flag

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -618,7 +618,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 | agent-burst-limit   |      |
 --------------|------
-description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice commercial %}}
+description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
+**NOTE**: The agent-burst-limit flag is deprecated.
+{{% /notice %}} {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -654,7 +654,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 | agent-burst-limit   |      |
 --------------|------
-description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice commercial %}}
+description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
+**NOTE**: The agent-burst-limit flag is deprecated.
+{{% /notice %}} {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -776,7 +776,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 | agent-burst-limit   |      |
 --------------|------
-description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice commercial %}}
+description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
+**NOTE**: The agent-burst-limit flag is deprecated.
+{{% /notice %}} {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -776,7 +776,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 | agent-burst-limit   |      |
 --------------|------
-description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice commercial %}}
+description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
+**NOTE**: The agent-burst-limit flag is deprecated.
+{{% /notice %}} {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer


### PR DESCRIPTION
## Description
Adds deprecation notice for backend config flag `agent-burst-limit`

## Motivation and Context
https://sumologic.slack.com/archives/C024XK35Z3Q/p1639585800273600