### PR TITLE
Retest algolia docsearch v3 without noindex==false

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -185,7 +185,6 @@
     appId: 'S633WESKWC',
     apiKey: '2aaea336f8b58143b17119944385071f',
     indexName: 'sensu',
-    ignoreNoIndex: true,
     algoliaOptions: {
       facetFilters: [
         [


### PR DESCRIPTION
## Description
Update the algolia config in our docs to retest the v3 search

## Motivation and Context
Retesting without the `ignoreNoIndex: true,` config setting in https://github.com/sensu/sensu-docs/pull/3638
