### PR TITLE
Fix link in PagerDuty guide

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -239,7 +239,7 @@ EOF
 
 ## Assign the pipeline to a check
 
-To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][2]).
+To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][3]).
 All the observability events that the check produces will be processed according to the pipeline's workflows.
 
 Assign your `cpu_check_alerts` pipeline to the `check_cpu` check to receive Slack alerts when the CPU usage of your system reaches the specific thresholds set in the check command.

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -239,7 +239,7 @@ EOF
 
 ## Assign the pipeline to a check
 
-To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][2]).
+To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][3]).
 All the observability events that the check produces will be processed according to the pipeline's workflows.
 
 Assign your `cpu_check_alerts` pipeline to the `check_cpu` check to receive Slack alerts when the CPU usage of your system reaches the specific thresholds set in the check command.


### PR DESCRIPTION
## Description
Fixes link for Monitor server resources that incorrectly points to the check reference

## Motivation and Context
Found when working on something else
