### PR TITLE
Updating tests for yaml linting and also changing to github actions

### DIFF
--- a/.github/main.yml
+++ b/.github/main.yml
@@ -1,0 +1,35 @@
+---
+name: Linting json and yaml
+
+on: push
+
+jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Lint YAML files
+        working-directory: ./tests
+        run: yamllint -c yamllint_sensudocs.yml content  
+  validate-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Lint JSON files
+        working-directory: ./tests
+        run: python json-validator.py --directory ../content --extension .md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,4 @@ jobs:
       - name: Lint JSON files
         working-directory: ./tests
         run: python json-validator.py --directory ../content --extension .md
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Lint YAML files
         working-directory: ./tests
-        run: yamllint -c yamllint_sensudocs.yml content  
+        run: yamllint -c yamllint_sensudocs.yml ../content  
   validate-json:
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 2.7
 
       - name: Lint JSON files
         working-directory: ./tests

--- a/tests/yamllint-validator.py
+++ b/tests/yamllint-validator.py
@@ -1,31 +1,34 @@
 import argparse
 import fnmatch
-import json
+from yamllint.config import YamlLintConfig
+from yamllint import linter
 import os
 import re
 import sys
 
-
-parser = argparse.ArgumentParser(description='Find text between markdown JSON tags')
+parser = argparse.ArgumentParser(description='Find text between markdown YAML tags')
 parser.add_argument('--extension', help='Extension of files to validate')
 parser.add_argument('--directory', help='Path of directory to recursively go through')
+parser.add_argument('--config', help='Path of the config to use')
 args = parser.parse_args()
 
 exit_status = 0
+
+conf = YamlLintConfig('extends: default')
 
 for root, dirs, files in os.walk(args.directory):
     for filename in fnmatch.filter(files, '*' + args.extension):
         with open(os.path.join(root, filename), "r") as validation_file:
 
             validation_data = validation_file.read()
-            x = re.findall(r'{{< code json >}}(.*?){{< /code >}}',
+            x = re.findall(r'{{< code yml >}}(.*?){{< /code >}}',
                            validation_data, re.DOTALL)
 
-            for json_block in x:
+            for yaml_block in x:
                 try:
-                    json.loads(json_block)
+                    linter.run(yaml_block,conf)
                 except ValueError as exception:
-                    print("In file " + validation_file.name + " the following JSON is invalid\n" + \
-                    str(exception) + "\n" + json_block + "\n")
+                    print("In file " + validation_file.name + " the following YAML is invalid\n" + \
+                    str(exception) + "\n" + yaml_block + "\n")
                     exit_status = 2
 sys.exit(exit_status)

--- a/tests/yamllint_sensudocs.yml
+++ b/tests/yamllint_sensudocs.yml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  #Suppress warnings for line length
+  line-length: disable
+
+  #Suppress warnings for comments
+  comments: disable

--- a/tests/yamllint_sensudocs.yml
+++ b/tests/yamllint_sensudocs.yml
@@ -1,9 +1,45 @@
 extends: default
 
-rules:
-  #Suppress warnings for line length
-  line-length: disable
+yaml-files:
+  - '*.yml'
+  - '*.md'
 
-  #Suppress warnings for comments
+ignore: |
+  content/sensu-go/*/api/
+  content/sensu-core
+  content/uchiwa
+  content/sensu-enterprise*
+  _index.md
+  platforms.md
+  commercial.md
+  versions.md
+  release-notes.md
+  get-started.md
+  demo.md
+  agent.yml
+  backend.yml
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
   comments: disable
-  
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length: disable
+  truthy: disable
+  trailing-spaces: disable

--- a/tests/yamllint_sensudocs.yml
+++ b/tests/yamllint_sensudocs.yml
@@ -6,3 +6,4 @@ rules:
 
   #Suppress warnings for comments
   comments: disable
+  


### PR DESCRIPTION
I know this isn't necessarily a best practice, but this will address #1223 and also upgrades the docs to use github actions. The benefit being that we don't have to rely on Travis and the yamllinting bits are native in Github actions.