### PR TITLE
Move sensuctl describe-type deprecation note to release notes

### DIFF
--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -577,6 +577,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
 - Added check hook output to event details page in the [web UI][153].
 - Added the [sensuctl describe-type command][144] to list all resource types.
+The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 - Added `annotations` and `labels` as [backend configuration][145] options.
 - Added [token substitution for assets][146].
 - Added `event.is_silenced` and `event.check.is_silenced` [field selectors][138].

--- a/content/sensu-go/6.3/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.3/sensuctl/back-up-recover.md
@@ -331,10 +331,6 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice note %}}
-**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
-{{% /notice %}}
-
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -671,6 +671,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
 - Added check hook output to event details page in the [web UI][153].
 - Added the [sensuctl describe-type command][144] to list all resource types.
+The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 - Added `annotations` and `labels` as [backend configuration][145] options.
 - Added [token substitution for assets][146].
 - Added `event.is_silenced` and `event.check.is_silenced` [field selectors][138].

--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -331,10 +331,6 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice note %}}
-**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
-{{% /notice %}}
-
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -828,6 +828,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
 - Added check hook output to event details page in the [web UI][153].
 - Added the [sensuctl describe-type command][144] to list all resource types.
+The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 - Added `annotations` and `labels` as [backend configuration][145] options.
 - Added [token substitution for assets][146].
 - Added `event.is_silenced` and `event.check.is_silenced` [field selectors][138].

--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -331,10 +331,6 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice note %}}
-**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
-{{% /notice %}}
-
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -957,6 +957,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
 - Added check hook output to event details page in the [web UI][153].
 - Added the [sensuctl describe-type command][144] to list all resource types.
+The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
 - Added `annotations` and `labels` as [backend configuration][145] options.
 - Added [token substitution for assets][146].
 - Added `event.is_silenced` and `event.check.is_silenced` [field selectors][138].

--- a/content/sensu-go/6.6/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.6/sensuctl/back-up-recover.md
@@ -331,10 +331,6 @@ API keys must be reissued, but you can use your backup as a reference for granti
 
 ## Supported resource types
 
-{{% notice note %}}
-**NOTE**: The `sensuctl describe-type` command deprecates `sensuctl dump --types`.
-{{% /notice %}}
-
 Use `sensuctl describe-type all` to retrieve the list of supported sensuctl dump resource types.
 
 {{% notice note %}}


### PR DESCRIPTION
## Description
Moves notes about `sensuctl dump --types` deprecation to 5.20.0 release notes

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3662
