### PR TITLE
Add not_silenced filter in references and guides

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -44,7 +44,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: pipe_handler_minimum
-  namespace: default
 spec:
   command: command-example
   type: pipe
@@ -55,8 +54,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "pipe_handler_minimum",
-    "namespace": "default"
+    "name": "pipe_handler_minimum"
   },
   "spec": {
     "command": "command-example",
@@ -91,7 +89,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: tcp_handler
-  namespace: default
 spec:
   socket:
     host: 10.0.1.99
@@ -105,8 +102,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "tcp_handler",
-    "namespace": "default"
+    "name": "tcp_handler"
   },
   "spec": {
     "type": "tcp",
@@ -131,7 +127,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: udp_handler
-  namespace: default
 spec:
   socket:
     host: 10.0.1.99
@@ -145,8 +140,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "udp_handler",
-    "namespace": "default"
+    "name": "udp_handler"
   },
   "spec": {
     "type": "udp",
@@ -181,7 +175,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: send_events_notify_operator
-  namespace: default
 spec:
   handlers:
   - elasticsearch
@@ -194,8 +187,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "send_events_notify_operator",
-    "namespace": "default"
+    "name": "send_events_notify_operator"
   },
   "spec": {
     "type": "set",
@@ -214,7 +206,6 @@ Now you can route observation data to Elasticsearch and alerts to OpsGenie with 
 {{% notice note %}}
 **NOTE**: Attributes defined in handler sets do not apply to the handlers they include.
 For example, `filters` and `mutator` attributes defined in a handler set will have no effect on handlers.
-Define these attributes in individual handlers instead.
 {{% /notice %}}
 
 ## Handler stacks
@@ -260,7 +251,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: keepalive
-  namespace: default
 spec:
   handlers:
   - slack
@@ -272,8 +262,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "keepalive",
-    "namespace": "default"
+    "name": "keepalive"
   },
   "spec": {
     "type": "set",
@@ -513,14 +502,16 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 filters:
-- occurrences
-- production
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
   "filters": [
-    "occurrences",
-    "production"
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
   ]
 }
 {{< /code >}}
@@ -771,13 +762,12 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
   - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
-  filters:
-  - is_incident
+  filters:  
+  - is_incident 
   - not_silenced
   handlers: []
   runtime_assets:
@@ -791,17 +781,16 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     ],
-    "filters": [
-      "is_incident",
-      "not_silenced"
+    "filters": [  
+      "is_incident",  
+      "not_silenced"  
     ],
     "handlers": [],
     "runtime_assets": [
@@ -830,7 +819,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: registration
-  namespace: default
 spec:
   handlers:
   - servicenow-cmdb
@@ -842,8 +830,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "registration",
-    "namespace": "default"
+    "name": "registration"
   },
   "spec": {
     "handlers": [
@@ -870,7 +857,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: notify_all_the_things
-  namespace: default
 spec:
   handlers:
   - slack
@@ -884,8 +870,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "notify_all_the_things",
-    "namespace": "default"
+    "name": "notify_all_the_things"
   },
   "spec": {
     "type": "set",
@@ -912,7 +897,6 @@ type: Handler
 api_version: core/v2 
 metadata:
   name: ansible-tower
-  namespace: ops
 spec: 
   type: pipe
   command: sensu-ansible-handler -h $ANSIBLE_HOST -t $ANSIBLE_TOKEN
@@ -928,8 +912,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ansible-tower",
-    "namespace": "ops"
+    "name": "ansible-tower"
   },
   "spec": {
     "type": "pipe",

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -94,6 +94,7 @@ sensuctl handler create influxdb-handler \
 --type pipe \
 --command "sensu-influxdb-handler -d sensu" \
 --env-vars "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086, INFLUXDB_USER=sensu, INFLUXDB_PASS=password" \
+--filters not_silenced \
 --runtime-assets sensu-influxdb-handler
 {{< /code >}}
 
@@ -126,16 +127,15 @@ The `influxdb-handler` resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: influxdb-handler
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
   - INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086
   - INFLUXDB_USER=sensu
   - INFLUXDB_PASS=password
-  filters: null
+  filters:
+  - not_silenced
   handlers: null
   runtime_assets:
   - sensu-influxdb-handler
@@ -149,9 +149,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "influxdb-handler",
-    "namespace": "default"
+    "name": "influxdb-handler"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -160,7 +158,9 @@ spec:
       "INFLUXDB_USER=sensu",
       "INFLUXDB_PASS=password"
     ],
-    "filters": null,
+    "filters": [
+      "not_silenced"
+    ],
     "handlers": null,
     "runtime_assets": [
       "sensu-influxdb-handler"
@@ -218,7 +218,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_metrics
-  namespace: default
 spec:
   check_hooks: null
   command: sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up
@@ -250,8 +249,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -239,7 +239,7 @@ Now you can refer to the `sumologic_url` secret in your handler to securely pass
 
 With your Sumo Logic HTTP Source Address URL configured as a secret, you can create a handler to send Sensu observability data to your Sumo Logic HTTP Logs and Metrics Source.
 
-To send data for all events (as opposed to only incidents), do not include an event filter in the handler definition.
+To send data for all events (as opposed to only incidents), create a handler that includes only the built-in [not_silenced event filter][20].
 Run the following command to create the  `sumologic` handler:
 
 {{< language-toggle >}}
@@ -256,6 +256,8 @@ spec:
     sensu-sumologic-handler --send-log --send-metrics
     --source-host "{{ .Entity.Name }}"
     --source-name "{{ .Check.Name }}"
+  filters:
+  - not_silenced
   type: pipe
   runtime_assets:
   - sumologic-handler
@@ -275,6 +277,9 @@ cat << EOF | sensuctl create
   },
   "spec": {
     "command": "sensu-sumologic-handler --send-log --send-metrics --source-host \"{{ .Entity.Name }}\" --source-name \"{{ .Check.Name }}\"",
+    "filters": [
+      "not_silenced"
+    ],
     "type": "pipe",
     "runtime_assets": [
       "sumologic-handler"
@@ -315,14 +320,12 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: sumologic
 spec:
   command: sensu-sumologic-handler --send-log --send-metrics --source-host "{{ .Entity.Name }}" --source-name "{{ .Check.Name }}"
   env_vars: null
-  filters: null
+  filters:
+  - not_silenced
   handlers: null
   runtime_assets:
   - sumologic-handler
@@ -338,16 +341,14 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "sumologic"
   },
   "spec": {
     "command": "sensu-sumologic-handler --send-log --send-metrics --source-host \"{{ .Entity.Name }}\" --source-name \"{{ .Check.Name }}\"",
     "env_vars": null,
-    "filters": null,
+    "filters": [
+      "not_silenced"
+    ],
     "handlers": null,
     "runtime_assets": [
       "sumologic-handler"
@@ -524,3 +525,4 @@ You can also configure a [Sumo Logic dashboard][10] to search, view, and analyze
 [17]: ../../../sensu-plus/
 [18]: ../sumo-logic-metrics-handlers/
 [19]: ../../../plugins/supported-integrations/sumologic/
+[20]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -211,7 +211,7 @@ Then run the updated command:
 {{< code shell >}}
 sensuctl handler create pagerduty \
 --type pipe \
---filters is_incident \
+--filters is_incident,not_silenced \
 --runtime-assets sensu/sensu-pagerduty-handler \
 --command "sensu-pagerduty-handler -t <pagerduty_key>"
 {{< /code >}}
@@ -243,14 +243,13 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler -t <pagerduty_key>
   env_vars: null
   filters:
   - is_incident
+  - not_silenced
   handlers: null
   runtime_assets:
   - sensu/sensu-pagerduty-handler
@@ -264,15 +263,14 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "pagerduty",
-    "namespace": "default"
+    "name": "pagerduty"
   },
   "spec": {
     "command": "sensu-pagerduty-handler -t <pagerduty_key>",
     "env_vars": null,
     "filters": [
-      "is_incident"
+      "is_incident",
+      "not_silenced"
     ],
     "handlers": null,
     "runtime_assets": [

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -108,6 +108,7 @@ sensuctl handler create slack \
 --type pipe \
 --env-vars "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX" \
 --command "sensu-slack-handler --channel '#monitoring'" \
+--filters not_silenced \
 --runtime-assets sensu-slack-handler
 {{< /code >}}
 
@@ -141,14 +142,13 @@ The `slack` handler resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
   - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX
-  filters: null
+  filters:
+  - not_silenced
   handlers: null
   runtime_assets:
   - sensu-slack-handler
@@ -162,16 +162,16 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
     ],
-    "filters": null,
+    "filters": [
+      "not_silenced"
+    ],
     "handlers": null,
     "runtime_assets": [
       "sensu-slack-handler"

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -44,7 +44,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: pipe_handler_minimum
-  namespace: default
 spec:
   command: command-example
   type: pipe
@@ -55,8 +54,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "pipe_handler_minimum",
-    "namespace": "default"
+    "name": "pipe_handler_minimum"
   },
   "spec": {
     "command": "command-example",
@@ -91,7 +89,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: tcp_handler
-  namespace: default
 spec:
   socket:
     host: 10.0.1.99
@@ -105,8 +102,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "tcp_handler",
-    "namespace": "default"
+    "name": "tcp_handler"
   },
   "spec": {
     "type": "tcp",
@@ -131,7 +127,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: udp_handler
-  namespace: default
 spec:
   socket:
     host: 10.0.1.99
@@ -145,8 +140,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "udp_handler",
-    "namespace": "default"
+    "name": "udp_handler"
   },
   "spec": {
     "type": "udp",
@@ -181,7 +175,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: send_events_notify_operator
-  namespace: default
 spec:
   handlers:
   - elasticsearch
@@ -194,8 +187,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "send_events_notify_operator",
-    "namespace": "default"
+    "name": "send_events_notify_operator"
   },
   "spec": {
     "type": "set",
@@ -214,7 +206,6 @@ Now you can route observation data to Elasticsearch and alerts to OpsGenie with 
 {{% notice note %}}
 **NOTE**: Attributes defined in handler sets do not apply to the handlers they include.
 For example, `filters` and `mutator` attributes defined in a handler set will have no effect on handlers.
-Define these attributes in individual handlers instead.
 {{% /notice %}}
 
 ## Handler stacks
@@ -260,7 +251,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: keepalive
-  namespace: default
 spec:
   handlers:
   - slack
@@ -272,8 +262,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "keepalive",
-    "namespace": "default"
+    "name": "keepalive"
   },
   "spec": {
     "type": "set",
@@ -513,14 +502,16 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 filters:
-- occurrences
-- production
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
   "filters": [
-    "occurrences",
-    "production"
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
   ]
 }
 {{< /code >}}
@@ -771,13 +762,12 @@ type: Handler
 api_version: core/v2
 metadata:
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
   - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
-  filters:
-  - is_incident
+  filters:  
+  - is_incident 
   - not_silenced
   handlers: []
   runtime_assets:
@@ -791,17 +781,16 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     ],
-    "filters": [
-      "is_incident",
-      "not_silenced"
+    "filters": [  
+      "is_incident",  
+      "not_silenced"  
     ],
     "handlers": [],
     "runtime_assets": [
@@ -830,7 +819,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: registration
-  namespace: default
 spec:
   handlers:
   - servicenow-cmdb
@@ -842,8 +830,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "registration",
-    "namespace": "default"
+    "name": "registration"
   },
   "spec": {
     "handlers": [
@@ -870,7 +857,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: notify_all_the_things
-  namespace: default
 spec:
   handlers:
   - slack
@@ -884,8 +870,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "notify_all_the_things",
-    "namespace": "default"
+    "name": "notify_all_the_things"
   },
   "spec": {
     "type": "set",
@@ -912,7 +897,6 @@ type: Handler
 api_version: core/v2 
 metadata:
   name: ansible-tower
-  namespace: ops
 spec: 
   type: pipe
   command: sensu-ansible-handler -h $ANSIBLE_HOST -t $ANSIBLE_TOKEN
@@ -928,8 +912,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ansible-tower",
-    "namespace": "ops"
+    "name": "ansible-tower"
   },
   "spec": {
     "type": "pipe",

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -94,6 +94,7 @@ sensuctl handler create influxdb-handler \
 --type pipe \
 --command "sensu-influxdb-handler -d sensu" \
 --env-vars "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086, INFLUXDB_USER=sensu, INFLUXDB_PASS=password" \
+--filters not_silenced \
 --runtime-assets sensu-influxdb-handler
 {{< /code >}}
 
@@ -126,16 +127,15 @@ The `influxdb-handler` resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: influxdb-handler
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
   - INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086
   - INFLUXDB_USER=sensu
   - INFLUXDB_PASS=password
-  filters: null
+  filters:
+  - not_silenced
   handlers: null
   runtime_assets:
   - sensu-influxdb-handler
@@ -149,9 +149,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "influxdb-handler",
-    "namespace": "default"
+    "name": "influxdb-handler"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -160,7 +158,9 @@ spec:
       "INFLUXDB_USER=sensu",
       "INFLUXDB_PASS=password"
     ],
-    "filters": null,
+    "filters": [
+      "not_silenced"
+    ],
     "handlers": null,
     "runtime_assets": [
       "sensu-influxdb-handler"
@@ -218,7 +218,6 @@ type: CheckConfig
 api_version: core/v2
 metadata:
   name: prometheus_metrics
-  namespace: default
 spec:
   check_hooks: null
   command: sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up
@@ -250,8 +249,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -239,7 +239,7 @@ Now you can refer to the `sumologic_url` secret in your handler to securely pass
 
 With your Sumo Logic HTTP Source Address URL configured as a secret, you can create a handler to send Sensu observability data to your Sumo Logic HTTP Logs and Metrics Source.
 
-To send data for all events (as opposed to only incidents), do not include an event filter in the handler definition.
+To send data for all events (as opposed to only incidents), create a handler that includes only the built-in [not_silenced event filter][20].
 Run the following command to create the  `sumologic` handler:
 
 {{< language-toggle >}}
@@ -256,6 +256,8 @@ spec:
     sensu-sumologic-handler --send-log --send-metrics
     --source-host "{{ .Entity.Name }}"
     --source-name "{{ .Check.Name }}"
+  filters:
+  - not_silenced
   type: pipe
   runtime_assets:
   - sumologic-handler
@@ -275,6 +277,9 @@ cat << EOF | sensuctl create
   },
   "spec": {
     "command": "sensu-sumologic-handler --send-log --send-metrics --source-host \"{{ .Entity.Name }}\" --source-name \"{{ .Check.Name }}\"",
+    "filters": [
+      "not_silenced"
+    ],
     "type": "pipe",
     "runtime_assets": [
       "sumologic-handler"
@@ -315,14 +320,12 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: sumologic
 spec:
   command: sensu-sumologic-handler --send-log --send-metrics --source-host "{{ .Entity.Name }}" --source-name "{{ .Check.Name }}"
   env_vars: null
-  filters: null
+  filters:
+  - not_silenced
   handlers: null
   runtime_assets:
   - sumologic-handler
@@ -338,16 +341,14 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "sumologic"
   },
   "spec": {
     "command": "sensu-sumologic-handler --send-log --send-metrics --source-host \"{{ .Entity.Name }}\" --source-name \"{{ .Check.Name }}\"",
     "env_vars": null,
-    "filters": null,
+    "filters": [
+      "not_silenced"
+    ],
     "handlers": null,
     "runtime_assets": [
       "sumologic-handler"
@@ -524,3 +525,4 @@ You can also configure a [Sumo Logic dashboard][10] to search, view, and analyze
 [17]: ../../../sensu-plus/
 [18]: ../sumo-logic-metrics-handlers/
 [19]: ../../../plugins/supported-integrations/sumologic/
+[20]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -211,7 +211,7 @@ Then run the updated command:
 {{< code shell >}}
 sensuctl handler create pagerduty \
 --type pipe \
---filters is_incident \
+--filters is_incident,not_silenced \
 --runtime-assets sensu/sensu-pagerduty-handler \
 --command "sensu-pagerduty-handler -t <pagerduty_key>"
 {{< /code >}}
@@ -243,14 +243,13 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler -t <pagerduty_key>
   env_vars: null
   filters:
   - is_incident
+  - not_silenced
   handlers: null
   runtime_assets:
   - sensu/sensu-pagerduty-handler
@@ -264,15 +263,14 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "pagerduty",
-    "namespace": "default"
+    "name": "pagerduty"
   },
   "spec": {
     "command": "sensu-pagerduty-handler -t <pagerduty_key>",
     "env_vars": null,
     "filters": [
-      "is_incident"
+      "is_incident",
+      "not_silenced"
     ],
     "handlers": null,
     "runtime_assets": [

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
@@ -108,6 +108,7 @@ sensuctl handler create slack \
 --type pipe \
 --env-vars "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX" \
 --command "sensu-slack-handler --channel '#monitoring'" \
+--filters not_silenced \
 --runtime-assets sensu-slack-handler
 {{< /code >}}
 
@@ -141,14 +142,13 @@ The `slack` handler resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
   - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX
-  filters: null
+  filters:
+  - not_silenced
   handlers: null
   runtime_assets:
   - sensu-slack-handler
@@ -162,16 +162,16 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"
     ],
-    "filters": null,
+    "filters": [
+      "not_silenced"
+    ],
     "handlers": null,
     "runtime_assets": [
       "sensu-slack-handler"

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -514,14 +514,16 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 filters:
-- occurrences
-- production
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
   "filters": [
-    "occurrences",
-    "production"
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -53,6 +53,9 @@ spec:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -80,6 +83,11 @@ spec:
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           },
@@ -190,6 +198,9 @@ spec:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -204,6 +215,9 @@ spec:
   - name: slack_alerts
     filters:
     - name: is_incident
+      type: EventFilter
+      api_version: core/v2
+    - name: not_silenced
       type: EventFilter
       api_version: core/v2
     - name: state_change_only
@@ -233,6 +247,11 @@ spec:
             "api_version": "core/v2"
           },
           {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
             "name": "state_change_only",
             "type": "EventFilter",
             "api_version": "core/v2"
@@ -254,6 +273,11 @@ spec:
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           },
@@ -363,6 +387,9 @@ spec:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -384,6 +411,11 @@ spec:
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           },
@@ -520,6 +552,9 @@ workflows:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -540,6 +575,11 @@ workflows:
       "filters": [
         {
           "name": "is_incident",
+          "type": "EventFilter",
+          "api_version": "core/v2"
+        },
+        {
+          "name": "not_silenced",
           "type": "EventFilter",
           "api_version": "core/v2"
         },
@@ -579,6 +619,9 @@ filters:
 - name: is_incident
   type: EventFilter
   api_version: core/v2
+- name: not_silenced
+  type: EventFilter
+  api_version: core/v2
 - name: state_change_only
   type: EventFilter
   api_version: core/v2
@@ -588,6 +631,11 @@ filters:
   "filters": [
     {
       "name": "is_incident",
+      "type": "EventFilter",
+      "api_version": "core/v2"
+    },
+    {
+      "name": "not_silenced",
       "type": "EventFilter",
       "api_version": "core/v2"
     },
@@ -843,4 +891,3 @@ api_version: core/v2
 [29]: ../../../observability-pipeline/
 [30]: ../../observe-filter/route-alerts/#configure-contact-routing-with-a-pipeline
 [31]: ../../observe-filter/filters/#built-in-event-filters
-

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -126,9 +126,7 @@ The `influxdb-handler` resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: influxdb-handler
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
@@ -149,9 +147,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "influxdb-handler",
-    "namespace": "default"
+    "name": "influxdb-handler"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -185,7 +181,7 @@ You can share, reuse, and maintain this handler just like you would code: [save 
 With your handler configured, you can add it to a [pipeline][16] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [has_metrics][17] event filter and the InfluxDB handler you've already configured.
+In this case, the pipeline includes the built-in [has_metrics][17] and [not_silenced][20] event filters and the InfluxDB handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -202,6 +198,9 @@ spec:
   - name: influxdb_metrics
     filters:
     - name: has_metrics
+      type: EventFilter
+      api_version: core/v2
+    - name: not_silenced
       type: EventFilter
       api_version: core/v2
     handler:
@@ -226,6 +225,11 @@ cat << EOF | sensuctl create
         "filters": [
           {
             "name": "has_metrics",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           }
@@ -315,9 +319,7 @@ The updated `prometheus_metrics` check definition will be similar to this exampl
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prometheus_metrics
-  namespace: default
 spec:
   check_hooks: null
   command: sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up
@@ -351,9 +353,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "check_hooks": null,
@@ -438,3 +438,4 @@ Now that you know how to apply an InfluxDB handler to metrics, read [Aggregate m
 [17]: ../../observe-filter/filters/#built-in-filter-has_metrics
 [18]: ../../../sensuctl/
 [19]: ../../observe-schedule/subscriptions/
+[20]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -312,9 +312,6 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: sumologic
 spec:
   command: sensu-sumologic-handler --send-log --send-metrics --source-host "{{ .Entity.Name }}" --source-name "{{ .Check.Name }}"
@@ -335,10 +332,6 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "sumologic"
   },
   "spec": {
@@ -372,7 +365,7 @@ spec:
 With your Sumo Logic handler configured, you can add it to a [pipeline][14] workflow.
 A single pipeline workflow can include one or more event filters, one mutator, and one handler.
 
-To send data for all events (as opposed to only incidents), create a pipeline that includes only the Sumo Logic handler you've already configured &mdash; no event filters or mutators.
+To send data for all events (as opposed to only incidents), create a pipeline that includes only the Sumo Logic handler you've already configured and the built-in [not_silenced event filter][20] &mdash; no mutators.
 To add the pipeline, run:
 
 {{< language-toggle >}}
@@ -387,6 +380,10 @@ metadata:
 spec:
   workflows:
   - name: logs_to_sumologic
+    filters:
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     handler:
       name: sumologic
       type: Handler
@@ -406,6 +403,13 @@ cat << EOF | sensuctl create
     "workflows": [
       {
         "name": "logs_to_sumologic",
+        "filters": [
+          {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
         "handler": {
           "name": "sumologic",
           "type": "Handler",
@@ -591,3 +595,4 @@ In addition to the traditional handler we used in this example, you can use [Sen
 [17]: ../../../sensu-plus/
 [18]: ../sumo-logic-metrics-handlers/
 [19]: ../../../plugins/supported-integrations/sumologic/
+[20]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -135,9 +135,7 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler -t <pagerduty_key>
   env_vars: null
@@ -154,9 +152,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "pagerduty",
-    "namespace": "default"
+    "name": "pagerduty"
   },
   "spec": {
     "command": "sensu-pagerduty-handler -t <pagerduty_key>",
@@ -178,12 +174,12 @@ spec:
 **PRO TIP**: You can also [view complete resource definitions in the Sensu web UI](../../../web-ui/view-manage-resources/#view-resource-data-in-the-web-ui).
 {{% /notice %}}
 
-## Create a pipeline with an event filter and handler
+## Create a pipeline with event filters and a handler
 
 With your handler configured, you can add it to a [pipeline][17] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [is_incident][21] event filter and the PagerDuty handler you've already configured.
+In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the PagerDuty handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -200,6 +196,9 @@ spec:
   - name: pagerduty_alerts
     filters:
     - name: is_incident
+      type: EventFilter
+      api_version: core/v2
+    - name: not_silenced
       type: EventFilter
       api_version: core/v2
     handler:
@@ -224,6 +223,11 @@ cat << EOF | sensuctl create
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           }
@@ -456,3 +460,4 @@ Learn more about the [Sensu PagerDuty integration][14] and our curated, configur
 [19]: ../../observe-events/
 [20]: ../pipelines/
 [21]: ../../observe-filter/filters/#built-in-filter-is_incident
+[22]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -94,7 +94,7 @@ After you save your webhook, you can find the webhook URL under **Integration Se
 ## Create a handler
 
 Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the `sensu-slack-handler` dynamic runtime asset.
-Edit the sensuctl command below to include your Slack webhook URL and the channel where you want to receive events.
+Before you run the sensuctl command below, edit it to include your Slack webhook URL and the channel where you want to receive events:
 
 {{< code shell >}}
 sensuctl handler create slack \
@@ -134,9 +134,7 @@ The `slack` handler resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -155,9 +153,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -186,10 +182,10 @@ You can share and reuse this handler like code &mdash; [save it to a file][15] a
 
 ## Create a pipeline that includes the handler
 
-With your handler configured, you can add it to a [pipeline][17] workflow.
+With your handler configured, you can add it to a [pipeline][8] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-For now, the pipeline includes only the `slack` handler so that you receive an alert for every event the check generates (including events with OK status).
+For now, the pipeline includes only the `slack` handler and the built-in [not_silenced][22] event filter so that you receive an alert for every event the check generates (including events with OK status).
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -204,6 +200,10 @@ metadata:
 spec:
   workflows:
   - name: slack_alerts
+    filters:
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     handler:
       name: slack
       type: Handler
@@ -223,6 +223,13 @@ cat << EOF | sensuctl create
     "workflows": [
       {
         "name": "slack_alerts",
+        "filters": [
+          {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
         "handler": {
           "name": "slack",
           "type": "Handler",
@@ -391,7 +398,7 @@ Read [Troubleshoot Sensu][7] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"event pipe handler executed","output":"","status":0`.
 
-## Add an event filter to the pipeline
+## Add another event filter to the pipeline
 
 At this point, the `cpu_check_alerts` pipeline has probably sent quite a few Slack messages for events with OK (`0`) status.
 To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in [is_incident][19] event filter to the pipeline:
@@ -409,6 +416,9 @@ spec:
   workflows:
   - name: slack_alerts
     filters:
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: is_incident
       type: EventFilter
       api_version: core/v2
@@ -432,6 +442,11 @@ cat << EOF | sensuctl create
       {
         "name": "slack_alerts",
         "filters": [
+          {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
           {
             "name": "is_incident",
             "type": "EventFilter",
@@ -485,3 +500,4 @@ Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generate
 [19]: ../../observe-filter/filters/#built-in-filter-is_incident
 [20]: ../../../sensuctl/
 [21]: ../../observe-schedule/subscriptions/
+[22]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -514,14 +514,16 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 filters:
-- occurrences
-- production
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
   "filters": [
-    "occurrences",
-    "production"
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
@@ -53,6 +53,9 @@ spec:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -80,6 +83,11 @@ spec:
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           },
@@ -190,6 +198,9 @@ spec:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -204,6 +215,9 @@ spec:
   - name: slack_alerts
     filters:
     - name: is_incident
+      type: EventFilter
+      api_version: core/v2
+    - name: not_silenced
       type: EventFilter
       api_version: core/v2
     - name: state_change_only
@@ -233,6 +247,11 @@ spec:
             "api_version": "core/v2"
           },
           {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
             "name": "state_change_only",
             "type": "EventFilter",
             "api_version": "core/v2"
@@ -254,6 +273,11 @@ spec:
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           },
@@ -363,6 +387,9 @@ spec:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -384,6 +411,11 @@ spec:
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           },
@@ -520,6 +552,9 @@ workflows:
     - name: is_incident
       type: EventFilter
       api_version: core/v2
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: state_change_only
       type: EventFilter
       api_version: core/v2
@@ -540,6 +575,11 @@ workflows:
       "filters": [
         {
           "name": "is_incident",
+          "type": "EventFilter",
+          "api_version": "core/v2"
+        },
+        {
+          "name": "not_silenced",
           "type": "EventFilter",
           "api_version": "core/v2"
         },
@@ -579,6 +619,9 @@ filters:
 - name: is_incident
   type: EventFilter
   api_version: core/v2
+- name: not_silenced
+  type: EventFilter
+  api_version: core/v2
 - name: state_change_only
   type: EventFilter
   api_version: core/v2
@@ -588,6 +631,11 @@ filters:
   "filters": [
     {
       "name": "is_incident",
+      "type": "EventFilter",
+      "api_version": "core/v2"
+    },
+    {
+      "name": "not_silenced",
       "type": "EventFilter",
       "api_version": "core/v2"
     },
@@ -843,4 +891,3 @@ api_version: core/v2
 [29]: ../../../observability-pipeline/
 [30]: ../../observe-filter/route-alerts/#configure-contact-routing-with-a-pipeline
 [31]: ../../observe-filter/filters/#built-in-event-filters
-

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -126,9 +126,7 @@ The `influxdb-handler` resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: influxdb-handler
-  namespace: default
 spec:
   command: sensu-influxdb-handler -d sensu
   env_vars:
@@ -149,9 +147,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "influxdb-handler",
-    "namespace": "default"
+    "name": "influxdb-handler"
   },
   "spec": {
     "command": "sensu-influxdb-handler -d sensu",
@@ -185,7 +181,7 @@ You can share, reuse, and maintain this handler just like you would code: [save 
 With your handler configured, you can add it to a [pipeline][16] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [has_metrics][17] event filter and the InfluxDB handler you've already configured.
+In this case, the pipeline includes the built-in [has_metrics][17] and [not_silenced][20] event filters and the InfluxDB handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -202,6 +198,9 @@ spec:
   - name: influxdb_metrics
     filters:
     - name: has_metrics
+      type: EventFilter
+      api_version: core/v2
+    - name: not_silenced
       type: EventFilter
       api_version: core/v2
     handler:
@@ -226,6 +225,11 @@ cat << EOF | sensuctl create
         "filters": [
           {
             "name": "has_metrics",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           }
@@ -315,9 +319,7 @@ The updated `prometheus_metrics` check definition will be similar to this exampl
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prometheus_metrics
-  namespace: default
 spec:
   check_hooks: null
   command: sensu-prometheus-collector -prom-url http://localhost:9090 -prom-query up
@@ -351,9 +353,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "prometheus_metrics",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "prometheus_metrics"
   },
   "spec": {
     "check_hooks": null,
@@ -438,3 +438,4 @@ Now that you know how to apply an InfluxDB handler to metrics, read [Aggregate m
 [17]: ../../observe-filter/filters/#built-in-filter-has_metrics
 [18]: ../../../sensuctl/
 [19]: ../../observe-schedule/subscriptions/
+[20]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -312,9 +312,6 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: sumologic
 spec:
   command: sensu-sumologic-handler --send-log --send-metrics --source-host "{{ .Entity.Name }}" --source-name "{{ .Check.Name }}"
@@ -335,10 +332,6 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
     "name": "sumologic"
   },
   "spec": {
@@ -372,7 +365,7 @@ spec:
 With your Sumo Logic handler configured, you can add it to a [pipeline][14] workflow.
 A single pipeline workflow can include one or more event filters, one mutator, and one handler.
 
-To send data for all events (as opposed to only incidents), create a pipeline that includes only the Sumo Logic handler you've already configured &mdash; no event filters or mutators.
+To send data for all events (as opposed to only incidents), create a pipeline that includes only the Sumo Logic handler you've already configured and the built-in [not_silenced event filter][20] &mdash; no mutators.
 To add the pipeline, run:
 
 {{< language-toggle >}}
@@ -387,6 +380,10 @@ metadata:
 spec:
   workflows:
   - name: logs_to_sumologic
+    filters:
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     handler:
       name: sumologic
       type: Handler
@@ -406,6 +403,13 @@ cat << EOF | sensuctl create
     "workflows": [
       {
         "name": "logs_to_sumologic",
+        "filters": [
+          {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
         "handler": {
           "name": "sumologic",
           "type": "Handler",
@@ -591,3 +595,4 @@ In addition to the traditional handler we used in this example, you can use [Sen
 [17]: ../../../sensu-plus/
 [18]: ../sumo-logic-metrics-handlers/
 [19]: ../../../plugins/supported-integrations/sumologic/
+[20]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -135,9 +135,7 @@ The response will list the complete handler resource definition:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: pagerduty
-  namespace: default
 spec:
   command: sensu-pagerduty-handler -t <pagerduty_key>
   env_vars: null
@@ -154,9 +152,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "pagerduty",
-    "namespace": "default"
+    "name": "pagerduty"
   },
   "spec": {
     "command": "sensu-pagerduty-handler -t <pagerduty_key>",
@@ -178,12 +174,12 @@ spec:
 **PRO TIP**: You can also [view complete resource definitions in the Sensu web UI](../../../web-ui/view-manage-resources/#view-resource-data-in-the-web-ui).
 {{% /notice %}}
 
-## Create a pipeline with an event filter and handler
+## Create a pipeline with event filters and a handler
 
 With your handler configured, you can add it to a [pipeline][17] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [is_incident][21] event filter and the PagerDuty handler you've already configured.
+In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the PagerDuty handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -200,6 +196,9 @@ spec:
   - name: pagerduty_alerts
     filters:
     - name: is_incident
+      type: EventFilter
+      api_version: core/v2
+    - name: not_silenced
       type: EventFilter
       api_version: core/v2
     handler:
@@ -224,6 +223,11 @@ cat << EOF | sensuctl create
         "filters": [
           {
             "name": "is_incident",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
+          {
+            "name": "not_silenced",
             "type": "EventFilter",
             "api_version": "core/v2"
           }
@@ -456,3 +460,4 @@ Learn more about the [Sensu PagerDuty integration][14] and our curated, configur
 [19]: ../../observe-events/
 [20]: ../pipelines/
 [21]: ../../observe-filter/filters/#built-in-filter-is_incident
+[22]: ../../observe-filter/filters/#built-in-filter-not_silenced

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -94,7 +94,7 @@ After you save your webhook, you can find the webhook URL under **Integration Se
 ## Create a handler
 
 Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the `sensu-slack-handler` dynamic runtime asset.
-Edit the sensuctl command below to include your Slack webhook URL and the channel where you want to receive events.
+Before you run the sensuctl command below, edit it to include your Slack webhook URL and the channel where you want to receive events:
 
 {{< code shell >}}
 sensuctl handler create slack \
@@ -134,9 +134,7 @@ The `slack` handler resource definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -155,9 +153,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -189,7 +185,7 @@ You can share and reuse this handler like code &mdash; [save it to a file][15] a
 With your handler configured, you can add it to a [pipeline][8] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-For now, the pipeline includes only the `slack` handler so that you receive an alert for every event the check generates (including events with OK status).
+For now, the pipeline includes only the `slack` handler and the built-in [not_silenced][22] event filter so that you receive an alert for every event the check generates (including events with OK status).
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -204,6 +200,10 @@ metadata:
 spec:
   workflows:
   - name: slack_alerts
+    filters:
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     handler:
       name: slack
       type: Handler
@@ -223,6 +223,13 @@ cat << EOF | sensuctl create
     "workflows": [
       {
         "name": "slack_alerts",
+        "filters": [
+          {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          }
+        ],
         "handler": {
           "name": "slack",
           "type": "Handler",
@@ -391,7 +398,7 @@ Read [Troubleshoot Sensu][7] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"event pipe handler executed","output":"","status":0`.
 
-## Add an event filter to the pipeline
+## Add another event filter to the pipeline
 
 At this point, the `cpu_check_alerts` pipeline has probably sent quite a few Slack messages for events with OK (`0`) status.
 To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in [is_incident][19] event filter to the pipeline:
@@ -409,6 +416,9 @@ spec:
   workflows:
   - name: slack_alerts
     filters:
+    - name: not_silenced
+      type: EventFilter
+      api_version: core/v2
     - name: is_incident
       type: EventFilter
       api_version: core/v2
@@ -432,6 +442,11 @@ cat << EOF | sensuctl create
       {
         "name": "slack_alerts",
         "filters": [
+          {
+            "name": "not_silenced",
+            "type": "EventFilter",
+            "api_version": "core/v2"
+          },
           {
             "name": "is_incident",
             "type": "EventFilter",
@@ -485,3 +500,4 @@ Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generate
 [19]: ../../observe-filter/filters/#built-in-filter-is_incident
 [20]: ../../../sensuctl/
 [21]: ../../observe-schedule/subscriptions/
+[22]: ../../observe-filter/filters/#built-in-filter-not_silenced


### PR DESCRIPTION
## Description
Adds the not_silenced event filter in pipeline and handler references, as well as guides where applicable, to help standardize the filter's usage.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3716
