### PR TITLE
Restore Algolia DocSearch v2 after v3 testing

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -182,11 +182,9 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
   var docsearchOptions = {
-    appId: 'S633WESKWC',
-    apiKey: '2aaea336f8b58143b17119944385071f',
+    apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
     indexName: 'sensu',
     inputSelector: '#desktop-search',
-    ignoreRobotsTxtRules: true,
     algoliaOptions: {
       facetFilters: [
         [


### PR DESCRIPTION
## Description
Restores Algolia DocSearch v2 after unsuccessful testing with v3

Testing PRs:
https://github.com/sensu/sensu-docs/pull/3638
https://github.com/sensu/sensu-docs/pull/3639
https://github.com/sensu/sensu-docs/pull/3641
https://github.com/sensu/sensu-docs/pull/3642