### PR TITLE
Fix typo and add upgrade note for web UI events search

### DIFF
--- a/content/sensu-go/6.6/web-ui/search.md
+++ b/content/sensu-go/6.6/web-ui/search.md
@@ -39,9 +39,13 @@ In Sensu Go 6.6.5, if a web UI search reaches the limit for the events or entiti
 On the events page, if you use etcd for event storage, search queries will stop after returning a certain number of events:
 
 - In Sensu Go 6.6.3 and 6.6.4, search queries will return a maximum of 25,000 events.
-- In Sensu Go 6.6.5, seach queries will return a maximum of 50,000 events.
+- In Sensu Go 6.6.5, search queries will return a maximum of 50,000 events.
 
 For example, in Sensu Go 6.6.5, if you use etcd for event storage and you search in a namespace that has more than 50,000 matching events, the search results will not include matching events beyond the first 50,000.
+
+{{% notice note %}}
+**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.6.5 to retrieve up to 50,000 results in web UI events searches.
+{{% /notice %}}
 
 ### Entities search limit
 


### PR DESCRIPTION
## Description
In https://docs.sensu.io/sensu-go/latest/web-ui/search/#events-search-limit, fixes typo "seach" and adds note about upgrading to 6.6.5 for the 50,000-result events search limit.