### PR TITLE
Fix note formatting for paragraph breaks

### DIFF
--- a/content/sensu-go/6.3/api/enterprise/business-service-monitoring.md
+++ b/content/sensu-go/6.3/api/enterprise/business-service-monitoring.md
@@ -16,8 +16,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.
-
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.<br><br>
 Requests to `enterprise/bsm/v1` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/use-federation.md
@@ -84,8 +84,7 @@ This prerequisite extends to configuring the following Sensu backend etcd parame
 
 {{% notice warning %}}
 **WARNING**: You *must* provide an explicit, non-default etcd configuration to secure etcd communication in transit.
-If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.
-
+If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.<br><br>
 This includes providing non-default values for the `etcd-advertise-client-urls` and `etcd-listen-client-urls` backend parameters and creating a [certificate and key](../generate-certificates/) for the `etcd-cert-file` and `etcd-key-file` values.
 The default values are not suitable for use under federation.
 {{% /notice %}}
@@ -222,8 +221,7 @@ This allows you to centrally define RBAC policy on the `gateway` cluster and rep
 1. Configure one etcd replicator per cluster for each RBAC policy resource, across all namespaces, for each backend in the federation.
 {{% notice note %}}
 **NOTE**: Create a replicator for each resource type you want to replicate.
-Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.
-
+Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.<br><br>
 The [etcd replicators reference](../etcdreplicators/) includes [examples](../etcdreplicators#etcd-replicator-examples) you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -22,8 +22,7 @@ This guide requires Sensu plugins using dynamic runtime assets.
 For more information about using Sensu plugins, read [Use dynamic runtime assets to install plugins][1].
 
 {{% notice note %}}
-**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.
-
+**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.<br><br>
 This guide does not describe Sensu agent [keepalive monitoring](../../../observability-pipeline/observe-schedule/agent/#keepalive-monitoring).
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -36,9 +36,8 @@ sensuctl dump all --format json --file my-resources.json
 After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
 
 {{% notice note %}}
-**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
-In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
-
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.<br><br>
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
@@ -325,8 +324,7 @@ sensuctl create -f backup/rbac.json
 
 {{% notice note %}}
 **NOTE**: When you export users, required password attributes are not included.
-You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
-
+You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.<br><br>
 You can't restore API keys or users from a sensuctl dump backup.
 API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -484,8 +484,7 @@ The `sensuctl prune` subcommand allows you to delete resources that do not appea
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.<br><br>
 `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}

--- a/content/sensu-go/6.4/api/enterprise/business-service-monitoring.md
+++ b/content/sensu-go/6.4/api/enterprise/business-service-monitoring.md
@@ -16,8 +16,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.
-
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.<br><br>
 Requests to `enterprise/bsm/v1` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/use-federation.md
@@ -90,8 +90,7 @@ This prerequisite extends to configuring the following Sensu backend etcd parame
 
 {{% notice warning %}}
 **WARNING**: You *must* provide an explicit, non-default etcd configuration to secure etcd communication in transit.
-If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.
-
+If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.<br><br>
 This includes providing non-default values for the `etcd-advertise-client-urls` and `etcd-listen-client-urls` backend parameters and creating a [certificate and key](../generate-certificates/) for the `etcd-cert-file` and `etcd-key-file` values.
 The default values are not suitable for use under federation.
 {{% /notice %}}
@@ -228,8 +227,7 @@ This allows you to centrally define RBAC policy on the `gateway` cluster and rep
 1. Configure one etcd replicator per cluster for each RBAC policy resource, across all namespaces, for each backend in the federation.
 {{% notice note %}}
 **NOTE**: Create a replicator for each resource type you want to replicate.
-Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.
-
+Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.<br><br>
 The [etcd replicators reference](../etcdreplicators/) includes [examples](../etcdreplicators#etcd-replicator-examples) you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -22,8 +22,7 @@ This guide requires Sensu plugins using dynamic runtime assets.
 For more information about using Sensu plugins, read [Use dynamic runtime assets to install plugins][1].
 
 {{% notice note %}}
-**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.
-
+**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.<br><br>
 This guide does not describe Sensu agent [keepalive monitoring](../../../observability-pipeline/observe-schedule/agent/#keepalive-monitoring).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -36,9 +36,8 @@ sensuctl dump all --format json --file my-resources.json
 After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
 
 {{% notice note %}}
-**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
-In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
-
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.<br><br>
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
@@ -325,8 +324,7 @@ sensuctl create -f backup/rbac.json
 
 {{% notice note %}}
 **NOTE**: When you export users, required password attributes are not included.
-You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
-
+You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.<br><br>
 You can't restore API keys or users from a sensuctl dump backup.
 API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -484,8 +484,7 @@ The `sensuctl prune` subcommand allows you to delete resources that do not appea
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.<br><br>
 `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}

--- a/content/sensu-go/6.5/api/enterprise/business-service-monitoring.md
+++ b/content/sensu-go/6.5/api/enterprise/business-service-monitoring.md
@@ -16,8 +16,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.
-
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.<br><br>
 Requests to `enterprise/bsm/v1` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -90,8 +90,7 @@ This prerequisite extends to configuring the following Sensu backend etcd parame
 
 {{% notice warning %}}
 **WARNING**: You *must* provide an explicit, non-default etcd configuration to secure etcd communication in transit.
-If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.
-
+If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.<br><br>
 This includes providing non-default values for the `etcd-advertise-client-urls` and `etcd-listen-client-urls` backend parameters and creating a [certificate and key](../generate-certificates/) for the `etcd-cert-file` and `etcd-key-file` values.
 The default values are not suitable for use under federation.
 {{% /notice %}}
@@ -228,8 +227,7 @@ This allows you to centrally define RBAC policy on the `gateway` cluster and rep
 1. Configure one etcd replicator per cluster for each RBAC policy resource, across all namespaces, for each backend in the federation.
 {{% notice note %}}
 **NOTE**: Create a replicator for each resource type you want to replicate.
-Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.
-
+Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.<br><br>
 The [etcd replicators reference](../etcdreplicators/) includes [examples](../etcdreplicators#etcd-replicator-examples) you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -22,8 +22,7 @@ This guide requires Sensu plugins using dynamic runtime assets.
 For more information about using Sensu plugins, read [Use dynamic runtime assets to install plugins][1].
 
 {{% notice note %}}
-**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.
-
+**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.<br><br>
 This guide does not describe Sensu agent [keepalive monitoring](../../../observability-pipeline/observe-schedule/agent/#keepalive-monitoring).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -36,9 +36,8 @@ sensuctl dump all --format json --file my-resources.json
 After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
 
 {{% notice note %}}
-**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
-In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
-
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.<br><br>
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
@@ -325,8 +324,7 @@ sensuctl create -f backup/rbac.json
 
 {{% notice note %}}
 **NOTE**: When you export users, required password attributes are not included.
-You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
-
+You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.<br><br>
 You can't restore API keys or users from a sensuctl dump backup.
 API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -476,8 +476,7 @@ The `sensuctl prune` subcommand allows you to delete resources that do not appea
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.<br><br>
 `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}

--- a/content/sensu-go/6.6/api/enterprise/business-service-monitoring.md
+++ b/content/sensu-go/6.6/api/enterprise/business-service-monitoring.md
@@ -16,8 +16,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 {{% notice note %}}
-**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.
-
+**NOTE**: Business service monitoring (BSM) is in public preview and is subject to change.<br><br>
 Requests to `enterprise/bsm/v1` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-the-authentication-api).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.
 {{% /notice %}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -493,9 +493,9 @@ If a Sensu agent fails to send keepalive events over the period specified by the
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.
+**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.
+As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
@@ -90,8 +90,7 @@ This prerequisite extends to configuring the following Sensu backend etcd parame
 
 {{% notice warning %}}
 **WARNING**: You *must* provide an explicit, non-default etcd configuration to secure etcd communication in transit.
-If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.
-
+If you do not properly configure secure etcd communication, your Sensu configuration will be vulnerable to unauthorized manipulation via etcd client connections.<br><br>
 This includes providing non-default values for the `etcd-advertise-client-urls` and `etcd-listen-client-urls` backend parameters and creating a [certificate and key](../generate-certificates/) for the `etcd-cert-file` and `etcd-key-file` values.
 The default values are not suitable for use under federation.
 {{% /notice %}}
@@ -228,8 +227,7 @@ This allows you to centrally define RBAC policy on the `gateway` cluster and rep
 1. Configure one etcd replicator per cluster for each RBAC policy resource, across all namespaces, for each backend in the federation.
 {{% notice note %}}
 **NOTE**: Create a replicator for each resource type you want to replicate.
-Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.
-
+Replicating `namespace` resources will **not** replicate the Sensu resources that belong to those namespaces.<br><br>
 The [etcd replicators reference](../etcdreplicators/) includes [examples](../etcdreplicators#etcd-replicator-examples) you can follow for `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` resources.
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -22,8 +22,7 @@ This guide requires Sensu plugins using dynamic runtime assets.
 For more information about using Sensu plugins, read [Use dynamic runtime assets to install plugins][1].
 
 {{% notice note %}}
-**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.
-
+**NOTE**: Although this guide describes approaches for monitoring a single backend, these strategies are also useful for monitoring individual members of a backend cluster.<br><br>
 This guide does not describe Sensu agent [keepalive monitoring](../../../observability-pipeline/observe-schedule/agent/#keepalive-monitoring).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.6/sensuctl/back-up-recover.md
@@ -36,9 +36,8 @@ sensuctl dump all --format json --file my-resources.json
 After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
 
 {{% notice note %}}
-**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.
-In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.
-
+**NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
+In addition, sensuctl create does not restore API keys from a sensuctl dump backup, although you can use your backup as a reference for granting new API keys.<br><br>
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
@@ -325,8 +324,7 @@ sensuctl create -f backup/rbac.json
 
 {{% notice note %}}
 **NOTE**: When you export users, required password attributes are not included.
-You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.
-
+You must add a [`password_hash`](../#generate-a-password-hash) or `password` to `users` resources before restoring them with the `sensuctl create` command.<br><br>
 You can't restore API keys or users from a sensuctl dump backup.
 API keys must be reissued, but you can use your backup as a reference for granting new API keys to replace the exported keys.
 {{% /notice %}}

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -476,8 +476,7 @@ The `sensuctl prune` subcommand allows you to delete resources that do not appea
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}
-**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.
-
+**NOTE**: `sensuctl prune` is an alpha feature and may include breaking changes.<br><br>
 `sensuctl prune` can only delete resources that have the label `sensu.io/managed_by: sensuctl`, which Sensu automatically adds to all resources created with sensuctl.
 This means you can only use `sensuctl prune` to delete resources that were created with sensuctl.
 {{% /notice %}}


### PR DESCRIPTION
## Description
In all notice callouts throughout the docs, fixes line breaks created with double returns to use `<br><br>` for separate paragraphs within the notice.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3660