### PR TITLE
Add response filtering examples on individual API doc pages

### DIFF
--- a/content/sensu-go/6.3/api/core/checks.md
+++ b/content/sensu-go/6.3/api/core/checks.md
@@ -496,6 +496,107 @@ description               | Removes a single hook from a check (specified by the
 example url               | http://hostname:8080/api/core/v2/namespaces/default/checks/check-cpu/hooks/critical/hook/process_tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of checks with response filtering
+
+The `/checks` API endpoint supports [response filtering][5] for a subset of check data based on labels and the following fields:
+
+- `check.name`
+- `check.namespace`
+- `check.handlers`
+- `check.publish`
+- `check.round_robin`
+- `check.runtime_assets`
+- `check.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/checks` API endpoint with [response filtering][5], resulting in a JSON array that contains only [check definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
+--data-urlencode 'fieldSelector="linux" in check.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/checks (GET) with response filters | 
+---------------|------
+description    | Returns the list of checks that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/checks
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/checks/
 [2]: ../../../observability-pipeline/observe-schedule/hooks/

--- a/content/sensu-go/6.3/api/core/checks.md
+++ b/content/sensu-go/6.3/api/core/checks.md
@@ -551,6 +551,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /checks (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/checks.md
+++ b/content/sensu-go/6.3/api/core/checks.md
@@ -520,7 +520,7 @@ HTTP/1.1 200 OK
 [
   {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": ["slack"],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -546,8 +546,7 @@ HTTP/1.1 200 OK
       "namespace": "default",
       "created_by": "admin"
     },
-    "secrets": null,
-    "pipelines": []
+    "secrets": null
   }
 ]
 {{< /code >}}
@@ -565,7 +564,7 @@ output         | {{< code shell >}}
 [
   {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": ["slack"],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -591,8 +590,7 @@ output         | {{< code shell >}}
       "namespace": "default",
       "created_by": "admin"
     },
-    "secrets": null,
-    "pipelines": []
+    "secrets": null
   }
 ]
 {{< /code >}}

--- a/content/sensu-go/6.3/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.3/api/core/cluster-role-bindings.md
@@ -422,6 +422,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterrolebindings (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.3/api/core/cluster-role-bindings.md
@@ -369,6 +369,105 @@ description               | Removes a cluster role binding from Sensu (specified
 example url               | http://hostname:8080/api/core/v2/clusterrolebindings/ops-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster role bindings with response filtering
+
+The `/clusterrolebindings` API endpoint supports [response filtering][3] for a subset of cluster role binding data based on labels and the following fields:
+
+- `clusterrolebinding.name`
+- `clusterrolebinding.role_ref.name`
+- `clusterrolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/clusterrolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role binding definitions][1] whose `role_ref.name` includes `cluster-user`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterrolebindings -G \
+--data-urlencode 'fieldSelector="cluster-user" in clusterrolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterrolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterrolebindings
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/cluster-roles.md
+++ b/content/sensu-go/6.3/api/core/cluster-roles.md
@@ -461,6 +461,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterroles (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/cluster-roles.md
+++ b/content/sensu-go/6.3/api/core/cluster-roles.md
@@ -392,6 +392,141 @@ description               | Removes a cluster role from Sensu (specified by the 
 example url               | http://hostname:8080/api/core/v2/clusterroles/global-event-reader
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster roles with response filtering
+
+The `/clusterroles` API endpoint supports [response filtering][3] for a subset of cluster role data based on labels and the `clusterrole.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/clusterroles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role definitions][1] whose `clusterrole.name` includes `admin`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterroles -G \
+--data-urlencode 'fieldSelector=clusterrole.name matches "admin"'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterroles (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterroles
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/entities.md
+++ b/content/sensu-go/6.3/api/core/entities.md
@@ -777,6 +777,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /entities (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/entities.md
+++ b/content/sensu-go/6.3/api/core/entities.md
@@ -657,6 +657,237 @@ description               | Removes a entity from Sensu (specified by the entity
 example url               | http://hostname:8080/api/core/v2/namespaces/default/entities/server1
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of entities with response filtering
+
+The `/entities` API endpoint supports [response filtering][5] for a subset of entity data based on labels and the following fields:
+
+- `entity.name`
+- `entity.namespace`
+- `entity.deregister`
+- `entity.entity_class`
+- `entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/entities` API endpoint with [response filtering][5], resulting in a JSON array that contains only [entity definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
+--data-urlencode 'fieldSelector="linux" in entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/entities (GET) with response filters | 
+---------------|------
+description    | Returns the list of entities that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/entities
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-entities/entities/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/events.md
+++ b/content/sensu-go/6.3/api/core/events.md
@@ -38,7 +38,9 @@ HTTP/1.1 200 OK
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -155,13 +157,6 @@ HTTP/1.1 200 OK
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -187,7 +182,9 @@ output         | {{< code shell >}}
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -304,13 +301,6 @@ output         | {{< code shell >}}
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -421,7 +411,9 @@ HTTP/1.1 200 OK
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -538,13 +530,6 @@ HTTP/1.1 200 OK
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -676,13 +661,6 @@ HTTP/1.1 200 OK
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "8717b1dc-47d2-4b73-a259-ee2645cadbf5",
     "metadata": {
       "namespace": "default"
@@ -707,7 +685,9 @@ output               | {{< code json >}}
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -824,13 +804,6 @@ output               | {{< code json >}}
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -962,13 +935,6 @@ output               | {{< code json >}}
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "8717b1dc-47d2-4b73-a259-ee2645cadbf5",
     "metadata": {
       "namespace": "default"
@@ -997,7 +963,9 @@ HTTP/1.1 200 OK
 {
   "check": {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": [
+      "pagerduty"
+    ],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -1105,13 +1073,6 @@ HTTP/1.1 200 OK
     },
     "sensu_agent_version": "6.2.7"
   },
-  "pipelines": [
-    {
-      "api_version": "core/v2",
-      "type": "Pipeline",
-      "name": "incident_alerts"
-    }
-  ],
   "id": "9a9c7515-0a04-43f3-9351-d8da88942b1b",
   "metadata": {
     "namespace": "default"
@@ -1135,7 +1096,9 @@ output               | {{< code json >}}
 {
   "check": {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": [
+      "pagerduty"
+    ],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -1243,13 +1206,6 @@ output               | {{< code json >}}
     },
     "sensu_agent_version": "6.2.7"
   },
-  "pipelines": [
-    {
-      "api_version": "core/v2",
-      "type": "Pipeline",
-      "name": "incident_alerts"
-    }
-  ],
   "id": "9a9c7515-0a04-43f3-9351-d8da88942b1b",
   "metadata": {
     "namespace": "default"
@@ -1574,6 +1530,467 @@ HTTP/1.1 204 No Content
 description               | Deletes the event created by the specified entity using the specified check.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/events/server1/check-cpu 
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+## Get a subset of events with response filtering
+
+The `/events` API endpoint supports [response filtering][10] for a subset of event data based on labels and the following fields:
+
+- `event.name`
+- `event.namespace`
+- `event.is_silenced`
+- `event.check.handlers`
+- `event.check.is_silenced`
+- `event.check.name`
+- `event.check.publish`
+- `event.check.round_robin`
+- `event.check.runtime_assets`
+- `event.check.status`
+- `event.check.subscriptions`
+- `event.entity.deregister`
+- `event.entity.entity_class`
+- `event.entity.name` 
+- `event.entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/events` API endpoint with [response filtering][10], resulting in a JSON array that contains only [event definitions][1] for entities whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
+--data-urlencode 'fieldSelector="linux" in event.entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [
+        "pagerduty"
+      ],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos"
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/events (GET) with response filters | 
+---------------|------
+description    | Returns the list of events that match the [response filters][10] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/events
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [
+        "pagerduty"
+      ],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos"
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2
+  }
+]
+{{< /code >}}
 
 
 [1]: ../../../observability-pipeline/observe-events/events/

--- a/content/sensu-go/6.3/api/core/events.md
+++ b/content/sensu-go/6.3/api/core/events.md
@@ -1771,6 +1771,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /events (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/filters.md
+++ b/content/sensu-go/6.3/api/core/filters.md
@@ -322,6 +322,92 @@ description               | Removes the specified event filter from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/filters/development_filter
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of filters with response filtering
+
+The `/filters` API endpoint supports [response filtering][3] for a subset of filter data based on labels and the following fields:
+
+- `filter.name`
+- `filter.namespace`
+- `filter.action`
+- `filter.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/filters` API endpoint with [response filtering][3], resulting in a JSON array that contains only [filter definitions][1] whose action is `allow`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/filters -G \
+--data-urlencode 'fieldSelector=filter.action == allow'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/filters (GET) with response filters | 
+---------------|------
+description    | Returns the list of filters that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/filters
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-filter/filters/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/filters.md
+++ b/content/sensu-go/6.3/api/core/filters.md
@@ -369,6 +369,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /filters (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/handlers.md
+++ b/content/sensu-go/6.3/api/core/handlers.md
@@ -393,6 +393,93 @@ description               | Removes the specified handler from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/handlers/slack
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of handlers with response filtering
+
+The `/handlers` API endpoint supports [response filtering][3] for a subset of handler data based on labels and the following fields:
+
+- `handler.name`
+- `handler.namespace`
+- `handler.filters`
+- `handler.handlers`
+- `handler.mutator`
+- `handler.type`
+
+### Example
+
+The following example demonstrates a request to the `/handlers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [handler definitions][1] in the `default` namespace **and** whose filters include `state_change_only`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/handlers -G \
+--data-urlencode 'fieldSelector=state_change_only in handler.filters && handler.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/handlers (GET) with response filters | 
+---------------|------
+description    | Returns the list of handlers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/handlers
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.3/api/core/handlers.md
+++ b/content/sensu-go/6.3/api/core/handlers.md
@@ -441,6 +441,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /handlers (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/hooks.md
+++ b/content/sensu-go/6.3/api/core/hooks.md
@@ -353,6 +353,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /hooks (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/hooks.md
+++ b/content/sensu-go/6.3/api/core/hooks.md
@@ -308,6 +308,90 @@ description               | Removes the specified hook from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of hooks with response filtering
+
+The `/hooks` API endpoint supports [response filtering][3] for a subset of hook data based on labels and the following fields:
+
+- `hook.name`
+- `hook.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/hooks` API endpoint with [response filtering][3], resulting in a JSON array that contains only [hook definitions][1] in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/hooks -G \
+--data-urlencode 'fieldSelector=hook.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/hooks (GET) with response filters | 
+---------------|------
+description    | Returns the list of hooks that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/hooks
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/hooks/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/mutators.md
+++ b/content/sensu-go/6.3/api/core/mutators.md
@@ -350,6 +350,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /mutators (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/mutators.md
+++ b/content/sensu-go/6.3/api/core/mutators.md
@@ -311,6 +311,77 @@ description               | Removes the specified mutator from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/mutators/example-mutator
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of mutators with response filtering
+
+The `/mutators` API endpoint supports [response filtering][3] for a subset of mutator data based on labels and the following fields:
+
+- `mutator.name`
+- `mutator.namespace`
+- `mutator.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/mutators` API endpoint with [response filtering][3], resulting in a JSON array that contains only [mutator definitions][1] that are in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/mutators -G \
+--data-urlencode 'fieldSelector=mutator.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/mutators (GET) with response filters | 
+---------------|------
+description    | Returns the list of mutators that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/mutators
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-transform/mutators/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/namespaces.md
+++ b/content/sensu-go/6.3/api/core/namespaces.md
@@ -203,6 +203,44 @@ output         | {{< code shell >}}
 ]
 {{< /code >}}
 
-[1]: ../../../operations/control-access/rbac/
-[2]: ../../#limit-query-parameter
+## Get a subset of namespaces with response filtering
+
+The `/namespaces` API endpoint supports [response filtering][3] for a subset of namespace data based on labels and the field `namespace.name`.
+
+### Example
+
+The following example demonstrates a request to the `/namespaces` API endpoint with [response filtering][3], resulting in a JSON array that contains only the [namespace definitions][1] for the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/namespaces -G \
+--data-urlencode 'fieldSelector=namespace.name == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/namespaces (GET) with response filters | 
+---------------|------
+description    | Returns the list of namespaces that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/namespaces
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/namespaces/
+[2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.3/api/core/namespaces.md
+++ b/content/sensu-go/6.3/api/core/namespaces.md
@@ -223,6 +223,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /namespaces (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/role-bindings.md
+++ b/content/sensu-go/6.3/api/core/role-bindings.md
@@ -400,6 +400,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /rolebindings (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/role-bindings.md
+++ b/content/sensu-go/6.3/api/core/role-bindings.md
@@ -346,6 +346,106 @@ description               | Removes the specified role binding from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/rolebindings/dev-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of role bindings with response filtering
+
+The `/rolebindings` API endpoint supports [response filtering][3] for a subset of role binding data based on labels and the following fields:
+
+- `rolebinding.name`
+- `rolebinding.namespace`
+- `rolebinding.role_ref.name`
+- `rolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/rolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role binding definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/rolebindings -G \
+--data-urlencode 'fieldSelector="event-reader" in rolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/rolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/rolebindings
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/roles.md
+++ b/content/sensu-go/6.3/api/core/roles.md
@@ -491,6 +491,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /roles (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/roles.md
+++ b/content/sensu-go/6.3/api/core/roles.md
@@ -398,6 +398,186 @@ description               | Removes the specified role from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of roles with response filtering
+
+The `/roles` API endpoint supports [response filtering][3] for a subset of role data based on labels and the following fields:
+
+- `role.name`
+- `role.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/roles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/roles -G \
+--data-urlencode 'fieldSelector=role.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/roles (GET) with response filters | 
+---------------|------
+description    | Returns the list of roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/roles
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.3/api/core/silenced.md
+++ b/content/sensu-go/6.3/api/core/silenced.md
@@ -447,6 +447,71 @@ output               | {{< code json >}}
 ]
 {{< /code >}}
 
+## Get a subset of silences with response filtering
+
+The `/silenced` API endpoint supports [response filtering][3] for a subset of silences data based on labels and the following fields:
+
+- `silenced.name`
+- `silenced.namespace`
+- `silenced.check`
+- `silenced.creator`
+- `silenced.expire_on_resolve`
+- `silenced.subscription`
+
+### Example
+
+The following example demonstrates a request to the `/silenced` API endpoint with [response filtering][3], resulting in a JSON array that contains only [silence definitions][1] with the `linux` subscription.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector="linux" in silenced.subscription'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/silenced (GET) with response filters | 
+---------------|------
+description    | Returns the list of silences that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/silenced
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/silencing/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.3/api/core/silenced.md
+++ b/content/sensu-go/6.3/api/core/silenced.md
@@ -484,6 +484,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /silenced (GET) with response filters | 

--- a/content/sensu-go/6.3/api/core/users.md
+++ b/content/sensu-go/6.3/api/core/users.md
@@ -430,7 +430,75 @@ description               | Removes the specified user from the specified group.
 example url               | http://hostname:8080/api/core/v2/users/alice/groups/ops
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-[1]: ../../../operations/control-access/rbac#user-specification
+## Get a subset of users with response filtering
+
+The `/users` API endpoint supports [response filtering][3] for a subset of user data based on labels and the following fields:
+
+- `user.username`
+- `user.disabled`
+- `user.groups`
+
+### Example
+
+The following example demonstrates a request to the `/users` API endpoint with [response filtering][3], resulting in a JSON array that contains only [user definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/users -G \
+--data-urlencode 'fieldSelector="dev" in user.groups'
+
+HTTP/1.1 200 OK
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/users (GET) with response filters | 
+---------------|------
+description    | Returns the list of users that match the [response filters][8] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/users
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/rbac#users
 [2]: ../../#pagination
 [3]: https://en.wikipedia.org/wiki/Bcrypt
 [4]: ../../../sensuctl/#generate-a-password-hash

--- a/content/sensu-go/6.3/api/core/users.md
+++ b/content/sensu-go/6.3/api/core/users.md
@@ -467,6 +467,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /users (GET) with response filters | 

--- a/content/sensu-go/6.3/api/enterprise/secrets.md
+++ b/content/sensu-go/6.3/api/enterprise/secrets.md
@@ -26,7 +26,7 @@ The `/providers` API endpoint provides HTTP GET access to a list of secrets prov
 
 ### Example {#providers-get-example}
 
-The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of secrets providers.
+The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of [secrets provider definitions][1].
 
 {{< code shell >}}
 curl -X GET \
@@ -72,7 +72,7 @@ Learn more in the [secrets providers reference](../../../operations/manage-secre
 description    | Returns the list of secrets providers.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
 query parameters | `types`: Defines which type of secrets provider to retrieve. Join with `&` to retrieve multiple types: `?types=Env&types=VaultProvider`.
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -274,13 +274,89 @@ description               | Deletes the specified provider from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/providers/my_vault
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets providers with response filtering
+
+The `/providers` API endpoint supports [response filtering][3] for a subset of secrets providers data based on labels and the `provider.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/providers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets provider definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/providers -G \
+--data-urlencode 'fieldSelector=provider.name == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/providers (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets providers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
 ## Get all secrets
 
 The `/secrets` API endpoint provides HTTP GET access to a list of secrets.
 
 ### Example {#secrets-get-example}
 
-The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of secrets for the specified namespace.
+The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of [secrets definitions][5] for the specified namespace.
 
 {{< code shell >}}
 curl -X GET \
@@ -311,7 +387,7 @@ HTTP/1.1 200 OK
 ---------------|------
 description    | Returns the list of secrets for the specified namespace.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -460,5 +536,120 @@ description               | Deletes the specified secret from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets/sensu-ansible-token
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets with response filtering
 
-[4]: ../../#response-filtering
+The `/secrets` API endpoint supports [response filtering][3] for a subset of secrets data based on labels and the following fields:
+
+- `secret.name`
+- `secret.namespace`
+- `secret.provider`
+- `secret.id`
+
+### Example
+
+The following example demonstrates a request to the `/secrets` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets definitions][2] for the `vault` provider.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/secrets -G \
+--data-urlencode 'fieldSelector=secret.provider == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/secrets (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/secrets
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/manage-secrets/secrets-providers/
+[2]: ../../../operations/manage-secrets/secrets/
+[3]: ../../#response-filtering

--- a/content/sensu-go/6.3/api/enterprise/secrets.md
+++ b/content/sensu-go/6.3/api/enterprise/secrets.md
@@ -314,6 +314,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /providers (GET) with response filters | 
@@ -596,6 +600,10 @@ HTTP/1.1 200 OK
   }
 ]
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
 
 ### API Specification
 

--- a/content/sensu-go/6.4/api/core/checks.md
+++ b/content/sensu-go/6.4/api/core/checks.md
@@ -496,6 +496,107 @@ description               | Removes a single hook from a check (specified by the
 example url               | http://hostname:8080/api/core/v2/namespaces/default/checks/check-cpu/hooks/critical/hook/process_tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of checks with response filtering
+
+The `/checks` API endpoint supports [response filtering][5] for a subset of check data based on labels and the following fields:
+
+- `check.name`
+- `check.namespace`
+- `check.handlers`
+- `check.publish`
+- `check.round_robin`
+- `check.runtime_assets`
+- `check.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/checks` API endpoint with [response filtering][5], resulting in a JSON array that contains only [check definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
+--data-urlencode 'fieldSelector="linux" in check.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/checks (GET) with response filters | 
+---------------|------
+description    | Returns the list of checks that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/checks
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/checks/
 [2]: ../../../observability-pipeline/observe-schedule/hooks/

--- a/content/sensu-go/6.4/api/core/checks.md
+++ b/content/sensu-go/6.4/api/core/checks.md
@@ -551,6 +551,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /checks (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/checks.md
+++ b/content/sensu-go/6.4/api/core/checks.md
@@ -520,7 +520,7 @@ HTTP/1.1 200 OK
 [
   {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": ["slack"],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -546,8 +546,7 @@ HTTP/1.1 200 OK
       "namespace": "default",
       "created_by": "admin"
     },
-    "secrets": null,
-    "pipelines": []
+    "secrets": null
   }
 ]
 {{< /code >}}
@@ -565,7 +564,7 @@ output         | {{< code shell >}}
 [
   {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": ["slack"],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -591,8 +590,7 @@ output         | {{< code shell >}}
       "namespace": "default",
       "created_by": "admin"
     },
-    "secrets": null,
-    "pipelines": []
+    "secrets": null
   }
 ]
 {{< /code >}}

--- a/content/sensu-go/6.4/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.4/api/core/cluster-role-bindings.md
@@ -422,6 +422,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterrolebindings (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.4/api/core/cluster-role-bindings.md
@@ -369,6 +369,105 @@ description               | Removes a cluster role binding from Sensu (specified
 example url               | http://hostname:8080/api/core/v2/clusterrolebindings/ops-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster role bindings with response filtering
+
+The `/clusterrolebindings` API endpoint supports [response filtering][3] for a subset of cluster role binding data based on labels and the following fields:
+
+- `clusterrolebinding.name`
+- `clusterrolebinding.role_ref.name`
+- `clusterrolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/clusterrolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role binding definitions][1] whose `role_ref.name` includes `cluster-user`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterrolebindings -G \
+--data-urlencode 'fieldSelector="cluster-user" in clusterrolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterrolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterrolebindings
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/cluster-roles.md
+++ b/content/sensu-go/6.4/api/core/cluster-roles.md
@@ -461,6 +461,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterroles (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/cluster-roles.md
+++ b/content/sensu-go/6.4/api/core/cluster-roles.md
@@ -392,6 +392,141 @@ description               | Removes a cluster role from Sensu (specified by the 
 example url               | http://hostname:8080/api/core/v2/clusterroles/global-event-reader
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster roles with response filtering
+
+The `/clusterroles` API endpoint supports [response filtering][3] for a subset of cluster role data based on labels and the `clusterrole.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/clusterroles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role definitions][1] whose `clusterrole.name` includes `admin`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterroles -G \
+--data-urlencode 'fieldSelector=clusterrole.name matches "admin"'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterroles (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterroles
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/entities.md
+++ b/content/sensu-go/6.4/api/core/entities.md
@@ -777,6 +777,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /entities (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/entities.md
+++ b/content/sensu-go/6.4/api/core/entities.md
@@ -657,6 +657,237 @@ description               | Removes a entity from Sensu (specified by the entity
 example url               | http://hostname:8080/api/core/v2/namespaces/default/entities/server1
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of entities with response filtering
+
+The `/entities` API endpoint supports [response filtering][5] for a subset of entity data based on labels and the following fields:
+
+- `entity.name`
+- `entity.namespace`
+- `entity.deregister`
+- `entity.entity_class`
+- `entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/entities` API endpoint with [response filtering][5], resulting in a JSON array that contains only [entity definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
+--data-urlencode 'fieldSelector="linux" in entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/entities (GET) with response filters | 
+---------------|------
+description    | Returns the list of entities that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/entities
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-entities/entities/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/events.md
+++ b/content/sensu-go/6.4/api/core/events.md
@@ -38,7 +38,9 @@ HTTP/1.1 200 OK
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -155,13 +157,6 @@ HTTP/1.1 200 OK
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -187,7 +182,9 @@ output         | {{< code shell >}}
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -304,13 +301,6 @@ output         | {{< code shell >}}
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -421,7 +411,9 @@ HTTP/1.1 200 OK
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -538,13 +530,6 @@ HTTP/1.1 200 OK
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -676,13 +661,6 @@ HTTP/1.1 200 OK
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "8717b1dc-47d2-4b73-a259-ee2645cadbf5",
     "metadata": {
       "namespace": "default"
@@ -707,7 +685,9 @@ output               | {{< code json >}}
   {
     "check": {
       "command": "check-cpu-usage -w 75 -c 90",
-      "handlers": [],
+      "handlers": [
+        "pagerduty"
+      ],
       "high_flap_threshold": 0,
       "interval": 60,
       "low_flap_threshold": 0,
@@ -824,13 +804,6 @@ output               | {{< code json >}}
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "da53be74-be42-4862-a481-b7e3236e8e6d",
     "metadata": {
       "namespace": "default"
@@ -962,13 +935,6 @@ output               | {{< code json >}}
       },
       "sensu_agent_version": "6.2.7"
     },
-    "pipelines": [
-      {
-        "api_version": "core/v2",
-        "type": "Pipeline",
-        "name": "incident_alerts"
-      }
-    ],
     "id": "8717b1dc-47d2-4b73-a259-ee2645cadbf5",
     "metadata": {
       "namespace": "default"
@@ -997,7 +963,9 @@ HTTP/1.1 200 OK
 {
   "check": {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": [
+      "pagerduty"
+    ],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -1105,13 +1073,6 @@ HTTP/1.1 200 OK
     },
     "sensu_agent_version": "6.2.7"
   },
-  "pipelines": [
-    {
-      "api_version": "core/v2",
-      "type": "Pipeline",
-      "name": "incident_alerts"
-    }
-  ],
   "id": "9a9c7515-0a04-43f3-9351-d8da88942b1b",
   "metadata": {
     "namespace": "default"
@@ -1135,7 +1096,9 @@ output               | {{< code json >}}
 {
   "check": {
     "command": "check-cpu-usage -w 75 -c 90",
-    "handlers": [],
+    "handlers": [
+      "pagerduty"
+    ],
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
@@ -1243,13 +1206,6 @@ output               | {{< code json >}}
     },
     "sensu_agent_version": "6.2.7"
   },
-  "pipelines": [
-    {
-      "api_version": "core/v2",
-      "type": "Pipeline",
-      "name": "incident_alerts"
-    }
-  ],
   "id": "9a9c7515-0a04-43f3-9351-d8da88942b1b",
   "metadata": {
     "namespace": "default"
@@ -1574,6 +1530,467 @@ HTTP/1.1 204 No Content
 description               | Deletes the event created by the specified entity using the specified check.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/events/server1/check-cpu 
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+
+## Get a subset of events with response filtering
+
+The `/events` API endpoint supports [response filtering][10] for a subset of event data based on labels and the following fields:
+
+- `event.name`
+- `event.namespace`
+- `event.is_silenced`
+- `event.check.handlers`
+- `event.check.is_silenced`
+- `event.check.name`
+- `event.check.publish`
+- `event.check.round_robin`
+- `event.check.runtime_assets`
+- `event.check.status`
+- `event.check.subscriptions`
+- `event.entity.deregister`
+- `event.entity.entity_class`
+- `event.entity.name` 
+- `event.entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/events` API endpoint with [response filtering][10], resulting in a JSON array that contains only [event definitions][1] for entities whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
+--data-urlencode 'fieldSelector="linux" in event.entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [
+        "pagerduty"
+      ],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos"
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/events (GET) with response filters | 
+---------------|------
+description    | Returns the list of events that match the [response filters][10] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/events
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [
+        "pagerduty"
+      ],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos"
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2
+  }
+]
+{{< /code >}}
 
 
 [1]: ../../../observability-pipeline/observe-events/events/

--- a/content/sensu-go/6.4/api/core/events.md
+++ b/content/sensu-go/6.4/api/core/events.md
@@ -1771,6 +1771,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /events (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/filters.md
+++ b/content/sensu-go/6.4/api/core/filters.md
@@ -322,6 +322,92 @@ description               | Removes the specified event filter from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/filters/development_filter
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of filters with response filtering
+
+The `/filters` API endpoint supports [response filtering][3] for a subset of filter data based on labels and the following fields:
+
+- `filter.name`
+- `filter.namespace`
+- `filter.action`
+- `filter.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/filters` API endpoint with [response filtering][3], resulting in a JSON array that contains only [filter definitions][1] whose action is `allow`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/filters -G \
+--data-urlencode 'fieldSelector=filter.action == allow'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/filters (GET) with response filters | 
+---------------|------
+description    | Returns the list of filters that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/filters
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-filter/filters/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/filters.md
+++ b/content/sensu-go/6.4/api/core/filters.md
@@ -369,6 +369,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /filters (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/handlers.md
+++ b/content/sensu-go/6.4/api/core/handlers.md
@@ -393,6 +393,93 @@ description               | Removes the specified handler from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/handlers/slack
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of handlers with response filtering
+
+The `/handlers` API endpoint supports [response filtering][3] for a subset of handler data based on labels and the following fields:
+
+- `handler.name`
+- `handler.namespace`
+- `handler.filters`
+- `handler.handlers`
+- `handler.mutator`
+- `handler.type`
+
+### Example
+
+The following example demonstrates a request to the `/handlers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [handler definitions][1] in the `default` namespace **and** whose filters include `state_change_only`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/handlers -G \
+--data-urlencode 'fieldSelector=state_change_only in handler.filters && handler.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/handlers (GET) with response filters | 
+---------------|------
+description    | Returns the list of handlers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/handlers
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.4/api/core/handlers.md
+++ b/content/sensu-go/6.4/api/core/handlers.md
@@ -441,6 +441,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /handlers (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/hooks.md
+++ b/content/sensu-go/6.4/api/core/hooks.md
@@ -353,6 +353,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /hooks (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/hooks.md
+++ b/content/sensu-go/6.4/api/core/hooks.md
@@ -308,6 +308,90 @@ description               | Removes the specified hook from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of hooks with response filtering
+
+The `/hooks` API endpoint supports [response filtering][3] for a subset of hook data based on labels and the following fields:
+
+- `hook.name`
+- `hook.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/hooks` API endpoint with [response filtering][3], resulting in a JSON array that contains only [hook definitions][1] in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/hooks -G \
+--data-urlencode 'fieldSelector=hook.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/hooks (GET) with response filters | 
+---------------|------
+description    | Returns the list of hooks that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/hooks
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/hooks/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/mutators.md
+++ b/content/sensu-go/6.4/api/core/mutators.md
@@ -350,6 +350,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /mutators (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/mutators.md
+++ b/content/sensu-go/6.4/api/core/mutators.md
@@ -311,6 +311,77 @@ description               | Removes the specified mutator from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/mutators/example-mutator
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of mutators with response filtering
+
+The `/mutators` API endpoint supports [response filtering][3] for a subset of mutator data based on labels and the following fields:
+
+- `mutator.name`
+- `mutator.namespace`
+- `mutator.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/mutators` API endpoint with [response filtering][3], resulting in a JSON array that contains only [mutator definitions][1] that are in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/mutators -G \
+--data-urlencode 'fieldSelector=mutator.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/mutators (GET) with response filters | 
+---------------|------
+description    | Returns the list of mutators that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/mutators
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-transform/mutators/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/namespaces.md
+++ b/content/sensu-go/6.4/api/core/namespaces.md
@@ -203,6 +203,44 @@ output         | {{< code shell >}}
 ]
 {{< /code >}}
 
-[1]: ../../../operations/control-access/rbac/
-[2]: ../../#limit-query-parameter
+## Get a subset of namespaces with response filtering
+
+The `/namespaces` API endpoint supports [response filtering][3] for a subset of namespace data based on labels and the field `namespace.name`.
+
+### Example
+
+The following example demonstrates a request to the `/namespaces` API endpoint with [response filtering][3], resulting in a JSON array that contains only the [namespace definitions][1] for the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/namespaces -G \
+--data-urlencode 'fieldSelector=namespace.name == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/namespaces (GET) with response filters | 
+---------------|------
+description    | Returns the list of namespaces that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/namespaces
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/namespaces/
+[2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.4/api/core/namespaces.md
+++ b/content/sensu-go/6.4/api/core/namespaces.md
@@ -223,6 +223,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /namespaces (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/role-bindings.md
+++ b/content/sensu-go/6.4/api/core/role-bindings.md
@@ -400,6 +400,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /rolebindings (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/role-bindings.md
+++ b/content/sensu-go/6.4/api/core/role-bindings.md
@@ -346,6 +346,106 @@ description               | Removes the specified role binding from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/rolebindings/dev-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of role bindings with response filtering
+
+The `/rolebindings` API endpoint supports [response filtering][3] for a subset of role binding data based on labels and the following fields:
+
+- `rolebinding.name`
+- `rolebinding.namespace`
+- `rolebinding.role_ref.name`
+- `rolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/rolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role binding definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/rolebindings -G \
+--data-urlencode 'fieldSelector="event-reader" in rolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/rolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/rolebindings
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/roles.md
+++ b/content/sensu-go/6.4/api/core/roles.md
@@ -491,6 +491,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /roles (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/roles.md
+++ b/content/sensu-go/6.4/api/core/roles.md
@@ -398,6 +398,186 @@ description               | Removes the specified role from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of roles with response filtering
+
+The `/roles` API endpoint supports [response filtering][3] for a subset of role data based on labels and the following fields:
+
+- `role.name`
+- `role.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/roles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/roles -G \
+--data-urlencode 'fieldSelector=role.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/roles (GET) with response filters | 
+---------------|------
+description    | Returns the list of roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/roles
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.4/api/core/silenced.md
+++ b/content/sensu-go/6.4/api/core/silenced.md
@@ -447,6 +447,71 @@ output               | {{< code json >}}
 ]
 {{< /code >}}
 
+## Get a subset of silences with response filtering
+
+The `/silenced` API endpoint supports [response filtering][3] for a subset of silences data based on labels and the following fields:
+
+- `silenced.name`
+- `silenced.namespace`
+- `silenced.check`
+- `silenced.creator`
+- `silenced.expire_on_resolve`
+- `silenced.subscription`
+
+### Example
+
+The following example demonstrates a request to the `/silenced` API endpoint with [response filtering][3], resulting in a JSON array that contains only [silence definitions][1] with the `linux` subscription.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector="linux" in silenced.subscription'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/silenced (GET) with response filters | 
+---------------|------
+description    | Returns the list of silences that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/silenced
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/silencing/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.4/api/core/silenced.md
+++ b/content/sensu-go/6.4/api/core/silenced.md
@@ -484,6 +484,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /silenced (GET) with response filters | 

--- a/content/sensu-go/6.4/api/core/users.md
+++ b/content/sensu-go/6.4/api/core/users.md
@@ -430,7 +430,75 @@ description               | Removes the specified user from the specified group.
 example url               | http://hostname:8080/api/core/v2/users/alice/groups/ops
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-[1]: ../../../operations/control-access/rbac#user-specification
+## Get a subset of users with response filtering
+
+The `/users` API endpoint supports [response filtering][3] for a subset of user data based on labels and the following fields:
+
+- `user.username`
+- `user.disabled`
+- `user.groups`
+
+### Example
+
+The following example demonstrates a request to the `/users` API endpoint with [response filtering][3], resulting in a JSON array that contains only [user definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/users -G \
+--data-urlencode 'fieldSelector="dev" in user.groups'
+
+HTTP/1.1 200 OK
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/users (GET) with response filters | 
+---------------|------
+description    | Returns the list of users that match the [response filters][8] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/users
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/rbac#users
 [2]: ../../#pagination
 [3]: https://en.wikipedia.org/wiki/Bcrypt
 [4]: ../../../sensuctl/#generate-a-password-hash

--- a/content/sensu-go/6.4/api/core/users.md
+++ b/content/sensu-go/6.4/api/core/users.md
@@ -467,6 +467,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /users (GET) with response filters | 

--- a/content/sensu-go/6.4/api/enterprise/secrets.md
+++ b/content/sensu-go/6.4/api/enterprise/secrets.md
@@ -26,7 +26,7 @@ The `/providers` API endpoint provides HTTP GET access to a list of secrets prov
 
 ### Example {#providers-get-example}
 
-The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of secrets providers.
+The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of [secrets provider definitions][1].
 
 {{< code shell >}}
 curl -X GET \
@@ -72,7 +72,7 @@ Learn more in the [secrets providers reference](../../../operations/manage-secre
 description    | Returns the list of secrets providers.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
 query parameters | `types`: Defines which type of secrets provider to retrieve. Join with `&` to retrieve multiple types: `?types=Env&types=VaultProvider`.
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -274,13 +274,89 @@ description               | Deletes the specified provider from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/providers/my_vault
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets providers with response filtering
+
+The `/providers` API endpoint supports [response filtering][3] for a subset of secrets providers data based on labels and the `provider.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/providers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets provider definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/providers -G \
+--data-urlencode 'fieldSelector=provider.name == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/providers (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets providers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
 ## Get all secrets
 
 The `/secrets` API endpoint provides HTTP GET access to a list of secrets.
 
 ### Example {#secrets-get-example}
 
-The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of secrets for the specified namespace.
+The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of [secrets definitions][5] for the specified namespace.
 
 {{< code shell >}}
 curl -X GET \
@@ -311,7 +387,7 @@ HTTP/1.1 200 OK
 ---------------|------
 description    | Returns the list of secrets for the specified namespace.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -460,5 +536,120 @@ description               | Deletes the specified secret from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets/sensu-ansible-token
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets with response filtering
 
-[4]: ../../#response-filtering
+The `/secrets` API endpoint supports [response filtering][3] for a subset of secrets data based on labels and the following fields:
+
+- `secret.name`
+- `secret.namespace`
+- `secret.provider`
+- `secret.id`
+
+### Example
+
+The following example demonstrates a request to the `/secrets` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets definitions][2] for the `vault` provider.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/secrets -G \
+--data-urlencode 'fieldSelector=secret.provider == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/secrets (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/secrets
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/manage-secrets/secrets-providers/
+[2]: ../../../operations/manage-secrets/secrets/
+[3]: ../../#response-filtering

--- a/content/sensu-go/6.4/api/enterprise/secrets.md
+++ b/content/sensu-go/6.4/api/enterprise/secrets.md
@@ -314,6 +314,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /providers (GET) with response filters | 
@@ -596,6 +600,10 @@ HTTP/1.1 200 OK
   }
 ]
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
 
 ### API Specification
 

--- a/content/sensu-go/6.5/api/core/checks.md
+++ b/content/sensu-go/6.5/api/core/checks.md
@@ -532,6 +532,107 @@ description               | Removes a single hook from a check (specified by the
 example url               | http://hostname:8080/api/core/v2/namespaces/default/checks/check-cpu/hooks/critical/hook/process_tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of checks with response filtering
+
+The `/checks` API endpoint supports [response filtering][5] for a subset of check data based on labels and the following fields:
+
+- `check.name`
+- `check.namespace`
+- `check.handlers`
+- `check.publish`
+- `check.round_robin`
+- `check.runtime_assets`
+- `check.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/checks` API endpoint with [response filtering][5], resulting in a JSON array that contains only [check definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
+--data-urlencode 'fieldSelector="linux" in check.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/checks (GET) with response filters | 
+---------------|------
+description    | Returns the list of checks that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/checks
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/checks/
 [2]: ../../../observability-pipeline/observe-schedule/hooks/

--- a/content/sensu-go/6.5/api/core/checks.md
+++ b/content/sensu-go/6.5/api/core/checks.md
@@ -588,6 +588,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /checks (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.5/api/core/cluster-role-bindings.md
@@ -422,6 +422,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterrolebindings (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.5/api/core/cluster-role-bindings.md
@@ -369,6 +369,105 @@ description               | Removes a cluster role binding from Sensu (specified
 example url               | http://hostname:8080/api/core/v2/clusterrolebindings/ops-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster role bindings with response filtering
+
+The `/clusterrolebindings` API endpoint supports [response filtering][3] for a subset of cluster role binding data based on labels and the following fields:
+
+- `clusterrolebinding.name`
+- `clusterrolebinding.role_ref.name`
+- `clusterrolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/clusterrolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role binding definitions][1] whose `role_ref.name` includes `cluster-user`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterrolebindings -G \
+--data-urlencode 'fieldSelector="cluster-user" in clusterrolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterrolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterrolebindings
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/cluster-roles.md
+++ b/content/sensu-go/6.5/api/core/cluster-roles.md
@@ -461,6 +461,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterroles (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/cluster-roles.md
+++ b/content/sensu-go/6.5/api/core/cluster-roles.md
@@ -392,6 +392,141 @@ description               | Removes a cluster role from Sensu (specified by the 
 example url               | http://hostname:8080/api/core/v2/clusterroles/global-event-reader
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster roles with response filtering
+
+The `/clusterroles` API endpoint supports [response filtering][3] for a subset of cluster role data based on labels and the `clusterrole.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/clusterroles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role definitions][1] whose `clusterrole.name` includes `admin`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterroles -G \
+--data-urlencode 'fieldSelector=clusterrole.name matches "admin"'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterroles (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterroles
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/entities.md
+++ b/content/sensu-go/6.5/api/core/entities.md
@@ -777,6 +777,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /entities (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/entities.md
+++ b/content/sensu-go/6.5/api/core/entities.md
@@ -657,6 +657,237 @@ description               | Removes a entity from Sensu (specified by the entity
 example url               | http://hostname:8080/api/core/v2/namespaces/default/entities/server1
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of entities with response filtering
+
+The `/entities` API endpoint supports [response filtering][5] for a subset of entity data based on labels and the following fields:
+
+- `entity.name`
+- `entity.namespace`
+- `entity.deregister`
+- `entity.entity_class`
+- `entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/entities` API endpoint with [response filtering][5], resulting in a JSON array that contains only [entity definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
+--data-urlencode 'fieldSelector="linux" in entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/entities (GET) with response filters | 
+---------------|------
+description    | Returns the list of entities that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/entities
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-entities/entities/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/events.md
+++ b/content/sensu-go/6.5/api/core/events.md
@@ -1620,6 +1620,479 @@ description               | Deletes the event created by the specified entity us
 example url               | http://hostname:8080/api/core/v2/namespaces/default/events/server1/check-cpu 
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of events with response filtering
+
+The `/events` API endpoint supports [response filtering][10] for a subset of event data based on labels and the following fields:
+
+- `event.name`
+- `event.namespace`
+- `event.is_silenced`
+- `event.check.handlers`
+- `event.check.is_silenced`
+- `event.check.name`
+- `event.check.publish`
+- `event.check.round_robin`
+- `event.check.runtime_assets`
+- `event.check.status`
+- `event.check.subscriptions`
+- `event.entity.deregister`
+- `event.entity.entity_class`
+- `event.entity.name` 
+- `event.entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/events` API endpoint with [response filtering][10], resulting in a JSON array that contains only [event definitions][1] for entities whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
+--data-urlencode 'fieldSelector="linux" in event.entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos",
+      "pipelines": []
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2,
+    "pipelines": [
+      {
+        "api_version": "core/v2",
+        "type": "Pipeline",
+        "name": "metrics_workflows"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/events (GET) with response filters | 
+---------------|------
+description    | Returns the list of events that match the [response filters][10] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/events
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos",
+      "pipelines": []
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2,
+    "pipelines": [
+      {
+        "api_version": "core/v2",
+        "type": "Pipeline",
+        "name": "metrics_workflows"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-events/events/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/events.md
+++ b/content/sensu-go/6.5/api/core/events.md
@@ -1866,6 +1866,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /events (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/filters.md
+++ b/content/sensu-go/6.5/api/core/filters.md
@@ -322,6 +322,92 @@ description               | Removes the specified event filter from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/filters/development_filter
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of filters with response filtering
+
+The `/filters` API endpoint supports [response filtering][3] for a subset of filter data based on labels and the following fields:
+
+- `filter.name`
+- `filter.namespace`
+- `filter.action`
+- `filter.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/filters` API endpoint with [response filtering][3], resulting in a JSON array that contains only [filter definitions][1] whose action is `allow`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/filters -G \
+--data-urlencode 'fieldSelector=filter.action == allow'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/filters (GET) with response filters | 
+---------------|------
+description    | Returns the list of filters that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/filters
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-filter/filters/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/filters.md
+++ b/content/sensu-go/6.5/api/core/filters.md
@@ -369,6 +369,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /filters (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/handlers.md
+++ b/content/sensu-go/6.5/api/core/handlers.md
@@ -393,6 +393,93 @@ description               | Removes the specified handler from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/handlers/slack
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of handlers with response filtering
+
+The `/handlers` API endpoint supports [response filtering][3] for a subset of handler data based on labels and the following fields:
+
+- `handler.name`
+- `handler.namespace`
+- `handler.filters`
+- `handler.handlers`
+- `handler.mutator`
+- `handler.type`
+
+### Example
+
+The following example demonstrates a request to the `/handlers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [handler definitions][1] in the `default` namespace **and** whose filters include `state_change_only`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/handlers -G \
+--data-urlencode 'fieldSelector=state_change_only in handler.filters && handler.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/handlers (GET) with response filters | 
+---------------|------
+description    | Returns the list of handlers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/handlers
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.5/api/core/handlers.md
+++ b/content/sensu-go/6.5/api/core/handlers.md
@@ -441,6 +441,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /handlers (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/hooks.md
+++ b/content/sensu-go/6.5/api/core/hooks.md
@@ -353,6 +353,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /hooks (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/hooks.md
+++ b/content/sensu-go/6.5/api/core/hooks.md
@@ -308,6 +308,90 @@ description               | Removes the specified hook from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of hooks with response filtering
+
+The `/hooks` API endpoint supports [response filtering][3] for a subset of hook data based on labels and the following fields:
+
+- `hook.name`
+- `hook.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/hooks` API endpoint with [response filtering][3], resulting in a JSON array that contains only [hook definitions][1] in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/hooks -G \
+--data-urlencode 'fieldSelector=hook.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/hooks (GET) with response filters | 
+---------------|------
+description    | Returns the list of hooks that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/hooks
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/hooks/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/mutators.md
+++ b/content/sensu-go/6.5/api/core/mutators.md
@@ -311,6 +311,109 @@ description               | Removes the specified mutator from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/mutators/example-mutator
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of mutators with response filtering
+
+The `/mutators` API endpoint supports [response filtering][3] for a subset of mutator data based on labels and the following fields:
+
+- `mutator.name`
+- `mutator.namespace`
+- `mutator.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/mutators` API endpoint with [response filtering][3], resulting in a JSON array that contains only [mutator definitions][1] that are in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/mutators -G \
+--data-urlencode 'fieldSelector=mutator.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "add_check_label",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": null,
+    "secrets": null,
+    "type": "javascript",
+    "eval": "data = JSON.parse(JSON.stringify(event)); delete data.check.metadata.name; delete data.entity.metadata.labels.app_id; return JSON.stringify(data)"
+  },
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/mutators (GET) with response filters | 
+---------------|------
+description    | Returns the list of mutators that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/mutators
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "add_check_label",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": null,
+    "secrets": null,
+    "type": "javascript",
+    "eval": "data = JSON.parse(JSON.stringify(event)); delete data.check.metadata.name; delete data.entity.metadata.labels.app_id; return JSON.stringify(data)"
+  },
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-transform/mutators/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/mutators.md
+++ b/content/sensu-go/6.5/api/core/mutators.md
@@ -366,6 +366,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /mutators (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/namespaces.md
+++ b/content/sensu-go/6.5/api/core/namespaces.md
@@ -203,6 +203,44 @@ output         | {{< code shell >}}
 ]
 {{< /code >}}
 
-[1]: ../../../operations/control-access/rbac/
-[2]: ../../#limit-query-parameter
+## Get a subset of namespaces with response filtering
+
+The `/namespaces` API endpoint supports [response filtering][3] for a subset of namespace data based on labels and the field `namespace.name`.
+
+### Example
+
+The following example demonstrates a request to the `/namespaces` API endpoint with [response filtering][3], resulting in a JSON array that contains only the [namespace definitions][1] for the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/namespaces -G \
+--data-urlencode 'fieldSelector=namespace.name == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/namespaces (GET) with response filters | 
+---------------|------
+description    | Returns the list of namespaces that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/namespaces
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/namespaces/
+[2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.5/api/core/namespaces.md
+++ b/content/sensu-go/6.5/api/core/namespaces.md
@@ -223,6 +223,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /namespaces (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/role-bindings.md
+++ b/content/sensu-go/6.5/api/core/role-bindings.md
@@ -400,6 +400,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /rolebindings (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/role-bindings.md
+++ b/content/sensu-go/6.5/api/core/role-bindings.md
@@ -346,6 +346,106 @@ description               | Removes the specified role binding from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/rolebindings/dev-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of role bindings with response filtering
+
+The `/rolebindings` API endpoint supports [response filtering][3] for a subset of role binding data based on labels and the following fields:
+
+- `rolebinding.name`
+- `rolebinding.namespace`
+- `rolebinding.role_ref.name`
+- `rolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/rolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role binding definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/rolebindings -G \
+--data-urlencode 'fieldSelector="event-reader" in rolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/rolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/rolebindings
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/roles.md
+++ b/content/sensu-go/6.5/api/core/roles.md
@@ -491,6 +491,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /roles (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/roles.md
+++ b/content/sensu-go/6.5/api/core/roles.md
@@ -398,6 +398,186 @@ description               | Removes the specified role from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of roles with response filtering
+
+The `/roles` API endpoint supports [response filtering][3] for a subset of role data based on labels and the following fields:
+
+- `role.name`
+- `role.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/roles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/roles -G \
+--data-urlencode 'fieldSelector=role.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/roles (GET) with response filters | 
+---------------|------
+description    | Returns the list of roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/roles
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.5/api/core/silenced.md
+++ b/content/sensu-go/6.5/api/core/silenced.md
@@ -447,6 +447,71 @@ output               | {{< code json >}}
 ]
 {{< /code >}}
 
+## Get a subset of silences with response filtering
+
+The `/silenced` API endpoint supports [response filtering][3] for a subset of silences data based on labels and the following fields:
+
+- `silenced.name`
+- `silenced.namespace`
+- `silenced.check`
+- `silenced.creator`
+- `silenced.expire_on_resolve`
+- `silenced.subscription`
+
+### Example
+
+The following example demonstrates a request to the `/silenced` API endpoint with [response filtering][3], resulting in a JSON array that contains only [silence definitions][1] with the `linux` subscription.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector="linux" in silenced.subscription'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/silenced (GET) with response filters | 
+---------------|------
+description    | Returns the list of silences that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/silenced
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/silencing/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.5/api/core/silenced.md
+++ b/content/sensu-go/6.5/api/core/silenced.md
@@ -484,6 +484,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /silenced (GET) with response filters | 

--- a/content/sensu-go/6.5/api/core/users.md
+++ b/content/sensu-go/6.5/api/core/users.md
@@ -430,7 +430,75 @@ description               | Removes the specified user from the specified group.
 example url               | http://hostname:8080/api/core/v2/users/alice/groups/ops
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-[1]: ../../../operations/control-access/rbac#user-specification
+## Get a subset of users with response filtering
+
+The `/users` API endpoint supports [response filtering][3] for a subset of user data based on labels and the following fields:
+
+- `user.username`
+- `user.disabled`
+- `user.groups`
+
+### Example
+
+The following example demonstrates a request to the `/users` API endpoint with [response filtering][3], resulting in a JSON array that contains only [user definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/users -G \
+--data-urlencode 'fieldSelector="dev" in user.groups'
+
+HTTP/1.1 200 OK
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/users (GET) with response filters | 
+---------------|------
+description    | Returns the list of users that match the [response filters][8] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/users
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/rbac#users
 [2]: ../../#pagination
 [3]: https://en.wikipedia.org/wiki/Bcrypt
 [4]: ../../../sensuctl/#generate-a-password-hash

--- a/content/sensu-go/6.5/api/core/users.md
+++ b/content/sensu-go/6.5/api/core/users.md
@@ -467,6 +467,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /users (GET) with response filters | 

--- a/content/sensu-go/6.5/api/enterprise/secrets.md
+++ b/content/sensu-go/6.5/api/enterprise/secrets.md
@@ -26,7 +26,7 @@ The `/providers` API endpoint provides HTTP GET access to a list of secrets prov
 
 ### Example {#providers-get-example}
 
-The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of secrets providers.
+The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of [secrets provider definitions][1].
 
 {{< code shell >}}
 curl -X GET \
@@ -72,7 +72,7 @@ Learn more in the [secrets providers reference](../../../operations/manage-secre
 description    | Returns the list of secrets providers.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
 query parameters | `types`: Defines which type of secrets provider to retrieve. Join with `&` to retrieve multiple types: `?types=Env&types=VaultProvider`.
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -274,13 +274,89 @@ description               | Deletes the specified provider from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/providers/my_vault
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets providers with response filtering
+
+The `/providers` API endpoint supports [response filtering][3] for a subset of secrets providers data based on labels and the `provider.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/providers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets provider definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/providers -G \
+--data-urlencode 'fieldSelector=provider.name == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/providers (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets providers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
 ## Get all secrets
 
 The `/secrets` API endpoint provides HTTP GET access to a list of secrets.
 
 ### Example {#secrets-get-example}
 
-The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of secrets for the specified namespace.
+The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of [secrets definitions][5] for the specified namespace.
 
 {{< code shell >}}
 curl -X GET \
@@ -311,7 +387,7 @@ HTTP/1.1 200 OK
 ---------------|------
 description    | Returns the list of secrets for the specified namespace.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -460,5 +536,120 @@ description               | Deletes the specified secret from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets/sensu-ansible-token
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets with response filtering
 
-[4]: ../../#response-filtering
+The `/secrets` API endpoint supports [response filtering][3] for a subset of secrets data based on labels and the following fields:
+
+- `secret.name`
+- `secret.namespace`
+- `secret.provider`
+- `secret.id`
+
+### Example
+
+The following example demonstrates a request to the `/secrets` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets definitions][2] for the `vault` provider.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/secrets -G \
+--data-urlencode 'fieldSelector=secret.provider == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/secrets (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/secrets
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/manage-secrets/secrets-providers/
+[2]: ../../../operations/manage-secrets/secrets/
+[3]: ../../#response-filtering

--- a/content/sensu-go/6.5/api/enterprise/secrets.md
+++ b/content/sensu-go/6.5/api/enterprise/secrets.md
@@ -314,6 +314,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /providers (GET) with response filters | 
@@ -596,6 +600,10 @@ HTTP/1.1 200 OK
   }
 ]
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
 
 ### API Specification
 

--- a/content/sensu-go/6.6/api/core/assets.md
+++ b/content/sensu-go/6.6/api/core/assets.md
@@ -382,6 +382,120 @@ description     | Deletes the specified Sensu dynamic runtime asset.
 example URL     | http://hostname:8080/api/core/v2/namespaces/default/assets/sensu-slack-handler
 response codes  | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of assets with response filtering
+
+The `/assets` API endpoint supports [response filtering][3] for a subset of asset data based on labels and the following fields:
+
+- `asset.name`
+- `asset.namespace`
+- `asset.filters`
+
+### Example TODO
+
+The following example demonstrates a request to the `/assets` API endpoint with response filtering, resulting in a JSON array that contains only [dynamic runtime asset definitions][1] with a `windows` filter value.
+
+{{< code shell >}}
+curl -H "Authorization: Key X" http://127.0.0.1:8080/api/core/v2/assets -G \
+--data-urlencode 'fieldSelector="entity.system.os == 'windows'" in asset.filters'
+
+curl -H "Authorization: Key X" http://127.0.0.1:8080/api/core/v2/assets -G \
+--data-urlencode 'fieldSelector="entity.system.os == 'linux'" in asset.filters'
+
+curl -H "Authorization: Key X" http://127.0.0.1:8080/api/core/v2/assets -G \
+--data-urlencode 'fieldSelector=check in asset.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "url": "https://github.com/sensu/sensu-influxdb-handler/releases/download/3.1.2/sensu-influxdb-handler_3.1.2_linux_amd64.tar.gz",
+    "sha512": "612c6ff9928841090c4d23bf20aaf7558e4eed8977a848cf9e2899bb13a13e7540bac2b63e324f39d9b1257bb479676bc155b24e21bf93c722b812b0f15cb3bd",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu-influxdb-handler",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://github.com/sensu/sensu-slack-handler/releases/download/1.0.3/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
+    "sha512": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu-slack-handler",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification {#assets-get-specification}
+
+/assets (GET)  | 
+---------------|------
+description    | Returns the list of dynamic runtime assets.
+example url    | http://hostname:8080/api/core/v2/namespaces/default/assets
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response filtering | This endpoint supports [API response filtering][3].
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "url": "https://github.com/sensu/sensu-influxdb-handler/releases/download/3.1.2/sensu-influxdb-handler_3.1.2_linux_amd64.tar.gz",
+    "sha512": "612c6ff9928841090c4d23bf20aaf7558e4eed8977a848cf9e2899bb13a13e7540bac2b63e324f39d9b1257bb479676bc155b24e21bf93c722b812b0f15cb3bd",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu-influxdb-handler",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://github.com/sensu/sensu-slack-handler/releases/download/1.0.3/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
+    "sha512": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu-slack-handler",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../plugins/assets/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/checks.md
+++ b/content/sensu-go/6.6/api/core/checks.md
@@ -532,6 +532,107 @@ description               | Removes a single hook from a check (specified by the
 example url               | http://hostname:8080/api/core/v2/namespaces/default/checks/check-cpu/hooks/critical/hook/process_tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of checks with response filtering
+
+The `/checks` API endpoint supports [response filtering][5] for a subset of check data based on labels and the following fields:
+
+- `check.name`
+- `check.namespace`
+- `check.handlers`
+- `check.publish`
+- `check.round_robin`
+- `check.runtime_assets`
+- `check.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/checks` API endpoint with [response filtering][5], resulting in a JSON array that contains only [check definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/checks -G \
+--data-urlencode 'fieldSelector="linux" in check.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/checks (GET) with response filters | 
+---------------|------
+description    | Returns the list of checks that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/checks
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "command": "check-cpu-usage -w 75 -c 90",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": [
+      "check-cpu-usage"
+    ],
+    "subscriptions": [
+      "system"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "secrets": null,
+    "pipelines": []
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/checks/
 [2]: ../../../observability-pipeline/observe-schedule/hooks/

--- a/content/sensu-go/6.6/api/core/checks.md
+++ b/content/sensu-go/6.6/api/core/checks.md
@@ -588,6 +588,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /checks (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.6/api/core/cluster-role-bindings.md
@@ -422,6 +422,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterrolebindings (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/cluster-role-bindings.md
+++ b/content/sensu-go/6.6/api/core/cluster-role-bindings.md
@@ -369,6 +369,105 @@ description               | Removes a cluster role binding from Sensu (specified
 example url               | http://hostname:8080/api/core/v2/clusterrolebindings/ops-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster role bindings with response filtering
+
+The `/clusterrolebindings` API endpoint supports [response filtering][3] for a subset of cluster role binding data based on labels and the following fields:
+
+- `clusterrolebinding.name`
+- `clusterrolebinding.role_ref.name`
+- `clusterrolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/clusterrolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role binding definitions][1] whose `role_ref.name` includes `cluster-user`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterrolebindings -G \
+--data-urlencode 'fieldSelector="cluster-user" in clusterrolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterrolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterrolebindings
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "ann-binder",
+      "created_by": "admin"
+    }
+  },
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "bonita"
+      }
+    ],
+    "role_ref": {
+      "type": "ClusterRole",
+      "name": "cluster-user"
+    },
+    "metadata": {
+      "name": "bonita-binder",
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/cluster-roles.md
+++ b/content/sensu-go/6.6/api/core/cluster-roles.md
@@ -461,6 +461,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /clusterroles (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/cluster-roles.md
+++ b/content/sensu-go/6.6/api/core/cluster-roles.md
@@ -392,6 +392,141 @@ description               | Removes a cluster role from Sensu (specified by the 
 example url               | http://hostname:8080/api/core/v2/clusterroles/global-event-reader
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of cluster roles with response filtering
+
+The `/clusterroles` API endpoint supports [response filtering][3] for a subset of cluster role data based on labels and the `clusterrole.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/clusterroles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [cluster role definitions][1] whose `clusterrole.name` includes `admin`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/clusterroles -G \
+--data-urlencode 'fieldSelector=clusterrole.name matches "admin"'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/clusterroles (GET) with response filters | 
+---------------|------
+description    | Returns the list of cluster roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/clusterroles
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "silenced",
+          "roles",
+          "rolebindings"
+        ],
+        "resource_names": null
+      },
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "*"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "cluster-admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/entities.md
+++ b/content/sensu-go/6.6/api/core/entities.md
@@ -777,6 +777,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /entities (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/entities.md
+++ b/content/sensu-go/6.6/api/core/entities.md
@@ -657,6 +657,237 @@ description               | Removes a entity from Sensu (specified by the entity
 example url               | http://hostname:8080/api/core/v2/namespaces/default/entities/server1
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of entities with response filtering
+
+The `/entities` API endpoint supports [response filtering][5] for a subset of entity data based on labels and the following fields:
+
+- `entity.name`
+- `entity.namespace`
+- `entity.deregister`
+- `entity.entity_class`
+- `entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/entities` API endpoint with [response filtering][5], resulting in a JSON array that contains only [entity definitions][1] whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/entities -G \
+--data-urlencode 'fieldSelector="linux" in entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/entities (GET) with response filters | 
+---------------|------
+description    | Returns the list of entities that match the [response filters][5] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/entities
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "entity_class": "agent",
+    "system": {
+      "network": {
+        "interfaces": null
+      },
+      "libc_type": "",
+      "vm_system": "",
+      "vm_role": "",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:datastore01"
+    ],
+    "last_seen": 0,
+    "deregister": false,
+    "deregistration": {},
+    "metadata": {
+      "name": "datastore01",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1",
+        "service_type": "datastore",
+        "sensu.io/managed_by": "sensuctl"
+      }
+    },
+    "sensu_agent_version": ""
+  },
+  {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "sensu-centos",
+      "os": "linux",
+      "platform": "centos",
+      "platform_family": "rhel",
+      "platform_version": "7.5.1804",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8",
+              "::1/128"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "08:00:27:8b:c9:3f",
+            "addresses": [
+              "10.0.2.15/24",
+              "fe80::c68e:8fd8:32f0:7c5d/64"
+            ]
+          },
+          {
+            "name": "eth1",
+            "mac": "08:00:27:3b:a9:9f",
+            "addresses": [
+              "192.168.56.23/24",
+              "fe80::a00:27ff:fe3b:a99f/64"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64",
+      "libc_type": "glibc",
+      "vm_system": "vbox",
+      "vm_role": "guest",
+      "cloud_provider": "",
+      "processes": null
+    },
+    "subscriptions": [
+      "linux",
+      "entity:sensu-centos"
+    ],
+    "last_seen": 1644615964,
+    "deregister": false,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "sensu-centos",
+      "namespace": "default"
+    },
+    "sensu_agent_version": "6.6.5"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-entities/entities/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/events.md
+++ b/content/sensu-go/6.6/api/core/events.md
@@ -1620,6 +1620,479 @@ description               | Deletes the event created by the specified entity us
 example url               | http://hostname:8080/api/core/v2/namespaces/default/events/server1/check-cpu 
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of events with response filtering
+
+The `/events` API endpoint supports [response filtering][10] for a subset of event data based on labels and the following fields:
+
+- `event.name`
+- `event.namespace`
+- `event.is_silenced`
+- `event.check.handlers`
+- `event.check.is_silenced`
+- `event.check.name`
+- `event.check.publish`
+- `event.check.round_robin`
+- `event.check.runtime_assets`
+- `event.check.status`
+- `event.check.subscriptions`
+- `event.entity.deregister`
+- `event.entity.entity_class`
+- `event.entity.name` 
+- `event.entity.subscriptions`
+
+### Example
+
+The following example demonstrates a request to the `/events` API endpoint with [response filtering][10], resulting in a JSON array that contains only [event definitions][1] for entities whose subscriptions include `linux`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/events -G \
+--data-urlencode 'fieldSelector="linux" in event.entity.subscriptions'
+
+HTTP/1.1 200 OK
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos",
+      "pipelines": []
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2,
+    "pipelines": [
+      {
+        "api_version": "core/v2",
+        "type": "Pipeline",
+        "name": "metrics_workflows"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/events (GET) with response filters | 
+---------------|------
+description    | Returns the list of events that match the [response filters][10] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/events
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "timestamp": 1644848031,
+    "entity": {
+      "entity_class": "agent",
+      "system": {
+        "hostname": "sensu-centos",
+        "os": "linux",
+        "platform": "centos",
+        "platform_family": "rhel",
+        "platform_version": "7.5.1804",
+        "network": {
+          "interfaces": [
+            {
+              "name": "lo",
+              "addresses": [
+                "127.0.0.1/8",
+                "::1/128"
+              ]
+            },
+            {
+              "name": "eth0",
+              "mac": "08:00:27:8b:c9:3f",
+              "addresses": [
+                "10.0.2.15/24",
+                "fe80::c68e:8fd8:32f0:7c5d/64"
+              ]
+            },
+            {
+              "name": "eth1",
+              "mac": "08:00:27:3b:a9:9f",
+              "addresses": [
+                "192.168.56.23/24",
+                "fe80::a00:27ff:fe3b:a99f/64"
+              ]
+            }
+          ]
+        },
+        "arch": "amd64",
+        "libc_type": "glibc",
+        "vm_system": "vbox",
+        "vm_role": "guest",
+        "cloud_provider": "",
+        "processes": null
+      },
+      "subscriptions": [
+        "linux",
+        "entity:sensu-centos",
+        "system"
+      ],
+      "last_seen": 1644848029,
+      "deregister": false,
+      "deregistration": {},
+      "user": "agent",
+      "redact": [
+        "password",
+        "passwd",
+        "pass",
+        "api_key",
+        "api_token",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "secret"
+      ],
+      "metadata": {
+        "name": "sensu-centos",
+        "namespace": "default",
+        "created_by": "admin"
+      },
+      "sensu_agent_version": "6.6.5"
+    },
+    "check": {
+      "command": "check-cpu-usage -w 1 -c 2",
+      "handlers": [],
+      "high_flap_threshold": 0,
+      "interval": 15,
+      "low_flap_threshold": 0,
+      "publish": true,
+      "runtime_assets": [
+        "check-cpu-usage"
+      ],
+      "subscriptions": [
+        "system"
+      ],
+      "proxy_entity_name": "",
+      "check_hooks": null,
+      "stdin": false,
+      "subdue": null,
+      "ttl": 0,
+      "timeout": 0,
+      "round_robin": false,
+      "duration": 2.010462294,
+      "executed": 1644848029,
+      "history": [
+        {
+          "status": 2,
+          "executed": 1644847740
+        },
+        {
+          "status": 1,
+          "executed": 1644847755
+        },
+        {
+          "status": 1,
+          "executed": 1644847770
+        },
+        {
+          "status": 2,
+          "executed": 1644847785
+        },
+        {
+          "status": 2,
+          "executed": 1644847800
+        },
+        {
+          "status": 1,
+          "executed": 1644847815
+        },
+        {
+          "status": 2,
+          "executed": 1644847830
+        },
+        {
+          "status": 1,
+          "executed": 1644847845
+        },
+        {
+          "status": 1,
+          "executed": 1644847860
+        },
+        {
+          "status": 1,
+          "executed": 1644847875
+        },
+        {
+          "status": 1,
+          "executed": 1644847890
+        },
+        {
+          "status": 0,
+          "executed": 1644847905
+        },
+        {
+          "status": 2,
+          "executed": 1644847920
+        },
+        {
+          "status": 1,
+          "executed": 1644847935
+        },
+        {
+          "status": 0,
+          "executed": 1644847950
+        },
+        {
+          "status": 0,
+          "executed": 1644847965
+        },
+        {
+          "status": 2,
+          "executed": 1644847980
+        },
+        {
+          "status": 2,
+          "executed": 1644847995
+        },
+        {
+          "status": 1,
+          "executed": 1644848010
+        },
+        {
+          "status": 1,
+          "executed": 1644848014
+        },
+        {
+          "status": 0,
+          "executed": 1644848029
+        }
+      ],
+      "issued": 1644848029,
+      "output": "check-cpu-usage OK: 0.51% CPU usage | cpu_idle=99.49, cpu_system=0.51, cpu_user=0.00, cpu_nice=0.00, cpu_iowait=0.00, cpu_irq=0.00, cpu_softirq=0.00, cpu_steal=0.00, cpu_guest=0.00, cpu_guestnice=0.00\n",
+      "state": "passing",
+      "status": 0,
+      "total_state_change": 59,
+      "last_ok": 1644848029,
+      "occurrences": 1,
+      "occurrences_watermark": 2,
+      "output_metric_format": "",
+      "output_metric_handlers": null,
+      "env_vars": null,
+      "metadata": {
+        "name": "check_cpu",
+        "namespace": "default"
+      },
+      "secrets": null,
+      "is_silenced": false,
+      "scheduler": "memory",
+      "processed_by": "sensu-centos",
+      "pipelines": []
+    },
+    "metadata": {
+      "namespace": "default"
+    },
+    "id": "f5ef6190-a8e2-4660-9ad1-02ae0a2e89f4",
+    "sequence": 2,
+    "pipelines": [
+      {
+        "api_version": "core/v2",
+        "type": "Pipeline",
+        "name": "metrics_workflows"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-events/events/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/events.md
+++ b/content/sensu-go/6.6/api/core/events.md
@@ -1866,6 +1866,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /events (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/filters.md
+++ b/content/sensu-go/6.6/api/core/filters.md
@@ -322,6 +322,92 @@ description               | Removes the specified event filter from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/filters/development_filter
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of filters with response filtering
+
+The `/filters` API endpoint supports [response filtering][3] for a subset of filter data based on labels and the following fields:
+
+- `filter.name`
+- `filter.namespace`
+- `filter.action`
+- `filter.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/filters` API endpoint with [response filtering][3], resulting in a JSON array that contains only [filter definitions][1] whose action is `allow`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/filters -G \
+--data-urlencode 'fieldSelector=filter.action == allow'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/filters (GET) with response filters | 
+---------------|------
+description    | Returns the list of filters that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/filters
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "filter_interval_60_hourly",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.interval == 60",
+      "event.check.occurrences == 1 || event.check.occurrences % 60 == 0"
+    ],
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "state_change_only",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "action": "allow",
+    "expressions": [
+      "event.check.occurrences == 1"
+    ],
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-filter/filters/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/filters.md
+++ b/content/sensu-go/6.6/api/core/filters.md
@@ -369,6 +369,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /filters (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/handlers.md
+++ b/content/sensu-go/6.6/api/core/handlers.md
@@ -393,6 +393,93 @@ description               | Removes the specified handler from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/handlers/slack
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of handlers with response filtering
+
+The `/handlers` API endpoint supports [response filtering][3] for a subset of handler data based on labels and the following fields:
+
+- `handler.name`
+- `handler.namespace`
+- `handler.filters`
+- `handler.handlers`
+- `handler.mutator`
+- `handler.type`
+
+### Example
+
+The following example demonstrates a request to the `/handlers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [handler definitions][1] in the `default` namespace **and** whose filters include `state_change_only`.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/handlers -G \
+--data-urlencode 'fieldSelector=state_change_only in handler.filters && handler.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/handlers (GET) with response filters | 
+---------------|------
+description    | Returns the list of handlers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/handlers
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "slack",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "type": "pipe",
+    "command": "sensu-slack-handler --channel '#monitoring'",
+    "timeout": 0,
+    "handlers": null,
+    "filters": [
+      "state_change_only"
+    ],
+    "env_vars": null,
+    "runtime_assets": [
+      "sensu-slack-handler"
+    ],
+    "secrets": [
+      {
+        "name": "SLACK_WEBHOOK_URL",
+        "secret": "slack_webhook_url"
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/handlers/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.6/api/core/handlers.md
+++ b/content/sensu-go/6.6/api/core/handlers.md
@@ -441,6 +441,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /handlers (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/hooks.md
+++ b/content/sensu-go/6.6/api/core/hooks.md
@@ -353,6 +353,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /hooks (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/hooks.md
+++ b/content/sensu-go/6.6/api/core/hooks.md
@@ -308,6 +308,90 @@ description               | Removes the specified hook from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/hooks/process-tree
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of hooks with response filtering
+
+The `/hooks` API endpoint supports [response filtering][3] for a subset of hook data based on labels and the following fields:
+
+- `hook.name`
+- `hook.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/hooks` API endpoint with [response filtering][3], resulting in a JSON array that contains only [hook definitions][1] in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/hooks -G \
+--data-urlencode 'fieldSelector=hook.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/hooks (GET) with response filters | 
+---------------|------
+description    | Returns the list of hooks that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/hooks
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "process_tree",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "command": "ps aux",
+    "timeout": 10,
+    "stdin": false,
+    "runtime_assets": null
+  },
+  {
+    "metadata": {
+      "name": "restart_nginx",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "sudo systemctl start nginx",
+    "timeout": 60,
+    "stdin": false,
+    "runtime_assets": null
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-schedule/hooks/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/mutators.md
+++ b/content/sensu-go/6.6/api/core/mutators.md
@@ -311,6 +311,109 @@ description               | Removes the specified mutator from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/mutators/example-mutator
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of mutators with response filtering
+
+The `/mutators` API endpoint supports [response filtering][3] for a subset of mutator data based on labels and the following fields:
+
+- `mutator.name`
+- `mutator.namespace`
+- `mutator.runtime_assets`
+
+### Example
+
+The following example demonstrates a request to the `/mutators` API endpoint with [response filtering][3], resulting in a JSON array that contains only [mutator definitions][1] that are in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/mutators -G \
+--data-urlencode 'fieldSelector=mutator.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "add_check_label",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": null,
+    "secrets": null,
+    "type": "javascript",
+    "eval": "data = JSON.parse(JSON.stringify(event)); delete data.check.metadata.name; delete data.entity.metadata.labels.app_id; return JSON.stringify(data)"
+  },
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/mutators (GET) with response filters | 
+---------------|------
+description    | Returns the list of mutators that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/mutators
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "add_check_label",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": null,
+    "secrets": null,
+    "type": "javascript",
+    "eval": "data = JSON.parse(JSON.stringify(event)); delete data.check.metadata.name; delete data.entity.metadata.labels.app_id; return JSON.stringify(data)"
+  },
+  {
+    "metadata": {
+      "name": "example-mutator",
+      "namespace": "production",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    },
+    "command": "example_mutator.go",
+    "timeout": 0,
+    "env_vars": null,
+    "runtime_assets": [
+      "example-mutator-asset"
+    ],
+    "secrets": null,
+    "type": "pipe"
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../observability-pipeline/observe-transform/mutators/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/mutators.md
+++ b/content/sensu-go/6.6/api/core/mutators.md
@@ -366,6 +366,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /mutators (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/namespaces.md
+++ b/content/sensu-go/6.6/api/core/namespaces.md
@@ -45,7 +45,7 @@ HTTP/1.1 200 OK
 ---------------|------
 description    | Returns the list of namespaces.
 example url    | http://hostname:8080/api/core/v2/namespaces
-pagination     | This endpoint supports pagination using the [`limit` query parameter][2].
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
 response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
@@ -203,6 +203,44 @@ output         | {{< code shell >}}
 ]
 {{< /code >}}
 
-[1]: ../../../operations/control-access/rbac/
-[2]: ../../#limit-query-parameter
+## Get a subset of namespaces with response filtering
+
+The `/namespaces` API endpoint supports [response filtering][3] for a subset of namespace data based on labels and the field `namespace.name`.
+
+### Example
+
+The following example demonstrates a request to the `/namespaces` API endpoint with [response filtering][3], resulting in a JSON array that contains only the [namespace definitions][1] for the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/namespaces -G \
+--data-urlencode 'fieldSelector=namespace.name == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/namespaces (GET) with response filters | 
+---------------|------
+description    | Returns the list of namespaces that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/namespaces
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "name": "production"
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/namespaces/
+[2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.6/api/core/namespaces.md
+++ b/content/sensu-go/6.6/api/core/namespaces.md
@@ -223,6 +223,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /namespaces (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/role-bindings.md
+++ b/content/sensu-go/6.6/api/core/role-bindings.md
@@ -400,6 +400,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /rolebindings (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/role-bindings.md
+++ b/content/sensu-go/6.6/api/core/role-bindings.md
@@ -346,6 +346,106 @@ description               | Removes the specified role binding from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/rolebindings/dev-binding
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of role bindings with response filtering
+
+The `/rolebindings` API endpoint supports [response filtering][3] for a subset of role binding data based on labels and the following fields:
+
+- `rolebinding.name`
+- `rolebinding.namespace`
+- `rolebinding.role_ref.name`
+- `rolebinding.role_ref.type`
+
+### Example
+
+The following example demonstrates a request to the `/rolebindings` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role binding definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/rolebindings -G \
+--data-urlencode 'fieldSelector="event-reader" in rolebinding.role_ref.name'
+
+HTTP/1.1 200 OK
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/rolebindings (GET) with response filters | 
+---------------|------
+description    | Returns the list of role bindings that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/rolebindings
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "subjects": [
+      {
+        "type": "User",
+        "name": "ann"
+      },
+      {
+        "type": "User",
+        "name": "bonita"
+      },
+      {
+        "type": "Group",
+        "name": "admins"
+      },
+      {
+        "type": "Group",
+        "name": "read-events"
+      }
+    ],
+    "role_ref": {
+      "type": "Role",
+      "name": "event-reader"
+    },
+    "metadata": {
+      "name": "event-reader-binding",
+      "namespace": "default",
+      "labels": {
+        "sensu.io/managed_by": "sensuctl"
+      },
+      "created_by": "admin"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/roles.md
+++ b/content/sensu-go/6.6/api/core/roles.md
@@ -491,6 +491,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /roles (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/roles.md
+++ b/content/sensu-go/6.6/api/core/roles.md
@@ -398,6 +398,186 @@ description               | Removes the specified role from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/roles/read-only
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of roles with response filtering
+
+The `/roles` API endpoint supports [response filtering][3] for a subset of role data based on labels and the following fields:
+
+- `role.name`
+- `role.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/roles` API endpoint with [response filtering][3], resulting in a JSON array that contains only [role definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/roles -G \
+--data-urlencode 'fieldSelector=role.namespace == default'
+
+HTTP/1.1 200 OK
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/roles (GET) with response filters | 
+---------------|------
+description    | Returns the list of roles that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/roles
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "*"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "admin_role",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list",
+          "create",
+          "update",
+          "delete"
+        ],
+        "resources": [
+          "assets",
+          "checks",
+          "entities",
+          "events",
+          "filters",
+          "handlers",
+          "hooks",
+          "mutators",
+          "pipelines",
+          "rolebindings",
+          "roles",
+          "silenced"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "namespaced-resources-all-verbs",
+      "namespace": "default",
+      "created_by": "admin"
+    }
+  },
+  {
+    "rules": [
+      {
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "resources": [
+          "events"
+        ],
+        "resource_names": null
+      }
+    ],
+    "metadata": {
+      "name": "system:pipeline",
+      "namespace": "default"
+    }
+  }
+]
+{{< /code >}}
+
 
 [1]: ../../../operations/control-access/rbac/
 [2]: ../../#pagination

--- a/content/sensu-go/6.6/api/core/silenced.md
+++ b/content/sensu-go/6.6/api/core/silenced.md
@@ -447,6 +447,71 @@ output               | {{< code json >}}
 ]
 {{< /code >}}
 
+## Get a subset of silences with response filtering
+
+The `/silenced` API endpoint supports [response filtering][3] for a subset of silences data based on labels and the following fields:
+
+- `silenced.name`
+- `silenced.namespace`
+- `silenced.check`
+- `silenced.creator`
+- `silenced.expire_on_resolve`
+- `silenced.subscription`
+
+### Example
+
+The following example demonstrates a request to the `/silenced` API endpoint with [response filtering][3], resulting in a JSON array that contains only [silence definitions][1] with the `linux` subscription.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/silenced -G \
+--data-urlencode 'fieldSelector="linux" in silenced.subscription'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/silenced (GET) with response filters | 
+---------------|------
+description    | Returns the list of silences that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/silenced
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "linux:*",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "expire": -1,
+    "expire_on_resolve": false,
+    "creator": "admin",
+    "subscription": "linux",
+    "begin": 1644868317,
+    "expire_at": 0
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/silencing/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.6/api/core/silenced.md
+++ b/content/sensu-go/6.6/api/core/silenced.md
@@ -484,6 +484,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /silenced (GET) with response filters | 

--- a/content/sensu-go/6.6/api/core/users.md
+++ b/content/sensu-go/6.6/api/core/users.md
@@ -430,7 +430,75 @@ description               | Removes the specified user from the specified group.
 example url               | http://hostname:8080/api/core/v2/users/alice/groups/ops
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
-[1]: ../../../operations/control-access/rbac#user-specification
+## Get a subset of users with response filtering
+
+The `/users` API endpoint supports [response filtering][3] for a subset of user data based on labels and the following fields:
+
+- `user.username`
+- `user.disabled`
+- `user.groups`
+
+### Example
+
+The following example demonstrates a request to the `/users` API endpoint with [response filtering][3], resulting in a JSON array that contains only [user definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/users -G \
+--data-urlencode 'fieldSelector="dev" in user.groups'
+
+HTTP/1.1 200 OK
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/users (GET) with response filters | 
+---------------|------
+description    | Returns the list of users that match the [response filters][8] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/users
+pagination     | This endpoint supports [pagination][2] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "username": "alice",
+    "groups": [
+      "ops",
+      "dev"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "balan",
+    "groups": [
+      "testing",
+      "dev"
+    ],
+    "disabled": false
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/control-access/rbac#users
 [2]: ../../#pagination
 [3]: https://en.wikipedia.org/wiki/Bcrypt
 [4]: ../../../sensuctl/#generate-a-password-hash

--- a/content/sensu-go/6.6/api/core/users.md
+++ b/content/sensu-go/6.6/api/core/users.md
@@ -467,6 +467,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /users (GET) with response filters | 

--- a/content/sensu-go/6.6/api/enterprise/secrets.md
+++ b/content/sensu-go/6.6/api/enterprise/secrets.md
@@ -26,7 +26,7 @@ The `/providers` API endpoint provides HTTP GET access to a list of secrets prov
 
 ### Example {#providers-get-example}
 
-The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of secrets providers.
+The following example demonstrates a request to the `/providers` API endpoint, resulting in a list of [secrets provider definitions][1].
 
 {{< code shell >}}
 curl -X GET \
@@ -72,7 +72,7 @@ Learn more in the [secrets providers reference](../../../operations/manage-secre
 description    | Returns the list of secrets providers.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
 query parameters | `types`: Defines which type of secrets provider to retrieve. Join with `&` to retrieve multiple types: `?types=Env&types=VaultProvider`.
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -274,13 +274,89 @@ description               | Deletes the specified provider from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/providers/my_vault
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets providers with response filtering
+
+The `/providers` API endpoint supports [response filtering][3] for a subset of secrets providers data based on labels and the `provider.name` field.
+
+### Example
+
+The following example demonstrates a request to the `/providers` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets provider definitions][1] that are in the `default` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/providers -G \
+--data-urlencode 'fieldSelector=provider.name == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/providers (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets providers that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/providers
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "VaultProvider",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "vault",
+      "created_by": "admin"
+    },
+    "spec": {
+      "client": {
+        "address": "http://localhost:8200",
+        "agent_address": "",
+        "max_retries": 2,
+        "rate_limiter": {
+          "burst": 100,
+          "limit": 10
+        },
+        "timeout": "20s",
+        "tls": null,
+        "token": "\\u003croot_token\\u003e",
+        "version": "v2"
+      }
+    }
+  }
+]
+{{< /code >}}
+
 ## Get all secrets
 
 The `/secrets` API endpoint provides HTTP GET access to a list of secrets.
 
 ### Example {#secrets-get-example}
 
-The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of secrets for the specified namespace.
+The following example demonstrates a request to the `/secrets` API endpoint, resulting in a list of [secrets definitions][5] for the specified namespace.
 
 {{< code shell >}}
 curl -X GET \
@@ -311,7 +387,7 @@ HTTP/1.1 200 OK
 ---------------|------
 description    | Returns the list of secrets for the specified namespace.
 example url    | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets
-response filtering | This endpoint supports [API response filtering][4].
+response filtering | This endpoint supports [API response filtering][3].
 response type  | Array
 response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 output         | {{< code shell >}}
@@ -460,5 +536,120 @@ description               | Deletes the specified secret from Sensu.
 example url               | http://hostname:8080/api/enterprise/secrets/v1/namespaces/default/secrets/sensu-ansible-token
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of secrets with response filtering
 
-[4]: ../../#response-filtering
+The `/secrets` API endpoint supports [response filtering][3] for a subset of secrets data based on labels and the following fields:
+
+- `secret.name`
+- `secret.namespace`
+- `secret.provider`
+- `secret.id`
+
+### Example
+
+The following example demonstrates a request to the `/secrets` API endpoint with [response filtering][3], resulting in a JSON array that contains only [secrets definitions][2] for the `vault` provider.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/enterprise/secrets/v1/secrets -G \
+--data-urlencode 'fieldSelector=secret.provider == vault'
+
+HTTP/1.1 200 OK
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+### API Specification
+
+/secrets (GET) with response filters | 
+---------------|------
+description    | Returns the list of secrets that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/enterprise/secrets/v1/secrets
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "pagerduty_key",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/pagerduty#key",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sensu-ansible",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/database#password",
+      "provider": "vault"
+    }
+  },
+  {
+    "type": "Secret",
+    "api_version": "secrets/v1",
+    "metadata": {
+      "name": "sumologic_url",
+      "namespace": "default",
+      "created_by": "admin"
+    },
+    "spec": {
+      "id": "secret/sumologic#key",
+      "provider": "vault"
+    }
+  }
+]
+{{< /code >}}
+
+
+[1]: ../../../operations/manage-secrets/secrets-providers/
+[2]: ../../../operations/manage-secrets/secrets/
+[3]: ../../#response-filtering

--- a/content/sensu-go/6.6/api/enterprise/secrets.md
+++ b/content/sensu-go/6.6/api/enterprise/secrets.md
@@ -314,6 +314,10 @@ HTTP/1.1 200 OK
 ]
 {{< /code >}}
 
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
 ### API Specification
 
 /providers (GET) with response filters | 
@@ -596,6 +600,10 @@ HTTP/1.1 200 OK
   }
 ]
 {{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
 
 ### API Specification
 


### PR DESCRIPTION
## Description
For API endpoints that support response filtering, adds an explanation and example on individual API doc pages, with links to the API overview response filtering section.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3661