### PR TITLE
Migrate to Algolia DocSearch v3

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -182,7 +182,8 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
   var docsearchOptions = {
-    apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
+    appId: 'S633WESKWC',
+    apiKey: '2aaea336f8b58143b17119944385071f',
     indexName: 'sensu',
     inputSelector: '#desktop-search', 
     algoliaOptions: {


### PR DESCRIPTION
## Description
Updates Algolia API key and adds app ID in https://github.com/sensu/sensu-docs/blob/master/layouts/partials/footer_js.html

## Motivation and Context
Algolia is migrating to v3 of DocSearch and will stop v2 crawls in Feb/March
