### PR TITLE
Change code tag for asset add responses to use text instead of shell

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -38,7 +38,7 @@ sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.4.0
 added asset: sensu/http-checks:0.4.0
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -211,7 +211,7 @@ sensuctl asset add sensu/sensu-go-fatigue-check-filter:0.8.1 -r fatigue-filter
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 added asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -52,7 +52,7 @@ sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.3.0
 added asset: sensu/sensu-go-has-contact-filter:0.3.0
 
@@ -210,7 +210,7 @@ sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.5.0
 added asset: sensu/sensu-slack-handler:1.5.0
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 added asset: sensu/sensu-influxdb-handler:3.7.0
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -71,7 +71,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-sumologic-handler:0.3.0
 added asset: sensu/sensu-sumologic-handler:0.3.0
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -32,7 +32,7 @@ sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -32,7 +32,7 @@ sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.4.0
 added asset: sensu/http-checks:0.4.0
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -37,7 +37,7 @@ sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-cpu-usage:0.2.2
 added asset: sensu/check-cpu-usage:0.2.2
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -200,7 +200,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0
 added asset: sensu/sensu-influxdb-handler:3.7.0
 
@@ -291,7 +291,7 @@ sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-co
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-prometheus-collector:1.3.2
 added asset: sensu/sensu-prometheus-collector:1.3.2
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -43,7 +43,7 @@ sensuctl asset add sensu/check-disk-usage:0.4.1
 {{< /code >}}
 
    You will receive a response to confirm that the asset was added:
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-disk-usage:0.4.1
 added asset: sensu/check-disk-usage:0.4.1
 

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -193,7 +193,7 @@ sensuctl asset add sensu/sensu-ec2-handler:0.4.0
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-ec2-handler:0.4.0
 added asset: sensu/sensu-ec2-handler:0.4.0
 

--- a/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -46,7 +46,7 @@ sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.5.0
 added asset: sensu/http-checks:0.5.0
 

--- a/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
@@ -33,7 +33,7 @@ sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-pagerduty-handler:1.2.0
 added asset: sensu/sensu-pagerduty-handler:1.2.0
 

--- a/content/sensu-go/6.3/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.3/sensuctl/sensuctl-bonsai.md
@@ -36,7 +36,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.1.1
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.1
 added asset: sensu/sensu-influxdb-handler:3.1.1
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -38,7 +38,7 @@ sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.4.0
 added asset: sensu/http-checks:0.4.0
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -211,7 +211,7 @@ sensuctl asset add sensu/sensu-go-fatigue-check-filter:0.8.1 -r fatigue-filter
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 added asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -52,7 +52,7 @@ sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.3.0
 added asset: sensu/sensu-go-has-contact-filter:0.3.0
 
@@ -210,7 +210,7 @@ sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.5.0
 added asset: sensu/sensu-slack-handler:1.5.0
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 added asset: sensu/sensu-influxdb-handler:3.7.0
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -71,7 +71,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-sumologic-handler:0.3.0
 added asset: sensu/sensu-sumologic-handler:0.3.0
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
@@ -32,7 +32,7 @@ sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.0.3
 added asset: sensu/sensu-slack-handler:1.0.3
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -32,7 +32,7 @@ sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.4.0
 added asset: sensu/http-checks:0.4.0
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -37,7 +37,7 @@ sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-cpu-usage:0.2.2
 added asset: sensu/check-cpu-usage:0.2.2
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -200,7 +200,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0
 added asset: sensu/sensu-influxdb-handler:3.7.0
 
@@ -291,7 +291,7 @@ sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-co
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-prometheus-collector:1.3.2
 added asset: sensu/sensu-prometheus-collector:1.3.2
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -43,7 +43,7 @@ sensuctl asset add sensu/check-disk-usage:0.4.1
 {{< /code >}}
 
    You will receive a response to confirm that the asset was added:
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-disk-usage:0.4.1
 added asset: sensu/check-disk-usage:0.4.1
 

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -193,7 +193,7 @@ sensuctl asset add sensu/sensu-ec2-handler:0.4.0
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-ec2-handler:0.4.0
 added asset: sensu/sensu-ec2-handler:0.4.0
 

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -46,7 +46,7 @@ sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.5.0
 added asset: sensu/http-checks:0.5.0
 

--- a/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
@@ -33,7 +33,7 @@ sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-pagerduty-handler:1.2.0
 added asset: sensu/sensu-pagerduty-handler:1.2.0
 

--- a/content/sensu-go/6.4/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.4/sensuctl/sensuctl-bonsai.md
@@ -36,7 +36,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.1.1
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.1.1
 added asset: sensu/sensu-influxdb-handler:3.1.1
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -38,7 +38,7 @@ sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.4.0
 added asset: sensu/http-checks:0.4.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -325,7 +325,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 added asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -54,7 +54,7 @@ sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.3.0
 added asset: sensu/sensu-go-has-contact-filter:0.3.0
 
@@ -73,7 +73,7 @@ sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
 added asset: sensu/sensu-slack-handler:1.5.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 added asset: sensu/sensu-influxdb-handler:3.7.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -71,7 +71,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-sumologic-handler:0.3.0
 added asset: sensu/sensu-sumologic-handler:0.3.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -37,7 +37,7 @@ sensuctl asset add sensu/sensu-email-handler:1.2.2 -r email-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-email-handler:1.2.2
 added asset: sensu/sensu-email-handler:1.2.2
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -64,7 +64,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-pagerduty-handler:2.2.0
 added asset: sensu/sensu-pagerduty-handler:2.2.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -34,7 +34,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.5.0
 added asset: sensu/sensu-slack-handler:1.5.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -32,7 +32,7 @@ sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.4.0
 added asset: sensu/http-checks:0.4.0
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -37,7 +37,7 @@ sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-cpu-usage:0.2.2
 added asset: sensu/check-cpu-usage:0.2.2
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -200,7 +200,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0
 added asset: sensu/sensu-influxdb-handler:3.7.0
 
@@ -346,7 +346,7 @@ sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-co
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-prometheus-collector:1.3.2
 added asset: sensu/sensu-prometheus-collector:1.3.2
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -43,7 +43,7 @@ sensuctl asset add sensu/check-disk-usage:0.6.0
 {{< /code >}}
 
    You will receive a response to confirm that the asset was added:
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-disk-usage:0.6.0
 added asset: sensu/check-disk-usage:0.6.0
 

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -193,7 +193,7 @@ sensuctl asset add sensu/sensu-ec2-handler:0.4.0
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-ec2-handler:0.4.0
 added asset: sensu/sensu-ec2-handler:0.4.0
 

--- a/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -46,7 +46,7 @@ sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.5.0
 added asset: sensu/http-checks:0.5.0
 

--- a/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
@@ -33,7 +33,7 @@ sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-pagerduty-handler:2.2.0
 added asset: sensu/sensu-pagerduty-handler:2.2.0
 

--- a/content/sensu-go/6.5/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.5/sensuctl/sensuctl-bonsai.md
@@ -36,7 +36,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0
 added asset: sensu/sensu-influxdb-handler:3.7.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -38,7 +38,7 @@ sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.5.0
 added asset: sensu/http-checks:0.5.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -325,7 +325,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the asset
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 added asset: sensu/sensu-go-fatigue-check-filter:0.8.1
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
@@ -54,7 +54,7 @@ sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-go-has-contact-filter:0.3.0
 added asset: sensu/sensu-go-has-contact-filter:0.3.0
 
@@ -73,7 +73,7 @@ sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
 added asset: sensu/sensu-slack-handler:1.5.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -31,7 +31,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 added asset: sensu/sensu-influxdb-handler:3.7.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -71,7 +71,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-sumologic-handler:0.3.0
 added asset: sensu/sensu-sumologic-handler:0.3.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
@@ -37,7 +37,7 @@ sensuctl asset add sensu/sensu-email-handler:1.2.2 -r email-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-email-handler:1.2.2
 added asset: sensu/sensu-email-handler:1.2.2
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -64,7 +64,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-pagerduty-handler:2.2.0
 added asset: sensu/sensu-pagerduty-handler:2.2.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -34,7 +34,7 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-slack-handler:1.5.0
 added asset: sensu/sensu-slack-handler:1.5.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -32,7 +32,7 @@ sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.5.0
 added asset: sensu/http-checks:0.5.0
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -37,7 +37,7 @@ sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-cpu-usage:0.2.2
 added asset: sensu/check-cpu-usage:0.2.2
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -200,7 +200,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0
 added asset: sensu/sensu-influxdb-handler:3.7.0
 
@@ -346,7 +346,7 @@ sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-co
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-prometheus-collector:1.3.2
 added asset: sensu/sensu-prometheus-collector:1.3.2
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
@@ -43,7 +43,7 @@ sensuctl asset add sensu/check-disk-usage:0.6.0
 {{< /code >}}
 
    You will receive a response to confirm that the asset was added:
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/check-disk-usage:0.6.0
 added asset: sensu/check-disk-usage:0.6.0
 

--- a/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
@@ -193,7 +193,7 @@ sensuctl asset add sensu/sensu-ec2-handler:0.4.0
 
 The response will indicate that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-ec2-handler:0.4.0
 added asset: sensu/sensu-ec2-handler:0.4.0
 

--- a/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -46,7 +46,7 @@ sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
 
 The response will confirm that the asset was added:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/http-checks:0.5.0
 added asset: sensu/http-checks:0.5.0
 

--- a/content/sensu-go/6.6/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.6/plugins/use-assets-to-install-plugins.md
@@ -33,7 +33,7 @@ sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-pagerduty-handler:2.2.0
 added asset: sensu/sensu-pagerduty-handler:2.2.0
 

--- a/content/sensu-go/6.6/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.6/sensuctl/sensuctl-bonsai.md
@@ -36,7 +36,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0
 
 The response should be similar to this example:
 
-{{< code shell >}}
+{{< code text >}}
 fetching bonsai asset: sensu/sensu-influxdb-handler:3.7.0
 added asset: sensu/sensu-influxdb-handler:3.7.0
 


### PR DESCRIPTION
## Description
Changes the code tag for all asset add responses to `{{< code text >}}` instead of `{{< code shell >}}`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3672
