### PR TITLE
Fix attribute in output metric tags example

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -910,15 +910,35 @@ Use output metric tags for the output metric formats that do not natively suppor
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
 You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.timestamp` attribute:
+For example, these tags will list the `event.timestamp` and `event.entity.name` attributes:
 
-{{< code shell >}}
-"output_metric_tags": [
-  {
-    "name": "time",
-    "value": "{{ .timestamp }}"
-  }
-]{{< /code >}}
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+output_metric_tags:
+- name: time
+  value: "{{ .timestamp }}"
+- name: entity_name
+  value: "{{ .entity.name }}"
+{{< /code >}}
+
+{{< code json >}}
+{
+  "output_metric_tags": [
+    {
+      "name": "time",
+      "value": "{{ .timestamp }}"
+    },
+    {
+      "name": "entity_name",
+      "value": "{{ .entity.name }}"
+    }
+  ]
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Process extracted and tagged metrics
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -909,14 +909,14 @@ Use output metric tags for the output metric formats that do not natively suppor
 
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
-You can use [check token substitution][22] for the [value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.time` attribute:
+You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
+For example, this tag will list the `event.timestamp` attribute:
 
 {{< code shell >}}
 "output_metric_tags": [
   {
-    "name": "instance",
-    "value": "{{ .entity.system.hostname }}"
+    "name": "time",
+    "value": "{{ .timestamp }}"
   }
 ]{{< /code >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -910,15 +910,35 @@ Use output metric tags for the output metric formats that do not natively suppor
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
 You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.timestamp` attribute:
+For example, these tags will list the `event.timestamp` and `event.entity.name` attributes:
 
-{{< code shell >}}
-"output_metric_tags": [
-  {
-    "name": "time",
-    "value": "{{ .timestamp }}"
-  }
-]{{< /code >}}
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+output_metric_tags:
+- name: time
+  value: "{{ .timestamp }}"
+- name: entity_name
+  value: "{{ .entity.name }}"
+{{< /code >}}
+
+{{< code json >}}
+{
+  "output_metric_tags": [
+    {
+      "name": "time",
+      "value": "{{ .timestamp }}"
+    },
+    {
+      "name": "entity_name",
+      "value": "{{ .entity.name }}"
+    }
+  ]
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Process extracted and tagged metrics
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -909,14 +909,14 @@ Use output metric tags for the output metric formats that do not natively suppor
 
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
-You can use [check token substitution][22] for the [value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.time` attribute:
+You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
+For example, this tag will list the `event.timestamp` attribute:
 
 {{< code shell >}}
 "output_metric_tags": [
   {
-    "name": "instance",
-    "value": "{{ .entity.system.hostname }}"
+    "name": "time",
+    "value": "{{ .timestamp }}"
   }
 ]{{< /code >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -897,14 +897,14 @@ Use output metric tags for the output metric formats that do not natively suppor
 
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
-You can use [check token substitution][22] for the [value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.time` attribute:
+You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
+For example, this tag will list the `event.timestamp` attribute:
 
 {{< code shell >}}
 "output_metric_tags": [
   {
-    "name": "instance",
-    "value": "{{ .entity.system.hostname }}"
+    "name": "time",
+    "value": "{{ .timestamp }}"
   }
 ]{{< /code >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -898,15 +898,35 @@ Use output metric tags for the output metric formats that do not natively suppor
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
 You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.timestamp` attribute:
+For example, these tags will list the `event.timestamp` and `event.entity.name` attributes:
 
-{{< code shell >}}
-"output_metric_tags": [
-  {
-    "name": "time",
-    "value": "{{ .timestamp }}"
-  }
-]{{< /code >}}
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+output_metric_tags:
+- name: time
+  value: "{{ .timestamp }}"
+- name: entity_name
+  value: "{{ .entity.name }}"
+{{< /code >}}
+
+{{< code json >}}
+{
+  "output_metric_tags": [
+    {
+      "name": "time",
+      "value": "{{ .timestamp }}"
+    },
+    {
+      "name": "entity_name",
+      "value": "{{ .entity.name }}"
+    }
+  ]
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Process extracted and tagged metrics
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -897,14 +897,14 @@ Use output metric tags for the output metric formats that do not natively suppor
 
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
-You can use [check token substitution][22] for the [value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.time` attribute:
+You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
+For example, this tag will list the `event.timestamp` attribute:
 
 {{< code shell >}}
 "output_metric_tags": [
   {
-    "name": "instance",
-    "value": "{{ .entity.system.hostname }}"
+    "name": "time",
+    "value": "{{ .timestamp }}"
   }
 ]{{< /code >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -898,15 +898,35 @@ Use output metric tags for the output metric formats that do not natively suppor
 Values for output metric tags are passed through to the metric points produced by check output metric extraction for formats that natively support tags (InfluxDB Line Protocol, OpenTSDB Data Specification, and Prometheus Exposition Text).
 
 You can use [check token substitution][22] for the [output_metric_tags value attribute][21] to include any event attribute in an output metric tag.
-For example, this tag will list the `event.timestamp` attribute:
+For example, these tags will list the `event.timestamp` and `event.entity.name` attributes:
 
-{{< code shell >}}
-"output_metric_tags": [
-  {
-    "name": "time",
-    "value": "{{ .timestamp }}"
-  }
-]{{< /code >}}
+{{< language-toggle >}}
+
+{{< code yml >}}
+---
+output_metric_tags:
+- name: time
+  value: "{{ .timestamp }}"
+- name: entity_name
+  value: "{{ .entity.name }}"
+{{< /code >}}
+
+{{< code json >}}
+{
+  "output_metric_tags": [
+    {
+      "name": "time",
+      "value": "{{ .timestamp }}"
+    },
+    {
+      "name": "entity_name",
+      "value": "{{ .entity.name }}"
+    }
+  ]
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Process extracted and tagged metrics
 


### PR DESCRIPTION
## Description
The example at https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/#enrich-metrics-with-tags is incorrect in a couple ways.

Here's the current example:
```
For example, this tag will list the event.time attribute:

"output_metric_tags": [
  {
    "name": "instance",
    "value": "{{ .entity.system.hostname }}"
  }
]
```

Problems:
- There is no `event.time` attribute in Sensu events. It's `event.timestamp`.
- The code uses `{{ .entity.system.hostname }}`.

This PR fixes these issues -- uses `event.timestamp` instead and adds a second attribute to the example.

## Motivation and Context
Found when working on the JS mutators blog