### PR TITLE
Revert "Migrate to Algolia DocSearch v3"

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -182,8 +182,7 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
   var docsearchOptions = {
-    appId: 'S633WESKWC',
-    apiKey: '2aaea336f8b58143b17119944385071f',
+    apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
     indexName: 'sensu',
     inputSelector: '#desktop-search', 
     algoliaOptions: {


### PR DESCRIPTION
Looks like the new DocSearch doesn't work on Core, Enterprise, Enterprise Dashboard, or Uchiwa docs.

Reverts sensu/sensu-docs#3606