### PR TITLE
Copy button formatting

### DIFF
--- a/static/stylesheets/scss/_code.scss
+++ b/static/stylesheets/scss/_code.scss
@@ -26,10 +26,7 @@ pre {
     color: #FFFFFF;
     background-color: #2C3458;
     border: 1.75px solid #D5D6DE;
-    border-top-left-radius: 0;
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 5px;
+    border-radius: 0 0 0 5px;
     white-space: nowrap;
     padding: 4px 4px 5px 4px;
     margin: 0 0 0 1px;


### PR DESCRIPTION
Signed-off-by: Hillary Fraley <hfraley@sumologic.com>

## Description
Sets top-right border radius to 0 for copy/copied button on code examples.

![before](https://user-images.githubusercontent.com/19190208/156407671-7b667b86-8370-4664-9c2c-a73e413a23f6.png) ![after](https://user-images.githubusercontent.com/19190208/156407692-7254b2b2-4b82-43fd-9414-d2572a838234.png)

## Motivation and Context
Noticed when working on PR to optionally disable copy button
