### PR TITLE
Replace references to API doc pages with API endpoint pathways

### DIFF
--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -120,7 +120,7 @@ export SENSU_ACCESS_TOKEN=`curl -X GET -u "$SENSU_USER:$SENSU_PASS" -s http://lo
 
 The [sensuctl reference][7] demonstrates how to use the `sensuctl env` command to export your access token, token expiry time, and refresh token as environment variables.
 
-### Authenticate with the authentication API
+### Authenticate with /auth API endpoints
 
 Use the [authentication API][12] and your Sensu username and password to generate access tokens and refresh tokens.
 The [`/auth` API endpoint][12] lets you generate short-lived API tokens using your Sensu username and password.
@@ -196,7 +196,7 @@ To regenerate a valid access token, run any sensuctl command (like `sensuctl eve
 
 ### Authenticate with an API key
 
-Each Sensu API key (core/v2.APIKey) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
+Each Sensu API key ([core/v2/apikey][19]) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
 The advantages of authenticating with API keys rather than [access tokens][14] include:
 
 - **More efficient integration**: Check and handler plugins and other code can integrate with the Sensu API without implementing the logic required to authenticate via the `/auth` API endpoint to periodically refresh the access token
@@ -226,7 +226,7 @@ Created: /api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
 {{< /code >}}
 
    {{% notice protip %}}
-**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [APIkeys API](apikeys/#create-a-new-api-key).
+**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [POST core/v2/apikeys endpoint](core/apikeys/#create-a-new-api-key).
 {{% /notice %}}
 
 2. Export your API key to the `SENSU_API_KEY` environment variable:
@@ -264,7 +264,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to core/v2/checks:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -274,7 +274,7 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK` and th
 
 ## Pagination
 
-The Sensu API supports response pagination for most `core/v2` GET endpoints that return an array.
+The Sensu API supports response pagination for most core/v2 GET endpoints that return an array.
 You can request a paginated response with the `limit` and `continue` query parameters.
 
 ### Limit query parameter
@@ -777,19 +777,20 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/si
 [2]: ../operations/deploy-sensu/install-sensu#install-sensuctl
 [3]: ../operations/control-access/rbac/
 [4]: ../observability-pipeline/observe-schedule/agent/
-[5]: health/
-[6]: metrics/
+[5]: other/health/
+[6]: other/metrics/
 [7]: ../sensuctl/environment-variables/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
-[11]: auth/#authtoken-post
-[12]: auth/
+[11]: other/auth/#authtoken-post
+[12]: other/auth/
 [13]: #operators
 [14]: #authentication-quickstart
 [15]: #examples
 [16]: #limit-query-parameter
 [17]: #authenticate-with-an-api-key
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
+[19]: core/apikeys/
 [20]: #authenticate-with-the-authentication-api
 [21]: ../observability-pipeline/observe-schedule/backend/#api-request-limit
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match

--- a/content/sensu-go/6.3/api/core/apikeys.md
+++ b/content/sensu-go/6.3/api/core/apikeys.md
@@ -74,7 +74,7 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with [/auth API endpoints](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
 This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
 If you prefer, you can [create a new API key with sensuctl](../../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}

--- a/content/sensu-go/6.3/api/core/tessen.md
+++ b/content/sensu-go/6.3/api/core/tessen.md
@@ -15,8 +15,8 @@ menu:
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}
 
-The Tessen API provides HTTP access to manage [Tessen][1] configuration.
-Access to the Tessen API is restricted to the default [`admin` user][2].
+The core/v2/tessen API endpoints provide HTTP access to manage [Tessen][1] configuration.
+Access to core/v2/tessen is restricted to the default [`admin` user][2].
 
 ## Get the active Tessen configuration {#tessen-get}
 

--- a/content/sensu-go/6.3/api/core/users.md
+++ b/content/sensu-go/6.3/api/core/users.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice note %}}
 **NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
-To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [authentication providers API](../../enterprise/authproviders/).<br><br>
+To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.3/api/enterprise/prune.md
+++ b/content/sensu-go/6.3/api/enterprise/prune.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 {{% notice note %}}
 **NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The prune API requires [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
 
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.3/api/enterprise/secrets.md
+++ b/content/sensu-go/6.3/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, the secrets API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/api/other/auth.md
+++ b/content/sensu-go/6.3/api/other/auth.md
@@ -74,7 +74,7 @@ HTTP/1.1 200 OK
 
 /auth/test (GET)     |     |
 ---------------------|------
-description          | Tests basic authentication credentials (username and password) that were created with Sensu's [users API][1].
+description          | Tests basic authentication credentials (username and password) that were created with Sensu's [core/v2/users API][1].
 example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
@@ -244,7 +244,7 @@ At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
 If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
-You can also use sensuctl or the license API to [view your overall entity count and limit][5].
+You can also use sensuctl or the /license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -206,7 +206,7 @@ spec:
 
 ### Manage agent entities via the backend
 
-You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+You can manage agent entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33], just like any other Sensu resource.
 This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 Management via the backend is the default configuration for agent entities.
@@ -216,7 +216,7 @@ Management via the backend is the default configuration for agent entities.
 In this case, the entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
 
-If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+If you delete an agent entity that you modified with sensuctl, the core/v2/entities API endpoints, or the web UI, it will revert to the original configuration from `agent.yml`.
 If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
 
 ### Manage agent entities via the agent
@@ -239,7 +239,7 @@ You must set `deregister: true` in `agent.yml` before the agent entity is create
 Proxy entities are dynamically created entities that Sensu adds to the entity store if an entity does not already exist for a check result.
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 
-You can modify proxy entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+You can modify proxy entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 If you start an agent with the same name as an existing proxy entity, Sensu will change the proxy entity's class to `agent` and update its `system` field with information from the agent configuration.
 
@@ -323,7 +323,7 @@ For more information, read [Get started with commercial features](../../../comme
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
-Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+Create and modify service entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 ### Service entity example
 
@@ -384,7 +384,7 @@ sensu-agent start --labels url=sensu.docs.io
 
 {{% notice note %}}
 **NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
-Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ### Proxy entity labels {#proxy-entities-managed}

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/_index.md
@@ -310,9 +310,9 @@ You can create events with proxy entities, which are dynamically created entitie
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 Read [Monitor external resources][1] to learn how to use a proxy entity to monitor a website.
 
-## Events API
+## core/v2/events API endpoints
 
-Sensu's [events API][15] provides HTTP access to create, retrieve, update, and delete events.
+Sensu's [core/v2/events API endpoints][15] provide HTTP access to create, retrieve, update, and delete events.
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
@@ -327,7 +327,7 @@ If you create a new event that references an entity that does not already exist,
 [9]: checks/#subscriptions
 [11]: ../observe-schedule/agent/
 [12]: ../observe-schedule/
-[13]: #events-api
+[13]: #corev2events-api-endpoints
 [14]: ../observe-schedule/agent/#detect-silent-failures
 [15]: ../../api/core/events/
 [16]: ../observe-schedule/agent/

--- a/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-events/events.md
@@ -868,12 +868,12 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 - [Create events using the agent TCP and UDP sockets][12]
 - [Create events using the StatsD listener][13]
 
-## Create events using the events API
+## Create events with the core/v2/events API endpoints
 
-You can send events directly to the Sensu pipeline using the [events API][16].
-To create an event, send a JSON event definition to the [events API PUT endpoint][14].
+You can send events directly to the Sensu pipeline using the [core/v2/events API endpoints][16].
+To create an event, send a JSON event definition to the [core/v2/events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+If you use the core/v2/events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
 
 {{% notice note %}}
 **NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
@@ -881,7 +881,7 @@ If you use the events API to create a new event referencing an entity that does 
 
 ## Manage events
 
-You can manage events using the [Sensu web UI][15], [events API][16], and [sensuctl][17] command line tool.
+You can manage events using the [Sensu web UI][15], [core/v2/events API endpoints][16], and [sensuctl][17] command line tool.
 
 ### View events
 
@@ -904,7 +904,7 @@ sensuctl event info <entity-name> <check-name>
 With both the `list` and `info` commands, you can specify an [output format][18] using the `--format` flag:
 
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
-- `json` format for use with the [events API][16]
+- `json` format for use with [core/v2/events API endpoints][16]
 
 {{< language-toggle >}}
 {{< code shell "YML" >}}
@@ -1353,7 +1353,7 @@ created_by: "admin"
 
 |timestamp   |      |
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created via the [events API][35], you can specify a `timestamp` value in the request body.
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
 required     | false
 type         | Integer
 default      | Time that the event occurred
@@ -1388,7 +1388,7 @@ id: 431a0085-96da-4521-863f-c38b480701e9
 
 sequence     |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [events API][35].
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1404,7 +1404,7 @@ sequence: 1
 
 |entity      |      |
 -------------|------
-description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
+description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [core/v2/events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
 type         | Map
 required     | true
 example      | {{< language-toggle >}}
@@ -1687,7 +1687,7 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [events API][35], the default `executed` value is `0` unless you specify a value in the request body.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [core/v2/events API][35], the default `executed` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1732,7 +1732,7 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [events API][35], the default `issued` value is `0` unless you specify a value in the request body.
+description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1748,7 +1748,7 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [core/v2/events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1764,7 +1764,7 @@ last_ok: 1552506033
 
 occurrences  |      |
 -------------|------
-description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
+description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -1780,7 +1780,7 @@ occurrences: 1
 
 occurrences_watermark | |
 -------------|------
-description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. In events created with the [events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
+description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -1865,7 +1865,7 @@ state: passing
 
 status       |      |
 -------------|------
-description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
+description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [core/v2/events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1881,7 +1881,7 @@ status: 0
 
 total_state_change | |
 -------------|------
-description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
+description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [core/v2/events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1899,7 +1899,7 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [events API][35], the `executed` default value is `0`.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [core/v2/events API][35], the `executed` default value is `0`.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -534,7 +534,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [events API][43].
+The returned object uses the same format as responses for the [core/v2/events API]][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 
@@ -552,7 +552,7 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [events API][43].
+The events in the returned array use the same format as responses for the [core/v2/events API]][43].
 
 ## Event filter specification
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -80,7 +80,7 @@ This communication is via clear text by default.
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 {{% notice note %}}
-**NOTE**: For information about your agent transport status, use the [health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
+**NOTE**: For information about your agent transport status, use the [/health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
 {{% /notice %}}
 
 ## Create observability events using service checks
@@ -498,7 +498,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -322,7 +322,7 @@ spec:
 
 ### Ad hoc scheduling
 
-In addition to automatic execution, you can create checks to be scheduled manually using the [checks API][34].
+In addition to automatic execution, you can create checks to be scheduled manually using [core/v2/checks API endpoints][34].
 To create a check with ad-hoc scheduling, set the `publish` attribute to `false` in addition to an `interval` or `cron` schedule.
 
 #### Example ad hoc check
@@ -708,7 +708,7 @@ annotations:
 ### Spec attributes
 
 {{% notice note %}}
-**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../../api/core/events/#create-a-new-event) /events API.
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent events API](../agent/#events-post) or the [backend core/v2/events API](../../../api/core/events/#create-a-new-event).
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -24,8 +24,8 @@ Use Sensu handlers to [process extracted metrics][11] and route them to database
 You can also use Sensu's [time-series and long-term event storage integrations][18] to process service and time-series metrics.
 
 {{% notice note %}}
-**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu metrics API.
-For information about HTTP GET access to internal Sensu metrics, read our [metrics API](../../../api/other/metrics/) documentation.
+**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu /metrics API.
+For information about HTTP GET access to internal Sensu metrics, read our [/metrics API](../../../api/other/metrics/) documentation.
 {{% /notice %}}
 
 ## Metric check example

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/rule-templates.md
@@ -153,7 +153,7 @@ For example, you might set the minimum threshold at 10 web servers with an OK st
 
 The `aggregate` rule template is useful in dynamic environments and environments with some tolerance for failure.
 
-To review the `aggregate` resource definition, retrieve it with a GET request to the BSM API:
+To review the `aggregate` resource definition, retrieve it with a GET request to /enterprise/bsm/v1:
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
@@ -100,7 +100,7 @@ sensu-agent start --subscriptions linux,webserver --log-level debug
 
 Now your agent entity will execute checks with the `linux` or `webserver` subscriptions.
 
-To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [entities API][18], or the [web UI][19].
+To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [core/v2/entities API endpoints][18], or the [web UI][19].
 
 ## Configure subscriptions
 
@@ -118,14 +118,14 @@ For example, an agent entity with `name: "i-424242"` subscribes to check request
 This makes it possible to generate ad hoc check requests that target specific entities via the API.
 
 {{% notice note %}}
-**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ## Publish checks
 
 If you want Sensu to automatically schedule and execute a check according to its subscriptions, set the [`publish` attribute][12] to `true` in the check definition.
 
-You can also manually schedule [ad hoc check execution][11] with the [check API][16], whether the `publish` attribute is set to `true` or `false`.
+You can also manually schedule [ad hoc check execution][11] with the [core/v2/checks API endpoints][16], whether the `publish` attribute is set to `true` or `false`.
 To target the subscriptions defined in the check, include only the check name in the request body (for example, `"check": "check_cpu"`).
 To override the check's subscriptions and target an alternate entity or group of entities, add the subscriptions attribute to the request body:
 

--- a/content/sensu-go/6.3/operations/control-access/_index.md
+++ b/content/sensu-go/6.3/operations/control-access/_index.md
@@ -33,7 +33,7 @@ Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutu
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with the [users API][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.3/operations/control-access/apikeys.md
+++ b/content/sensu-go/6.3/operations/control-access/apikeys.md
@@ -17,7 +17,7 @@ Unlike [authentication tokens][2], API keys are persistent and do not need to be
 
 The Sensu backend generates API keys, and you can provide them to applications that want to interact with the Sensu API.
 
-Use the [APIKey API][1] to create, retrieve, and delete API keys.
+Use the [core/v2/apikeys API endpoints][1] to create, retrieve, and delete API keys.
 
 ## API key example
 

--- a/content/sensu-go/6.3/operations/control-access/sso.md
+++ b/content/sensu-go/6.3/operations/control-access/sso.md
@@ -64,7 +64,7 @@ The response will list your authentication provider types and names:
 
 ## Manage authentication providers
 
-View and delete authentication providers with the [authentication providers API][10] or these sensuctl commands.
+View and delete authentication providers with [enterprise/authentication/v2 API endpoints][10] or these sensuctl commands.
 
 To view active authentication providers:
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/_index.md
@@ -36,7 +36,7 @@ To deploy Sensu for use outside of a local development environment, [install Sen
 3. [Run a Sensu cluster][6], a group of three or more sensu-backend nodes connected to a shared database, to improve Sensu's availability, reliability, and durability.
 4. [Reach multi-cluster visibility][7] with federation so you can gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI and mirror your changes in one cluster to follower clusters.
 
-Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the federation API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
+Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the enterprise/federation/v1 API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
 
 ## Scale your Sensu implementation
 

--- a/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/datastore.md
@@ -16,7 +16,7 @@ Sensu stores the most recent event for each entity and check pair using either a
 Using Sensu with an external etcd cluster requires etcd 3.3.2.
 Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
 
-You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
+You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and [core/v2/events API endpoints][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
 ## Use default event storage

--- a/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/etcdreplicators.md
@@ -18,7 +18,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
+**NOTE**: EtcdReplicator is a datatype in the enterprise/federation/v1 API, which is only accessible for users who have a cluster role that permits access to replication resources.
 {{% /notice %}}
 
 Etcd replicators allow you to manage [RBAC][3] resources in one place and mirror the changes to follower clusters.
@@ -243,7 +243,7 @@ If your configuration is incorrect, replication will not work.
 
 ## Create a replicator
 
-You can use the the [federation API][2] directly or [`sensuctl create`][4] to create replicators.
+You can use [enterprise/federation/v1 API endpoints][2] directly or [`sensuctl create`][4] to create replicators.
 
 When you create or update a replicator, an entry is added to the store and a new replicator process will spin up.
 The replicator process watches the keyspace of the resource to be replicated and replicates all keys to the specified cluster in a last-write-wins fashion.

--- a/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
@@ -239,9 +239,9 @@ Otherwise, your user credentials are the username and password you provided with
 
 Select the ☰ icon to explore the web UI.
 
-### 5. Make a request to the health API
+### 5. Make a request to the /health API
 
-To make sure the backend is up and running, use the Sensu [health API][35] to check the backend's health.
+To make sure the backend is up and running, use the Sensu [/health API][35] to check the backend's health.
 You should receive a response that includes `"Healthy": true`.
 
 {{< code shell >}}
@@ -462,7 +462,7 @@ To confirm that the agent is registered with Sensu and is sending keepalive even
 
 ### 4. Verify an example event
 
-With your backend and agent still running, send this request to the Sensu events API:
+With your backend and agent still running, send this request to the Sensu core/v2/events API:
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -18,7 +18,7 @@ menu:
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
+Sensu's [enterprise/federation/v1 API endpoints][1] allow you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
 
 {{< figure src="/images/federation-switcher-clusters.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-clusters.gif" target="_blank" >}}
@@ -410,7 +410,7 @@ spec:
 
 ## Get a unified view of all your clusters in the web UI
 
-After you create clusters using the federation API, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
+After you create clusters using enterprise/federation/v1 API endpoints, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
 Use the namespace switcher to change between namespaces across federated clusters:
 
 {{< figure src="/images/federation-switcher-animated.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-animated.gif" target="_blank" >}}

--- a/content/sensu-go/6.3/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/license.md
@@ -21,7 +21,7 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 {{< figure src="/images/go-license-download.png" alt="Screenshot of Sensu account license download" link="/images/go-license-download.png" target="_blank" >}}
 
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
-With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [/license API][4].
 
 {{% notice note %}}
 **NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -175,7 +175,7 @@ To set up RBAC in Sensu Go, read the [RBAC reference][13] and [Create a read-onl
 ## Silencing
 
 Silencing is disabled by default in Sensu Go.
-You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or the core/v2/silenced API endpoint.
+You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or core/v2/silenced API endpoints.
 Read the Sensu Go [silencing reference][105] for more information.
 
 ## Token substitution
@@ -429,7 +429,7 @@ Review your Sensu Core check configuration for the following attributes and make
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
 `filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
-`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or the core/v2/silenced API endpoint.
+`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [handlers][103].
 
 #### 5. Upload your config to your Sensu Go instance

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -126,7 +126,7 @@ spec: {}
 
 ## Secrets providers configuration
 
-You can use the [Secrets API][2] to create, view, and manage your secrets providers configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] to create, view, and manage your secrets providers configuration.
 
 For example, to retrieve the list of secrets providers:
 
@@ -454,7 +454,7 @@ version: v1
 
 limit        | 
 -------------|------ 
-description  | Maximum number of secrets requests per second that can be transmitted to the backend with the secrets API.
+description  | Maximum number of secrets requests per second that can be transmitted to the backend with enterprise/secrets/v1.
 required     | false
 type         | Float
 example      | {{< language-toggle >}}
@@ -470,7 +470,7 @@ limit: 10.0
 
 burst        | 
 -------------|------ 
-description  | Maximum amount of burst allowed in a rate interval for the secrets API.
+description  | Maximum amount of burst allowed in a rate interval for enterprise/secrets/v1.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets.md
@@ -108,7 +108,7 @@ The database secret contains a key called `password,` and its value is the passw
 
 ## Secret configuration
 
-You can use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
 To manage secrets configuration with sensuctl, configure sensuctl as the default [`admin` user][6].
 
 The [standard sensuctl subcommands][4] are available for secrets (list, info, and delete).

--- a/content/sensu-go/6.3/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/_index.md
@@ -22,8 +22,8 @@ Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sen
 
 ## Retrieve cluster health data
 
-The [health reference][3] explains how to use Sensu’s health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
-Learn how to read the JSON response for health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
+The [health reference][3] explains how to use Sensu’s /health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
+Learn how to read the JSON response for /health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
 
 ## Learn about Tessen
 

--- a/content/sensu-go/6.3/operations/monitor-sensu/health.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/health.md
@@ -12,7 +12,7 @@ menu:
     parent: monitor-sensu
 ---
 
-Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
+Use Sensu's [/health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
 
 A request to the health endpoint retrieves a JSON map with health data for your Sensu instance.
 

--- a/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -91,7 +91,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [health API endpoint][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
 **NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.

--- a/content/sensu-go/6.3/operations/monitor-sensu/tessen.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/tessen.md
@@ -23,8 +23,8 @@ Read [Troubleshoot Sensu][5] to set the Sensu backend log level and view logs.
 
 ## Configure Tessen
 
-You can use the [Tessen API][2] and [sensuctl][3] to view your Tessen configuration.
-If you are using an unlicensed Sensu instances, you can also use the [Tessen API][2] and [sensuctl][3] to opt in or opt out of Tessen.
+You can use [core/v2/tessen][2] and [sensuctl][3] to view your Tessen configuration.
+If you are using an unlicensed Sensu instances, you can also use [core/v2/tessen][2] and [sensuctl][3] to opt in or opt out of Tessen.
 
 {{% notice note %}}
 **NOTE**: Tessen is enabled by default on Sensu backends and required for [licensed](../../maintain-sensu/license/) Sensu instances.

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -224,7 +224,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 
 The latest release of Sensu Go, version 6.2.0, is now available for download! Sensu Go 5.x and configuration management users rejoice: this release adds support for agent local configuration (that is, agent.yml) managed entities! Agent entities may now be managed exclusively by their agents when `sensu-agent` is started with the new `agent-managed-entity` configuration option. This makes it more straightforward to migrate from Sensu Go 5.x to 6.x, as existing agent entity management workflows like Puppet will just work with the new option enabled! Note that you will not be able to edit agent-managed entities via the backend REST API or web UI.
 
-Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, the prune API no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
+Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, enterprise/prune/v1alpha no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 
@@ -244,7 +244,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][193]) Refactored entity limiter to ensure that warning messages about approaching a license's entity or entity class limit are now only displayed for users with `create` or `update` permissions for the license.
-- ([Commercial feature][193]) The [prune API][194] and its [sensuctl interface][195] now require less-broad permissions.
+- ([Commercial feature][193]) The [enterprise/prune/v1alpha API] endpoints[194] and the [sensuctl interface][195] now require less-broad permissions.
 - Adjusted the format for silenced entry dates and durations in sensuctl tabular-format output. For all silenced entries, the begin date is now listed in RFC 3339 format. For silenced entries that have not begun, the list displays the expiration date in RFC 3339 format. For silenced entires with no expiration date, the list displays `-1`. For silenced entries that have begun, the list displays the duration (for example, 1m30s).
 - Sensuctl and sensu-backend now ask users to retype their passwords when creating a new password in interactive mode.
 
@@ -267,7 +267,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 **FIXES:**
 
-- Fixed a bug that could cause a panic in the backend entity API.
+- Fixed a bug that could cause a panic in the backend core/v2/entities API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
 - When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
@@ -351,7 +351,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - Added the [`output_metric_tags` attribute][182] for checks so you can apply custom tags to enrich metric points produced by check output metric extraction.
 - A warning is now logged when you request a dynamic runtime asset that does not exist.
 - The trusted CA file is now used for agent, backend, and sensuctl asset retrieval.
-- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the entities API.
+- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the core/v2/entities API endpoints.
 - Updated the [Sensu TimescaleDB Handler][187] to write tags as a JSON object instead of an array of objects, which facilitates tags queries.
 - Updated the [Sensu Go Data Source for Grafana][188] plugin to support using API keys, fetching resources from all namespaces, using Sensu's built-in resposne filtering, grouping aggregation results by attribute, and number of [other improvements][189].
 
@@ -594,7 +594,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **FIXES:**
 
-- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster health API.
+- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster /health API.
 - In the [web UI][153], any leading and trailing whitespace is now trimmed from the username when authenticating.
 - The [web UI][153] preferences dialog now displays only the first five groups a user belongs to, which makes the sign-out button more accessible.
 - In the [web UI][153], the deregistration handler no longer appears as `undefined` on the entity details page.
@@ -682,7 +682,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.1.
 This release is packed with new features, improvements, and fixes, including our first alpha feature: declarative configuration pruning to help keep your Sensu instance in sync with Infrastructure as Code workflows.
 Other exciting additions include the ability to save and share your filtered searches in the web UI, plus a new `matches` substring match operator that you can use to refine your filtering results!
 Improvements include a new `created_by` field in resource metadata and a `float_type` field that stores whether your system uses hard float or soft float.
-We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the health API payload.
+We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the /health API payload.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.19.0.
 
@@ -741,9 +741,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 **IMPROVEMENTS:**
 
 - The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
-- If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+- If you use the [core/v2/events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
-- The version API now retrieves the Sensu agent version for the Sensu instance.
+- The /version API now retrieves the Sensu agent version for the Sensu instance.
 - Log messages now indicate which filter dropped an event.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
@@ -753,8 +753,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
-- Fixed a bug that prevented [API response filtering][119] from working properly for the silenced API.
-- Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
+- Fixed a bug that prevented [API response filtering][119] from working properly for core/v2/silenced API endpoints.
+- Improved event payload validation for the [core/v2/events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 - Sensuctl now supports the `http_proxy`, `https_proxy`, and `no_proxy` environment variables.
 - The [`auth/test` endpoint][120] now returns the correct error messages.
 
@@ -1173,7 +1173,7 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Silenced entries are now retrieved from the cache when determining whether an event is silenced.
 - The Sensu API now returns an error when trying to delete an entity that does not exist.
 - The agent WebSocket connection now performs basic authorization.
-- The events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
+- The core/v2/events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
@@ -1222,7 +1222,7 @@ Read the [web UI docs][65] to get started using the Sensu web UI.
 PostgreSQL can handle significantly higher volumes of Sensu events, letting you scale Sensu beyond etcd's storage limits.
 Read the [datastore reference][61] for more information.
 - Sensu now includes a cluster ID API endpoint and `sensuctl cluster id` command to return the unique Sensu cluster ID.
-Read the [cluster API docs][62] for more information.
+Read the [core/v2/cluster API endpoint docs][62] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1294,7 +1294,7 @@ Read the [upgrade guide][51] for more information.
 Read the [sensuctl reference][45] for more information.
 - Sensu backends now support the `etcd-cipher-suites` configuration option, letting you specify the cipher suites that can be used with etcd TLS configuration.
 Read the [backend reference][47] for more information.
-- The Sensu API now includes the version API, returning version information for your Sensu instance.
+- The Sensu API now includes the /version API, returning version information for your Sensu instance.
 Review the [API docs][46] for more information.
 - Tessen now collects the numbers of events processed and resources created, giving us better insight into how we can improve Sensu.
 As always, all Tessen transmissions are logged for complete transparency.
@@ -1311,7 +1311,7 @@ Read the [backend reference][50] for more information.
 **FIXES:**
 
 - Events produced by checks now execute the correct number of write operations to etcd.
-- API pagination tokens for the users and namespaces APIs now work as expected.
+- API pagination tokens for the core/v2/users and core/v2/namespaces API endpoints now work as expected.
 - Keepalive events for deleted and deregistered entities are now cleaned up as expected.
 
 **KNOWN ISSUES:**
@@ -1359,7 +1359,7 @@ Review the [API docs][34] and [sensuctl reference][35] for usage examples.
 Read the [guide to configuring an authentication provider][37] for more information.
 - ([Commercial feature][33]) Sensu's LDAP and Active Directory integrations now support connecting to an authentication provider using anonymous binding.
 Read the [LDAP][38] and [Active Directory][39] binding configuration docs to learn more.
-- The [health API][36] response now includes the cluster ID.
+- the [/health API][36] response now includes the cluster ID.
 - The `sensuctl cluster health` and `sensuctl cluster member-list` commands now include the cluster ID in tabular format.
 
 **FIXES:**
@@ -1424,8 +1424,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.4.0.
 read the [web UI docs][23] for a preview.
 - The Sensu API now supports pagination using the `limit` and `continue` query parameters, letting you limit your API responses to a maximum number of objects and making it easier to handle large datasets.
 Read the [API overview][22] for more information.
-- Sensu now surfaces internal metrics using the metrics API.
-Read the [metrics API reference][31] for more information.
+- Sensu now surfaces internal metrics using the /metrics API.
+Read the [/metrics API documentation][31] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1437,8 +1437,8 @@ Read the [agent reference][26] for more information.
 **FIXES:**
 
 - The backend now processes events without persisting metrics to etcd.
-- The events API POST and PUT endpoints now add the current timestamp to new events by default.
-- The users API now returns a 404 response code if a username cannot be found.
+- The core/v2/events API POST and PUT endpoints now add the current timestamp to new events by default.
+- The core/v2/users API endpoints now return a 404 response code if a username cannot be found.
 - The sensuctl command line tool now correctly accepts global flags when passed after a subcommand flag (for example, `--format yaml --namespace development`).
 - The `sensuctl handler delete` and `sensuctl filter delete` commands now correctly delete resources from the currently configured namespace.
 - The agent now terminates consistently on SIGTERM and SIGINT.

--- a/content/sensu-go/6.3/sensuctl/_index.md
+++ b/content/sensu-go/6.3/sensuctl/_index.md
@@ -30,7 +30,7 @@ sensuctl configure
 This starts the prompts for interactive sensuctl setup.
 When prompted, choose the authentication method you wish to use: username/password or OIDC.
 
-Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the [Sensu authentication API][14].
+Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -340,7 +340,7 @@ API keys must be reissued, but you can use your backup as a reference for granti
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -538,7 +538,7 @@ The response will list all supported `sensuctl prune` resource types:
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 #### sensuctl prune flags

--- a/content/sensu-go/6.3/web-ui/_index.md
+++ b/content/sensu-go/6.3/web-ui/_index.md
@@ -36,7 +36,7 @@ After you [start the Sensu backend][1], you can access the web UI in your browse
 
 Sign in to the web UI with the username and password you used to configure [sensuctl][2].
 
-The web UI uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][7].
+The web UI uses your username and password to obtain access and refresh tokens via the Sensu [/auth API][7].
 The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 The access and refresh tokens are saved in your browser's local storage.

--- a/content/sensu-go/6.3/web-ui/searches-reference.md
+++ b/content/sensu-go/6.3/web-ui/searches-reference.md
@@ -21,7 +21,7 @@ For more information, read [Get started with commercial features](../../commerci
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
 The saved searches feature is designed to be used directly in the [web UI][3].
-However, you can create, retrieve, update, and delete saved searches with the [searches API][4].
+However, you can create, retrieve, update, and delete saved searches with [enterprise/searches/v1 API endpoints][4].
 
 ## Search for events with any status except passing
 

--- a/content/sensu-go/6.3/web-ui/webconfig.md
+++ b/content/sensu-go/6.3/web-ui/webconfig.md
@@ -21,7 +21,7 @@ You can define a single custom web UI configuration to federate to all, some, or
 
 ## Create a web UI configuration
 
-Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
+Use the [enterprise/web/v1 API POST endpoint][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
 The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
 
 {{% notice note %}}

--- a/content/sensu-go/6.4/api/_index.md
+++ b/content/sensu-go/6.4/api/_index.md
@@ -120,7 +120,7 @@ export SENSU_ACCESS_TOKEN=`curl -X GET -u "$SENSU_USER:$SENSU_PASS" -s http://lo
 
 The [sensuctl reference][7] demonstrates how to use the `sensuctl env` command to export your access token, token expiry time, and refresh token as environment variables.
 
-### Authenticate with the authentication API
+### Authenticate with /auth API endpoints
 
 Use the [authentication API][12] and your Sensu username and password to generate access tokens and refresh tokens.
 The [`/auth` API endpoint][12] lets you generate short-lived API tokens using your Sensu username and password.
@@ -196,7 +196,7 @@ To regenerate a valid access token, run any sensuctl command (like `sensuctl eve
 
 ### Authenticate with an API key
 
-Each Sensu API key (core/v2.APIKey) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
+Each Sensu API key ([core/v2/apikey][19]) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
 The advantages of authenticating with API keys rather than [access tokens][14] include:
 
 - **More efficient integration**: Check and handler plugins and other code can integrate with the Sensu API without implementing the logic required to authenticate via the `/auth` API endpoint to periodically refresh the access token
@@ -226,7 +226,7 @@ Created: /api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
 {{< /code >}}
 
    {{% notice protip %}}
-**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [APIkeys API](apikeys/#create-a-new-api-key).
+**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [POST core/v2/apikeys endpoint](core/apikeys/#create-a-new-api-key).
 {{% /notice %}}
 
 2. Export your API key to the `SENSU_API_KEY` environment variable:
@@ -264,7 +264,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to core/v2/checks:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -274,7 +274,7 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK` and th
 
 ## Pagination
 
-The Sensu API supports response pagination for most `core/v2` GET endpoints that return an array.
+The Sensu API supports response pagination for most core/v2 GET endpoints that return an array.
 You can request a paginated response with the `limit` and `continue` query parameters.
 
 ### Limit query parameter
@@ -777,19 +777,20 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/si
 [2]: ../operations/deploy-sensu/install-sensu#install-sensuctl
 [3]: ../operations/control-access/rbac/
 [4]: ../observability-pipeline/observe-schedule/agent/
-[5]: health/
-[6]: metrics/
+[5]: other/health/
+[6]: other/metrics/
 [7]: ../sensuctl/environment-variables/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
-[11]: auth/#authtoken-post
-[12]: auth/
+[11]: other/auth/#authtoken-post
+[12]: other/auth/
 [13]: #operators
 [14]: #authentication-quickstart
 [15]: #examples
 [16]: #limit-query-parameter
 [17]: #authenticate-with-an-api-key
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
+[19]: core/apikeys/
 [20]: #authenticate-with-the-authentication-api
 [21]: ../observability-pipeline/observe-schedule/backend/#api-request-limit
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match

--- a/content/sensu-go/6.4/api/core/apikeys.md
+++ b/content/sensu-go/6.4/api/core/apikeys.md
@@ -74,7 +74,7 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with [/auth API endpoints](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
 This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
 If you prefer, you can [create a new API key with sensuctl](../../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}

--- a/content/sensu-go/6.4/api/core/tessen.md
+++ b/content/sensu-go/6.4/api/core/tessen.md
@@ -15,8 +15,8 @@ menu:
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}
 
-The Tessen API provides HTTP access to manage [Tessen][1] configuration.
-Access to the Tessen API is restricted to the default [`admin` user][2].
+The core/v2/tessen API endpoints provide HTTP access to manage [Tessen][1] configuration.
+Access to core/v2/tessen is restricted to the default [`admin` user][2].
 
 ## Get the active Tessen configuration {#tessen-get}
 

--- a/content/sensu-go/6.4/api/core/users.md
+++ b/content/sensu-go/6.4/api/core/users.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice note %}}
 **NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
-To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [authentication providers API](../../enterprise/authproviders/).<br><br>
+To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.4/api/enterprise/prune.md
+++ b/content/sensu-go/6.4/api/enterprise/prune.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 {{% notice note %}}
 **NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The prune API requires [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
 
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.4/api/enterprise/secrets.md
+++ b/content/sensu-go/6.4/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, the secrets API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/api/other/auth.md
+++ b/content/sensu-go/6.4/api/other/auth.md
@@ -74,7 +74,7 @@ HTTP/1.1 200 OK
 
 /auth/test (GET)     |     |
 ---------------------|------
-description          | Tests basic authentication credentials (username and password) that were created with Sensu's [users API][1].
+description          | Tests basic authentication credentials (username and password) that were created with Sensu's [core/v2/users API][1].
 example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
@@ -244,7 +244,7 @@ At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
 If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
-You can also use sensuctl or the license API to [view your overall entity count and limit][5].
+You can also use sensuctl or the /license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -206,7 +206,7 @@ spec:
 
 ### Manage agent entities via the backend
 
-You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+You can manage agent entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33], just like any other Sensu resource.
 This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 Management via the backend is the default configuration for agent entities.
@@ -216,7 +216,7 @@ Management via the backend is the default configuration for agent entities.
 In this case, the entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
 
-If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+If you delete an agent entity that you modified with sensuctl, the core/v2/entities API endpoints, or the web UI, it will revert to the original configuration from `agent.yml`.
 If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
 
 ### Manage agent entities via the agent
@@ -239,7 +239,7 @@ You must set `deregister: true` in `agent.yml` before the agent entity is create
 Proxy entities are dynamically created entities that Sensu adds to the entity store if an entity does not already exist for a check result.
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 
-You can modify proxy entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+You can modify proxy entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 If you start an agent with the same name as an existing proxy entity, Sensu will change the proxy entity's class to `agent` and update its `system` field with information from the agent configuration.
 
@@ -323,7 +323,7 @@ For more information, read [Get started with commercial features](../../../comme
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
-Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+Create and modify service entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 ### Service entity example
 
@@ -382,7 +382,7 @@ sensu-agent start --labels url=sensu.docs.io
 
 {{% notice note %}}
 **NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
-Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ### Proxy entity labels {#proxy-entities-managed}

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/_index.md
@@ -310,9 +310,9 @@ You can create events with proxy entities, which are dynamically created entitie
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 Read [Monitor external resources][1] to learn how to use a proxy entity to monitor a website.
 
-## Events API
+## core/v2/events API endpoints
 
-Sensu's [events API][15] provides HTTP access to create, retrieve, update, and delete events.
+Sensu's [core/v2/events API endpoints][15] provide HTTP access to create, retrieve, update, and delete events.
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
@@ -327,7 +327,7 @@ If you create a new event that references an entity that does not already exist,
 [9]: checks/#subscriptions
 [11]: ../observe-schedule/agent/
 [12]: ../observe-schedule/
-[13]: #events-api
+[13]: #corev2events-api-endpoints
 [14]: ../observe-schedule/agent/#detect-silent-failures
 [15]: ../../api/core/events/
 [16]: ../observe-schedule/agent/

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
@@ -868,12 +868,12 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 - [Create events using the agent TCP and UDP sockets][12]
 - [Create events using the StatsD listener][13]
 
-## Create events using the events API
+## Create events with the core/v2/events API endpoints
 
-You can send events directly to the Sensu pipeline using the [events API][16].
-To create an event, send a JSON event definition to the [events API PUT endpoint][14].
+You can send events directly to the Sensu pipeline using the [core/v2/events API endpoints][16].
+To create an event, send a JSON event definition to the [core/v2/events API PUT endpoint][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+If you use the core/v2/events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
 
 {{% notice note %}}
 **NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
@@ -881,7 +881,7 @@ If you use the events API to create a new event referencing an entity that does 
 
 ## Manage events
 
-You can manage events using the [Sensu web UI][15], [events API][16], and [sensuctl][17] command line tool.
+You can manage events using the [Sensu web UI][15], [core/v2/events API endpoints][16], and [sensuctl][17] command line tool.
 
 ### View events
 
@@ -904,7 +904,7 @@ sensuctl event info <entity-name> <check-name>
 With both the `list` and `info` commands, you can specify an [output format][18] using the `--format` flag:
 
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
-- `json` format for use with the [events API][16]
+- `json` format for use with [core/v2/events API endpoints][16]
 
 {{< language-toggle >}}
 {{< code shell "YML" >}}
@@ -1353,7 +1353,7 @@ created_by: "admin"
 
 |timestamp   |      |
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created via the [events API][35], you can specify a `timestamp` value in the request body.
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
 required     | false
 type         | Integer
 default      | Time that the event occurred
@@ -1388,7 +1388,7 @@ id: 431a0085-96da-4521-863f-c38b480701e9
 
 sequence     |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [events API][35].
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1404,7 +1404,7 @@ sequence: 1
 
 |entity      |      |
 -------------|------
-description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
+description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [core/v2/events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
 type         | Map
 required     | true
 example      | {{< language-toggle >}}
@@ -1687,7 +1687,7 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [events API][35], the default `executed` value is `0` unless you specify a value in the request body.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [core/v2/events API][35], the default `executed` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1732,7 +1732,7 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [events API][35], the default `issued` value is `0` unless you specify a value in the request body.
+description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1748,7 +1748,7 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [core/v2/events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1764,7 +1764,7 @@ last_ok: 1552506033
 
 occurrences  |      |
 -------------|------
-description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
+description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -1780,7 +1780,7 @@ occurrences: 1
 
 occurrences_watermark | |
 -------------|------
-description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. In events created with the [events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
+description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -1865,7 +1865,7 @@ state: passing
 
 status       |      |
 -------------|------
-description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
+description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [core/v2/events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1881,7 +1881,7 @@ status: 0
 
 total_state_change | |
 -------------|------
-description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
+description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [core/v2/events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -1899,7 +1899,7 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [events API][35], the `executed` default value is `0`.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [core/v2/events API][35], the `executed` default value is `0`.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -534,7 +534,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [events API][43].
+The returned object uses the same format as responses for the [core/v2/events API]][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 
@@ -552,7 +552,7 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [events API][43].
+The events in the returned array use the same format as responses for the [core/v2/events API]][43].
 
 ## Event filter specification
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -80,7 +80,7 @@ This communication is via clear text by default.
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 {{% notice note %}}
-**NOTE**: For information about your agent transport status, use the [health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
+**NOTE**: For information about your agent transport status, use the [/health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
 {{% /notice %}}
 
 ## Create observability events using service checks
@@ -498,7 +498,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -321,7 +321,7 @@ spec:
 
 ### Ad hoc scheduling
 
-In addition to automatic execution, you can create checks to be scheduled manually using the [checks API][34].
+In addition to automatic execution, you can create checks to be scheduled manually using [core/v2/checks API endpoints][34].
 To create a check with ad-hoc scheduling, set the `publish` attribute to `false` in addition to an `interval` or `cron` schedule.
 
 #### Example ad hoc check
@@ -707,7 +707,7 @@ annotations:
 ### Spec attributes
 
 {{% notice note %}}
-**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../../api/core/events/#create-a-new-event) /events API.
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent events API](../agent/#events-post) or the [backend core/v2/events API](../../../api/core/events/#create-a-new-event).
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -24,8 +24,8 @@ Use Sensu handlers to [process extracted metrics][11] and route them to database
 You can also use Sensu's [time-series and long-term event storage integrations][18] to process service and time-series metrics.
 
 {{% notice note %}}
-**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu metrics API.
-For information about HTTP GET access to internal Sensu metrics, read our [metrics API](../../../api/other/metrics/) documentation.
+**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu /metrics API.
+For information about HTTP GET access to internal Sensu metrics, read our [/metrics API](../../../api/other/metrics/) documentation.
 {{% /notice %}}
 
 ## Metric check example

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -153,7 +153,7 @@ For example, you might set the minimum threshold at 10 web servers with an OK st
 
 The `aggregate` rule template is useful in dynamic environments and environments with some tolerance for failure.
 
-To review the `aggregate` resource definition, retrieve it with a GET request to the BSM API:
+To review the `aggregate` resource definition, retrieve it with a GET request to /enterprise/bsm/v1:
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
@@ -100,7 +100,7 @@ sensu-agent start --subscriptions linux,webserver --log-level debug
 
 Now your agent entity will execute checks with the `linux` or `webserver` subscriptions.
 
-To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [entities API][18], or the [web UI][19].
+To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [core/v2/entities API endpoints][18], or the [web UI][19].
 
 ## Configure subscriptions
 
@@ -118,14 +118,14 @@ For example, an agent entity with `name: "i-424242"` subscribes to check request
 This makes it possible to generate ad hoc check requests that target specific entities via the API.
 
 {{% notice note %}}
-**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ## Publish checks
 
 If you want Sensu to automatically schedule and execute a check according to its subscriptions, set the [`publish` attribute][12] to `true` in the check definition.
 
-You can also manually schedule [ad hoc check execution][11] with the [check API][16], whether the `publish` attribute is set to `true` or `false`.
+You can also manually schedule [ad hoc check execution][11] with the [core/v2/checks API endpoints][16], whether the `publish` attribute is set to `true` or `false`.
 To target the subscriptions defined in the check, include only the check name in the request body (for example, `"check": "check_cpu"`).
 To override the check's subscriptions and target an alternate entity or group of entities, add the subscriptions attribute to the request body:
 

--- a/content/sensu-go/6.4/operations/control-access/_index.md
+++ b/content/sensu-go/6.4/operations/control-access/_index.md
@@ -33,7 +33,7 @@ Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutu
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with the [users API][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.4/operations/control-access/apikeys.md
+++ b/content/sensu-go/6.4/operations/control-access/apikeys.md
@@ -17,7 +17,7 @@ Unlike [authentication tokens][2], API keys are persistent and do not need to be
 
 The Sensu backend generates API keys, and you can provide them to applications that want to interact with the Sensu API.
 
-Use the [APIKey API][1] to create, retrieve, and delete API keys.
+Use the [core/v2/apikeys API endpoints][1] to create, retrieve, and delete API keys.
 
 ## API key example
 

--- a/content/sensu-go/6.4/operations/control-access/sso.md
+++ b/content/sensu-go/6.4/operations/control-access/sso.md
@@ -64,7 +64,7 @@ The response will list your authentication provider types and names:
 
 ## Manage authentication providers
 
-View and delete authentication providers with the [authentication providers API][10] or these sensuctl commands.
+View and delete authentication providers with [enterprise/authentication/v2 API endpoints][10] or these sensuctl commands.
 
 To view active authentication providers:
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/_index.md
@@ -36,7 +36,7 @@ To deploy Sensu for use outside of a local development environment, [install Sen
 3. [Run a Sensu cluster][6], a group of three or more sensu-backend nodes connected to a shared database, to improve Sensu's availability, reliability, and durability.
 4. [Reach multi-cluster visibility][7] with federation so you can gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI and mirror your changes in one cluster to follower clusters.
 
-Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the federation API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
+Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the enterprise/federation/v1 API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
 
 ## Scale your Sensu implementation
 

--- a/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/datastore.md
@@ -16,7 +16,7 @@ Sensu stores the most recent event for each entity and check pair using either a
 Using Sensu with an external etcd cluster requires etcd 3.3.2.
 Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
 
-You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
+You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and [core/v2/events API endpoints][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
 ## Use default event storage

--- a/content/sensu-go/6.4/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/etcdreplicators.md
@@ -18,7 +18,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
+**NOTE**: EtcdReplicator is a datatype in the enterprise/federation/v1 API, which is only accessible for users who have a cluster role that permits access to replication resources.
 {{% /notice %}}
 
 Etcd replicators allow you to manage [RBAC][3] resources in one place and mirror the changes to follower clusters.
@@ -243,7 +243,7 @@ If your configuration is incorrect, replication will not work.
 
 ## Create a replicator
 
-You can use the the [federation API][2] directly or [`sensuctl create`][4] to create replicators.
+You can use [enterprise/federation/v1 API endpoints][2] directly or [`sensuctl create`][4] to create replicators.
 
 When you create or update a replicator, an entry is added to the store and a new replicator process will spin up.
 The replicator process watches the keyspace of the resource to be replicated and replicates all keys to the specified cluster in a last-write-wins fashion.

--- a/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
@@ -239,9 +239,9 @@ Otherwise, your user credentials are the username and password you provided with
 
 Select the ☰ icon to explore the web UI.
 
-### 5. Make a request to the health API
+### 5. Make a request to the /health API
 
-To make sure the backend is up and running, use the Sensu [health API][35] to check the backend's health.
+To make sure the backend is up and running, use the Sensu [/health API][35] to check the backend's health.
 You should receive a response that includes `"Healthy": true`.
 
 {{< code shell >}}
@@ -462,7 +462,7 @@ To confirm that the agent is registered with Sensu and is sending keepalive even
 
 ### 4. Verify an example event
 
-With your backend and agent still running, send this request to the Sensu events API:
+With your backend and agent still running, send this request to the Sensu core/v2/events API:
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -18,7 +18,7 @@ menu:
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
+Sensu's [enterprise/federation/v1 API endpoints][1] allow you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
 
 {{< figure src="/images/federation-switcher-clusters.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-clusters.gif" target="_blank" >}}
@@ -416,7 +416,7 @@ spec:
 
 ## Get a unified view of all your clusters in the web UI
 
-After you create clusters using the federation API, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
+After you create clusters using enterprise/federation/v1 API endpoints, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
 Use the namespace switcher to change between namespaces across federated clusters:
 
 {{< figure src="/images/federation-switcher-animated.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-animated.gif" target="_blank" >}}

--- a/content/sensu-go/6.4/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/license.md
@@ -21,7 +21,7 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 {{< figure src="/images/go-license-download.png" alt="Screenshot of Sensu account license download" link="/images/go-license-download.png" target="_blank" >}}
 
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
-With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [/license API][4].
 
 {{% notice note %}}
 **NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -175,7 +175,7 @@ To set up RBAC in Sensu Go, read the [RBAC reference][13] and [Create a read-onl
 ## Silencing
 
 Silencing is disabled by default in Sensu Go.
-You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or the core/v2/silenced API endpoint.
+You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or core/v2/silenced API endpoints.
 Read the Sensu Go [silencing reference][105] for more information.
 
 ## Token substitution
@@ -429,7 +429,7 @@ Review your Sensu Core check configuration for the following attributes and make
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
 `filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
-`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or the core/v2/silenced API endpoint.
+`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [handlers][103].
 
 #### 5. Upload your config to your Sensu Go instance

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
@@ -126,7 +126,7 @@ spec: {}
 
 ## Secrets providers configuration
 
-You can use the [Secrets API][2] to create, view, and manage your secrets providers configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] to create, view, and manage your secrets providers configuration.
 
 For example, to retrieve the list of secrets providers:
 
@@ -454,7 +454,7 @@ version: v1
 
 limit        | 
 -------------|------ 
-description  | Maximum number of secrets requests per second that can be transmitted to the backend with the secrets API.
+description  | Maximum number of secrets requests per second that can be transmitted to the backend with enterprise/secrets/v1.
 required     | false
 type         | Float
 example      | {{< language-toggle >}}
@@ -470,7 +470,7 @@ limit: 10.0
 
 burst        | 
 -------------|------ 
-description  | Maximum amount of burst allowed in a rate interval for the secrets API.
+description  | Maximum amount of burst allowed in a rate interval for enterprise/secrets/v1.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets.md
@@ -108,7 +108,7 @@ The database secret contains a key called `password,` and its value is the passw
 
 ## Secret configuration
 
-You can use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
 To manage secrets configuration with sensuctl, configure sensuctl as the default [`admin` user][6].
 
 The [standard sensuctl subcommands][4] are available for secrets (list, info, and delete).

--- a/content/sensu-go/6.4/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/_index.md
@@ -22,8 +22,8 @@ Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sen
 
 ## Retrieve cluster health data
 
-The [health reference][3] explains how to use Sensu’s health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
-Learn how to read the JSON response for health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
+The [health reference][3] explains how to use Sensu’s /health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
+Learn how to read the JSON response for /health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
 
 ## Learn about Tessen
 

--- a/content/sensu-go/6.4/operations/monitor-sensu/health.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/health.md
@@ -12,7 +12,7 @@ menu:
     parent: monitor-sensu
 ---
 
-Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
+Use Sensu's [/health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
 
 A request to the health endpoint retrieves a JSON map with health data for your Sensu instance.
 

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -91,7 +91,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [health API endpoint][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
 **NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.

--- a/content/sensu-go/6.4/operations/monitor-sensu/tessen.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/tessen.md
@@ -23,8 +23,8 @@ Read [Troubleshoot Sensu][5] to set the Sensu backend log level and view logs.
 
 ## Configure Tessen
 
-You can use the [Tessen API][2] and [sensuctl][3] to view your Tessen configuration.
-If you are using an unlicensed Sensu instances, you can also use the [Tessen API][2] and [sensuctl][3] to opt in or opt out of Tessen.
+You can use [core/v2/tessen][2] and [sensuctl][3] to view your Tessen configuration.
+If you are using an unlicensed Sensu instances, you can also use [core/v2/tessen][2] and [sensuctl][3] to opt in or opt out of Tessen.
 
 {{% notice note %}}
 **NOTE**: Tessen is enabled by default on Sensu backends and required for [licensed](../../maintain-sensu/license/) Sensu instances.

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -105,7 +105,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.3.
 
 **August 31, 2021** &mdash; The latest release of Sensu Go, version 6.4.2, is now available for download.
 
-This patch adds a backend configuration attribute that allows parallel event log encoding, as well as two summary metrics for the metrics API endpoint.
+This patch adds a backend configuration attribute that allows parallel event log encoding, as well as two summary metrics for the /metrics API endpoint.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.4.2.
 
@@ -115,7 +115,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.2.
 
 **IMPROVEMENTS:**
 
-- Added sensu_go_agentd_event_bytes and sensu_go_store_event_bytes summary metrics to the [metrics API endpoint][227]. sensu_go_agentd_event_bytes tracks the sizes of events, in bytes, received by agentd on the backend. sensu_go_store_event_bytes tracks event sizes, in bytes, received by the etcd store on the backend.
+- Added sensu_go_agentd_event_bytes and sensu_go_store_event_bytes summary metrics to the [/metrics API endpoint][227]. sensu_go_agentd_event_bytes tracks the sizes of events, in bytes, received by agentd on the backend. sensu_go_store_event_bytes tracks event sizes, in bytes, received by the etcd store on the backend.
 
 ## 6.4.1 release notes
 
@@ -318,7 +318,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 
 The latest release of Sensu Go, version 6.2.0, is now available for download! Sensu Go 5.x and configuration management users rejoice: this release adds support for agent local configuration (that is, agent.yml) managed entities! Agent entities may now be managed exclusively by their agents when `sensu-agent` is started with the new `agent-managed-entity` configuration option. This makes it more straightforward to migrate from Sensu Go 5.x to 6.x, as existing agent entity management workflows like Puppet will just work with the new option enabled! Note that you will not be able to edit agent-managed entities via the backend REST API or web UI.
 
-Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, the prune API no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
+Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, enterprise/prune/v1alpha no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 
@@ -338,7 +338,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][193]) Refactored entity limiter to ensure that warning messages about approaching a license's entity or entity class limit are now only displayed for users with `create` or `update` permissions for the license.
-- ([Commercial feature][193]) The [prune API][194] and its [sensuctl interface][195] now require less-broad permissions.
+- ([Commercial feature][193]) The [enterprise/prune/v1alpha API] endpoints[194] and the [sensuctl interface][195] now require less-broad permissions.
 - Adjusted the format for silenced entry dates and durations in sensuctl tabular-format output. For all silenced entries, the begin date is now listed in RFC 3339 format. For silenced entries that have not begun, the list displays the expiration date in RFC 3339 format. For silenced entires with no expiration date, the list displays `-1`. For silenced entries that have begun, the list displays the duration (for example, 1m30s).
 - Sensuctl and sensu-backend now ask users to retype their passwords when creating a new password in interactive mode.
 
@@ -361,7 +361,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 **FIXES:**
 
-- Fixed a bug that could cause a panic in the backend entity API.
+- Fixed a bug that could cause a panic in the backend core/v2/entities API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
 - When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
@@ -445,7 +445,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - Added the [`output_metric_tags` attribute][182] for checks so you can apply custom tags to enrich metric points produced by check output metric extraction.
 - A warning is now logged when you request a dynamic runtime asset that does not exist.
 - The trusted CA file is now used for agent, backend, and sensuctl asset retrieval.
-- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the entities API.
+- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the core/v2/entities API endpoints.
 - Updated the [Sensu TimescaleDB Handler][187] to write tags as a JSON object instead of an array of objects, which facilitates tags queries.
 - Updated the [Sensu Go Data Source for Grafana][188] plugin to support using API keys, fetching resources from all namespaces, using Sensu's built-in resposne filtering, grouping aggregation results by attribute, and number of [other improvements][189].
 
@@ -688,7 +688,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **FIXES:**
 
-- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster health API.
+- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster /health API.
 - In the [web UI][153], any leading and trailing whitespace is now trimmed from the username when authenticating.
 - The [web UI][153] preferences dialog now displays only the first five groups a user belongs to, which makes the sign-out button more accessible.
 - In the [web UI][153], the deregistration handler no longer appears as `undefined` on the entity details page.
@@ -776,7 +776,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.1.
 This release is packed with new features, improvements, and fixes, including our first alpha feature: declarative configuration pruning to help keep your Sensu instance in sync with Infrastructure as Code workflows.
 Other exciting additions include the ability to save and share your filtered searches in the web UI, plus a new `matches` substring match operator that you can use to refine your filtering results!
 Improvements include a new `created_by` field in resource metadata and a `float_type` field that stores whether your system uses hard float or soft float.
-We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the health API payload.
+We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the /health API payload.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.19.0.
 
@@ -835,9 +835,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 **IMPROVEMENTS:**
 
 - The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
-- If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+- If you use the [core/v2/events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
-- The version API now retrieves the Sensu agent version for the Sensu instance.
+- The /version API now retrieves the Sensu agent version for the Sensu instance.
 - Log messages now indicate which filter dropped an event.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
@@ -847,8 +847,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
-- Fixed a bug that prevented [API response filtering][119] from working properly for the silenced API.
-- Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
+- Fixed a bug that prevented [API response filtering][119] from working properly for core/v2/silenced API endpoints.
+- Improved event payload validation for the [core/v2/events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 - Sensuctl now supports the `http_proxy`, `https_proxy`, and `no_proxy` environment variables.
 - The [`auth/test` endpoint][120] now returns the correct error messages.
 
@@ -1267,7 +1267,7 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Silenced entries are now retrieved from the cache when determining whether an event is silenced.
 - The Sensu API now returns an error when trying to delete an entity that does not exist.
 - The agent WebSocket connection now performs basic authorization.
-- The events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
+- The core/v2/events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
@@ -1316,7 +1316,7 @@ Read the [web UI docs][65] to get started using the Sensu web UI.
 PostgreSQL can handle significantly higher volumes of Sensu events, letting you scale Sensu beyond etcd's storage limits.
 Read the [datastore reference][61] for more information.
 - Sensu now includes a cluster ID API endpoint and `sensuctl cluster id` command to return the unique Sensu cluster ID.
-Read the [cluster API docs][62] for more information.
+Read the [core/v2/cluster API endpoint docs][62] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1388,7 +1388,7 @@ Read the [upgrade guide][51] for more information.
 Read the [sensuctl reference][45] for more information.
 - Sensu backends now support the `etcd-cipher-suites` configuration option, letting you specify the cipher suites that can be used with etcd TLS configuration.
 Read the [backend reference][47] for more information.
-- The Sensu API now includes the version API, returning version information for your Sensu instance.
+- The Sensu API now includes the /version API, returning version information for your Sensu instance.
 Review the [API docs][46] for more information.
 - Tessen now collects the numbers of events processed and resources created, giving us better insight into how we can improve Sensu.
 As always, all Tessen transmissions are logged for complete transparency.
@@ -1405,7 +1405,7 @@ Read the [backend reference][50] for more information.
 **FIXES:**
 
 - Events produced by checks now execute the correct number of write operations to etcd.
-- API pagination tokens for the users and namespaces APIs now work as expected.
+- API pagination tokens for the core/v2/users and core/v2/namespaces API endpoints now work as expected.
 - Keepalive events for deleted and deregistered entities are now cleaned up as expected.
 
 **KNOWN ISSUES:**
@@ -1453,7 +1453,7 @@ Review the [API docs][34] and [sensuctl reference][35] for usage examples.
 Read the [guide to configuring an authentication provider][37] for more information.
 - ([Commercial feature][33]) Sensu's LDAP and Active Directory integrations now support connecting to an authentication provider using anonymous binding.
 Read the [LDAP][38] and [Active Directory][39] binding configuration docs to learn more.
-- The [health API][36] response now includes the cluster ID.
+- the [/health API][36] response now includes the cluster ID.
 - The `sensuctl cluster health` and `sensuctl cluster member-list` commands now include the cluster ID in tabular format.
 
 **FIXES:**
@@ -1518,8 +1518,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.4.0.
 read the [web UI docs][23] for a preview.
 - The Sensu API now supports pagination using the `limit` and `continue` query parameters, letting you limit your API responses to a maximum number of objects and making it easier to handle large datasets.
 Read the [API overview][22] for more information.
-- Sensu now surfaces internal metrics using the metrics API.
-Read the [metrics API reference][31] for more information.
+- Sensu now surfaces internal metrics using the /metrics API.
+Read the [/metrics API documentation][31] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1531,8 +1531,8 @@ Read the [agent reference][26] for more information.
 **FIXES:**
 
 - The backend now processes events without persisting metrics to etcd.
-- The events API POST and PUT endpoints now add the current timestamp to new events by default.
-- The users API now returns a 404 response code if a username cannot be found.
+- The core/v2/events API POST and PUT endpoints now add the current timestamp to new events by default.
+- The core/v2/users API endpoints now return a 404 response code if a username cannot be found.
 - The sensuctl command line tool now correctly accepts global flags when passed after a subcommand flag (for example, `--format yaml --namespace development`).
 - The `sensuctl handler delete` and `sensuctl filter delete` commands now correctly delete resources from the currently configured namespace.
 - The agent now terminates consistently on SIGTERM and SIGINT.

--- a/content/sensu-go/6.4/sensuctl/_index.md
+++ b/content/sensu-go/6.4/sensuctl/_index.md
@@ -30,7 +30,7 @@ sensuctl configure
 This starts the prompts for interactive sensuctl setup.
 When prompted, choose the authentication method you wish to use: username/password or OIDC.
 
-Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the [Sensu authentication API][14].
+Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 

--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -340,7 +340,7 @@ API keys must be reissued, but you can use your backup as a reference for granti
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -538,7 +538,7 @@ The response will list all supported `sensuctl prune` resource types:
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 #### sensuctl prune flags

--- a/content/sensu-go/6.4/web-ui/_index.md
+++ b/content/sensu-go/6.4/web-ui/_index.md
@@ -35,7 +35,7 @@ After you [start the Sensu backend][1], you can access the web UI in your browse
 
 Sign in to the web UI with the username and password you used to configure [sensuctl][2].
 
-The web UI uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][7].
+The web UI uses your username and password to obtain access and refresh tokens via the Sensu [/auth API][7].
 The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 The access and refresh tokens are saved in your browser's local storage.

--- a/content/sensu-go/6.4/web-ui/searches-reference.md
+++ b/content/sensu-go/6.4/web-ui/searches-reference.md
@@ -21,7 +21,7 @@ For more information, read [Get started with commercial features](../../commerci
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
 The saved searches feature is designed to be used directly in the [web UI][3].
-However, you can create, retrieve, update, and delete saved searches with the [searches API][4].
+However, you can create, retrieve, update, and delete saved searches with [enterprise/searches/v1 API endpoints][4].
 
 ## Search for events with any status except passing
 

--- a/content/sensu-go/6.4/web-ui/webconfig.md
+++ b/content/sensu-go/6.4/web-ui/webconfig.md
@@ -21,7 +21,7 @@ You can define a single custom web UI configuration to federate to all, some, or
 
 ## Create a web UI configuration
 
-Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
+Use the [enterprise/web/v1 API POST endpoint][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
 The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
 
 {{% notice note %}}

--- a/content/sensu-go/6.5/api/_index.md
+++ b/content/sensu-go/6.5/api/_index.md
@@ -120,7 +120,7 @@ export SENSU_ACCESS_TOKEN=`curl -X GET -u "$SENSU_USER:$SENSU_PASS" -s http://lo
 
 The [sensuctl reference][7] demonstrates how to use the `sensuctl env` command to export your access token, token expiry time, and refresh token as environment variables.
 
-### Authenticate with the authentication API
+### Authenticate with /auth API endpoints
 
 Use the [authentication API][12] and your Sensu username and password to generate access tokens and refresh tokens.
 The [`/auth` API endpoint][12] lets you generate short-lived API tokens using your Sensu username and password.
@@ -196,7 +196,7 @@ To regenerate a valid access token, run any sensuctl command (like `sensuctl eve
 
 ### Authenticate with an API key
 
-Each Sensu API key (core/v2.APIKey) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
+Each Sensu API key ([core/v2/apikey][19]) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
 The advantages of authenticating with API keys rather than [access tokens][14] include:
 
 - **More efficient integration**: Check and handler plugins and other code can integrate with the Sensu API without implementing the logic required to authenticate via the `/auth` API endpoint to periodically refresh the access token
@@ -226,7 +226,7 @@ Created: /api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
 {{< /code >}}
 
    {{% notice protip %}}
-**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [APIkeys API](apikeys/#create-a-new-api-key).
+**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [POST core/v2/apikeys endpoint](core/apikeys/#create-a-new-api-key).
 {{% /notice %}}
 
 2. Export your API key to the `SENSU_API_KEY` environment variable:
@@ -264,7 +264,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to core/v2/checks:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -274,7 +274,7 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK` and th
 
 ## Pagination
 
-The Sensu API supports response pagination for most `core/v2` GET endpoints that return an array.
+The Sensu API supports response pagination for most core/v2 GET endpoints that return an array.
 You can request a paginated response with the `limit` and `continue` query parameters.
 
 ### Limit query parameter
@@ -777,19 +777,20 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/si
 [2]: ../operations/deploy-sensu/install-sensu#install-sensuctl
 [3]: ../operations/control-access/rbac/
 [4]: ../observability-pipeline/observe-schedule/agent/
-[5]: health/
-[6]: metrics/
+[5]: other/health/
+[6]: other/metrics/
 [7]: ../sensuctl/environment-variables/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
-[11]: auth/#authtoken-post
-[12]: auth/
+[11]: other/auth/#authtoken-post
+[12]: other/auth/
 [13]: #operators
 [14]: #authentication-quickstart
 [15]: #examples
 [16]: #limit-query-parameter
 [17]: #authenticate-with-an-api-key
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
+[19]: core/apikeys/
 [20]: #authenticate-with-the-authentication-api
 [21]: ../observability-pipeline/observe-schedule/backend/#api-request-limit
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match

--- a/content/sensu-go/6.5/api/core/apikeys.md
+++ b/content/sensu-go/6.5/api/core/apikeys.md
@@ -74,7 +74,7 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with [/auth API endpoints](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
 This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
 If you prefer, you can [create a new API key with sensuctl](../../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}

--- a/content/sensu-go/6.5/api/core/tessen.md
+++ b/content/sensu-go/6.5/api/core/tessen.md
@@ -15,8 +15,8 @@ menu:
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}
 
-The Tessen API provides HTTP access to manage [Tessen][1] configuration.
-Access to the Tessen API is restricted to the default [`admin` user][2].
+The core/v2/tessen API endpoints provide HTTP access to manage [Tessen][1] configuration.
+Access to core/v2/tessen is restricted to the default [`admin` user][2].
 
 ## Get the active Tessen configuration {#tessen-get}
 

--- a/content/sensu-go/6.5/api/core/users.md
+++ b/content/sensu-go/6.5/api/core/users.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice note %}}
 **NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
-To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [authentication providers API](../../enterprise/authproviders/).<br><br>
+To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.5/api/enterprise/prune.md
+++ b/content/sensu-go/6.5/api/enterprise/prune.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 {{% notice note %}}
 **NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The prune API requires [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
 
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.5/api/enterprise/secrets.md
+++ b/content/sensu-go/6.5/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, the secrets API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/api/other/auth.md
+++ b/content/sensu-go/6.5/api/other/auth.md
@@ -74,7 +74,7 @@ HTTP/1.1 200 OK
 
 /auth/test (GET)     |     |
 ---------------------|------
-description          | Tests basic authentication credentials (username and password) that were created with Sensu's [users API][1].
+description          | Tests basic authentication credentials (username and password) that were created with Sensu's [core/v2/users API][1].
 example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
@@ -244,7 +244,7 @@ At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
 If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
-You can also use sensuctl or the license API to [view your overall entity count and limit][5].
+You can also use sensuctl or the /license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -206,7 +206,7 @@ spec:
 
 ### Manage agent entities via the backend
 
-You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+You can manage agent entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33], just like any other Sensu resource.
 This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 Management via the backend is the default configuration for agent entities.
@@ -216,7 +216,7 @@ Management via the backend is the default configuration for agent entities.
 In this case, the entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
 
-If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+If you delete an agent entity that you modified with sensuctl, the core/v2/entities API endpoints, or the web UI, it will revert to the original configuration from `agent.yml`.
 If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
 
 ### Manage agent entities via the agent
@@ -239,7 +239,7 @@ You must set `deregister: true` in `agent.yml` before the agent entity is create
 Proxy entities are dynamically created entities that Sensu adds to the entity store if an entity does not already exist for a check result.
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 
-You can modify proxy entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+You can modify proxy entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 If you start an agent with the same name as an existing proxy entity, Sensu will change the proxy entity's class to `agent` and update its `system` field with information from the agent configuration.
 
@@ -323,7 +323,7 @@ For more information, read [Get started with commercial features](../../../comme
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
-Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+Create and modify service entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 ### Service entity example
 
@@ -382,7 +382,7 @@ sensu-agent start --labels url=sensu.docs.io
 
 {{% notice note %}}
 **NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
-Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ### Proxy entity labels {#proxy-entities-managed}

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/_index.md
@@ -527,9 +527,9 @@ You can create events with proxy entities, which are dynamically created entitie
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 Read [Monitor external resources][1] to learn how to use a proxy entity to monitor a website.
 
-## Events API
+## core/v2/events API endpoints
 
-Sensu's [events API][15] provides HTTP access to create, retrieve, update, and delete events.
+Sensu's [core/v2/events API endpoints][15] provide HTTP access to create, retrieve, update, and delete events.
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
@@ -544,7 +544,7 @@ If you create a new event that references an entity that does not already exist,
 [9]: checks/#subscriptions
 [11]: ../observe-schedule/agent/
 [12]: ../observe-schedule/
-[13]: #events-api
+[13]: #corev2events-api-endpoints
 [14]: ../observe-schedule/agent/#detect-silent-failures
 [15]: ../../api/core/events/
 [16]: ../observe-schedule/agent/

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -1976,12 +1976,12 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 - [Create events using the agent TCP and UDP sockets][12]
 - [Create events using the StatsD listener][13]
 
-## Create events using the events API
+## Create events with the core/v2/events API endpoints
 
 You can send events directly to the Sensu observability pipeline using the [core/v2 API events endpoint][16].
 To create an event, send a JSON event definition with a [PUT request to core/v2/events][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+If you use the core/v2/events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
 
 {{% notice note %}}
 **NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
@@ -1989,7 +1989,7 @@ If you use the events API to create a new event referencing an entity that does 
 
 ## Manage events
 
-You can manage events using the [Sensu web UI][15], [events API][16], and [sensuctl][17] command line tool.
+You can manage events using the [Sensu web UI][15], [core/v2/events API endpoints][16], and [sensuctl][17] command line tool.
 
 ### View events
 
@@ -2012,7 +2012,7 @@ sensuctl event info <entity-name> <check-name>
 With both the `list` and `info` commands, you can specify an [output format][18] using the `--format` flag:
 
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
-- `json` format for use with the [events API][16]
+- `json` format for use with [core/v2/events API endpoints][16]
 
 {{< language-toggle >}}
 {{< code shell "YML" >}}
@@ -2548,7 +2548,7 @@ name: is_incident
 
 |timestamp   |      |
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created via the [events API][35], you can specify a `timestamp` value in the request body.
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
 required     | false
 type         | Integer
 default      | Time that the event occurred
@@ -2583,7 +2583,7 @@ id: 431a0085-96da-4521-863f-c38b480701e9
 
 sequence     |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [events API][35].
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2599,7 +2599,7 @@ sequence: 1
 
 |entity      |      |
 -------------|------
-description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
+description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [core/v2/events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
 type         | Map
 required     | true
 example      | {{< language-toggle >}}
@@ -2874,7 +2874,7 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [events API][35], the default `executed` value is `0` unless you specify a value in the request body.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [core/v2/events API][35], the default `executed` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2919,7 +2919,7 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [events API][35], the default `issued` value is `0` unless you specify a value in the request body.
+description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2935,7 +2935,7 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [core/v2/events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2951,7 +2951,7 @@ last_ok: 1552506033
 
 occurrences  |      |
 -------------|------
-description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
+description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -2967,7 +2967,7 @@ occurrences: 1
 
 occurrences_watermark | |
 -------------|------
-description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. In events created with the [events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
+description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -3070,7 +3070,7 @@ state: passing
 
 status       |      |
 -------------|------
-description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
+description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [core/v2/events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -3086,7 +3086,7 @@ status: 0
 
 total_state_change | |
 -------------|------
-description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
+description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [core/v2/events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -3104,7 +3104,7 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [events API][35], the `executed` default value is `0`.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [core/v2/events API][35], the `executed` default value is `0`.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -552,7 +552,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [events API][43].
+The returned object uses the same format as responses for the [core/v2/events API]][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 
@@ -570,7 +570,7 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [events API][43].
+The events in the returned array use the same format as responses for the [core/v2/events API]][43].
 
 ## Event filter specification
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -80,7 +80,7 @@ This communication is via clear text by default.
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 {{% notice note %}}
-**NOTE**: For information about your agent transport status, use the [health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
+**NOTE**: For information about your agent transport status, use the [/health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
 {{% /notice %}}
 
 ## Create observability events using service checks
@@ -504,7 +504,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -321,7 +321,7 @@ spec:
 
 ### Ad hoc scheduling
 
-In addition to automatic execution, you can create checks to be scheduled manually using the [checks API][34].
+In addition to automatic execution, you can create checks to be scheduled manually using [core/v2/checks API endpoints][34].
 To create a check with ad-hoc scheduling, set the `publish` attribute to `false` in addition to an `interval` or `cron` schedule.
 
 #### Example ad hoc check
@@ -718,7 +718,7 @@ annotations:
 ### Spec attributes
 
 {{% notice note %}}
-**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../../api/core/events/#create-a-new-event) /events API.
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent events API](../agent/#events-post) or the [backend core/v2/events API](../../../api/core/events/#create-a-new-event).
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -24,8 +24,8 @@ Use Sensu handlers to [process extracted metrics][11] and route them to database
 You can also use Sensu's [time-series and long-term event storage integrations][18] to process service and time-series metrics.
 
 {{% notice note %}}
-**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu metrics API.
-For information about HTTP GET access to internal Sensu metrics, read our [metrics API](../../../api/other/metrics/) documentation.
+**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu /metrics API.
+For information about HTTP GET access to internal Sensu metrics, read our [/metrics API](../../../api/other/metrics/) documentation.
 {{% /notice %}}
 
 ## Metric check example

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
@@ -153,7 +153,7 @@ For example, you might set the minimum threshold at 10 web servers with an OK st
 
 The `aggregate` rule template is useful in dynamic environments and environments with some tolerance for failure.
 
-To review the `aggregate` resource definition, retrieve it with a GET request to the BSM API:
+To review the `aggregate` resource definition, retrieve it with a GET request to /enterprise/bsm/v1:
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
@@ -100,7 +100,7 @@ sensu-agent start --subscriptions linux,webserver --log-level debug
 
 Now your agent entity will execute checks with the `linux` or `webserver` subscriptions.
 
-To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [entities API][18], or the [web UI][19].
+To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [core/v2/entities API endpoints][18], or the [web UI][19].
 
 ## Configure subscriptions
 
@@ -118,14 +118,14 @@ For example, an agent entity with `name: "i-424242"` subscribes to check request
 This makes it possible to generate ad hoc check requests that target specific entities via the API.
 
 {{% notice note %}}
-**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ## Publish checks
 
 If you want Sensu to automatically schedule and execute a check according to its subscriptions, set the [`publish` attribute][12] to `true` in the check definition.
 
-You can also manually schedule [ad hoc check execution][11] with the [check API][16], whether the `publish` attribute is set to `true` or `false`.
+You can also manually schedule [ad hoc check execution][11] with the [core/v2/checks API endpoints][16], whether the `publish` attribute is set to `true` or `false`.
 To target the subscriptions defined in the check, include only the check name in the request body (for example, `"check": "check_cpu"`).
 To override the check's subscriptions and target an alternate entity or group of entities, add the subscriptions attribute to the request body:
 

--- a/content/sensu-go/6.5/operations/control-access/_index.md
+++ b/content/sensu-go/6.5/operations/control-access/_index.md
@@ -33,7 +33,7 @@ Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutu
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with the [users API][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.5/operations/control-access/apikeys.md
+++ b/content/sensu-go/6.5/operations/control-access/apikeys.md
@@ -17,7 +17,7 @@ Unlike [authentication tokens][2], API keys are persistent and do not need to be
 
 The Sensu backend generates API keys, and you can provide them to applications that want to interact with the Sensu API.
 
-Use the [APIKey API][1] to create, retrieve, and delete API keys.
+Use the [core/v2/apikeys API endpoints][1] to create, retrieve, and delete API keys.
 
 ## API key example
 

--- a/content/sensu-go/6.5/operations/control-access/sso.md
+++ b/content/sensu-go/6.5/operations/control-access/sso.md
@@ -64,7 +64,7 @@ The response will list your authentication provider types and names:
 
 ## Manage authentication providers
 
-View and delete authentication providers with the [authentication providers API][10] or these sensuctl commands.
+View and delete authentication providers with [enterprise/authentication/v2 API endpoints][10] or these sensuctl commands.
 
 To view active authentication providers:
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/_index.md
@@ -36,7 +36,7 @@ To deploy Sensu for use outside of a local development environment, [install Sen
 3. [Run a Sensu cluster][6], a group of three or more sensu-backend nodes connected to a shared database, to improve Sensu's availability, reliability, and durability.
 4. [Reach multi-cluster visibility][7] with federation so you can gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI and mirror your changes in one cluster to follower clusters.
 
-Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the federation API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
+Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the enterprise/federation/v1 API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
 
 ## Scale your Sensu implementation
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/datastore.md
@@ -16,7 +16,7 @@ Sensu stores the most recent event for each entity and check pair using either a
 Using Sensu with an external etcd cluster requires etcd 3.3.2.
 Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
 
-You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
+You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and [core/v2/events API endpoints][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
 ## Use default event storage

--- a/content/sensu-go/6.5/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/etcdreplicators.md
@@ -18,7 +18,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
+**NOTE**: EtcdReplicator is a datatype in the enterprise/federation/v1 API, which is only accessible for users who have a cluster role that permits access to replication resources.
 {{% /notice %}}
 
 Etcd replicators allow you to manage [RBAC][3] resources in one place and mirror the changes to follower clusters.
@@ -243,7 +243,7 @@ If your configuration is incorrect, replication will not work.
 
 ## Create a replicator
 
-You can use the the [federation API][2] directly or [`sensuctl create`][4] to create replicators.
+You can use [enterprise/federation/v1 API endpoints][2] directly or [`sensuctl create`][4] to create replicators.
 
 When you create or update a replicator, an entry is added to the store and a new replicator process will spin up.
 The replicator process watches the keyspace of the resource to be replicated and replicates all keys to the specified cluster in a last-write-wins fashion.

--- a/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
@@ -239,9 +239,9 @@ Otherwise, your user credentials are the username and password you provided with
 
 Select the ☰ icon to explore the web UI.
 
-### 5. Make a request to the health API
+### 5. Make a request to the /health API
 
-To make sure the backend is up and running, use the Sensu [health API][35] to check the backend's health.
+To make sure the backend is up and running, use the Sensu [/health API][35] to check the backend's health.
 You should receive a response that includes `"Healthy": true`.
 
 {{< code shell >}}
@@ -462,7 +462,7 @@ To confirm that the agent is registered with Sensu and is sending keepalive even
 
 ### 4. Verify an example event
 
-With your backend and agent still running, send this request to the Sensu events API:
+With your backend and agent still running, send this request to the Sensu core/v2/events API:
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -18,7 +18,7 @@ menu:
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
+Sensu's [enterprise/federation/v1 API endpoints][1] allow you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
 
 {{< figure src="/images/federation-switcher-clusters.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-clusters.gif" target="_blank" >}}
@@ -416,7 +416,7 @@ spec:
 
 ## Get a unified view of all your clusters in the web UI
 
-After you create clusters using the federation API, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
+After you create clusters using enterprise/federation/v1 API endpoints, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
 Use the namespace switcher to change between namespaces across federated clusters:
 
 {{< figure src="/images/federation-switcher-animated-650plus.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-animated-650plus.gif" target="_blank" >}}

--- a/content/sensu-go/6.5/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/license.md
@@ -21,7 +21,7 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 {{< figure src="/images/go-license-download.png" alt="Screenshot of Sensu account license download" link="/images/go-license-download.png" target="_blank" >}}
 
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
-With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [/license API][4].
 
 {{% notice note %}}
 **NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -177,7 +177,7 @@ To set up RBAC in Sensu Go, read the [RBAC reference][13] and [Create a read-onl
 ## Silencing
 
 Silencing is disabled by default in Sensu Go.
-You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or the core/v2/silenced API endpoint.
+You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or core/v2/silenced API endpoints.
 Read the Sensu Go [silencing reference][105] for more information.
 
 ## Token substitution
@@ -431,7 +431,7 @@ Review your Sensu Core check configuration for the following attributes and make
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
 `filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
-`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or the core/v2/silenced API endpoint.
+`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [pipelines][100].
 
 #### 5. Upload your config to your Sensu Go instance

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
@@ -126,7 +126,7 @@ spec: {}
 
 ## Secrets providers configuration
 
-You can use the [Secrets API][2] to create, view, and manage your secrets providers configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] to create, view, and manage your secrets providers configuration.
 
 For example, to retrieve the list of secrets providers:
 
@@ -454,7 +454,7 @@ version: v1
 
 limit        | 
 -------------|------ 
-description  | Maximum number of secrets requests per second that can be transmitted to the backend with the secrets API.
+description  | Maximum number of secrets requests per second that can be transmitted to the backend with enterprise/secrets/v1.
 required     | false
 type         | Float
 example      | {{< language-toggle >}}
@@ -470,7 +470,7 @@ limit: 10.0
 
 burst        | 
 -------------|------ 
-description  | Maximum amount of burst allowed in a rate interval for the secrets API.
+description  | Maximum amount of burst allowed in a rate interval for enterprise/secrets/v1.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets.md
@@ -108,7 +108,7 @@ The database secret contains a key called `password,` and its value is the passw
 
 ## Secret configuration
 
-You can use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
 To manage secrets configuration with sensuctl, configure sensuctl as the default [`admin` user][6].
 
 The [standard sensuctl subcommands][4] are available for secrets (list, info, and delete).

--- a/content/sensu-go/6.5/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/_index.md
@@ -22,8 +22,8 @@ Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sen
 
 ## Retrieve cluster health data
 
-The [health reference][3] explains how to use Sensu’s health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
-Learn how to read the JSON response for health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
+The [health reference][3] explains how to use Sensu’s /health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
+Learn how to read the JSON response for /health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
 
 ## Learn about Tessen
 

--- a/content/sensu-go/6.5/operations/monitor-sensu/health.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/health.md
@@ -12,7 +12,7 @@ menu:
     parent: monitor-sensu
 ---
 
-Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
+Use Sensu's [/health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
 
 A request to the health endpoint retrieves a JSON map with health data for your Sensu instance.
 

--- a/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -91,7 +91,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [health API endpoint][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
 **NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.

--- a/content/sensu-go/6.5/operations/monitor-sensu/tessen.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/tessen.md
@@ -23,8 +23,8 @@ Read [Troubleshoot Sensu][5] to set the Sensu backend log level and view logs.
 
 ## Configure Tessen
 
-You can use the [Tessen API][2] and [sensuctl][3] to view your Tessen configuration.
-If you are using an unlicensed Sensu instances, you can also use the [Tessen API][2] and [sensuctl][3] to opt in or opt out of Tessen.
+You can use [core/v2/tessen][2] and [sensuctl][3] to view your Tessen configuration.
+If you are using an unlicensed Sensu instances, you can also use [core/v2/tessen][2] and [sensuctl][3] to opt in or opt out of Tessen.
 
 {{% notice note %}}
 **NOTE**: Tessen is enabled by default on Sensu backends and required for [licensed](../../maintain-sensu/license/) Sensu instances.

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -111,7 +111,7 @@ These flags allow you to configure the timeout for the respective HTTP servers' 
 
 **FIXES**
 - Updated the assets, pipeline, and eventd duration metrics added in [Sensu Go 6.5.2][255] to use milliseconds for consistency with other duration metrics.
-- Updated the version API so that responses reflect the versions of external etcd clusters based on the first available etcd endpoint.
+- Updated the /version API so that responses reflect the versions of external etcd clusters based on the first available etcd endpoint.
 - Fixed a bug that could cause sensu-backend and sensu-agent to panic due to concurrent websocket writes.
 - Sensu no longer logs an error when one side of a websocket tries to close a previously closed connection.
 - Sensu now retries keepalive lease grant operations that fail due to rate limiting.
@@ -213,7 +213,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.5.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][229]) Added [Sensu Plus][247], a built-in integration you can use to transmit your Sensu observability data to Sumo Logic via the Sumo Logic HTTP Logs and Metrics Source.
-- ([Commercial feature][229]) Added support for [Sumo Logic metrics handlers][230] and [TCP stream handlers][231]. The [pipeline API][232] provides HTTP access for retrieving and configuring Sumo Logic metrics handlers and TCP stream handlers.
+- ([Commercial feature][229]) Added support for [Sumo Logic metrics handlers][230] and [TCP stream handlers][231]. The [enterprise/pipeline/v1 API endpoints][232] provide HTTP access for retrieving and configuring Sumo Logic metrics handlers and TCP stream handlers.
 - ([Commercial feature][229]) You can now [view resource data][249] for events, entities, and configuration resources like checks and handlers directly in the web UI.
 - ([Commercial feature][229]) In the web UI, you can [execute individual checks on demand][250] either according to existing subscriptions or on specific agents by adding and removing subscriptions without making changes to the saved check subscriptions.
 - ([Commercial feature][229]) Added Prometheus metrics for TCP stream handlers:
@@ -262,7 +262,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.3.
 
 **August 31, 2021** &mdash; The latest release of Sensu Go, version 6.4.2, is now available for download.
 
-This patch adds a backend configuration attribute that allows parallel event log encoding, as well as two summary metrics for the metrics API endpoint.
+This patch adds a backend configuration attribute that allows parallel event log encoding, as well as two summary metrics for the /metrics API endpoint.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.4.2.
 
@@ -272,7 +272,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.2.
 
 **IMPROVEMENTS:**
 
-- Added sensu_go_agentd_event_bytes and sensu_go_store_event_bytes summary metrics to the [metrics API endpoint][227]. sensu_go_agentd_event_bytes tracks the sizes of events, in bytes, received by agentd on the backend. sensu_go_store_event_bytes tracks event sizes, in bytes, received by the etcd store on the backend.
+- Added sensu_go_agentd_event_bytes and sensu_go_store_event_bytes summary metrics to the [/metrics API endpoint][227]. sensu_go_agentd_event_bytes tracks the sizes of events, in bytes, received by agentd on the backend. sensu_go_store_event_bytes tracks event sizes, in bytes, received by the etcd store on the backend.
 
 ## 6.4.1 release notes
 
@@ -475,7 +475,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 
 The latest release of Sensu Go, version 6.2.0, is now available for download! Sensu Go 5.x and configuration management users rejoice: this release adds support for agent local configuration (that is, agent.yml) managed entities! Agent entities may now be managed exclusively by their agents when `sensu-agent` is started with the new `agent-managed-entity` configuration option. This makes it more straightforward to migrate from Sensu Go 5.x to 6.x, as existing agent entity management workflows like Puppet will just work with the new option enabled! Note that you will not be able to edit agent-managed entities via the backend REST API or web UI.
 
-Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, the prune API no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
+Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, enterprise/prune/v1alpha no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 
@@ -495,7 +495,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][193]) Refactored entity limiter to ensure that warning messages about approaching a license's entity or entity class limit are now only displayed for users with `create` or `update` permissions for the license.
-- ([Commercial feature][193]) The [prune API][194] and its [sensuctl interface][195] now require less-broad permissions.
+- ([Commercial feature][193]) The [enterprise/prune/v1alpha API] endpoints[194] and the [sensuctl interface][195] now require less-broad permissions.
 - Adjusted the format for silenced entry dates and durations in sensuctl tabular-format output. For all silenced entries, the begin date is now listed in RFC 3339 format. For silenced entries that have not begun, the list displays the expiration date in RFC 3339 format. For silenced entires with no expiration date, the list displays `-1`. For silenced entries that have begun, the list displays the duration (for example, 1m30s).
 - Sensuctl and sensu-backend now ask users to retype their passwords when creating a new password in interactive mode.
 
@@ -518,7 +518,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 **FIXES:**
 
-- Fixed a bug that could cause a panic in the backend entity API.
+- Fixed a bug that could cause a panic in the backend core/v2/entities API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
 - When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
@@ -602,7 +602,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - Added the [`output_metric_tags` attribute][182] for checks so you can apply custom tags to enrich metric points produced by check output metric extraction.
 - A warning is now logged when you request a dynamic runtime asset that does not exist.
 - The trusted CA file is now used for agent, backend, and sensuctl asset retrieval.
-- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the entities API.
+- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the core/v2/entities API endpoints.
 - Updated the [Sensu TimescaleDB Handler][187] to write tags as a JSON object instead of an array of objects, which facilitates tags queries.
 - Updated the [Sensu Go Data Source for Grafana][188] plugin to support using API keys, fetching resources from all namespaces, using Sensu's built-in resposne filtering, grouping aggregation results by attribute, and number of [other improvements][189].
 
@@ -845,7 +845,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **FIXES:**
 
-- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster health API.
+- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster /health API.
 - In the [web UI][153], any leading and trailing whitespace is now trimmed from the username when authenticating.
 - The [web UI][153] preferences dialog now displays only the first five groups a user belongs to, which makes the sign-out button more accessible.
 - In the [web UI][153], the deregistration handler no longer appears as `undefined` on the entity details page.
@@ -933,7 +933,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.1.
 This release is packed with new features, improvements, and fixes, including our first alpha feature: declarative configuration pruning to help keep your Sensu instance in sync with Infrastructure as Code workflows.
 Other exciting additions include the ability to save and share your filtered searches in the web UI, plus a new `matches` substring match operator that you can use to refine your filtering results!
 Improvements include a new `created_by` field in resource metadata and a `float_type` field that stores whether your system uses hard float or soft float.
-We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the health API payload.
+We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the /health API payload.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.19.0.
 
@@ -992,9 +992,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 **IMPROVEMENTS:**
 
 - The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
-- If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+- If you use the [core/v2/events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
-- The version API now retrieves the Sensu agent version for the Sensu instance.
+- The /version API now retrieves the Sensu agent version for the Sensu instance.
 - Log messages now indicate which filter dropped an event.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
@@ -1004,8 +1004,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
-- Fixed a bug that prevented [API response filtering][119] from working properly for the silenced API.
-- Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
+- Fixed a bug that prevented [API response filtering][119] from working properly for core/v2/silenced API endpoints.
+- Improved event payload validation for the [core/v2/events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 - Sensuctl now supports the `http_proxy`, `https_proxy`, and `no_proxy` environment variables.
 - The [`auth/test` endpoint][120] now returns the correct error messages.
 
@@ -1424,7 +1424,7 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Silenced entries are now retrieved from the cache when determining whether an event is silenced.
 - The Sensu API now returns an error when trying to delete an entity that does not exist.
 - The agent WebSocket connection now performs basic authorization.
-- The events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
+- The core/v2/events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
@@ -1473,7 +1473,7 @@ Read the [web UI docs][65] to get started using the Sensu web UI.
 PostgreSQL can handle significantly higher volumes of Sensu events, letting you scale Sensu beyond etcd's storage limits.
 Read the [datastore reference][61] for more information.
 - Sensu now includes a cluster ID API endpoint and `sensuctl cluster id` command to return the unique Sensu cluster ID.
-Read the [cluster API docs][62] for more information.
+Read the [core/v2/cluster API endpoint docs][62] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1545,7 +1545,7 @@ Read the [upgrade guide][51] for more information.
 Read the [sensuctl reference][45] for more information.
 - Sensu backends now support the `etcd-cipher-suites` configuration option, letting you specify the cipher suites that can be used with etcd TLS configuration.
 Read the [backend reference][47] for more information.
-- The Sensu API now includes the version API, returning version information for your Sensu instance.
+- The Sensu API now includes the /version API, returning version information for your Sensu instance.
 Review the [API docs][46] for more information.
 - Tessen now collects the numbers of events processed and resources created, giving us better insight into how we can improve Sensu.
 As always, all Tessen transmissions are logged for complete transparency.
@@ -1562,7 +1562,7 @@ Read the [backend reference][50] for more information.
 **FIXES:**
 
 - Events produced by checks now execute the correct number of write operations to etcd.
-- API pagination tokens for the users and namespaces APIs now work as expected.
+- API pagination tokens for the core/v2/users and core/v2/namespaces API endpoints now work as expected.
 - Keepalive events for deleted and deregistered entities are now cleaned up as expected.
 
 **KNOWN ISSUES:**
@@ -1610,7 +1610,7 @@ Review the [API docs][34] and [sensuctl reference][35] for usage examples.
 Read the [guide to configuring an authentication provider][37] for more information.
 - ([Commercial feature][33]) Sensu's LDAP and Active Directory integrations now support connecting to an authentication provider using anonymous binding.
 Read the [LDAP][38] and [Active Directory][39] binding configuration docs to learn more.
-- The [health API][36] response now includes the cluster ID.
+- the [/health API][36] response now includes the cluster ID.
 - The `sensuctl cluster health` and `sensuctl cluster member-list` commands now include the cluster ID in tabular format.
 
 **FIXES:**
@@ -1675,8 +1675,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.4.0.
 read the [web UI docs][23] for a preview.
 - The Sensu API now supports pagination using the `limit` and `continue` query parameters, letting you limit your API responses to a maximum number of objects and making it easier to handle large datasets.
 Read the [API overview][22] for more information.
-- Sensu now surfaces internal metrics using the metrics API.
-Read the [metrics API reference][31] for more information.
+- Sensu now surfaces internal metrics using the /metrics API.
+Read the [/metrics API documentation][31] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1688,8 +1688,8 @@ Read the [agent reference][26] for more information.
 **FIXES:**
 
 - The backend now processes events without persisting metrics to etcd.
-- The events API POST and PUT endpoints now add the current timestamp to new events by default.
-- The users API now returns a 404 response code if a username cannot be found.
+- The core/v2/events API POST and PUT endpoints now add the current timestamp to new events by default.
+- The core/v2/users API endpoints now return a 404 response code if a username cannot be found.
 - The sensuctl command line tool now correctly accepts global flags when passed after a subcommand flag (for example, `--format yaml --namespace development`).
 - The `sensuctl handler delete` and `sensuctl filter delete` commands now correctly delete resources from the currently configured namespace.
 - The agent now terminates consistently on SIGTERM and SIGINT.

--- a/content/sensu-go/6.5/sensuctl/_index.md
+++ b/content/sensu-go/6.5/sensuctl/_index.md
@@ -30,7 +30,7 @@ sensuctl configure
 This starts the prompts for interactive sensuctl setup.
 When prompted, choose the authentication method you wish to use: username/password or OIDC.
 
-Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the [Sensu authentication API][14].
+Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 

--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -340,7 +340,7 @@ API keys must be reissued, but you can use your backup as a reference for granti
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -533,7 +533,7 @@ The response will list all supported `sensuctl prune` resource types:
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 #### sensuctl prune flags

--- a/content/sensu-go/6.5/web-ui/_index.md
+++ b/content/sensu-go/6.5/web-ui/_index.md
@@ -35,7 +35,7 @@ After you [start the Sensu backend][1], you can access the web UI in your browse
 
 Sign in to the web UI with the username and password you used to configure [sensuctl][2].
 
-The web UI uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][7].
+The web UI uses your username and password to obtain access and refresh tokens via the Sensu [/auth API][7].
 The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 The access and refresh tokens are saved in your browser's local storage.

--- a/content/sensu-go/6.5/web-ui/searches-reference.md
+++ b/content/sensu-go/6.5/web-ui/searches-reference.md
@@ -21,7 +21,7 @@ For more information, read [Get started with commercial features](../../commerci
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
 The saved searches feature is designed to be used directly in the [web UI][3].
-However, you can create, retrieve, update, and delete saved searches with the [searches API][4].
+However, you can create, retrieve, update, and delete saved searches with [enterprise/searches/v1 API endpoints][4].
 
 ## Search for events with any status except passing
 

--- a/content/sensu-go/6.5/web-ui/webconfig.md
+++ b/content/sensu-go/6.5/web-ui/webconfig.md
@@ -21,7 +21,7 @@ You can define a single custom web UI configuration to federate to all, some, or
 
 ## Create a web UI configuration
 
-Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
+Use the [enterprise/web/v1 API POST endpoint][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
 The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
 
 {{% notice note %}}

--- a/content/sensu-go/6.6/api/_index.md
+++ b/content/sensu-go/6.6/api/_index.md
@@ -120,7 +120,7 @@ export SENSU_ACCESS_TOKEN=`curl -X GET -u "$SENSU_USER:$SENSU_PASS" -s http://lo
 
 The [sensuctl reference][7] demonstrates how to use the `sensuctl env` command to export your access token, token expiry time, and refresh token as environment variables.
 
-### Authenticate with the authentication API
+### Authenticate with /auth API endpoints
 
 Use the [authentication API][12] and your Sensu username and password to generate access tokens and refresh tokens.
 The [`/auth` API endpoint][12] lets you generate short-lived API tokens using your Sensu username and password.
@@ -196,7 +196,7 @@ To regenerate a valid access token, run any sensuctl command (like `sensuctl eve
 
 ### Authenticate with an API key
 
-Each Sensu API key (core/v2.APIKey) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
+Each Sensu API key ([core/v2/apikey][19]) is a persistent universally unique identifier (UUID) that maps to a stored Sensu username.
 The advantages of authenticating with API keys rather than [access tokens][14] include:
 
 - **More efficient integration**: Check and handler plugins and other code can integrate with the Sensu API without implementing the logic required to authenticate via the `/auth` API endpoint to periodically refresh the access token
@@ -226,7 +226,7 @@ Created: /api/core/v2/apikeys/83abef1e-e7d7-4beb-91fc-79ad90084d5b
 {{< /code >}}
 
    {{% notice protip %}}
-**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [APIkeys API](apikeys/#create-a-new-api-key).
+**PRO TIP**: Sensuctl is the most direct way to generate an API key, but you can also use the [POST core/v2/apikeys endpoint](core/apikeys/#create-a-new-api-key).
 {{% /notice %}}
 
 2. Export your API key to the `SENSU_API_KEY` environment variable:
@@ -264,7 +264,7 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/na
 
 ### Example
 
-This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to the checks API:
+This example uses the API key directly (rather than the `$SENSU_API_KEY` environment variable) to authenticate to core/v2/checks:
 
 {{< code shell >}}
 curl -H "Authorization: Key 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2" http://127.0.0.1:8080/api/core/v2/namespaces/default/checks
@@ -274,7 +274,7 @@ A successful request will return the HTTP response code `HTTP/1.1 200 OK` and th
 
 ## Pagination
 
-The Sensu API supports response pagination for most `core/v2` GET endpoints that return an array.
+The Sensu API supports response pagination for most core/v2 GET endpoints that return an array.
 You can request a paginated response with the `limit` and `continue` query parameters.
 
 ### Limit query parameter
@@ -777,19 +777,20 @@ curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/si
 [2]: ../operations/deploy-sensu/install-sensu#install-sensuctl
 [3]: ../operations/control-access/rbac/
 [4]: ../observability-pipeline/observe-schedule/agent/
-[5]: health/
-[6]: metrics/
+[5]: other/health/
+[6]: other/metrics/
 [7]: ../sensuctl/environment-variables/
 [9]: ../observability-pipeline/observe-entities/entities#metadata-attributes
 [10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
-[11]: auth/#authtoken-post
-[12]: auth/
+[11]: other/auth/#authtoken-post
+[12]: other/auth/
 [13]: #operators
 [14]: #authentication-quickstart
 [15]: #examples
 [16]: #limit-query-parameter
 [17]: #authenticate-with-an-api-key
 [18]: ../operations/control-access/use-apikeys/#sensuctl-management-commands
+[19]: core/apikeys/
 [20]: #authenticate-with-the-authentication-api
 [21]: ../observability-pipeline/observe-schedule/backend/#api-request-limit
 [22]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match

--- a/content/sensu-go/6.6/api/core/apikeys.md
+++ b/content/sensu-go/6.6/api/core/apikeys.md
@@ -74,7 +74,7 @@ In the following example, an HTTP POST request is submitted to the `/apikeys` AP
 The request returns a successful HTTP `201 Created` response, along with a `Location` header that contains the relative path to the new API key.
 
 {{% notice note %}}
-**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with the [authentication API](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
+**NOTE**: For the `/apikeys` POST endpoint, authenticate with a Sensu access token, which you can generate with [/auth API endpoints](../../#authenticate-with-the-authentication-api) or [sensuctl](../../#generate-an-api-access-token-with-sensuctl).
 This example uses `$SENSU_ACCESS_TOKEN` to represent a valid Sensu access token.<br><br>
 If you prefer, you can [create a new API key with sensuctl](../../../operations/control-access/use-apikeys/#sensuctl-management-commands) instead of using this endpoint.
 {{% /notice %}}

--- a/content/sensu-go/6.6/api/core/tessen.md
+++ b/content/sensu-go/6.6/api/core/tessen.md
@@ -15,8 +15,8 @@ menu:
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}
 
-The Tessen API provides HTTP access to manage [Tessen][1] configuration.
-Access to the Tessen API is restricted to the default [`admin` user][2].
+The core/v2/tessen API endpoints provide HTTP access to manage [Tessen][1] configuration.
+Access to core/v2/tessen is restricted to the default [`admin` user][2].
 
 ## Get the active Tessen configuration {#tessen-get}
 

--- a/content/sensu-go/6.6/api/core/users.md
+++ b/content/sensu-go/6.6/api/core/users.md
@@ -12,7 +12,7 @@ menu:
 
 {{% notice note %}}
 **NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
-To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [authentication providers API](../../enterprise/authproviders/).<br><br>
+To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.6/api/enterprise/prune.md
+++ b/content/sensu-go/6.6/api/enterprise/prune.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 {{% notice note %}}
 **NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The prune API requires [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
+The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
 
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.6/api/enterprise/secrets.md
+++ b/content/sensu-go/6.6/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, the secrets API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/api/other/auth.md
+++ b/content/sensu-go/6.6/api/other/auth.md
@@ -74,7 +74,7 @@ HTTP/1.1 200 OK
 
 /auth/test (GET)     |     |
 ---------------------|------
-description          | Tests basic authentication credentials (username and password) that were created with Sensu's [users API][1].
+description          | Tests basic authentication credentials (username and password) that were created with Sensu's [core/v2/users API][1].
 example url          | http://hostname:8080/auth/test
 response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invalid credentials**: 401 (Unauthorized)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/_index.md
@@ -244,7 +244,7 @@ At the same time, you cannot run more than 3,000 agents.
 If you use only 1,500 agent entities, you can have 8,500 proxy entities before you reach the overall entity limit of 10,000.
 
 If you have permission to create or update licenses, you will see messages in sensuctl and the web UI when you approach your licensed entity or entity class limit, as well as when you exceed these limits.
-You can also use sensuctl or the license API to [view your overall entity count and limit][5].
+You can also use sensuctl or the /license API to [view your overall entity count and limit][5].
 
 
 [1]: monitor-external-resources/

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -206,7 +206,7 @@ spec:
 
 ### Manage agent entities via the backend
 
-You can manage agent entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33], just like any other Sensu resource.
+You can manage agent entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33], just like any other Sensu resource.
 This means you do not need to update the `agent.yml` configuration file to add, update, or delete agent entity attributes like subscriptions and labels.
 
 Management via the backend is the default configuration for agent entities.
@@ -216,7 +216,7 @@ Management via the backend is the default configuration for agent entities.
 In this case, the entity attributes in `agent.yml` are used only for initial entity creation unless you delete the entity.
 {{% /notice %}}
 
-If you delete an agent entity that you modified with sensuctl, the entities API, or the web UI, it will revert to the original configuration from `agent.yml`.
+If you delete an agent entity that you modified with sensuctl, the core/v2/entities API endpoints, or the web UI, it will revert to the original configuration from `agent.yml`.
 If you change an agent entity's class to `proxy`, the backend will revert the change to `agent`.
 
 ### Manage agent entities via the agent
@@ -239,7 +239,7 @@ You must set `deregister: true` in `agent.yml` before the agent entity is create
 Proxy entities are dynamically created entities that Sensu adds to the entity store if an entity does not already exist for a check result.
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 
-You can modify proxy entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+You can modify proxy entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 If you start an agent with the same name as an existing proxy entity, Sensu will change the proxy entity's class to `agent` and update its `system` field with information from the agent configuration.
 
@@ -323,7 +323,7 @@ For more information, read [Get started with commercial features](../../../comme
 Service entities are dynamically created entities that Sensu adds to the entity store when a [service component][39] generates an event.
 Service entities allow Sensu to monitor [business services][38].
 
-Create and modify service entities via the backend with [sensuctl][37], the [entities API][36], and the [web UI][33].
+Create and modify service entities via the backend with [sensuctl][37], the [core/v2/entities API endpoints][36], and the [web UI][33].
 
 ### Service entity example
 
@@ -382,7 +382,7 @@ sensu-agent start --labels url=sensu.docs.io
 
 {{% notice note %}}
 **NOTE**: The entity attributes in `agent.yml` are used only for initial entity creation.
-Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+Modify existing agent entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ### Proxy entity labels {#proxy-entities-managed}

--- a/content/sensu-go/6.6/observability-pipeline/observe-events/_index.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-events/_index.md
@@ -527,9 +527,9 @@ You can create events with proxy entities, which are dynamically created entitie
 Proxy entities allow Sensu to monitor external resources on systems where you cannot install a Sensu agent, like a network switch or website.
 Read [Monitor external resources][1] to learn how to use a proxy entity to monitor a website.
 
-## Events API
+## core/v2/events API endpoints
 
-Sensu's [events API][15] provides HTTP access to create, retrieve, update, and delete events.
+Sensu's [core/v2/events API endpoints][15] provide HTTP access to create, retrieve, update, and delete events.
 If you create a new event that references an entity that does not already exist, the Sensu [backend][16] will automatically create a proxy entity when the event is published.
 
 
@@ -544,7 +544,7 @@ If you create a new event that references an entity that does not already exist,
 [9]: checks/#subscriptions
 [11]: ../observe-schedule/agent/
 [12]: ../observe-schedule/
-[13]: #events-api
+[13]: #corev2events-api-endpoints
 [14]: ../observe-schedule/agent/#detect-silent-failures
 [15]: ../../api/core/events/
 [16]: ../observe-schedule/agent/

--- a/content/sensu-go/6.6/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-events/events.md
@@ -1976,12 +1976,12 @@ Sensu agents can also act as a collector for metrics throughout your infrastruct
 - [Create events using the agent TCP and UDP sockets][12]
 - [Create events using the StatsD listener][13]
 
-## Create events using the events API
+## Create events with the core/v2/events API endpoints
 
 You can send events directly to the Sensu observability pipeline using the [core/v2 API events endpoint][16].
 To create an event, send a JSON event definition with a [PUT request to core/v2/events][14].
 
-If you use the events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
+If you use the core/v2/events API to create a new event referencing an entity that does not already exist, the sensu-backend will automatically create a proxy entity in the same namespace when the event is published.
 
 {{% notice note %}}
 **NOTE**: An agent cannot belong to, execute checks in, or create events in more than one namespace. 
@@ -1989,7 +1989,7 @@ If you use the events API to create a new event referencing an entity that does 
 
 ## Manage events
 
-You can manage events using the [Sensu web UI][15], [events API][16], and [sensuctl][17] command line tool.
+You can manage events using the [Sensu web UI][15], [core/v2/events API endpoints][16], and [sensuctl][17] command line tool.
 
 ### View events
 
@@ -2012,7 +2012,7 @@ sensuctl event info <entity-name> <check-name>
 With both the `list` and `info` commands, you can specify an [output format][18] using the `--format` flag:
 
 - `yaml` or `wrapped-json` formats for use with [`sensuctl create`][8]
-- `json` format for use with the [events API][16]
+- `json` format for use with [core/v2/events API endpoints][16]
 
 {{< language-toggle >}}
 {{< code shell "YML" >}}
@@ -2548,7 +2548,7 @@ name: is_incident
 
 |timestamp   |      |
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created via the [events API][35], you can specify a `timestamp` value in the request body.
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
 required     | false
 type         | Integer
 default      | Time that the event occurred
@@ -2583,7 +2583,7 @@ id: 431a0085-96da-4521-863f-c38b480701e9
 
 sequence     |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [events API][35].
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2599,7 +2599,7 @@ sequence: 1
 
 |entity      |      |
 -------------|------
-description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
+description  | [Entity attributes][2] from the originating entity (agent or proxy).<br><br>For events created with the [core/v2/events API][35], if the event's entity does not already exist, the sensu-backend automatically creates a proxy entity when the event is published.
 type         | Map
 required     | true
 example      | {{< language-toggle >}}
@@ -2874,7 +2874,7 @@ duration: 1.903135228
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [events API][35], the default `executed` value is `0` unless you specify a value in the request body.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `executed` value. For events created with the [core/v2/events API][35], the default `executed` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2919,7 +2919,7 @@ history:
 
 issued       |      |
 -------------|------
-description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [events API][35], the default `issued` value is `0` unless you specify a value in the request body.
+description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2935,7 +2935,7 @@ issued: 1552506033
 
 last_ok      |      |
 -------------|------
-description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
+description  | Last time that the check returned an OK status (`0`). In seconds since the Unix epoch.<br><br>For agent-executed checks, Sensu automatically populates the `last_ok` value. For events created with the [core/v2/events API][35], the `last_ok` attribute will default to `0` even if you specify OK status in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -2951,7 +2951,7 @@ last_ok: 1552506033
 
 occurrences  |      |
 -------------|------
-description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
+description  | Number of preceding events with the same status as the current event (OK, WARNING, CRITICAL, or UNKNOWN). Starting at `1`, the `occurrences` attribute increments for events with the same status as the preceding event and resets whenever the status changes. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -2967,7 +2967,7 @@ occurrences: 1
 
 occurrences_watermark | |
 -------------|------
-description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. In events created with the [events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
+description  | For incident and resolution events, the number of preceding events with an OK status (for incident events) or non-OK status (for resolution events). The `occurrences_watermark` attribute gives you useful information when looking at events that change status between OK (`0`)and non-OK (`1`-WARNING, `2`-CRITICAL, or UNKNOWN).<br><br>Sensu resets `occurrences_watermark` to `1` whenever an event for a given entity and check transitions between OK and non-OK. Within a sequence of only OK or only non-OK events, Sensu increments `occurrences_watermark` only when the `occurrences` attribute is greater than the preceding `occurrences_watermark`. Read [Use event data][31] for more information.<br><br>Sensu automatically populates the `occurrences_watermark` value. For events created with the [core/v2/events API][35], Sensu overwrites any `occurences_watermark` value you specify in the request body with the correct value.
 required     | false
 type         | Integer greater than 0
 example      | {{< language-toggle >}}
@@ -3070,7 +3070,7 @@ state: passing
 
 status       |      |
 -------------|------
-description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
+description  | Exit status code produced by the check.<ul><li>`0` indicates OK</li><li>`1` indicates WARNING</li><li>`2` indicates CRITICAL</li></ul>Exit status codes other than `0`, `1`, or `2` indicate an UNKNOWN or custom status..<br><br>For agent-executed checks, Sensu automatically populates the `status` value based on the check result. For events created with the [core/v2/events API][35], Sensu assumes the status is `0` (OK) unless you specify a non-zero value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -3086,7 +3086,7 @@ status: 0
 
 total_state_change | |
 -------------|------
-description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
+description  | Total state change percentage for the check's history.<br><br>For agent-executed checks, Sensu automatically populates the `total_state_change` value. For events created with the [core/v2/events API][35], the `total_state_change` attribute will default to `0` even if you specify a different value or change the `status` value in the request body.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}
@@ -3104,7 +3104,7 @@ total_state_change: 0
 
 executed     |      |
 -------------|------
-description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [events API][35], the `executed` default value is `0`.
+description  | Time at which the check request was executed. In seconds since the Unix epoch.<br><br>Sensu automatically populates the `executed` value with check execution data. For events created with the [core/v2/events API][35], the `executed` default value is `0`.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -552,7 +552,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [events API][43].
+The returned object uses the same format as responses for the [core/v2/events API]][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 
@@ -570,7 +570,7 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [events API][43].
+The events in the returned array use the same format as responses for the [core/v2/events API]][43].
 
 ## Event filter specification
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -80,7 +80,7 @@ This communication is via clear text by default.
 Follow [Secure Sensu][46] to configure the backend and agent for WebSocket Secure (wss) encrypted communication.
 
 {{% notice note %}}
-**NOTE**: For information about your agent transport status, use the [health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
+**NOTE**: For information about your agent transport status, use the [/health API](../../../api/other/health/#get-health-data-for-your-agent-transport).
 {{% /notice %}}
 
 ## Create observability events using service checks
@@ -504,7 +504,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -321,7 +321,7 @@ spec:
 
 ### Ad hoc scheduling
 
-In addition to automatic execution, you can create checks to be scheduled manually using the [checks API][34].
+In addition to automatic execution, you can create checks to be scheduled manually using [core/v2/checks API endpoints][34].
 To create a check with ad-hoc scheduling, set the `publish` attribute to `false` in addition to an `interval` or `cron` schedule.
 
 #### Example ad hoc check
@@ -718,7 +718,7 @@ annotations:
 ### Spec attributes
 
 {{% notice note %}}
-**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent](../agent/#events-post) or [backend](../../../api/core/events/#create-a-new-event) /events API.
+**NOTE**: Spec attributes are not required when sending an HTTP `POST` request to the [agent events API](../agent/#events-post) or the [backend core/v2/events API](../../../api/core/events/#create-a-new-event).
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -24,8 +24,8 @@ Use Sensu handlers to [process extracted metrics][11] and route them to database
 You can also use Sensu's [time-series and long-term event storage integrations][18] to process service and time-series metrics.
 
 {{% notice note %}}
-**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu metrics API.
-For information about HTTP GET access to internal Sensu metrics, read our [metrics API](../../../api/other/metrics/) documentation.
+**NOTE**: This reference describes the metrics component of observation data included in Sensu events, which is distinct from the Sensu /metrics API.
+For information about HTTP GET access to internal Sensu metrics, read our [/metrics API](../../../api/other/metrics/) documentation.
 {{% /notice %}}
 
 ## Metric check example

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/rule-templates.md
@@ -153,7 +153,7 @@ For example, you might set the minimum threshold at 10 web servers with an OK st
 
 The `aggregate` rule template is useful in dynamic environments and environments with some tolerance for failure.
 
-To review the `aggregate` resource definition, retrieve it with a GET request to the BSM API:
+To review the `aggregate` resource definition, retrieve it with a GET request to /enterprise/bsm/v1:
 
 {{< code shell >}}
 curl -X GET \

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/subscriptions.md
@@ -100,7 +100,7 @@ sensu-agent start --subscriptions linux,webserver --log-level debug
 
 Now your agent entity will execute checks with the `linux` or `webserver` subscriptions.
 
-To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [entities API][18], or the [web UI][19].
+To directly add, update, and delete subscriptions for individual entities, use [sensuctl][17], the [core/v2/entities API endpoints][18], or the [web UI][19].
 
 ## Configure subscriptions
 
@@ -118,14 +118,14 @@ For example, an agent entity with `name: "i-424242"` subscribes to check request
 This makes it possible to generate ad hoc check requests that target specific entities via the API.
 
 {{% notice note %}}
-**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [entities API](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
+**NOTE**: You can directly add, update, and delete subscriptions for individual entities via the backend with [sensuctl](../../../sensuctl/create-manage-resources/#update-resources), the [core/v2/entities API endpoints](../../../api/core/entities/), and the [web UI](../../../web-ui/view-manage-resources/#manage-entities).
 {{% /notice %}}
 
 ## Publish checks
 
 If you want Sensu to automatically schedule and execute a check according to its subscriptions, set the [`publish` attribute][12] to `true` in the check definition.
 
-You can also manually schedule [ad hoc check execution][11] with the [check API][16], whether the `publish` attribute is set to `true` or `false`.
+You can also manually schedule [ad hoc check execution][11] with the [core/v2/checks API endpoints][16], whether the `publish` attribute is set to `true` or `false`.
 To target the subscriptions defined in the check, include only the check name in the request body (for example, `"check": "check_cpu"`).
 To override the check's subscriptions and target an alternate entity or group of entities, add the subscriptions attribute to the request body:
 

--- a/content/sensu-go/6.6/operations/control-access/_index.md
+++ b/content/sensu-go/6.6/operations/control-access/_index.md
@@ -33,7 +33,7 @@ Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutu
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with the [users API][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.6/operations/control-access/apikeys.md
+++ b/content/sensu-go/6.6/operations/control-access/apikeys.md
@@ -17,7 +17,7 @@ Unlike [authentication tokens][2], API keys are persistent and do not need to be
 
 The Sensu backend generates API keys, and you can provide them to applications that want to interact with the Sensu API.
 
-Use the [APIKey API][1] to create, retrieve, and delete API keys.
+Use the [core/v2/apikeys API endpoints][1] to create, retrieve, and delete API keys.
 
 ## API key example
 

--- a/content/sensu-go/6.6/operations/control-access/sso.md
+++ b/content/sensu-go/6.6/operations/control-access/sso.md
@@ -64,7 +64,7 @@ The response will list your authentication provider types and names:
 
 ## Manage authentication providers
 
-View and delete authentication providers with the [authentication providers API][10] or these sensuctl commands.
+View and delete authentication providers with [enterprise/authentication/v2 API endpoints][10] or these sensuctl commands.
 
 To view active authentication providers:
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/_index.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/_index.md
@@ -36,7 +36,7 @@ To deploy Sensu for use outside of a local development environment, [install Sen
 3. [Run a Sensu cluster][6], a group of three or more sensu-backend nodes connected to a shared database, to improve Sensu's availability, reliability, and durability.
 4. [Reach multi-cluster visibility][7] with federation so you can gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI and mirror your changes in one cluster to follower clusters.
 
-Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the federation API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
+Read the [etcd replicators reference][9] to learn how the etcd-replicators datatype in the enterprise/federation/v1 API allows you to manage role-based access control (RBAC) resources in one place and mirror your changes to follower clusters.
 
 ## Scale your Sensu implementation
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
@@ -16,7 +16,7 @@ Sensu stores the most recent event for each entity and check pair using either a
 Using Sensu with an external etcd cluster requires etcd 3.3.2.
 Follow etcd's [clustering guide][21] using the same store configuration to stand up an external etcd cluster.
 
-You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and the [events API][11].
+You can access observability event data with the [Sensu web UI][9] Events page, [`sensuctl event` commands][10], and [core/v2/events API endpoints][11].
 For longer retention of observability event data, integrate Sensu with a time-series database like [InfluxDB][12] or a searchable index like ElasticSearch or Splunk.
 
 ## Use default event storage

--- a/content/sensu-go/6.6/operations/deploy-sensu/etcdreplicators.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/etcdreplicators.md
@@ -18,7 +18,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: EtcdReplicator is a datatype in the federation API, which is only accessible for users who have a cluster role that permits access to replication resources.
+**NOTE**: EtcdReplicator is a datatype in the enterprise/federation/v1 API, which is only accessible for users who have a cluster role that permits access to replication resources.
 {{% /notice %}}
 
 Etcd replicators allow you to manage [RBAC][3] resources in one place and mirror the changes to follower clusters.
@@ -243,7 +243,7 @@ If your configuration is incorrect, replication will not work.
 
 ## Create a replicator
 
-You can use the the [federation API][2] directly or [`sensuctl create`][4] to create replicators.
+You can use [enterprise/federation/v1 API endpoints][2] directly or [`sensuctl create`][4] to create replicators.
 
 When you create or update a replicator, an entry is added to the store and a new replicator process will spin up.
 The replicator process watches the keyspace of the resource to be replicated and replicates all keys to the specified cluster in a last-write-wins fashion.

--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -239,9 +239,9 @@ Otherwise, your user credentials are the username and password you provided with
 
 Select the ☰ icon to explore the web UI.
 
-### 5. Make a request to the health API
+### 5. Make a request to the /health API
 
-To make sure the backend is up and running, use the Sensu [health API][35] to check the backend's health.
+To make sure the backend is up and running, use the Sensu [/health API][35] to check the backend's health.
 You should receive a response that includes `"Healthy": true`.
 
 {{< code shell >}}
@@ -462,7 +462,7 @@ To confirm that the agent is registered with Sensu and is sending keepalive even
 
 ### 4. Verify an example event
 
-With your backend and agent still running, send this request to the Sensu events API:
+With your backend and agent still running, send this request to the Sensu core/v2/events API:
 
 {{< code shell >}}
 curl -X POST \

--- a/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
@@ -18,7 +18,7 @@ menu:
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
-Sensu's [federation API][1] allows you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
+Sensu's [enterprise/federation/v1 API endpoints][1] allow you to register external clusters, gain visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI, and mirror your changes in one cluster to follower clusters.
 This is useful when you want to provide a single entry point for Sensu users who need to manage monitoring across multiple distinct physical data centers, cloud regions, or providers.
 
 {{< figure src="/images/federation-switcher-clusters-6-6-0.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-clusters-6-6-0.gif" target="_blank" >}}
@@ -416,7 +416,7 @@ spec:
 
 ## Get a unified view of all your clusters in the web UI
 
-After you create clusters using the federation API, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
+After you create clusters using enterprise/federation/v1 API endpoints, you can log in to the `gateway` Sensu web UI to view them as the `federation-viewer` user.
 Use the namespace switcher to change between namespaces across federated clusters:
 
 {{< figure src="/images/federation-switcher-animated-6-6-0.gif" alt="Animated demonstration of federated views in Sensu Web UI" link="/images/federation-switcher-animated-6-6-0.gif" target="_blank" >}}

--- a/content/sensu-go/6.6/operations/maintain-sensu/license.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/license.md
@@ -21,7 +21,7 @@ Log in to your Sensu account at [account.sensu.io][1] and click **Download licen
 {{< figure src="/images/go-license-download.png" alt="Screenshot of Sensu account license download" link="/images/go-license-download.png" target="_blank" >}}
 
 Save your license to a file such as `sensu_license.yml` or `sensu_license.json`.
-With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [license API][4].
+With the license file downloaded and saved to a file, you can activate your license with sensuctl or the [/license API][4].
 
 {{% notice note %}}
 **NOTE**: For [clustered configurations](../../deploy-sensu/cluster-sensu), you only need to activate your license for one of the backends within the cluster.

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -177,7 +177,7 @@ To set up RBAC in Sensu Go, read the [RBAC reference][13] and [Create a read-onl
 ## Silencing
 
 Silencing is disabled by default in Sensu Go.
-You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or the core/v2/silenced API endpoint.
+You must explicitly enable silencing by creating silencing resource definitions with sensuctl, the Sensu web UI, or core/v2/silenced API endpoints.
 Read the Sensu Go [silencing reference][105] for more information.
 
 ## Token substitution
@@ -431,7 +431,7 @@ Review your Sensu Core check configuration for the following attributes and make
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
 `filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
-`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or the core/v2/silenced API endpoint.
+`handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [pipelines][100].
 
 #### 5. Upload your config to your Sensu Go instance

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-providers.md
@@ -126,7 +126,7 @@ spec: {}
 
 ## Secrets providers configuration
 
-You can use the [Secrets API][2] to create, view, and manage your secrets providers configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] to create, view, and manage your secrets providers configuration.
 
 For example, to retrieve the list of secrets providers:
 
@@ -454,7 +454,7 @@ version: v1
 
 limit        | 
 -------------|------ 
-description  | Maximum number of secrets requests per second that can be transmitted to the backend with the secrets API.
+description  | Maximum number of secrets requests per second that can be transmitted to the backend with enterprise/secrets/v1.
 required     | false
 type         | Float
 example      | {{< language-toggle >}}
@@ -470,7 +470,7 @@ limit: 10.0
 
 burst        | 
 -------------|------ 
-description  | Maximum amount of burst allowed in a rate interval for the secrets API.
+description  | Maximum amount of burst allowed in a rate interval for enterprise/secrets/v1.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets.md
@@ -108,7 +108,7 @@ The database secret contains a key called `password,` and its value is the passw
 
 ## Secret configuration
 
-You can use the [Secrets API][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
+You can use the [enterprise/secrets/v1 API endpoints][2] and [sensuctl][3] to create, view, and manage your secrets configuration.
 To manage secrets configuration with sensuctl, configure sensuctl as the default [`admin` user][6].
 
 The [standard sensuctl subcommands][4] are available for secrets (list, info, and delete).

--- a/content/sensu-go/6.6/operations/monitor-sensu/_index.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/_index.md
@@ -22,8 +22,8 @@ Read [Monitor Sensu with Sensu][2] to monitor the Sensu backend with another Sen
 
 ## Retrieve cluster health data
 
-The [health reference][3] explains how to use Sensu’s health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
-Learn how to read the JSON response for health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
+The [health reference][3] explains how to use Sensu’s /health API to ensure your backend is up and running and check the health of your etcd cluster members and PostgreSQL datastore resources.
+Learn how to read the JSON response for /health API requests by reviewing examples of responses for clusters with healthy and unhealthy members and the response specification.
 
 ## Learn about Tessen
 

--- a/content/sensu-go/6.6/operations/monitor-sensu/health.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/health.md
@@ -12,7 +12,7 @@ menu:
     parent: monitor-sensu
 ---
 
-Use Sensu's [health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
+Use Sensu's [/health API][1] to make sure your backend is up and running and check the health of your etcd cluster members and [PostgreSQL datastore resources][2].
 
 A request to the health endpoint retrieves a JSON map with health data for your Sensu instance.
 

--- a/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -91,7 +91,7 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [health API endpoint][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
 **NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.

--- a/content/sensu-go/6.6/operations/monitor-sensu/tessen.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/tessen.md
@@ -23,8 +23,8 @@ Read [Troubleshoot Sensu][5] to set the Sensu backend log level and view logs.
 
 ## Configure Tessen
 
-You can use the [Tessen API][2] and [sensuctl][3] to view your Tessen configuration.
-If you are using an unlicensed Sensu instances, you can also use the [Tessen API][2] and [sensuctl][3] to opt in or opt out of Tessen.
+You can use [core/v2/tessen][2] and [sensuctl][3] to view your Tessen configuration.
+If you are using an unlicensed Sensu instances, you can also use [core/v2/tessen][2] and [sensuctl][3] to opt in or opt out of Tessen.
 
 {{% notice note %}}
 **NOTE**: Tessen is enabled by default on Sensu backends and required for [licensed](../../maintain-sensu/license/) Sensu instances.

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -193,7 +193,7 @@ These flags allow you to configure the timeout for the respective HTTP servers' 
 
 **FIXES**
 - Updated the assets, pipeline, and eventd duration metrics added in [Sensu Go 6.5.2][255] to use milliseconds for consistency with other duration metrics.
-- Updated the version API so that responses reflect the versions of external etcd clusters based on the first available etcd endpoint.
+- Updated the /version API so that responses reflect the versions of external etcd clusters based on the first available etcd endpoint.
 - Fixed a bug that could cause sensu-backend and sensu-agent to panic due to concurrent websocket writes.
 - Sensu no longer logs an error when one side of a websocket tries to close a previously closed connection.
 - Sensu now retries keepalive lease grant operations that fail due to rate limiting.
@@ -295,7 +295,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.5.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][229]) Added [Sensu Plus][247], a built-in integration you can use to transmit your Sensu observability data to Sumo Logic via the Sumo Logic HTTP Logs and Metrics Source.
-- ([Commercial feature][229]) Added support for [Sumo Logic metrics handlers][230] and [TCP stream handlers][231]. The [pipeline API][232] provides HTTP access for retrieving and configuring Sumo Logic metrics handlers and TCP stream handlers.
+- ([Commercial feature][229]) Added support for [Sumo Logic metrics handlers][230] and [TCP stream handlers][231]. The [enterprise/pipeline/v1 API endpoints][232] provide HTTP access for retrieving and configuring Sumo Logic metrics handlers and TCP stream handlers.
 - ([Commercial feature][229]) You can now [view resource data][249] for events, entities, and configuration resources like checks and handlers directly in the web UI.
 - ([Commercial feature][229]) In the web UI, you can [execute individual checks on demand][250] either according to existing subscriptions or on specific agents by adding and removing subscriptions without making changes to the saved check subscriptions.
 - ([Commercial feature][229]) Added Prometheus metrics for TCP stream handlers:
@@ -344,7 +344,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.3.
 
 **August 31, 2021** &mdash; The latest release of Sensu Go, version 6.4.2, is now available for download.
 
-This patch adds a backend configuration attribute that allows parallel event log encoding, as well as two summary metrics for the metrics API endpoint.
+This patch adds a backend configuration attribute that allows parallel event log encoding, as well as two summary metrics for the /metrics API endpoint.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.4.2.
 
@@ -354,7 +354,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.4.2.
 
 **IMPROVEMENTS:**
 
-- Added sensu_go_agentd_event_bytes and sensu_go_store_event_bytes summary metrics to the [metrics API endpoint][227]. sensu_go_agentd_event_bytes tracks the sizes of events, in bytes, received by agentd on the backend. sensu_go_store_event_bytes tracks event sizes, in bytes, received by the etcd store on the backend.
+- Added sensu_go_agentd_event_bytes and sensu_go_store_event_bytes summary metrics to the [/metrics API endpoint][227]. sensu_go_agentd_event_bytes tracks the sizes of events, in bytes, received by agentd on the backend. sensu_go_store_event_bytes tracks event sizes, in bytes, received by the etcd store on the backend.
 
 ## 6.4.1 release notes
 
@@ -557,7 +557,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 
 The latest release of Sensu Go, version 6.2.0, is now available for download! Sensu Go 5.x and configuration management users rejoice: this release adds support for agent local configuration (that is, agent.yml) managed entities! Agent entities may now be managed exclusively by their agents when `sensu-agent` is started with the new `agent-managed-entity` configuration option. This makes it more straightforward to migrate from Sensu Go 5.x to 6.x, as existing agent entity management workflows like Puppet will just work with the new option enabled! Note that you will not be able to edit agent-managed entities via the backend REST API or web UI.
 
-Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, the prune API no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
+Sensu Go 6.2.0 includes significant feature enhancements such as PostgreSQL backend round robin check scheduling for increased reliability and consistency, an updated format for silenced entry dates and durations in sensuctl tabular-format output, and a /health API endpoint for agent WebSocket transport status. This release delivers important bug fixes like consistently using `event_id` in logs and eliminating the sensuctl error when Vault provider SSL certificates do not exist on the local system. Also, enterprise/prune/v1alpha no longer requires cluster-wide permissions; users with limited permissions can put it to use in their namespaces!
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 
@@ -577,7 +577,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.0.
 **IMPROVEMENTS:**
 
 - ([Commercial feature][193]) Refactored entity limiter to ensure that warning messages about approaching a license's entity or entity class limit are now only displayed for users with `create` or `update` permissions for the license.
-- ([Commercial feature][193]) The [prune API][194] and its [sensuctl interface][195] now require less-broad permissions.
+- ([Commercial feature][193]) The [enterprise/prune/v1alpha API] endpoints[194] and the [sensuctl interface][195] now require less-broad permissions.
 - Adjusted the format for silenced entry dates and durations in sensuctl tabular-format output. For all silenced entries, the begin date is now listed in RFC 3339 format. For silenced entries that have not begun, the list displays the expiration date in RFC 3339 format. For silenced entires with no expiration date, the list displays `-1`. For silenced entries that have begun, the list displays the duration (for example, 1m30s).
 - Sensuctl and sensu-backend now ask users to retype their passwords when creating a new password in interactive mode.
 
@@ -600,7 +600,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.4.
 
 **FIXES:**
 
-- Fixed a bug that could cause a panic in the backend entity API.
+- Fixed a bug that could cause a panic in the backend core/v2/entities API.
 - The agent asset fetching mechanism now respects HTTP proxy environment variables when `trusted-ca-file` is configured.
 - When an asset artifact retrieved by the agent does not match the expected checksum, the logged error now includes the size of the retrieved artifact and more clearly identifies the expected and actual checksums.
 
@@ -684,7 +684,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - Added the [`output_metric_tags` attribute][182] for checks so you can apply custom tags to enrich metric points produced by check output metric extraction.
 - A warning is now logged when you request a dynamic runtime asset that does not exist.
 - The trusted CA file is now used for agent, backend, and sensuctl asset retrieval.
-- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the entities API.
+- Per-entity subscriptions (such as `entity:entityName`) are always available for agent entities, even you remove subscriptions via the core/v2/entities API endpoints.
 - Updated the [Sensu TimescaleDB Handler][187] to write tags as a JSON object instead of an array of objects, which facilitates tags queries.
 - Updated the [Sensu Go Data Source for Grafana][188] plugin to support using API keys, fetching resources from all namespaces, using Sensu's built-in resposne filtering, grouping aggregation results by attribute, and number of [other improvements][189].
 
@@ -927,7 +927,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **FIXES:**
 
-- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster health API.
+- ([Commercial feature][141]) Database connections no longer leak after queries to the cluster /health API.
 - In the [web UI][153], any leading and trailing whitespace is now trimmed from the username when authenticating.
 - The [web UI][153] preferences dialog now displays only the first five groups a user belongs to, which makes the sign-out button more accessible.
 - In the [web UI][153], the deregistration handler no longer appears as `undefined` on the entity details page.
@@ -1015,7 +1015,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.1.
 This release is packed with new features, improvements, and fixes, including our first alpha feature: declarative configuration pruning to help keep your Sensu instance in sync with Infrastructure as Code workflows.
 Other exciting additions include the ability to save and share your filtered searches in the web UI, plus a new `matches` substring match operator that you can use to refine your filtering results!
 Improvements include a new `created_by` field in resource metadata and a `float_type` field that stores whether your system uses hard float or soft float.
-We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the health API payload.
+We've also added agent and sensuctl builds for MIPS architectures, moved Bonsai logs to the `debug` level, and added PostgreSQL health information to the /health API payload.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.19.0.
 
@@ -1074,9 +1074,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 **IMPROVEMENTS:**
 
 - The `event.entity.entity_class` value now defaults to `proxy` for [`POST /events`][114] requests.
-- If you use the [events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
+- If you use the [core/v2/events API][118] to create a new event with an entity that does not already exist, the sensu-backend will automatically create a proxy entity when the event is published.
 - Sensuctl now accepts Bonsai asset versions that include a prefix with the letter `v` (for example, `v1.2.0`).
-- The version API now retrieves the Sensu agent version for the Sensu instance.
+- The /version API now retrieves the Sensu agent version for the Sensu instance.
 - Log messages now indicate which filter dropped an event.
 - Sensu now reads and writes `initializationKey` to and from EtcdRoot, with legacy support (read-only) as a fallback.
 - Sensu will now check for an HTTP response other than `200 OK` response when fetching assets.
@@ -1086,8 +1086,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.18.0.
 
 - ([Commercial feature][115]) [Label selectors][116] and [field selectors][117] now accept single and double quotes to identify strings.
 - Fixed a bug that prevented wrapped resources from having their namespaces set by the default sensuctl configuration.
-- Fixed a bug that prevented [API response filtering][119] from working properly for the silenced API.
-- Improved event payload validation for the [events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
+- Fixed a bug that prevented [API response filtering][119] from working properly for core/v2/silenced API endpoints.
+- Improved event payload validation for the [core/v2/events API][118] so that events that do not match the URL parameters on the `/events/:entity/:check` endpoint are rejected.
 - Sensuctl now supports the `http_proxy`, `https_proxy`, and `no_proxy` environment variables.
 - The [`auth/test` endpoint][120] now returns the correct error messages.
 
@@ -1506,7 +1506,7 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Silenced entries are now retrieved from the cache when determining whether an event is silenced.
 - The Sensu API now returns an error when trying to delete an entity that does not exist.
 - The agent WebSocket connection now performs basic authorization.
-- The events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
+- The core/v2/events API now correctly applies the current timestamp by default, fixing a regression in 5.10.0.
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
@@ -1555,7 +1555,7 @@ Read the [web UI docs][65] to get started using the Sensu web UI.
 PostgreSQL can handle significantly higher volumes of Sensu events, letting you scale Sensu beyond etcd's storage limits.
 Read the [datastore reference][61] for more information.
 - Sensu now includes a cluster ID API endpoint and `sensuctl cluster id` command to return the unique Sensu cluster ID.
-Read the [cluster API docs][62] for more information.
+Read the [core/v2/cluster API endpoint docs][62] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1627,7 +1627,7 @@ Read the [upgrade guide][51] for more information.
 Read the [sensuctl reference][45] for more information.
 - Sensu backends now support the `etcd-cipher-suites` configuration option, letting you specify the cipher suites that can be used with etcd TLS configuration.
 Read the [backend reference][47] for more information.
-- The Sensu API now includes the version API, returning version information for your Sensu instance.
+- The Sensu API now includes the /version API, returning version information for your Sensu instance.
 Review the [API docs][46] for more information.
 - Tessen now collects the numbers of events processed and resources created, giving us better insight into how we can improve Sensu.
 As always, all Tessen transmissions are logged for complete transparency.
@@ -1644,7 +1644,7 @@ Read the [backend reference][50] for more information.
 **FIXES:**
 
 - Events produced by checks now execute the correct number of write operations to etcd.
-- API pagination tokens for the users and namespaces APIs now work as expected.
+- API pagination tokens for the core/v2/users and core/v2/namespaces API endpoints now work as expected.
 - Keepalive events for deleted and deregistered entities are now cleaned up as expected.
 
 **KNOWN ISSUES:**
@@ -1692,7 +1692,7 @@ Review the [API docs][34] and [sensuctl reference][35] for usage examples.
 Read the [guide to configuring an authentication provider][37] for more information.
 - ([Commercial feature][33]) Sensu's LDAP and Active Directory integrations now support connecting to an authentication provider using anonymous binding.
 Read the [LDAP][38] and [Active Directory][39] binding configuration docs to learn more.
-- The [health API][36] response now includes the cluster ID.
+- the [/health API][36] response now includes the cluster ID.
 - The `sensuctl cluster health` and `sensuctl cluster member-list` commands now include the cluster ID in tabular format.
 
 **FIXES:**
@@ -1757,8 +1757,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.4.0.
 read the [web UI docs][23] for a preview.
 - The Sensu API now supports pagination using the `limit` and `continue` query parameters, letting you limit your API responses to a maximum number of objects and making it easier to handle large datasets.
 Read the [API overview][22] for more information.
-- Sensu now surfaces internal metrics using the metrics API.
-Read the [metrics API reference][31] for more information.
+- Sensu now surfaces internal metrics using the /metrics API.
+Read the [/metrics API documentation][31] for more information.
 
 **IMPROVEMENTS:**
 
@@ -1770,8 +1770,8 @@ Read the [agent reference][26] for more information.
 **FIXES:**
 
 - The backend now processes events without persisting metrics to etcd.
-- The events API POST and PUT endpoints now add the current timestamp to new events by default.
-- The users API now returns a 404 response code if a username cannot be found.
+- The core/v2/events API POST and PUT endpoints now add the current timestamp to new events by default.
+- The core/v2/users API endpoints now return a 404 response code if a username cannot be found.
 - The sensuctl command line tool now correctly accepts global flags when passed after a subcommand flag (for example, `--format yaml --namespace development`).
 - The `sensuctl handler delete` and `sensuctl filter delete` commands now correctly delete resources from the currently configured namespace.
 - The agent now terminates consistently on SIGTERM and SIGINT.

--- a/content/sensu-go/6.6/sensuctl/_index.md
+++ b/content/sensu-go/6.6/sensuctl/_index.md
@@ -30,7 +30,7 @@ sensuctl configure
 This starts the prompts for interactive sensuctl setup.
 When prompted, choose the authentication method you wish to use: username/password or OIDC.
 
-Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the [Sensu authentication API][14].
+Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 

--- a/content/sensu-go/6.6/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.6/sensuctl/back-up-recover.md
@@ -340,7 +340,7 @@ API keys must be reissued, but you can use your backup as a reference for granti
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 {{< code shell >}}

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -533,7 +533,7 @@ The response will list all supported `sensuctl prune` resource types:
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: Short names are only supported for `core/v2` resources.
+**NOTE**: Short names are only supported for core/v2 resources.
 {{% /notice %}}
 
 #### sensuctl prune flags

--- a/content/sensu-go/6.6/web-ui/_index.md
+++ b/content/sensu-go/6.6/web-ui/_index.md
@@ -35,7 +35,7 @@ After you [start the Sensu backend][1], you can access the web UI in your browse
 
 Sign in to the web UI with the username and password you used to configure [sensuctl][2].
 
-The web UI uses your username and password to obtain access and refresh tokens via the [Sensu authentication API][7].
+The web UI uses your username and password to obtain access and refresh tokens via the Sensu [/auth API][7].
 The access and refresh tokens are [JSON Web Tokens (JWTs)][2] that Sensu issues to record the details of users' authenticated Sensu sessions.
 The backend digitally signs these tokens, and the tokens can't be changed without invalidating the signature.
 The access and refresh tokens are saved in your browser's local storage.

--- a/content/sensu-go/6.6/web-ui/searches-reference.md
+++ b/content/sensu-go/6.6/web-ui/searches-reference.md
@@ -21,7 +21,7 @@ For more information, read [Get started with commercial features](../../commerci
 With the saved searches feature, you can apply search parameters to your entities, events, and resources and save them to etcd in a [namespaced resource][2] named `searches`.
 
 The saved searches feature is designed to be used directly in the [web UI][3].
-However, you can create, retrieve, update, and delete saved searches with the [searches API][4].
+However, you can create, retrieve, update, and delete saved searches with [enterprise/searches/v1 API endpoints][4].
 
 ## Search for events with any status except passing
 

--- a/content/sensu-go/6.6/web-ui/webconfig.md
+++ b/content/sensu-go/6.6/web-ui/webconfig.md
@@ -21,7 +21,7 @@ You can define a single custom web UI configuration to federate to all, some, or
 
 ## Create a web UI configuration
 
-Use the [web UI configuration API][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
+Use the [enterprise/web/v1 API POST endpoint][2] or [sensuctl create][5] to create a `GlobalConfig` resource.
 The [web UI configuration reference][4] describes each attribute you can configure in the `GlobalConfig` resource.
 
 {{% notice note %}}


### PR DESCRIPTION
## Description
Throughout the docs, replaces references to API docs, like `checks API` with API endpoint pathways, like `core/v2/checks API endpoints`.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3581