### PR TITLE
Remove created_by and namespace from metadata in examples

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
@@ -45,7 +45,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: i-424242
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -69,8 +68,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "i-424242",
-    "namespace": "default"
+    "name": "i-424242"
   },
   "spec": {
     "deregister": false,
@@ -118,7 +116,6 @@ metadata:
     sensu.io/managed_by: sensuctl
     url: https://docs.sensu.io
   name: sensu-docs
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -146,8 +143,7 @@ spec:
       "sensu.io/managed_by": "sensuctl",
       "url": "https://docs.sensu.io"
     },
-    "name": "sensu-docs",
-    "namespace": "default"
+    "name": "sensu-docs"
   },
   "spec": {
     "deregister": false,
@@ -201,9 +197,7 @@ This example shows a service entity resource definition:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -213,9 +207,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -336,9 +336,7 @@ This example shows the resource definition for a service entity:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -468,6 +466,8 @@ sensuctl edit entity sensu-docs
 
 And update the metadata scope to include the `proxy_type` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -477,10 +477,28 @@ metadata:
     url: docs.sensu.io
     proxy_type: website
   name: sensu-docs
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "url": "docs.sensu.io",
+      "proxy_type": "website"
+    },
+    "name": "sensu-docs"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Proxy entity checks
 
@@ -551,6 +569,8 @@ sensuctl edit entity postgresql
 
 And update the metadata scope to include the `region` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -560,10 +580,28 @@ metadata:
     service_type: datastore
     region: us-west-1
   name: postgresql
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "service_type": "datastore",
+      "region": "us-west-1"
+    },
+    "name": "postgresql"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -84,9 +84,7 @@ This sensuctl command creates an event filter resource with the following defini
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -99,9 +97,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",
@@ -174,9 +170,7 @@ The updated handler definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -197,9 +191,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -458,9 +450,7 @@ The updated handler definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -481,9 +471,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -583,11 +583,9 @@ The sensuctl response will include the updated `check_cpu` resource definition i
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   labels:
     contacts: ops, dev
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -618,12 +616,10 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "labels": {
       "contacts": "ops, dev"
     },
-    "name": "check_cpu",
-    "namespace": "default"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/_index.md
@@ -38,9 +38,7 @@ Here's an example resource definition for a pipe handler &mdash; read [Send Slac
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -59,9 +57,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -443,9 +443,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -103,9 +103,7 @@ The response will list the complete check resource definition:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: file_exists
-  namespace: default
 spec:
   check_hooks: null
   command: check_file_exists --pattern /tmp/my-file.txt
@@ -136,9 +134,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "file_exists",
-    "namespace": "default"
+    "name": "file_exists"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -221,9 +221,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -254,9 +252,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "check_cpu",
-    "namespace": "default"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -129,9 +129,7 @@ The response will include the complete hook resource definition in the specified
 type: HookConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   runtime_assets: null
@@ -144,9 +142,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "process_tree",
-    "namespace": "default"
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -188,9 +188,7 @@ The sensuctl response will list the complete check resource definition &mdash; y
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: http-perf --url http://localhost --warning 1s --critical 2s
@@ -221,9 +219,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "collect-metrics",
-    "namespace": "default"
+    "name": "collect-metrics"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -170,9 +170,7 @@ The sensuctl response will include the complete `check_cpu` resource definition 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -202,9 +200,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,
@@ -389,11 +385,7 @@ The sensuctl response will include the complete `nginx_service` resource definit
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: nginx_service
-  namespace: default
 spec:
   check_hooks: null
   command: |
@@ -425,12 +417,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nginx_service",
-    "namespace": "default",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
-    "created_by": "admin"
+    "name": "nginx_service"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -236,7 +236,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-go-hello-world
-  namespace: default
 spec:
   builds:
   - sha512: 07665fda5b7c75e15e4322820aa7ddb791cc9338e38444e976e601bc7d7970592e806a7b88733690a238b7325437d31f85e98ae2fe47b008ca09c86530da9600
@@ -248,8 +247,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-go-hello-world",
-    "namespace": "default"
+    "name": "sensu-go-hello-world"
   },
   "spec": {
     "builds": [

--- a/content/sensu-go/6.3/observability-pipeline/observe-transform/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-transform/_index.md
@@ -40,7 +40,6 @@ type: Mutator
 api_version: core/v2
 metadata:
   name: sensu-check-status-metric-mutator
-  namespace: default
 spec:
   command: sensu-check-status-metric-mutator
   runtime_assets:
@@ -52,8 +51,7 @@ spec:
   "type": "Mutator",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-check-status-metric-mutator",
-    "namespace": "default"
+    "name": "sensu-check-status-metric-mutator"
   },
   "spec": {
     "command": "sensu-check-status-metric-mutator",

--- a/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-transform/mutators.md
@@ -40,7 +40,6 @@ type: Mutator
 api_version: core/v2
 metadata:
   name: mutator_minimum
-  namespace: default
 spec:
   command: example_mutator.go
 {{< /code >}}
@@ -50,8 +49,7 @@ spec:
   "type": "Mutator",
   "api_version": "core/v2",
   "metadata": {
-    "name": "mutator_minimum",
-    "namespace": "default"
+    "name": "mutator_minimum"
   },
   "spec": {
     "command": "example_mutator.go"
@@ -70,10 +68,7 @@ The following mutator definition uses an imaginary Sensu plugin, `example_mutato
 type: Mutator
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: example-mutator
-  namespace: default
 spec:
   command: example_mutator.go
   env_vars: []
@@ -86,10 +81,7 @@ spec:
   "type": "Mutator",
   "api_version": "core/v2",
   "metadata": {
-    "name": "example-mutator",
-    "namespace": "default",
-    "labels": null,
-    "annotations": null
+    "name": "example-mutator"
   },  
   "spec": {
     "command": "example_mutator.go",
@@ -140,7 +132,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: graphite
-  namespace: default
 spec:
   mutator: only_check_output
   socket:
@@ -154,8 +145,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "graphite",
-    "namespace": "default"
+    "name": "graphite"
   },
   "spec": {
     "type": "tcp",

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -88,7 +88,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: ec2-delete
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -104,8 +103,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-delete",
-    "namespace": "default"
+    "name": "ec2-delete"
   },
   "spec": {
     "rules": [
@@ -140,7 +138,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ec2-service-delete
-  namespace: default
 spec:
   role_ref:
     name: ec2-delete
@@ -154,8 +151,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-service-delete",
-    "namespace": "default"
+    "name": "ec2-service-delete"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.3/operations/control-access/create-read-only-user.md
@@ -62,9 +62,7 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: read-only
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -79,9 +77,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "read-only",
-    "namespace": "default"
+    "name": "read-only"
   },
   "spec": {
     "rules": [
@@ -113,9 +109,7 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-read-only
-  namespace: default
 spec:
   role_ref:
     name: read-only
@@ -129,9 +123,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "ops-read-only",
-    "namespace": "default"
+    "name": "ops-read-only"
   },
   "spec": {
     "role_ref": {
@@ -195,7 +187,6 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -211,7 +202,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -244,7 +234,6 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-event-reader
 spec:
   role_ref:
@@ -259,7 +248,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ops-event-reader"
   },
   "spec": {

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -670,9 +670,7 @@ This command creates the following role resource definition, which provides get,
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin
-  namespace: production
 spec:
   rules:
   - resources:
@@ -690,9 +688,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin",
-    "namespace": "production"
+    "name": "prod-admin"
   },
   "spec": {
     "rules": [
@@ -731,9 +727,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin-oncall
-  namespace: production
 spec:
   role_ref:
     name: prod-admin
@@ -748,9 +742,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin-oncall",
-    "namespace": "production"
+    "name": "prod-admin-oncall"
   },
   "spec": {
     "role_ref": {
@@ -787,7 +779,6 @@ This command creates the following cluster-wide role resource definition:
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -803,7 +794,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -1460,7 +1450,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
     - resources:
@@ -1484,8 +1473,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1522,7 +1510,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1537,8 +1524,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding",
-    "namespace": "default"
+    "name": "dev-binding"
   },
   "spec": {
     "role_ref": {
@@ -1569,7 +1555,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1593,8 +1578,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1631,7 +1615,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding-with-groups-prefix
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1646,8 +1629,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding-with-groups-prefix",
-    "namespace": "default"
+    "name": "dev-binding-with-groups-prefix"
   },
   "spec": {
     "role_ref": {
@@ -1713,7 +1695,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1742,8 +1723,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1785,7 +1765,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: alice-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1800,8 +1779,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "alice-default-admin",
-    "namespace": "default"
+    "name": "alice-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -1872,7 +1850,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1901,8 +1878,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1944,7 +1920,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ops-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1959,8 +1934,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ops-default-admin",
-    "namespace": "default"
+    "name": "ops-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -2613,7 +2587,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: silencing-script-binding-team-1
-  namespace: team1
 spec:
   role_ref:
     name: silencing-script
@@ -2627,8 +2600,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "silencing-script-binding-team-1",
-    "namespace": "team1"
+    "name": "silencing-script-binding-team-1"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.3/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.3/web-ui/webconfig-reference.md
@@ -63,8 +63,7 @@ spec:
   "type": "GlobalConfig",
   "api_version": "web/v1",
   "metadata": {
-    "name": "custom-web-ui",
-    "created_by": "admin"
+    "name": "custom-web-ui"
   },
   "spec": {
     "always_show_local_cluster": false,
@@ -135,7 +134,6 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
-  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
@@ -45,7 +45,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: i-424242
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -69,8 +68,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "i-424242",
-    "namespace": "default"
+    "name": "i-424242"
   },
   "spec": {
     "deregister": false,
@@ -115,10 +113,8 @@ api_version: core/v2
 metadata:
   labels:
     proxy_type: website
-    sensu.io/managed_by: sensuctl
     url: https://docs.sensu.io
   name: sensu-docs
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -143,11 +139,9 @@ spec:
   "metadata": {
     "labels": {
       "proxy_type": "website",
-      "sensu.io/managed_by": "sensuctl",
       "url": "https://docs.sensu.io"
     },
-    "name": "sensu-docs",
-    "namespace": "default"
+    "name": "sensu-docs"
   },
   "spec": {
     "deregister": false,
@@ -201,9 +195,7 @@ This example shows a service entity resource definition:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -213,9 +205,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -466,6 +466,8 @@ sensuctl edit entity sensu-docs
 
 And update the metadata scope to include the `proxy_type` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -475,10 +477,28 @@ metadata:
     url: docs.sensu.io
     proxy_type: website
   name: sensu-docs
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "url": "docs.sensu.io",
+      "proxy_type": "website"
+    },
+    "name": "sensu-docs"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Proxy entity checks
 
@@ -549,6 +569,8 @@ sensuctl edit entity postgresql
 
 And update the metadata scope to include the `region` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -558,10 +580,28 @@ metadata:
     service_type: datastore
     region: us-west-1
   name: postgresql
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "service_type": "datastore",
+      "region": "us-west-1"
+    },
+    "name": "postgresql"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -84,9 +84,7 @@ This sensuctl command creates an event filter resource with the following defini
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -99,9 +97,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",
@@ -174,9 +170,7 @@ The updated handler definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -197,9 +191,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",
@@ -458,9 +450,7 @@ The updated handler definition will be similar to this example:
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -481,9 +471,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -583,11 +583,9 @@ The sensuctl response will include the updated `check_cpu` resource definition i
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   labels:
     contacts: ops, dev
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -618,12 +616,10 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "labels": {
       "contacts": "ops, dev"
     },
-    "name": "check_cpu",
-    "namespace": "default"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/_index.md
@@ -38,9 +38,7 @@ Here's an example resource definition for a pipe handler &mdash; read [Send Slac
 type: Handler
 api_version: core/v2
 metadata:
-  created_by: admin
   name: slack
-  namespace: default
 spec:
   command: sensu-slack-handler --channel '#monitoring'
   env_vars:
@@ -59,9 +57,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "slack",
-    "namespace": "default"
+    "name": "slack"
   },
   "spec": {
     "command": "sensu-slack-handler --channel '#monitoring'",

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -443,9 +443,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -103,9 +103,7 @@ The response will list the complete check resource definition:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: file_exists
-  namespace: default
 spec:
   check_hooks: null
   command: check_file_exists --pattern /tmp/my-file.txt
@@ -136,9 +134,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "file_exists",
-    "namespace": "default"
+    "name": "file_exists"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
@@ -221,9 +221,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -129,9 +129,7 @@ The response will include the complete hook resource definition in the specified
 type: HookConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   runtime_assets: null
@@ -144,9 +142,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "process_tree",
-    "namespace": "default"
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -188,9 +188,7 @@ The sensuctl response will list the complete check resource definition &mdash; y
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: http-perf --url http://localhost --warning 1s --critical 2s
@@ -221,9 +219,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "collect-metrics",
-    "namespace": "default"
+    "name": "collect-metrics"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -170,9 +170,7 @@ The sensuctl response will include the complete `check_cpu` resource definition 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -202,9 +200,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,
@@ -389,11 +385,7 @@ The sensuctl response will include the complete `nginx_service` resource definit
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: nginx_service
-  namespace: default
 spec:
   check_hooks: null
   command: |
@@ -425,12 +417,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nginx_service",
-    "namespace": "default",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
-    "created_by": "admin"
+    "name": "nginx_service"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -236,7 +236,6 @@ type: Asset
 api_version: core/v2
 metadata:
   name: sensu-go-hello-world
-  namespace: default
 spec:
   builds:
   - sha512: 07665fda5b7c75e15e4322820aa7ddb791cc9338e38444e976e601bc7d7970592e806a7b88733690a238b7325437d31f85e98ae2fe47b008ca09c86530da9600
@@ -248,8 +247,7 @@ spec:
   "type": "Asset",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-go-hello-world",
-    "namespace": "default"
+    "name": "sensu-go-hello-world"
   },
   "spec": {
     "builds": [

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/_index.md
@@ -40,7 +40,6 @@ type: Mutator
 api_version: core/v2
 metadata:
   name: sensu-check-status-metric-mutator
-  namespace: default
 spec:
   command: sensu-check-status-metric-mutator
   runtime_assets:
@@ -52,8 +51,7 @@ spec:
   "type": "Mutator",
   "api_version": "core/v2",
   "metadata": {
-    "name": "sensu-check-status-metric-mutator",
-    "namespace": "default"
+    "name": "sensu-check-status-metric-mutator"
   },
   "spec": {
     "command": "sensu-check-status-metric-mutator",

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
@@ -40,7 +40,6 @@ type: Mutator
 api_version: core/v2
 metadata:
   name: mutator_minimum
-  namespace: default
 spec:
   command: example_mutator.go
 {{< /code >}}
@@ -50,8 +49,7 @@ spec:
   "type": "Mutator",
   "api_version": "core/v2",
   "metadata": {
-    "name": "mutator_minimum",
-    "namespace": "default"
+    "name": "mutator_minimum"
   },
   "spec": {
     "command": "example_mutator.go"
@@ -70,10 +68,7 @@ The following mutator definition uses an imaginary Sensu plugin, `example_mutato
 type: Mutator
 api_version: core/v2
 metadata:
-  annotations: null
-  labels: null
   name: example-mutator
-  namespace: default
 spec:
   command: example_mutator.go
   env_vars: []
@@ -140,7 +135,6 @@ type: Handler
 api_version: core/v2
 metadata:
   name: graphite
-  namespace: default
 spec:
   mutator: only_check_output
   socket:
@@ -154,8 +148,7 @@ spec:
   "type": "Handler",
   "api_version": "core/v2",
   "metadata": {
-    "name": "graphite",
-    "namespace": "default"
+    "name": "graphite"
   },
   "spec": {
     "type": "tcp",

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -88,7 +88,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: ec2-delete
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -104,8 +103,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-delete",
-    "namespace": "default"
+    "name": "ec2-delete"
   },
   "spec": {
     "rules": [
@@ -140,7 +138,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ec2-service-delete
-  namespace: default
 spec:
   role_ref:
     name: ec2-delete
@@ -154,8 +151,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-service-delete",
-    "namespace": "default"
+    "name": "ec2-service-delete"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
@@ -62,9 +62,7 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: read-only
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -79,9 +77,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "read-only",
-    "namespace": "default"
+    "name": "read-only"
   },
   "spec": {
     "rules": [
@@ -113,9 +109,7 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-read-only
-  namespace: default
 spec:
   role_ref:
     name: read-only
@@ -129,9 +123,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "ops-read-only",
-    "namespace": "default"
+    "name": "ops-read-only"
   },
   "spec": {
     "role_ref": {
@@ -195,7 +187,6 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -211,7 +202,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -244,7 +234,6 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-event-reader
 spec:
   role_ref:
@@ -259,7 +248,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ops-event-reader"
   },
   "spec": {

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -670,9 +670,7 @@ This command creates the following role resource definition, which provides get,
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin
-  namespace: production
 spec:
   rules:
   - resources:
@@ -690,9 +688,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin",
-    "namespace": "production"
+    "name": "prod-admin"
   },
   "spec": {
     "rules": [
@@ -731,9 +727,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin-oncall
-  namespace: production
 spec:
   role_ref:
     name: prod-admin
@@ -748,9 +742,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin-oncall",
-    "namespace": "production"
+    "name": "prod-admin-oncall"
   },
   "spec": {
     "role_ref": {
@@ -787,7 +779,6 @@ This command creates the following cluster-wide role resource definition:
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -803,7 +794,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -1460,7 +1450,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
     - resources:
@@ -1484,8 +1473,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1522,7 +1510,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1537,8 +1524,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding",
-    "namespace": "default"
+    "name": "dev-binding"
   },
   "spec": {
     "role_ref": {
@@ -1569,7 +1555,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1593,8 +1578,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1631,7 +1615,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding-with-groups-prefix
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1646,8 +1629,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding-with-groups-prefix",
-    "namespace": "default"
+    "name": "dev-binding-with-groups-prefix"
   },
   "spec": {
     "role_ref": {
@@ -1713,7 +1695,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1742,8 +1723,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1785,7 +1765,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: alice-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1800,8 +1779,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "alice-default-admin",
-    "namespace": "default"
+    "name": "alice-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -1872,7 +1850,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1901,8 +1878,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1944,7 +1920,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ops-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1959,8 +1934,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ops-default-admin",
-    "namespace": "default"
+    "name": "ops-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -2613,7 +2587,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: silencing-script-binding-team-1
-  namespace: team1
 spec:
   role_ref:
     name: silencing-script
@@ -2627,8 +2600,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "silencing-script-binding-team-1",
-    "namespace": "team1"
+    "name": "silencing-script-binding-team-1"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.4/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.4/web-ui/webconfig-reference.md
@@ -44,7 +44,6 @@ type: GlobalConfig
 api_version: web/v1
 metadata:
   name: custom-web-ui
-  created_by: admin
 spec:
   signin_message: with your LDAP or system credentials
   always_show_local_cluster: false
@@ -76,8 +75,7 @@ spec:
   "type": "GlobalConfig",
   "api_version": "web/v1",
   "metadata": {
-    "name": "custom-web-ui",
-    "created_by": "admin"
+    "name": "custom-web-ui"
   },
   "spec": {
     "signin_message": "with your LDAP or system credentials",
@@ -162,7 +160,6 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
-  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
@@ -45,7 +45,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: i-424242
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -69,8 +68,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "i-424242",
-    "namespace": "default"
+    "name": "i-424242"
   },
   "spec": {
     "deregister": false,
@@ -201,9 +199,7 @@ This example shows a service entity resource definition:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -213,9 +209,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -466,6 +466,8 @@ sensuctl edit entity sensu-docs
 
 And update the metadata scope to include the `proxy_type` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -475,10 +477,28 @@ metadata:
     url: docs.sensu.io
     proxy_type: website
   name: sensu-docs
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "url": "docs.sensu.io",
+      "proxy_type": "website"
+    },
+    "name": "sensu-docs"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Proxy entity checks
 
@@ -549,6 +569,8 @@ sensuctl edit entity postgresql
 
 And update the metadata scope to include the `region` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -558,10 +580,28 @@ metadata:
     service_type: datastore
     region: us-west-1
   name: postgresql
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "service_type": "datastore",
+      "region": "us-west-1"
+    },
+    "name": "postgresql"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -98,9 +98,7 @@ The event filter definition will be similar to this example:
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -113,9 +111,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",
@@ -256,9 +252,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -292,9 +286,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -291,9 +291,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -327,9 +325,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -309,9 +309,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -345,9 +343,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -129,9 +129,7 @@ The response will include the complete hook resource definition in the specified
 type: HookConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   runtime_assets: null
@@ -144,9 +142,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "process_tree",
-    "namespace": "default"
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -188,9 +188,7 @@ The sensuctl response will list the complete check resource definition &mdash; y
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: http-perf --url http://localhost --warning 1s --critical 2s
@@ -221,9 +219,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "collect-metrics",
-    "namespace": "default"
+    "name": "collect-metrics"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -170,9 +170,7 @@ The sensuctl response will include the complete `check_cpu` resource definition 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -203,9 +201,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,
@@ -395,11 +391,7 @@ The sensuctl response will include the complete `nginx_service` resource definit
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: nginx_service
-  namespace: default
 spec:
   check_hooks: null
   command: |
@@ -431,12 +423,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nginx_service",
-    "namespace": "default",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
-    "created_by": "admin"
+    "name": "nginx_service"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -88,7 +88,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: ec2-delete
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -104,8 +103,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-delete",
-    "namespace": "default"
+    "name": "ec2-delete"
   },
   "spec": {
     "rules": [
@@ -140,7 +138,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ec2-service-delete
-  namespace: default
 spec:
   role_ref:
     name: ec2-delete
@@ -154,8 +151,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-service-delete",
-    "namespace": "default"
+    "name": "ec2-service-delete"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.5/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.5/operations/control-access/create-read-only-user.md
@@ -62,9 +62,7 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: read-only
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -79,9 +77,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "read-only",
-    "namespace": "default"
+    "name": "read-only"
   },
   "spec": {
     "rules": [
@@ -113,9 +109,7 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-read-only
-  namespace: default
 spec:
   role_ref:
     name: read-only
@@ -129,9 +123,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "ops-read-only",
-    "namespace": "default"
+    "name": "ops-read-only"
   },
   "spec": {
     "role_ref": {
@@ -195,7 +187,6 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -211,7 +202,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -244,7 +234,6 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-event-reader
 spec:
   role_ref:
@@ -259,7 +248,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ops-event-reader"
   },
   "spec": {

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -677,9 +677,7 @@ This command creates the following role resource definition, which provides get,
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin
-  namespace: production
 spec:
   rules:
   - resources:
@@ -697,9 +695,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin",
-    "namespace": "production"
+    "name": "prod-admin"
   },
   "spec": {
     "rules": [
@@ -738,9 +734,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin-oncall
-  namespace: production
 spec:
   role_ref:
     name: prod-admin
@@ -755,9 +749,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin-oncall",
-    "namespace": "production"
+    "name": "prod-admin-oncall"
   },
   "spec": {
     "role_ref": {
@@ -794,7 +786,6 @@ This command creates the following cluster-wide role resource definition:
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -810,7 +801,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -1467,7 +1457,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
     - resources:
@@ -1492,8 +1481,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1531,7 +1519,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1546,8 +1533,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding",
-    "namespace": "default"
+    "name": "dev-binding"
   },
   "spec": {
     "role_ref": {
@@ -1578,7 +1564,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1603,8 +1588,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1642,7 +1626,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding-with-groups-prefix
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1657,8 +1640,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding-with-groups-prefix",
-    "namespace": "default"
+    "name": "dev-binding-with-groups-prefix"
   },
   "spec": {
     "role_ref": {
@@ -1724,7 +1706,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1754,8 +1735,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1798,7 +1778,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: alice-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1813,8 +1792,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "alice-default-admin",
-    "namespace": "default"
+    "name": "alice-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -1885,7 +1863,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1915,8 +1892,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1959,7 +1935,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ops-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1974,8 +1949,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ops-default-admin",
-    "namespace": "default"
+    "name": "ops-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -2636,7 +2610,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: silencing-script-binding-team-1
-  namespace: team1
 spec:
   role_ref:
     name: silencing-script
@@ -2650,8 +2623,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "silencing-script-binding-team-1",
-    "namespace": "team1"
+    "name": "silencing-script-binding-team-1"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.5/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.5/web-ui/webconfig-reference.md
@@ -44,7 +44,6 @@ type: GlobalConfig
 api_version: web/v1
 metadata:
   name: custom-web-ui
-  created_by: admin
 spec:
   signin_message: with your LDAP or system credentials
   always_show_local_cluster: false
@@ -76,8 +75,7 @@ spec:
   "type": "GlobalConfig",
   "api_version": "web/v1",
   "metadata": {
-    "name": "custom-web-ui",
-    "created_by": "admin"
+    "name": "custom-web-ui"
   },
   "spec": {
     "signin_message": "with your LDAP or system credentials",
@@ -162,7 +160,6 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
-  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/_index.md
@@ -45,7 +45,6 @@ type: Entity
 api_version: core/v2
 metadata:
   name: i-424242
-  namespace: default
 spec:
   deregister: false
   deregistration: {}
@@ -69,8 +68,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "name": "i-424242",
-    "namespace": "default"
+    "name": "i-424242"
   },
   "spec": {
     "deregister": false,
@@ -201,9 +199,7 @@ This example shows a service entity resource definition:
 type: Entity
 api_version: core/v2
 metadata:
-  created_by: admin
   name: postgresql
-  namespace: default
 spec:
   entity_class: service
 {{< /code >}}
@@ -213,9 +209,7 @@ spec:
   "type": "Entity",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "postgresql",
-    "namespace": "default"
+    "name": "postgresql"
   },
   "spec": {
     "entity_class": "service"

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -466,6 +466,8 @@ sensuctl edit entity sensu-docs
 
 And update the metadata scope to include the `proxy_type` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -475,10 +477,28 @@ metadata:
     url: docs.sensu.io
     proxy_type: website
   name: sensu-docs
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "url": "docs.sensu.io",
+      "proxy_type": "website"
+    },
+    "name": "sensu-docs"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 #### Proxy entity checks
 
@@ -549,6 +569,8 @@ sensuctl edit entity postgresql
 
 And update the metadata scope to include the `region` label:
 
+{{< language-toggle >}}
+
 {{< code yml >}}
 ---
 type: Entity
@@ -558,10 +580,28 @@ metadata:
     service_type: datastore
     region: us-west-1
   name: postgresql
-  namespace: default
 spec:
   '...': '...'
 {{< /code >}}
+
+{{< code json >}}
+{
+  "type": "Entity",
+  "api_version": "core/v2",
+  "metadata": {
+    "labels": {
+      "service_type": "datastore",
+      "region": "us-west-1"
+    },
+    "name": "postgresql"
+  },
+  "spec": {
+    "...": "..."
+  }
+}
+{{< /code >}}
+
+{{< /language-toggle >}}
 
 ## Entities specification
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -98,9 +98,7 @@ The event filter definition will be similar to this example:
 type: EventFilter
 api_version: core/v2
 metadata:
-  created_by: admin
   name: hourly
-  namespace: default
 spec:
   action: allow
   expressions:
@@ -113,9 +111,7 @@ spec:
   "type": "EventFilter",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "hourly",
-    "namespace": "default"
+    "name": "hourly"
   },
   "spec": {
     "action": "allow",
@@ -256,9 +252,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -292,9 +286,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -291,9 +291,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -327,9 +325,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -309,9 +309,7 @@ The updated check definition will be similar to this example:
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -345,9 +343,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -129,9 +129,7 @@ The response will include the complete hook resource definition in the specified
 type: HookConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: process_tree
-  namespace: default
 spec:
   command: ps aux
   runtime_assets: null
@@ -144,9 +142,7 @@ spec:
   "type": "HookConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "process_tree",
-    "namespace": "default"
+    "name": "process_tree"
   },
   "spec": {
     "command": "ps aux",

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -188,9 +188,7 @@ The sensuctl response will list the complete check resource definition &mdash; y
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: collect-metrics
-  namespace: default
 spec:
   check_hooks: null
   command: http-perf --url http://localhost --warning 1s --critical 2s
@@ -221,9 +219,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "collect-metrics",
-    "namespace": "default"
+    "name": "collect-metrics"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -170,9 +170,7 @@ The sensuctl response will include the complete `check_cpu` resource definition 
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
   name: check_cpu
-  namespace: default
 spec:
   check_hooks: null
   command: check-cpu-usage -w 75 -c 90
@@ -203,9 +201,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "check_cpu",
-    "namespace": "default",
-    "created_by": "admin"
+    "name": "check_cpu"
   },
   "spec": {
     "check_hooks": null,
@@ -395,11 +391,7 @@ The sensuctl response will include the complete `nginx_service` resource definit
 type: CheckConfig
 api_version: core/v2
 metadata:
-  created_by: admin
-  labels:
-    sensu.io/managed_by: sensuctl
   name: nginx_service
-  namespace: default
 spec:
   check_hooks: null
   command: |
@@ -431,12 +423,7 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "nginx_service",
-    "namespace": "default",
-    "labels": {
-      "sensu.io/managed_by": "sensuctl"
-    },
-    "created_by": "admin"
+    "name": "nginx_service"
   },
   "spec": {
     "check_hooks": null,

--- a/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
@@ -88,7 +88,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: ec2-delete
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -104,8 +103,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-delete",
-    "namespace": "default"
+    "name": "ec2-delete"
   },
   "spec": {
     "rules": [
@@ -140,7 +138,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ec2-service-delete
-  namespace: default
 spec:
   role_ref:
     name: ec2-delete
@@ -154,8 +151,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ec2-service-delete",
-    "namespace": "default"
+    "name": "ec2-service-delete"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.6/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.6/operations/control-access/create-read-only-user.md
@@ -62,9 +62,7 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: read-only
-  namespace: default
 spec:
   rules:
   - resource_names: null
@@ -79,9 +77,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "read-only",
-    "namespace": "default"
+    "name": "read-only"
   },
   "spec": {
     "rules": [
@@ -113,9 +109,7 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-read-only
-  namespace: default
 spec:
   role_ref:
     name: read-only
@@ -129,9 +123,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "ops-read-only",
-    "namespace": "default"
+    "name": "ops-read-only"
   },
   "spec": {
     "role_ref": {
@@ -195,7 +187,6 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -211,7 +202,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -244,7 +234,6 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 type: ClusterRoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: ops-event-reader
 spec:
   role_ref:
@@ -259,7 +248,6 @@ spec:
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "ops-event-reader"
   },
   "spec": {

--- a/content/sensu-go/6.6/operations/control-access/rbac.md
+++ b/content/sensu-go/6.6/operations/control-access/rbac.md
@@ -677,9 +677,7 @@ This command creates the following role resource definition, which provides get,
 type: Role
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin
-  namespace: production
 spec:
   rules:
   - resources:
@@ -697,9 +695,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin",
-    "namespace": "production"
+    "name": "prod-admin"
   },
   "spec": {
     "rules": [
@@ -738,9 +734,7 @@ This command creates the following role binding resource definition:
 type: RoleBinding
 api_version: core/v2
 metadata:
-  created_by: admin
   name: prod-admin-oncall
-  namespace: production
 spec:
   role_ref:
     name: prod-admin
@@ -755,9 +749,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
-    "name": "prod-admin-oncall",
-    "namespace": "production"
+    "name": "prod-admin-oncall"
   },
   "spec": {
     "role_ref": {
@@ -794,7 +786,6 @@ This command creates the following cluster-wide role resource definition:
 type: ClusterRole
 api_version: core/v2
 metadata:
-  created_by: admin
   name: global-event-reader
 spec:
   rules:
@@ -810,7 +801,6 @@ spec:
   "type": "ClusterRole",
   "api_version": "core/v2",
   "metadata": {
-    "created_by": "admin",
     "name": "global-event-reader"
   },
   "spec": {
@@ -1467,7 +1457,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
     - resources:
@@ -1492,8 +1481,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1531,7 +1519,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1546,8 +1533,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding",
-    "namespace": "default"
+    "name": "dev-binding"
   },
   "spec": {
     "role_ref": {
@@ -1578,7 +1564,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: workflow-creator
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1603,8 +1588,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "workflow-creator",
-    "namespace": "default"
+    "name": "workflow-creator"
   },
   "spec": {
     "rules": [
@@ -1642,7 +1626,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: dev-binding-with-groups-prefix
-  namespace: default
 spec:
   role_ref:
     name: workflow-creator
@@ -1657,8 +1640,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "dev-binding-with-groups-prefix",
-    "namespace": "default"
+    "name": "dev-binding-with-groups-prefix"
   },
   "spec": {
     "role_ref": {
@@ -1724,7 +1706,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1754,8 +1735,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1798,7 +1778,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: alice-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1813,8 +1792,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "alice-default-admin",
-    "namespace": "default"
+    "name": "alice-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -1885,7 +1863,6 @@ type: Role
 api_version: core/v2
 metadata:
   name: default-admin
-  namespace: default
 spec:
   rules:
   - resources:
@@ -1915,8 +1892,7 @@ spec:
   "type": "Role",
   "api_version": "core/v2",
   "metadata": {
-    "name": "default-admin",
-    "namespace": "default"
+    "name": "default-admin"
   },
   "spec": {
     "rules": [
@@ -1959,7 +1935,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: ops-default-admin
-  namespace: default
 spec:
   role_ref:
     name: default-admin
@@ -1974,8 +1949,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "ops-default-admin",
-    "namespace": "default"
+    "name": "ops-default-admin"
   },
   "spec": {
     "role_ref": {
@@ -2636,7 +2610,6 @@ type: RoleBinding
 api_version: core/v2
 metadata:
   name: silencing-script-binding-team-1
-  namespace: team1
 spec:
   role_ref:
     name: silencing-script
@@ -2650,8 +2623,7 @@ spec:
   "type": "RoleBinding",
   "api_version": "core/v2",
   "metadata": {
-    "name": "silencing-script-binding-team-1",
-    "namespace": "team1"
+    "name": "silencing-script-binding-team-1"
   },
   "spec": {
     "role_ref": {

--- a/content/sensu-go/6.6/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.6/web-ui/webconfig-reference.md
@@ -44,7 +44,6 @@ type: GlobalConfig
 api_version: web/v1
 metadata:
   name: custom-web-ui
-  created_by: admin
 spec:
   signin_message: with your LDAP or system credentials
   always_show_local_cluster: false
@@ -76,8 +75,7 @@ spec:
   "type": "GlobalConfig",
   "api_version": "web/v1",
   "metadata": {
-    "name": "custom-web-ui",
-    "created_by": "admin"
+    "name": "custom-web-ui"
   },
   "spec": {
     "signin_message": "with your LDAP or system credentials",
@@ -162,7 +160,6 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
-  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {


### PR DESCRIPTION
## Description
Removes created_by and namespace from the metadata in examples to make our examples more portable.

## Motivation and Context
Didn't quite get them all in https://github.com/sensu/sensu-docs/pull/3472
