### PR TITLE
Update 3: Add read/write and grant config info for external etcd in cluster guide

### DIFF
--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -325,6 +325,53 @@ To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
+### Configure key space access
+
+Follow these steps to configure read and write access to the `/sensu.io/` key space for your users so you can initialize a backend that uses etcd authentication.
+
+1. Add the `sensu` user:
+{{< highlight shell >}}
+etcdctl user add sensu
+{{< /highlight >}}
+
+2. Enter the `sensu` user password when prompted.
+
+3. Create the `sensu_readwrite` role:
+{{< highlight shell >}}
+etcdctl role add sensu_readwrite
+{{< /highlight >}}
+
+4. Grant read/write permissions to the `sensu_readwrite` role under the `/sensu.io/` key space:
+{{< highlight shell >}}
+etcdctl role grant-permission sensu_readwrite readwrite --from-key '/sensu.io/'
+{{< /highlight >}}
+
+5. Grant the `sensu_readwrite` role to the `sensu` user:
+{{< highlight shell >}}
+etcdctl user grant-role sensu sensu_readwrite
+{{< /highlight >}}
+
+6. Confirm that the grant is configured correctly:
+{{< highlight shell >}}
+/opt/etcd/etcdctl user get USERNAME --detail
+{{< /highlight >}}
+
+    You should see the following output:
+{{< highlight shell >}}
+User: USERNAME
+
+Role sensu_readwrite
+KV Read:
+  [/sensu.io/, <open ended>
+KV Write:
+  [/sensu.io/, <open ended>
+{{< /highlight >}}
+
+Etcd does not enable authentication by default, so additional configuration may be needed before etcd will enforce these controls.
+See the [etcd operators documentation][12] for details.
+
+### Start etcd
+
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/cluster-sensu.md
@@ -397,11 +397,10 @@ etcd \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `auto-compaction-mode` and `auto-compaction-retention` flags are important.
-Without these settings, your database may quickly reach etcd's maximum database size limit.
+**NOTE**: Without the `auto-compaction-mode` and `auto-compaction-retention` flags, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
+Tell Sensu to use this external etcd data source by adding the `sensu-backend` flag `--no-embed-etcd` to the original configuration and the path to a client certificate created using your CA:
 
 {{< code shell >}}
 sensu-backend start \

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -13,6 +13,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an etcd (default) or PostgreSQL database.
+Using Sensu with an external etcd cluster requires etcd 3.3.2.
+Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
+
 You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -497,3 +500,4 @@ enable_round_robin: true
 [18]: #datastore-specification
 [19]: ../install-sensu/#ports
 [20]: https://www.postgresql.org/docs/current/config-setting.html
+[21]: https://etcd.io/docs/latest/op-guide/clustering/

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -325,6 +325,53 @@ To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
+### Configure key space access
+
+Follow these steps to configure read and write access to the `/sensu.io/` key space for your users so you can initialize a backend that uses etcd authentication.
+
+1. Add the `sensu` user:
+{{< highlight shell >}}
+etcdctl user add sensu
+{{< /highlight >}}
+
+2. Enter the `sensu` user password when prompted.
+
+3. Create the `sensu_readwrite` role:
+{{< highlight shell >}}
+etcdctl role add sensu_readwrite
+{{< /highlight >}}
+
+4. Grant read/write permissions to the `sensu_readwrite` role under the `/sensu.io/` key space:
+{{< highlight shell >}}
+etcdctl role grant-permission sensu_readwrite readwrite --from-key '/sensu.io/'
+{{< /highlight >}}
+
+5. Grant the `sensu_readwrite` role to the `sensu` user:
+{{< highlight shell >}}
+etcdctl user grant-role sensu sensu_readwrite
+{{< /highlight >}}
+
+6. Confirm that the grant is configured correctly:
+{{< highlight shell >}}
+/opt/etcd/etcdctl user get USERNAME --detail
+{{< /highlight >}}
+
+    You should see the following output:
+{{< highlight shell >}}
+User: USERNAME
+
+Role sensu_readwrite
+KV Read:
+  [/sensu.io/, <open ended>
+KV Write:
+  [/sensu.io/, <open ended>
+{{< /highlight >}}
+
+Etcd does not enable authentication by default, so additional configuration may be needed before etcd will enforce these controls.
+See the [etcd operators documentation][12] for details.
+
+### Start etcd
+
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/cluster-sensu.md
@@ -397,11 +397,10 @@ etcd \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `auto-compaction-mode` and `auto-compaction-retention` flags are important.
-Without these settings, your database may quickly reach etcd's maximum database size limit.
+**NOTE**: Without the `auto-compaction-mode` and `auto-compaction-retention` flags, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
+Tell Sensu to use this external etcd data source by adding the `sensu-backend` flag `--no-embed-etcd` to the original configuration and the path to a client certificate created using your CA:
 
 {{< code shell >}}
 sensu-backend start \

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -13,6 +13,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an etcd (default) or PostgreSQL database.
+Using Sensu with an external etcd cluster requires etcd 3.3.2.
+Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
+
 You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -497,3 +500,5 @@ enable_round_robin: true
 [18]: #datastore-specification
 [19]: ../install-sensu/#ports
 [20]: https://www.postgresql.org/docs/current/config-setting.html
+[21]: https://etcd.io/docs/latest/op-guide/clustering/
+

--- a/content/sensu-go/6.5/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/cluster-sensu.md
@@ -325,6 +325,53 @@ To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
+### Configure key space access
+
+Follow these steps to configure read and write access to the `/sensu.io/` key space for your users so you can initialize a backend that uses etcd authentication.
+
+1. Add the `sensu` user:
+{{< highlight shell >}}
+etcdctl user add sensu
+{{< /highlight >}}
+
+2. Enter the `sensu` user password when prompted.
+
+3. Create the `sensu_readwrite` role:
+{{< highlight shell >}}
+etcdctl role add sensu_readwrite
+{{< /highlight >}}
+
+4. Grant read/write permissions to the `sensu_readwrite` role under the `/sensu.io/` key space:
+{{< highlight shell >}}
+etcdctl role grant-permission sensu_readwrite readwrite --from-key '/sensu.io/'
+{{< /highlight >}}
+
+5. Grant the `sensu_readwrite` role to the `sensu` user:
+{{< highlight shell >}}
+etcdctl user grant-role sensu sensu_readwrite
+{{< /highlight >}}
+
+6. Confirm that the grant is configured correctly:
+{{< highlight shell >}}
+/opt/etcd/etcdctl user get USERNAME --detail
+{{< /highlight >}}
+
+    You should see the following output:
+{{< highlight shell >}}
+User: USERNAME
+
+Role sensu_readwrite
+KV Read:
+  [/sensu.io/, <open ended>
+KV Write:
+  [/sensu.io/, <open ended>
+{{< /highlight >}}
+
+Etcd does not enable authentication by default, so additional configuration may be needed before etcd will enforce these controls.
+See the [etcd operators documentation][12] for details.
+
+### Start etcd
+
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/cluster-sensu.md
@@ -397,11 +397,10 @@ etcd \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `auto-compaction-mode` and `auto-compaction-retention` flags are important.
-Without these settings, your database may quickly reach etcd's maximum database size limit.
+**NOTE**: Without the `auto-compaction-mode` and `auto-compaction-retention` flags, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
+Tell Sensu to use this external etcd data source by adding the `sensu-backend` flag `--no-embed-etcd` to the original configuration and the path to a client certificate created using your CA:
 
 {{< code shell >}}
 sensu-backend start \

--- a/content/sensu-go/6.5/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/datastore.md
@@ -13,6 +13,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an etcd (default) or PostgreSQL database.
+Using Sensu with an external etcd cluster requires etcd 3.3.2.
+Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
+
 You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -497,3 +500,5 @@ enable_round_robin: true
 [18]: #datastore-specification
 [19]: ../install-sensu/#ports
 [20]: https://www.postgresql.org/docs/current/config-setting.html
+[21]: https://etcd.io/docs/latest/op-guide/clustering/
+

--- a/content/sensu-go/6.6/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/cluster-sensu.md
@@ -325,6 +325,53 @@ To use Sensu with an external etcd cluster, you must have etcd 3.3.2 or newer.
 To stand up an external etcd cluster, follow etcd's [clustering guide][2] using the same store configuration.
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 
+### Configure key space access
+
+Follow these steps to configure read and write access to the `/sensu.io/` key space for your users so you can initialize a backend that uses etcd authentication.
+
+1. Add the `sensu` user:
+{{< highlight shell >}}
+etcdctl user add sensu
+{{< /highlight >}}
+
+2. Enter the `sensu` user password when prompted.
+
+3. Create the `sensu_readwrite` role:
+{{< highlight shell >}}
+etcdctl role add sensu_readwrite
+{{< /highlight >}}
+
+4. Grant read/write permissions to the `sensu_readwrite` role under the `/sensu.io/` key space:
+{{< highlight shell >}}
+etcdctl role grant-permission sensu_readwrite readwrite --from-key '/sensu.io/'
+{{< /highlight >}}
+
+5. Grant the `sensu_readwrite` role to the `sensu` user:
+{{< highlight shell >}}
+etcdctl user grant-role sensu sensu_readwrite
+{{< /highlight >}}
+
+6. Confirm that the grant is configured correctly:
+{{< highlight shell >}}
+/opt/etcd/etcdctl user get USERNAME --detail
+{{< /highlight >}}
+
+    You should see the following output:
+{{< highlight shell >}}
+User: USERNAME
+
+Role sensu_readwrite
+KV Read:
+  [/sensu.io/, <open ended>
+KV Write:
+  [/sensu.io/, <open ended>
+{{< /highlight >}}
+
+Etcd does not enable authentication by default, so additional configuration may be needed before etcd will enforce these controls.
+See the [etcd operators documentation][12] for details.
+
+### Start etcd
+
 In this example, you will enable client-to-server and peer communication authentication [using self-signed TLS certificates][13].
 To start etcd for `backend-1` based on the [three-node configuration example][19]:
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/cluster-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/cluster-sensu.md
@@ -397,11 +397,10 @@ etcd \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: The `auto-compaction-mode` and `auto-compaction-retention` flags are important.
-Without these settings, your database may quickly reach etcd's maximum database size limit.
+**NOTE**: Without the `auto-compaction-mode` and `auto-compaction-retention` flags, your database may quickly reach etcd's maximum database size limit.
 {{% /notice %}}
 
-To tell Sensu to use this external etcd data source, add the `sensu-backend` flag `--no-embed-etcd` to the original configuration, along with the paths to certificates created using your Certificate Authority (CA) and a list of etcd client URLs:
+Tell Sensu to use this external etcd data source by adding the `sensu-backend` flag `--no-embed-etcd` to the original configuration and the path to a client certificate created using your CA:
 
 {{< code shell >}}
 sensu-backend start \

--- a/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
@@ -13,6 +13,9 @@ menu:
 ---
 
 Sensu stores the most recent event for each entity and check pair using either an etcd (default) or PostgreSQL database.
+Using Sensu with an external etcd cluster requires etcd 3.3.2.
+Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
+
 You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
@@ -497,3 +500,5 @@ enable_round_robin: true
 [18]: #datastore-specification
 [19]: ../install-sensu/#ports
 [20]: https://www.postgresql.org/docs/current/config-setting.html
+[21]: https://etcd.io/docs/latest/op-guide/clustering/
+


### PR DESCRIPTION
## Description
- Adds information about configuring read/write access and grant permission for etcd auth.
- Adds etcd compatibility info to datastore reference.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/2184

## Review Instructions
This PR replaces https://github.com/sensu/sensu-docs/pull/3130 to resolve conflicts.

Eric approved the instructions as written in ^