### PR TITLE
Remove statement that prune requires cluster-level permissions

### DIFF
--- a/content/sensu-go/6.3/api/enterprise/prune.md
+++ b/content/sensu-go/6.3/api/enterprise/prune.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-
+**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.<br><br>
+The pruning operation follows the role-based access control (RBAC) permissions of the current user.
+For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.<br><br>
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -492,7 +492,6 @@ This means you can only use `sensuctl prune` to delete resources that were creat
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
-In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 #### Supported resource types
 
@@ -671,7 +670,6 @@ Sensuctl supports the following formats:
 [32]: ../../operations/deploy-sensu/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
-[35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
 [38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.4/api/enterprise/prune.md
+++ b/content/sensu-go/6.4/api/enterprise/prune.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-
+**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.<br><br>
+The pruning operation follows the role-based access control (RBAC) permissions of the current user.
+For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.<br><br>
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -492,7 +492,6 @@ This means you can only use `sensuctl prune` to delete resources that were creat
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
-In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 #### Supported resource types
 
@@ -671,7 +670,6 @@ Sensuctl supports the following formats:
 [32]: ../../operations/deploy-sensu/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
-[35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
 [38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.5/api/enterprise/prune.md
+++ b/content/sensu-go/6.5/api/enterprise/prune.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-
+**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.<br><br>
+The pruning operation follows the role-based access control (RBAC) permissions of the current user.
+For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.<br><br>
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -484,7 +484,6 @@ This means you can only use `sensuctl prune` to delete resources that were creat
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
-In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 #### Supported resource types
 
@@ -667,7 +666,6 @@ Sensuctl supports the following formats:
 [32]: ../../operations/deploy-sensu/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
-[35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
 [38]: ../../operations/control-access/rbac/#namespaced-resource-types

--- a/content/sensu-go/6.6/api/enterprise/prune.md
+++ b/content/sensu-go/6.6/api/enterprise/prune.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.
-The enterprise/prune/v1alpha API endpoints require [cluster-level privileges](../../../operations/control-access/rbac/#roles-and-cluster-roles), even when all resources belong to the same namespace.
-
+**NOTE**: The `enterprise/prune/v1alpha` API endpoints are an alpha feature and may include breaking changes.<br><br>
+The pruning operation follows the role-based access control (RBAC) permissions of the current user.
+For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.<br><br>
 Requests to `enterprise/prune/v1alpha` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -484,7 +484,6 @@ This means you can only use `sensuctl prune` to delete resources that were creat
 
 The pruning operation always follows the role-based access control (RBAC) permissions of the current user.
 For example, to prune resources in the `dev` namespace, the current user who sends the prune command must have delete access to the `dev` namespace.
-In addition, pruning requires [cluster-level privileges][35], even when all resources belong to the same namespace.
 
 #### Supported resource types
 
@@ -667,7 +666,6 @@ Sensuctl supports the following formats:
 [32]: ../../operations/deploy-sensu/datastore/
 [33]: #create-resources-across-namespaces
 [34]: ../../operations/maintain-sensu/license/
-[35]: ../../operations/control-access/rbac/#roles-and-cluster-roles
 [36]: #sensuctl-create-flags
 [37]: ../../operations/control-access/oidc-auth/
 [38]: ../../operations/control-access/rbac/#namespaced-resource-types


### PR DESCRIPTION
## Description
Removes statement about prune requiring cluster-level permissions and clarifies that prune permissions are determined according to RBAC configuration. Cluster-level permissions are no longer required for prune as of 6.2.0.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3608