### PR TITLE
Update table of response filtering field selectors

### DIFF
--- a/content/sensu-go/6.3/api/_index.md
+++ b/content/sensu-go/6.3/api/_index.md
@@ -425,7 +425,7 @@ Here's the list of available fields:
 | ClusterRole | `clusterrole.name` |
 | ClusterRoleBinding | `clusterrolebinding.name` `clusterrolebinding.role_ref.name` `clusterrolebinding.role_ref.type`|
 | Entity | `entity.name` `entity.namespace` `entity.deregister` `entity.entity_class` `entity.subscriptions` |
-| Event | `event.is_silenced` `event.name` `event.namespace` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
+| Event | `event.name` `event.namespace` `event.is_silenced` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.state` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
 | Extension | `extension.name` `extension.namespace` |
 | Filter | `filter.name` `filter.namespace` `filter.action` `filter.runtime_assets` |
 | Handler | `handler.name` `handler.namespace` `handler.filters` `handler.handlers` `handler.mutator` `handler.type`| 
@@ -435,7 +435,7 @@ Here's the list of available fields:
 | Role | `role.name` `role.namespace` |
 | RoleBinding | `rolebinding.name` `rolebinding.namespace` `rolebinding.role_ref.name` `rolebinding.role_ref.type`|
 | Secrets | `secret.name` `secret.namespace` `secret.provider` `secret.id` |
-| SecretsProviders | `provider.name` `provider.namespace` |
+| SecretsProviders | `provider.name` |
 | Silenced | `silenced.name` `silenced.namespace` `silenced.check` `silenced.creator` `silenced.expire_on_resolve` `silenced.subscription` |
 | User | `user.username` `user.disabled` `user.groups` |
 

--- a/content/sensu-go/6.4/api/_index.md
+++ b/content/sensu-go/6.4/api/_index.md
@@ -425,7 +425,7 @@ Here's the list of available fields:
 | ClusterRole | `clusterrole.name` |
 | ClusterRoleBinding | `clusterrolebinding.name` `clusterrolebinding.role_ref.name` `clusterrolebinding.role_ref.type`|
 | Entity | `entity.name` `entity.namespace` `entity.deregister` `entity.entity_class` `entity.subscriptions` |
-| Event | `event.is_silenced` `event.name` `event.namespace` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
+| Event | `event.name` `event.namespace` `event.is_silenced` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.state` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
 | Extension | `extension.name` `extension.namespace` |
 | Filter | `filter.name` `filter.namespace` `filter.action` `filter.runtime_assets` |
 | Handler | `handler.name` `handler.namespace` `handler.filters` `handler.handlers` `handler.mutator` `handler.type`| 
@@ -435,7 +435,7 @@ Here's the list of available fields:
 | Role | `role.name` `role.namespace` |
 | RoleBinding | `rolebinding.name` `rolebinding.namespace` `rolebinding.role_ref.name` `rolebinding.role_ref.type`|
 | Secrets | `secret.name` `secret.namespace` `secret.provider` `secret.id` |
-| SecretsProviders | `provider.name` `provider.namespace` |
+| SecretsProviders | `provider.name` |
 | Silenced | `silenced.name` `silenced.namespace` `silenced.check` `silenced.creator` `silenced.expire_on_resolve` `silenced.subscription` |
 | User | `user.username` `user.disabled` `user.groups` |
 

--- a/content/sensu-go/6.5/api/_index.md
+++ b/content/sensu-go/6.5/api/_index.md
@@ -425,17 +425,18 @@ Here's the list of available fields:
 | ClusterRole | `clusterrole.name` |
 | ClusterRoleBinding | `clusterrolebinding.name` `clusterrolebinding.role_ref.name` `clusterrolebinding.role_ref.type`|
 | Entity | `entity.name` `entity.namespace` `entity.deregister` `entity.entity_class` `entity.subscriptions` |
-| Event | `event.is_silenced` `event.name` `event.namespace` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
+| Event | `event.name` `event.namespace` `event.is_silenced` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.state` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
 | Extension | `extension.name` `extension.namespace` |
 | Filter | `filter.name` `filter.namespace` `filter.action` `filter.runtime_assets` |
 | Handler | `handler.name` `handler.namespace` `handler.filters` `handler.handlers` `handler.mutator` `handler.type`| 
 | Hook | `hook.name` `hook.namespace` |
 | Mutator | `mutator.name` `mutator.namespace` `mutator.runtime_assets` |
 | Namespace | `namespace.name` |
+| Pipeline | `pipeline.name` `pipeline.namespace`
 | Role | `role.name` `role.namespace` |
 | RoleBinding | `rolebinding.name` `rolebinding.namespace` `rolebinding.role_ref.name` `rolebinding.role_ref.type`|
 | Secrets | `secret.name` `secret.namespace` `secret.provider` `secret.id` |
-| SecretsProviders | `provider.name` `provider.namespace` |
+| SecretsProviders | `provider.name` |
 | Silenced | `silenced.name` `silenced.namespace` `silenced.check` `silenced.creator` `silenced.expire_on_resolve` `silenced.subscription` |
 | User | `user.username` `user.disabled` `user.groups` |
 

--- a/content/sensu-go/6.5/api/core/pipelines.md
+++ b/content/sensu-go/6.5/api/core/pipelines.md
@@ -553,6 +553,147 @@ description               | Removes the specified pipeline from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/pipelines/slack_pipeline
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of pipelines with response filtering
+
+The `/pipelines` API endpoint supports [response filtering][3] for a subset of pipeline data based on labels and the following fields:
+
+- `pipeline.name`
+- `pipeline.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/pipelines` API endpoint with [response filtering][3], resulting in a JSON array that contains only [pipeline definitions][1] in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/pipelines -G \
+--data-urlencode 'fieldSelector=pipeline.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "sensu_email_alerts",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "labeled_email_alerts",
+        "filters": [
+          {
+            "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "state_change_only",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
+        "mutator": {
+          "name": "add_labels",
+          "type": "Mutator",
+          "api_version": "core/v2"
+        },
+        "handler": {
+          "name": "email",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "name": "sensu_to_sumo",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "logs_to_sumologic",
+        "handler": {
+          "name": "sumologic",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
+### API Specification
+
+/pipelines (GET) with response filters | 
+---------------|------
+description    | Returns the list of pipelines that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/pipelines
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "sensu_email_alerts",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "labeled_email_alerts",
+        "filters": [
+          {
+            "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "state_change_only",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
+        "mutator": {
+          "name": "add_labels",
+          "type": "Mutator",
+          "api_version": "core/v2"
+        },
+        "handler": {
+          "name": "email",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "name": "sensu_to_sumo",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "logs_to_sumologic",
+        "handler": {
+          "name": "sumologic",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/pipelines/
 [2]: ../../#pagination
 [3]: ../../#response-filtering

--- a/content/sensu-go/6.6/api/_index.md
+++ b/content/sensu-go/6.6/api/_index.md
@@ -425,17 +425,18 @@ Here's the list of available fields:
 | ClusterRole | `clusterrole.name` |
 | ClusterRoleBinding | `clusterrolebinding.name` `clusterrolebinding.role_ref.name` `clusterrolebinding.role_ref.type`|
 | Entity | `entity.name` `entity.namespace` `entity.deregister` `entity.entity_class` `entity.subscriptions` |
-| Event | `event.is_silenced` `event.name` `event.namespace` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
+| Event | `event.name` `event.namespace` `event.is_silenced` `event.check.handlers` `event.check.is_silenced` `event.check.name` `event.check.publish` `event.check.round_robin` `event.check.runtime_assets` `event.check.state` `event.check.status` `event.check.subscriptions` `event.entity.deregister` `event.entity.entity_class` `event.entity.name` `event.entity.subscriptions` |
 | Extension | `extension.name` `extension.namespace` |
 | Filter | `filter.name` `filter.namespace` `filter.action` `filter.runtime_assets` |
 | Handler | `handler.name` `handler.namespace` `handler.filters` `handler.handlers` `handler.mutator` `handler.type`| 
 | Hook | `hook.name` `hook.namespace` |
 | Mutator | `mutator.name` `mutator.namespace` `mutator.runtime_assets` |
 | Namespace | `namespace.name` |
+| Pipeline | `pipeline.name` `pipeline.namespace`
 | Role | `role.name` `role.namespace` |
 | RoleBinding | `rolebinding.name` `rolebinding.namespace` `rolebinding.role_ref.name` `rolebinding.role_ref.type`|
 | Secrets | `secret.name` `secret.namespace` `secret.provider` `secret.id` |
-| SecretsProviders | `provider.name` `provider.namespace` |
+| SecretsProviders | `provider.name` |
 | Silenced | `silenced.name` `silenced.namespace` `silenced.check` `silenced.creator` `silenced.expire_on_resolve` `silenced.subscription` |
 | User | `user.username` `user.disabled` `user.groups` |
 

--- a/content/sensu-go/6.6/api/core/pipelines.md
+++ b/content/sensu-go/6.6/api/core/pipelines.md
@@ -553,6 +553,147 @@ description               | Removes the specified pipeline from Sensu.
 example url               | http://hostname:8080/api/core/v2/namespaces/default/pipelines/slack_pipeline
 response codes            | <ul><li>**Success**: 204 (No Content)</li><li>**Missing**: 404 (Not Found)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
 
+## Get a subset of pipelines with response filtering
+
+The `/pipelines` API endpoint supports [response filtering][3] for a subset of pipeline data based on labels and the following fields:
+
+- `pipeline.name`
+- `pipeline.namespace`
+
+### Example
+
+The following example demonstrates a request to the `/pipelines` API endpoint with [response filtering][3], resulting in a JSON array that contains only [pipeline definitions][1] in the `production` namespace.
+
+{{< code shell >}}
+curl -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/pipelines -G \
+--data-urlencode 'fieldSelector=pipeline.namespace == production'
+
+HTTP/1.1 200 OK
+[
+  {
+    "metadata": {
+      "name": "sensu_email_alerts",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "labeled_email_alerts",
+        "filters": [
+          {
+            "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "state_change_only",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
+        "mutator": {
+          "name": "add_labels",
+          "type": "Mutator",
+          "api_version": "core/v2"
+        },
+        "handler": {
+          "name": "email",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "name": "sensu_to_sumo",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "logs_to_sumologic",
+        "handler": {
+          "name": "sumologic",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+{{% notice note %}}
+**NOTE**: Read [API response filtering](../../#response-filtering) for more filter statement examples that demonstrate how to filter responses using different operators with label and field selectors.
+{{% /notice %}}
+
+### API Specification
+
+/pipelines (GET) with response filters | 
+---------------|------
+description    | Returns the list of pipelines that match the [response filters][3] applied in the API request.
+example url    | http://hostname:8080/api/core/v2/pipelines
+pagination     | This endpoint supports [pagination][4] using the `limit` and `continue` query parameters.
+response type  | Array
+response codes | <ul><li>**Success**: 200 (OK)</li><li>**Error**: 500 (Internal Server Error)</li></ul>
+output         | {{< code shell >}}
+[
+  {
+    "metadata": {
+      "name": "sensu_email_alerts",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "labeled_email_alerts",
+        "filters": [
+          {
+            "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "state_change_only",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
+        "mutator": {
+          "name": "add_labels",
+          "type": "Mutator",
+          "api_version": "core/v2"
+        },
+        "handler": {
+          "name": "email",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "name": "sensu_to_sumo",
+      "namespace": "production",
+      "created_by": "admin"
+    },
+    "workflows": [
+      {
+        "name": "logs_to_sumologic",
+        "handler": {
+          "name": "sumologic",
+          "type": "Handler",
+          "api_version": "core/v2"
+        }
+      }
+    ]
+  }
+]
+{{< /code >}}
+
+
 [1]: ../../../observability-pipeline/observe-process/pipelines/
 [2]: ../../#pagination
 [3]: ../../#response-filtering


### PR DESCRIPTION
## Description
- Updates the table of field selectors at https://docs.sensu.io/sensu-go/latest/api/#field-selector
- Adds field selector filtering example to https://docs.sensu.io/sensu-go/latest/api/core/pipelines/

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3676
