### PR TITLE
[Do not merge] Testing config changes for LTS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,6 +57,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     notice = "Replaces Sensu Core and Enterprise"
     weight = 1
     latest = "6.6"
+    lts = "6.5"
 
     [[params.products.sensu_go.versions]]
     version = "6.6"

--- a/config.toml
+++ b/config.toml
@@ -58,6 +58,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     weight = 1
     latest = "6.6"
     lts = "6.5"
+    legacy = "6.4"
 
     [[params.products.sensu_go.versions]]
     version = "6.6"

--- a/layouts/partials/productVersionDropdown.html
+++ b/layouts/partials/productVersionDropdown.html
@@ -13,6 +13,7 @@
         {{ $.Scratch.Set "url" "" }}
           {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
           {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .lts) }}
+          {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .legacy) }}
         {{ $url := $.Scratch.Get "url" }}
         <a href="{{ $url }}">{{ .name }}</a>
       {{ end }}
@@ -31,6 +32,7 @@
       {{ cond (isset .Params "version") $pageversion "Version" }}
       {{ if (eq $pageversion $product_info.latest) }}(latest)&nbsp;{{ end }}
       {{ if (eq $pageversion $product_info.lts) }}(lts)&nbsp;{{ end }}
+      {{ if (eq $pageversion $product_info.legacy) }}(legacy)&nbsp;{{ end }}
       <i class="fa fa-chevron-down" aria-hidden="true"></i>
     </a>
     <div class="options">
@@ -49,7 +51,7 @@
           {{ else }}
             <a href="/{{ $.Section }}/{{ $version }}">
           {{ end }}
-            {{ $version }} {{ if eq $version $product_info.latest }}(latest){{ end }} {{ if eq $version $product_info.lts }}(lts){{ end }}
+            {{ $version }} {{ if eq $version $product_info.latest }}(latest){{ end }} {{ if eq $version $product_info.lts }}(lts){{ end }} {{ if eq $version $product_info.legacy }}(legacy){{ end }}
           </a>
         {{ end }}
       {{ end }}

--- a/layouts/partials/productVersionDropdown.html
+++ b/layouts/partials/productVersionDropdown.html
@@ -12,6 +12,7 @@
       {{ range sort .Site.Params.Products "weight" }} 
         {{ $.Scratch.Set "url" "" }}
           {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .latest) }}
+          {{ $.Scratch.Set "url" (printf "/%s/%s/" .identifier .lts) }}
         {{ $url := $.Scratch.Get "url" }}
         <a href="{{ $url }}">{{ .name }}</a>
       {{ end }}
@@ -29,6 +30,7 @@
     <a>
       {{ cond (isset .Params "version") $pageversion "Version" }}
       {{ if (eq $pageversion $product_info.latest) }}(latest)&nbsp;{{ end }}
+      {{ if (eq $pageversion $product_info.lts) }}(lts)&nbsp;{{ end }}
       <i class="fa fa-chevron-down" aria-hidden="true"></i>
     </a>
     <div class="options">
@@ -47,7 +49,7 @@
           {{ else }}
             <a href="/{{ $.Section }}/{{ $version }}">
           {{ end }}
-            {{ $version }} {{ if eq $version $product_info.latest }}(latest){{ end }}
+            {{ $version }} {{ if eq $version $product_info.latest }}(latest){{ end }} {{ if eq $version $product_info.lts }}(lts){{ end }}
           </a>
         {{ end }}
       {{ end }}

--- a/static.json
+++ b/static.json
@@ -43,6 +43,14 @@
             "url": "/sensu-go/latest/$1",
             "status": 302
         },
+        "~ ^/sensu-go/6.5/?((?<=\/).*)?$": {
+            "url": "/sensu-go/lts/$1",
+            "status": 302
+        },
+        "~ ^/sensu-go/6.4/?((?<=\/).*)?$": {
+            "url": "/sensu-go/legacy/$1",
+            "status": 302
+        },
         "~ ^/sensu-go/6.[0-2]/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 301


### PR DESCRIPTION
## Description
PR for testing and confirming config changes required for LTS

See https://github.com/sensu/sensu-enterprise-go/issues/2100

Running list of required docs site updates:
- [x] Designate the LTS and legacy versions in config.toml
- [x] Configure [layouts/partials/productVersionDropdown.html](https://github.com/sensu/sensu-docs/blob/main/layouts/partials/productVersionDropdown.html) to identify the config.toml-designated LTS and legacy versions
- [x] Add `/sensu-go/lts/$1` and `/sensu-go/legacy/$1` redirects to static.json
- [ ] Update [sensu-docs/layouts/partials/alertSection.html](https://github.com/sensu/sensu-docs/blob/main/layouts/partials/alertSection.html) to include banners with messages specific to latest, LTS, and legacy
- [ ] Update [gruntfile.js](https://github.com/sensu/sensu-docs/blob/main/Gruntfile.js) to perform similar tasks for LTS and legacy as for latest
- [ ] Semi-permanent 404 page for features that exist in one version of the product but not others (a current example: [Sensu Plus](https://docs.sensu.io/sensu-go/latest/sensu-plus/)...open page and select version 6.4) -- we had a version of this during the docs reorg project, added in https://github.com/sensu/sensu-docs/pull/2711 and unwound in https://github.com/sensu/sensu-docs/pull/3182

Running list of other required updates:
- [ ] Update docs wiki with versioning details (after all work is done)

Questions:
- [ ] How will LTS versioning be reflected in the docs? Will only the most recent minor release be marked as latest, LTS, or legacy? Will 5.x versions return to the docs site?