### PR TITLE
6.6.5: Event and entity search limits in web UI

### DIFF
--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -133,7 +133,8 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.3.
 
 **IMPROVEMENTS**
 
-- ([Commercial feature][259]) In the web UI, the default polling interval on the [entities page][261] is now 30 seconds to help reduce load on clusters. Also, the web UI response time and memory usage is substantially improved when opening the entities page in the default state (loading the first page of results, with no search filter applied).
+- ([Commercial feature][259]) In the web UI, the default polling interval on the [entities page][261] is now 30 seconds to help reduce load on clusters. Search results for entities are limited to the first 500 matching entities. Also, the web UI response time and memory usage is substantially improved when opening the entities page in the default state (loading the first page of results, with no search filter applied).
+- ([Commercial feature][259]) In the web UI, for instances that use etcd for event storage, search results for events are limited to 25,000 matching events. 
 - Added the [etcd-client-log-level][262] configuration flag for setting the log level of the etcd client used internally within sensu-backend.
 - The agentd daemon now starts up after all other daemons, which improves cluster recovery after the loss of a backend.
 - When using external etcd (the no-embed-etcd backend configuration flag is set to `true`), sensu-backend now crashes when its daemons do not stop within 30 seconds, which can happen due to an intentional shutdown or when database unavailability triggers an internal restart.

--- a/content/sensu-go/6.6/web-ui/search.md
+++ b/content/sensu-go/6.6/web-ui/search.md
@@ -23,6 +23,8 @@ You can also [save your favorite searches][8].
 In Sensu Go 6.6.3 and subsequent versions, if you use etcd for event storage, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
 Without these limits, the search operation can diminish cluster health.
 
+If a web UI search reaches the limit for the events or entities page, the results count at the bottom-right corner of the page will indicate that the total number of matches exceeds the number of results listed.
+
 {{% notice note %}}
 **NOTE**: The search limits on events and entities do not apply to Sensu Go versions prior to 6.6.3.
 {{% /notice %}}

--- a/content/sensu-go/6.6/web-ui/search.md
+++ b/content/sensu-go/6.6/web-ui/search.md
@@ -18,6 +18,29 @@ When you apply a search to a web UI page, it creates a unique link for the page 
 You can bookmark these links and share your favorite search combinations.
 You can also [save your favorite searches][8].
 
+## Events and entities search limits
+
+In Sensu Go 6.6.3 and subsequent versions, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
+Without these limits, the search operation can diminish cluster health.
+
+{{% notice note %}}
+**NOTE**: The search limits on events and entities do not apply to Sensu Go versions prior to 6.6.3.
+{{% /notice %}}
+
+### Events search limit
+
+On the events page, if you use etcd for event storage, search queries will stop after returning a certain number of events:
+
+- In Sensu Go 6.6.3 and 6.6.4, search queries will return a maximum of 25,000 events.
+- In Sensu Go 6.6.5, seach queries will return a maximum of 50,000 events.
+
+For example, in Sensu Go 6.6.5, if you use etcd for event storage and you search in a namespace that has more than 50,000 matching events, the search results will not include matching events beyond the first 50,000.
+
+### Entities search limit
+
+Starting with Sensu Go 6.6.3, search queries on the entities page will stop after retrieving approximately 500 matches.
+As a result, if your search matches more than 500 entities, the total results count at the bottom-right corner of the entities page will not accurately reflect the number of matching entities.
+
 ## Search operators
 
 Web UI search supports two equality-based operators, two set-based operators, one substring matching operator, and one logical operator.

--- a/content/sensu-go/6.6/web-ui/search.md
+++ b/content/sensu-go/6.6/web-ui/search.md
@@ -23,7 +23,7 @@ You can also [save your favorite searches][8].
 In Sensu Go 6.6.3 and subsequent versions, if you use etcd for event storage, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
 Without these limits, the search operation can diminish cluster health.
 
-If a web UI search reaches the limit for the events or entities page, the results count at the bottom-right corner of the page will indicate that the total number of matches exceeds the number of results listed.
+In Sensu Go 6.6.5, if a web UI search reaches the limit for the events or entities page, the results count at the bottom-right corner of the page will indicate that the total number of matches exceeds the number of results listed.
 
 {{% notice note %}}
 **NOTE**: The search limits on events and entities do not apply to Sensu Go versions prior to 6.6.3.

--- a/content/sensu-go/6.6/web-ui/search.md
+++ b/content/sensu-go/6.6/web-ui/search.md
@@ -20,7 +20,7 @@ You can also [save your favorite searches][8].
 
 ## Events and entities search limits
 
-In Sensu Go 6.6.3 and subsequent versions, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
+In Sensu Go 6.6.3 and subsequent versions, if you use etcd for event storage, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
 Without these limits, the search operation can diminish cluster health.
 
 {{% notice note %}}
@@ -38,7 +38,7 @@ For example, in Sensu Go 6.6.5, if you use etcd for event storage and you search
 
 ### Entities search limit
 
-Starting with Sensu Go 6.6.3, search queries on the entities page will stop after retrieving approximately 500 matches.
+Starting with Sensu Go 6.6.3, if you use etcd for event storage, search queries on the entities page will stop after retrieving approximately 500 matches.
 As a result, if your search matches more than 500 entities, the total results count at the bottom-right corner of the entities page will not accurately reflect the number of matching entities.
 
 ## Search operators


### PR DESCRIPTION
## Description
Documents the event and entity search limits in the web UI, starting in 6.6.3, in both the web UI search page and the 6.6.3 release notes.

## Motivation and Context
Issue: https://github.com/sensu/sensu-enterprise-go/issues/2012
PR: https://github.com/sensu/sensu-enterprise-go/pull/2018
