### PR TITLE
Fix an incorrectly formatted link in migrate guide

### DIFF
--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -444,7 +444,7 @@ sensuctl create --file /path/to/config.json
 
 {{% notice protip %}}
 **PRO TIP**: `sensuctl create` (and `sensuctl delete`) are powerful tools to help you manage your Sensu configs across namespaces.
-Read the [sensuctl reference][5] for more information.
+Read the [sensuctl reference](../../../sensuctl/) for more information.
 {{% /notice %}}
 
 Access your Sensu Go config using the [Sensu API][17].

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -444,7 +444,7 @@ sensuctl create --file /path/to/config.json
 
 {{% notice protip %}}
 **PRO TIP**: `sensuctl create` (and `sensuctl delete`) are powerful tools to help you manage your Sensu configs across namespaces.
-Read the [sensuctl reference][5] for more information.
+Read the [sensuctl reference](../../../sensuctl/) for more information.
 {{% /notice %}}
 
 Access your Sensu Go config using the [Sensu API][17].

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -444,7 +444,7 @@ sensuctl create --file /path/to/config.json
 
 {{% notice protip %}}
 **PRO TIP**: `sensuctl create` (and `sensuctl delete`) are powerful tools to help you manage your Sensu configs across namespaces.
-Read the [sensuctl reference][5] for more information.
+Read the [sensuctl reference](../../../sensuctl/) for more information.
 {{% /notice %}}
 
 Access your Sensu Go config using the [Sensu API][17].

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -444,7 +444,7 @@ sensuctl create --file /path/to/config.json
 
 {{% notice protip %}}
 **PRO TIP**: `sensuctl create` (and `sensuctl delete`) are powerful tools to help you manage your Sensu configs across namespaces.
-Read the [sensuctl reference][5] for more information.
+Read the [sensuctl reference](../../../sensuctl/) for more information.
 {{% /notice %}}
 
 Access your Sensu Go config using the [Sensu API][17].


### PR DESCRIPTION
Fixes an incorrectly formatted link in a pro tip callout in the migrate guide.