### PR TITLE
Restore algolia docsearch v2 config

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -182,9 +182,9 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
   var docsearchOptions = {
-    appId: 'S633WESKWC',
-    apiKey: '2aaea336f8b58143b17119944385071f',
+    apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
     indexName: 'sensu',
+    inputSelector: '#desktop-search',
     algoliaOptions: {
       facetFilters: [
         [


### PR DESCRIPTION
## Description
Restores Algolia docsearch v2 config after unsuccessful testing in https://github.com/sensu/sensu-docs/pull/3638 and https://github.com/sensu/sensu-docs/pull/3639