### PR TITLE
Test Algolia DocSearch v3 after updating crawler in dashboard

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -182,9 +182,9 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
   var docsearchOptions = {
-    apiKey: '2571a2aebb0465db1e7f18e14d8a55ac',
+    appId: `S633WESKWC`,
+    apiKey: '2aaea336f8b58143b17119944385071f',
     indexName: 'sensu',
-    inputSelector: '#desktop-search',
     algoliaOptions: {
       facetFilters: [
         [


### PR DESCRIPTION
## Description
Testing Algolia DocSearch v3 again with `ignoreNoIndex: true,` but this time configured in the crawler editor inside the crawler dashboard.

## Motivation and Context
I tried the in-browser dashboard crawler config