### PR TITLE
Fix handler name in Sensu Plus doc

### DIFF
--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -82,7 +82,7 @@ cat << EOF | sensuctl create
 type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
-  name: sumologic_http_log_metrics
+  name: sumo_logic_http_metrics
 spec:
   url: "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx"
   max_connections: 10
@@ -96,7 +96,7 @@ cat << EOF | sensuctl create
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics"
+    "name": "sumo_logic_http_metrics"
   },
   "spec": {
     "url": "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx",
@@ -120,7 +120,7 @@ cat << EOF | sensuctl create
 type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
-  name: sumologic_http_log_metrics
+  name: sumo_logic_http_metrics
 spec:
   url: $SUMO_LOGIC_SOURCE_URL
   secrets:
@@ -137,7 +137,7 @@ cat << EOF | sensuctl create
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics"
+    "name": "sumo_logic_http_metrics"
   },
   "spec": {
     "url": "$SUMO_LOGIC_SOURCE_URL",

--- a/content/sensu-go/6.6/sensu-plus.md
+++ b/content/sensu-go/6.6/sensu-plus.md
@@ -82,7 +82,7 @@ cat << EOF | sensuctl create
 type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
-  name: sumologic_http_log_metrics
+  name: sumo_logic_http_metrics
 spec:
   url: "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx"
   max_connections: 10
@@ -96,7 +96,7 @@ cat << EOF | sensuctl create
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics"
+    "name": "sumo_logic_http_metrics"
   },
   "spec": {
     "url": "https://collectors.sumologic.com/receiver/v1/http/xxxxxxxx",
@@ -120,7 +120,7 @@ cat << EOF | sensuctl create
 type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
-  name: sumologic_http_log_metrics
+  name: sumo_logic_http_metrics
 spec:
   url: $SUMO_LOGIC_SOURCE_URL
   secrets:
@@ -137,7 +137,7 @@ cat << EOF | sensuctl create
   "type": "SumoLogicMetricsHandler",
   "api_version": "pipeline/v1",
   "metadata": {
-    "name": "sumologic_http_log_metrics"
+    "name": "sumo_logic_http_metrics"
   },
   "spec": {
     "url": "$SUMO_LOGIC_SOURCE_URL",


### PR DESCRIPTION
## Description
Changes the Sumo Logic metrics handler name to sumo_logic_http_metrics

## Motivation and Context
Handler name does not match the name listed in pipeline
