### PR TITLE
6.6.6: Backend attempts PostgreSQL connection indefinitely if strict: true

### DIFF
--- a/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
@@ -446,7 +446,9 @@ pool_size: 20
 
 strict       |      |
 -------------|------
-description  | If `true`, when the PostgresConfig resource is created, configuration validation will include connecting to the PostgreSQL database and executing a query to confirm whether the connected user has permission to create database tables. Otherwise, `false`.<br><br>We recommend setting `strict: true` in most cases. If the connection fails or the user does not have permission to create database tables, resource configuration will fail and the configuration will not be persisted. This extended configuration is useful for debugging when you are not sure whether the configuration is correct or the database is working properly.
+description  | If `true`, when the PostgresConfig resource is created, configuration validation will include connecting to the PostgreSQL database and executing a query to confirm whether the connected user has permission to create database tables. Otherwise, `false`.<br><br>We recommend setting `strict: true` in most cases. If the connection fails or the user does not have permission to create database tables, resource configuration will fail and the configuration will not be persisted. This extended configuration is useful for debugging when you are not sure whether the configuration is correct or the database is working properly.{{% notice note %}}
+**NOTE**: As of Sensu Go 6.6.6, if `strict: true`, sensu-backend will try to connect to PostgreSQL indefinitely at 5-second intervals instead of falling back to etcd after 3 attempts.
+{{% /notice %}}
 required     | false
 default     | false
 type         | Boolean

--- a/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
@@ -447,7 +447,7 @@ pool_size: 20
 strict       |      |
 -------------|------
 description  | If `true`, when the PostgresConfig resource is created, configuration validation will include connecting to the PostgreSQL database and executing a query to confirm whether the connected user has permission to create database tables. Otherwise, `false`.<br><br>We recommend setting `strict: true` in most cases. If the connection fails or the user does not have permission to create database tables, resource configuration will fail and the configuration will not be persisted. This extended configuration is useful for debugging when you are not sure whether the configuration is correct or the database is working properly.{{% notice note %}}
-**NOTE**: As of Sensu Go 6.6.6, if `strict: true`, sensu-backend will try to connect to PostgreSQL indefinitely at 5-second intervals instead of falling back to etcd after 3 attempts.
+**NOTE**: As of Sensu Go 6.6.6, if `strict: true`, sensu-backend will try to connect to PostgreSQL indefinitely at 5-second intervals instead of reverting to etcd after 3 attempts.
 {{% /notice %}}
 required     | false
 default     | false


### PR DESCRIPTION
## Description
Adds a note in the Datastore reference spec table for the `strict` attribute to explain that as of Sensu Go 6.6.6, sensu-backend will try to connect to PostgreSQL indefinitely instead of failing to etcd after 3 attempts.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3677
