### PR TITLE
Move 'the' out of linked text

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/_index.md
@@ -223,7 +223,7 @@ Sensu's usage limits are based on entities.
 
 The free limit is 100 entities.
 All [commercial features][2] are available for free in the packaged Sensu Go distribution for up to 100 entities.
-If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read [the announcement on our blog][4] for more information about our usage policy.
+If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read the [announcement on our blog][4] for more information about our usage policy.
 
 Commercial licenses may include an entity limit and entity class limits:
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -21,7 +21,7 @@ All [commercial features][9] are available for free in the packaged Sensu Go dis
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
 
 Learn more about entity limits in the [license reference][29].
-Read [the announcement on our blog][11] for more information about our usage policy.
+Read the [announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
 

--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -97,7 +97,7 @@ The response should list the `http-checks` dynamic runtime asset:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ### Create the check

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -179,7 +179,7 @@ Sensu includes built-in event filters to help you customize event pipelines for 
 To start using built-in event filters, read [Send Slack alerts][4] and [Plan maintenance][5].
 
 {{% notice note %}}
-**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with [the repeated events filter definition](#filter-for-repeated-events).
+**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with the [repeated events filter definition](#filter-for-repeated-events).
 {{% /notice %}}
 
 ### Built-in filter: is_incident

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -248,7 +248,7 @@ You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 You've registered the dynamic runtime asset, but you still need to create the filter.

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -92,7 +92,7 @@ Run `sensuctl asset list --format yaml` to confirm that the dynamic runtime asse
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ### 2. Create contact filters

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -80,14 +80,14 @@ Run `sensuctl asset list` to confirm that the dynamic runtime asset is ready to 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the handler
 
 Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
-For more information about the Sensu InfluxDB handler, read [the asset page in Bonsai][13].
+For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 
 {{< code shell >}}
 sensuctl handler create influxdb-handler \

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -89,7 +89,7 @@ The response will list the available builds for the Sensu Sumo Logic Handler dyn
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Set up an HTTP Logs and Metrics Source

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -68,7 +68,7 @@ The dynamic runtime asset includes the `sensu-email-handler` command, which you 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Add an event filter

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-slack-alerts.md
@@ -87,7 +87,7 @@ Created
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Get a Slack webhook

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -790,7 +790,7 @@ interval: 60
 
 |cron        |      |
 -------------|------
-description  | When the check should be executed, using [cron syntax][14] or [these predefined schedules][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
+description  | When the check should be executed, using [cron syntax][14] or a [predefined schedule][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a check that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -98,7 +98,7 @@ The sensuctl response should list http-checks:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Install and configure NGINX

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -125,7 +125,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create a check to monitor a server

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
@@ -285,7 +285,7 @@ created_by: admin
 
 cron         | 
 -------------|------
-description  | When the service component should be executed, using [cron syntax][1] or [these predefined schedules][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
+description  | When the service component should be executed, using [cron syntax][1] or a [predefined schedule][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a service component that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -202,7 +202,7 @@ You can also download the dynamic runtime asset definition from [Bonsai][13] and
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Configure an EC2 handler for the service account

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -495,7 +495,7 @@ Sensu supports dynamic runtime assets for checks, filters, mutators, and handler
 Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own dynamic runtime assets, read the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
-To contribute to converting a Sensu plugin to a dynamic runtime asset, read [the Discourse post][70].
+To contribute to converting a Sensu plugin to a dynamic runtime asset, read [Contributing Assets for Existing Ruby Sensu Plugins][70] at the Sensu Community Forum on Discourse.
 
 ### Step 4: Translate Sensu Enterprise-only features
 

--- a/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.3/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -80,7 +80,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Monitor your Sensu backend instances

--- a/content/sensu-go/6.3/plugins/assets.md
+++ b/content/sensu-go/6.3/plugins/assets.md
@@ -588,7 +588,7 @@ dbfd4a714c0c51c57f77daeb62f4a21141665ae71440951399be2d899bf44b3634dad2e6f2516fff
 
 From here, you can host your dynamic runtime asset wherever you’d like.
 To make the asset available via [Bonsai][16], you’ll need to host it on GitHub.
-Learn more in [The “Hello World” of Sensu Assets][18] on Discourse.
+Learn more in [The “Hello World” of Sensu Assets][18] at the Sensu Community Forum on Discourse.
 
 To host your dynamic runtime asset on a different platform like Gitlab or Bitbucket, upload your asset there.
 You can also use Artifactory or even Apache or NGINX to serve your asset.

--- a/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
@@ -53,7 +53,7 @@ You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to do
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
+Read the [asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
 {{% /notice %}}
 
 ## Adjust the asset definition

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -907,7 +907,7 @@ All [commercial features][95] are available for free in the packaged Sensu Go di
 You will receive a warning when you approach the 100-entity limit (at 75%).
 
 If your Sensu instance includes more than 100 entities, [contact us][90] to learn how to upgrade your installation and increase your limit.
-Read [the blog announcement][91] for more information about our usage policy.
+Read the [blog announcement][91] for more information about our usage policy.
 
 **NEW FEATURES:**
 

--- a/content/sensu-go/6.3/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.3/sensuctl/sensuctl-bonsai.md
@@ -53,7 +53,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.1.1 --rename influxdb-handler
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Check your Sensu backend for outdated dynamic runtime assets

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/_index.md
@@ -221,7 +221,7 @@ Sensu's usage limits are based on entities.
 
 The free limit is 100 entities.
 All [commercial features][2] are available for free in the packaged Sensu Go distribution for up to 100 entities.
-If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read [the announcement on our blog][4] for more information about our usage policy.
+If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read the [announcement on our blog][4] for more information about our usage policy.
 
 Commercial licenses may include an entity limit and entity class limits:
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -21,7 +21,7 @@ All [commercial features][9] are available for free in the packaged Sensu Go dis
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
 
 Learn more about entity limits in the [license reference][29].
-Read [the announcement on our blog][11] for more information about our usage policy.
+Read the [announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -97,7 +97,7 @@ The response should list the `http-checks` dynamic runtime asset:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ### Create the check

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -179,7 +179,7 @@ Sensu includes built-in event filters to help you customize event pipelines for 
 To start using built-in event filters, read [Send Slack alerts][4] and [Plan maintenance][5].
 
 {{% notice note %}}
-**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with [the repeated events filter definition](#filter-for-repeated-events).
+**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with the [repeated events filter definition](#filter-for-repeated-events).
 {{% /notice %}}
 
 ### Built-in filter: is_incident

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -248,7 +248,7 @@ You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 You've registered the dynamic runtime asset, but you still need to create the filter.

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -92,7 +92,7 @@ Run `sensuctl asset list --format yaml` to confirm that the dynamic runtime asse
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ### 2. Create contact filters

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -80,14 +80,14 @@ Run `sensuctl asset list` to confirm that the dynamic runtime asset is ready to 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the handler
 
 Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
-For more information about the Sensu InfluxDB handler, read [the asset page in Bonsai][13].
+For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 
 {{< code shell >}}
 sensuctl handler create influxdb-handler \

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -89,7 +89,7 @@ The response will list the available builds for the Sensu Sumo Logic Handler dyn
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Set up an HTTP Logs and Metrics Source

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
@@ -68,7 +68,7 @@ The dynamic runtime asset includes the `sensu-email-handler` command, which you 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Add an event filter

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
@@ -87,7 +87,7 @@ Created
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Get a Slack webhook

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -789,7 +789,7 @@ interval: 60
 
 |cron        |      |
 -------------|------
-description  | When the check should be executed, using [cron syntax][14] or [these predefined schedules][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
+description  | When the check should be executed, using [cron syntax][14] or a [predefined schedule][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a check that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -98,7 +98,7 @@ The sensuctl response should list http-checks:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Install and configure NGINX

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -125,7 +125,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create a check to monitor a server

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -285,7 +285,7 @@ created_by: admin
 
 cron         | 
 -------------|------
-description  | When the service component should be executed, using [cron syntax][1] or [these predefined schedules][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
+description  | When the service component should be executed, using [cron syntax][1] or a [predefined schedule][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a service component that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -202,7 +202,7 @@ You can also download the dynamic runtime asset definition from [Bonsai][13] and
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Configure an EC2 handler for the service account

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -495,7 +495,7 @@ Sensu supports dynamic runtime assets for checks, filters, mutators, and handler
 Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own dynamic runtime assets, read the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
-To contribute to converting a Sensu plugin to a dynamic runtime asset, read [the Discourse post][70].
+To contribute to converting a Sensu plugin to a dynamic runtime asset, read [Contributing Assets for Existing Ruby Sensu Plugins][70] at the Sensu Community Forum on Discourse.
 
 ### Step 4: Translate Sensu Enterprise-only features
 

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -80,7 +80,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Monitor your Sensu backend instances

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -586,7 +586,7 @@ dbfd4a714c0c51c57f77daeb62f4a21141665ae71440951399be2d899bf44b3634dad2e6f2516fff
 
 From here, you can host your dynamic runtime asset wherever you’d like.
 To make the asset available via [Bonsai][16], you’ll need to host it on GitHub.
-Learn more in [The “Hello World” of Sensu Assets][18] on Discourse.
+Learn more in [The “Hello World” of Sensu Assets][18] at the Sensu Community Forum on Discourse.
 
 To host your dynamic runtime asset on a different platform like Gitlab or Bitbucket, upload your asset there.
 You can also use Artifactory or even Apache or NGINX to serve your asset.

--- a/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
@@ -53,7 +53,7 @@ You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to do
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
+Read the [asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
 {{% /notice %}}
 
 ## Adjust the asset definition

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -1001,7 +1001,7 @@ All [commercial features][95] are available for free in the packaged Sensu Go di
 You will receive a warning when you approach the 100-entity limit (at 75%).
 
 If your Sensu instance includes more than 100 entities, [contact us][90] to learn how to upgrade your installation and increase your limit.
-Read [the blog announcement][91] for more information about our usage policy.
+Read the [blog announcement][91] for more information about our usage policy.
 
 **NEW FEATURES:**
 

--- a/content/sensu-go/6.4/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.4/sensuctl/sensuctl-bonsai.md
@@ -53,7 +53,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.1.1 --rename influxdb-handler
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Check your Sensu backend for outdated dynamic runtime assets

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/_index.md
@@ -225,7 +225,7 @@ Sensu's usage limits are based on entities.
 
 The free limit is 100 entities.
 All [commercial features][2] are available for free in the packaged Sensu Go distribution for up to 100 entities.
-If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read [the announcement on our blog][4] for more information about our usage policy.
+If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read the [announcement on our blog][4] for more information about our usage policy.
 
 Commercial licenses may include an entity limit and entity class limits:
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -21,7 +21,7 @@ All [commercial features][9] are available for free in the packaged Sensu Go dis
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
 
 Learn more about entity limits in the [license reference][29].
-Read [the announcement on our blog][11] for more information about our usage policy.
+Read the [announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -97,7 +97,7 @@ The response should list the `http-checks` dynamic runtime asset:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ### Create the check

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -174,7 +174,7 @@ Sensu includes built-in event filters to help you customize event pipelines for 
 To start using built-in event filters, read [Send Slack alerts][4] and [Plan maintenance][5].
 
 {{% notice note %}}
-**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with [the repeated events filter definition](#filter-for-repeated-events).
+**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with the [repeated events filter definition](#filter-for-repeated-events).
 {{% /notice %}}
 
 ### Built-in filter: is_incident

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -358,7 +358,7 @@ You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 You've registered the dynamic runtime asset, but you still need to create the filter.

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -125,7 +125,7 @@ The response will confirm the available assets:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create contact filters

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -80,14 +80,14 @@ Run `sensuctl asset list` to confirm that the dynamic runtime asset is ready to 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the handler
 
 Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
-For more information about the Sensu InfluxDB handler, read [the asset page in Bonsai][13].
+For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 
 {{< code shell >}}
 sensuctl handler create influxdb-handler \

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -89,7 +89,7 @@ The response will list the available builds for the Sensu Sumo Logic Handler dyn
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Set up an HTTP Logs and Metrics Source

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -67,7 +67,7 @@ The dynamic runtime asset includes the `sensu-email-handler` command, which you 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Add an event filter

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -88,7 +88,7 @@ The response will list the available builds for the Sensu PagerDuty Handler dyna
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Add the PagerDuty handler

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -81,7 +81,7 @@ You can also download the latest dynamic runtime asset definition for your platf
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Get a Slack webhook

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -804,7 +804,7 @@ interval: 60
 
 |cron        |      |
 -------------|------
-description  | When the check should be executed, using [cron syntax][14] or [these predefined schedules][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
+description  | When the check should be executed, using [cron syntax][14] or a [predefined schedule][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a check that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -98,7 +98,7 @@ The sensuctl response should list http-checks:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Install and configure NGINX

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -125,7 +125,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create a check to monitor a server

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
@@ -285,7 +285,7 @@ created_by: admin
 
 cron         | 
 -------------|------
-description  | When the service component should be executed, using [cron syntax][1] or [these predefined schedules][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
+description  | When the service component should be executed, using [cron syntax][1] or a [predefined schedule][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a service component that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -202,7 +202,7 @@ You can also download the dynamic runtime asset definition from [Bonsai][13] and
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Configure an EC2 handler for the service account

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -497,7 +497,7 @@ Sensu supports dynamic runtime assets for checks, filters, mutators, and handler
 Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own dynamic runtime assets, read the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
-To contribute to converting a Sensu plugin to a dynamic runtime asset, read [the Discourse post][70].
+To contribute to converting a Sensu plugin to a dynamic runtime asset, read [Contributing Assets for Existing Ruby Sensu Plugins][70] at the Sensu Community Forum on Discourse.
 
 ### Step 4: Translate Sensu Enterprise-only features
 

--- a/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -80,7 +80,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Monitor your Sensu backend instances

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -586,7 +586,7 @@ dbfd4a714c0c51c57f77daeb62f4a21141665ae71440951399be2d899bf44b3634dad2e6f2516fff
 
 From here, you can host your dynamic runtime asset wherever you’d like.
 To make the asset available via [Bonsai][16], you’ll need to host it on GitHub.
-Learn more in [The “Hello World” of Sensu Assets][18] on Discourse.
+Learn more in [The “Hello World” of Sensu Assets][18] at the Sensu Community Forum on Discourse.
 
 To host your dynamic runtime asset on a different platform like Gitlab or Bitbucket, upload your asset there.
 You can also use Artifactory or even Apache or NGINX to serve your asset.

--- a/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
@@ -53,7 +53,7 @@ You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to do
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
+Read the [asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
 {{% /notice %}}
 
 ## Adjust the asset definition

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -1158,7 +1158,7 @@ All [commercial features][95] are available for free in the packaged Sensu Go di
 You will receive a warning when you approach the 100-entity limit (at 75%).
 
 If your Sensu instance includes more than 100 entities, [contact us][90] to learn how to upgrade your installation and increase your limit.
-Read [the blog announcement][91] for more information about our usage policy.
+Read the [blog announcement][91] for more information about our usage policy.
 
 **NEW FEATURES:**
 

--- a/content/sensu-go/6.5/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.5/sensuctl/sensuctl-bonsai.md
@@ -53,7 +53,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 --rename influxdb-handler
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Check your Sensu backend for outdated dynamic runtime assets

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/_index.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/_index.md
@@ -225,7 +225,7 @@ Sensu's usage limits are based on entities.
 
 The free limit is 100 entities.
 All [commercial features][2] are available for free in the packaged Sensu Go distribution for up to 100 entities.
-If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read [the announcement on our blog][4] for more information about our usage policy.
+If your Sensu instance includes more than 100 entities, [contact us][3] to learn how to upgrade your installation and increase your limit. Read the [announcement on our blog][4] for more information about our usage policy.
 
 Commercial licenses may include an entity limit and entity class limits:
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -21,7 +21,7 @@ All [commercial features][9] are available for free in the packaged Sensu Go dis
 If your Sensu instance includes more than 100 entities, [contact us][10] to learn how to upgrade your installation and increase your limit.
 
 Learn more about entity limits in the [license reference][29].
-Read [the announcement on our blog][11] for more information about our usage policy.
+Read the [announcement on our blog][11] for more information about our usage policy.
 
 ## Create and manage agent entities
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -97,7 +97,7 @@ The response should list the `http-checks` dynamic runtime asset:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ### Create the check

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -174,7 +174,7 @@ Sensu includes built-in event filters to help you customize event pipelines for 
 To start using built-in event filters, read [Send Slack alerts][4] and [Plan maintenance][5].
 
 {{% notice note %}}
-**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with [the repeated events filter definition](#filter-for-repeated-events).
+**NOTE**: Sensu Go does not include the built-in occurrence-based event filter in Sensu Core 1.x, but you can replicate its functionality with the [repeated events filter definition](#filter-for-repeated-events).
 {{% /notice %}}
 
 ### Built-in filter: is_incident

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -358,7 +358,7 @@ You can also download the asset directly from [Bonsai, the Sensu asset hub][9].
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 You've registered the dynamic runtime asset, but you still need to create the filter.

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
@@ -125,7 +125,7 @@ The response will confirm the available assets:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create contact filters

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -80,14 +80,14 @@ Run `sensuctl asset list` to confirm that the dynamic runtime asset is ready to 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the handler
 
 Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
-For more information about the Sensu InfluxDB handler, read [the asset page in Bonsai][13].
+For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 
 {{< code shell >}}
 sensuctl handler create influxdb-handler \

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -89,7 +89,7 @@ The response will list the available builds for the Sensu Sumo Logic Handler dyn
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Set up an HTTP Logs and Metrics Source

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
@@ -67,7 +67,7 @@ The dynamic runtime asset includes the `sensu-email-handler` command, which you 
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Add an event filter

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -88,7 +88,7 @@ The response will list the available builds for the Sensu PagerDuty Handler dyna
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Add the PagerDuty handler

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -81,7 +81,7 @@ You can also download the latest dynamic runtime asset definition for your platf
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Get a Slack webhook

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -804,7 +804,7 @@ interval: 60
 
 |cron        |      |
 -------------|------
-description  | When the check should be executed, using [cron syntax][14] or [these predefined schedules][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
+description  | When the check should be executed, using [cron syntax][14] or a [predefined schedule][15]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a check that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -98,7 +98,7 @@ The sensuctl response should list http-checks:
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Install and configure NGINX

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -125,7 +125,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create a check to monitor a server

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/service-components.md
@@ -285,7 +285,7 @@ created_by: admin
 
 cron         | 
 -------------|------
-description  | When the service component should be executed, using [cron syntax][1] or [these predefined schedules][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
+description  | When the service component should be executed, using [cron syntax][1] or a [predefined schedule][2]. Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][3] for the cron attribute. {{% notice note %}}
 **NOTE**: If you're using YAML to create a service component that uses cron scheduling and the first character of the cron schedule is an asterisk (`*`), place the entire cron schedule inside single or double quotes (for example, `cron: '* * * * *'`).
 {{% /notice %}}
 required     | true (unless `interval` is configured)

--- a/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
@@ -202,7 +202,7 @@ You can also download the dynamic runtime asset definition from [Bonsai][13] and
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Configure an EC2 handler for the service account

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -497,7 +497,7 @@ Sensu supports dynamic runtime assets for checks, filters, mutators, and handler
 Discover, download, and share dynamic runtime assets with [Bonsai][68], the Sensu asset hub.
 
 To create your own dynamic runtime assets, read the [asset reference][12] and [guide to sharing an asset on Bonsai][69].
-To contribute to converting a Sensu plugin to a dynamic runtime asset, read [the Discourse post][70].
+To contribute to converting a Sensu plugin to a dynamic runtime asset, read [Contributing Assets for Existing Ruby Sensu Plugins][70] at the Sensu Community Forum on Discourse.
 
 ### Step 4: Translate Sensu Enterprise-only features
 

--- a/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -80,7 +80,7 @@ Because plugins are published for multiple platforms, including Linux and Window
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Monitor your Sensu backend instances

--- a/content/sensu-go/6.6/plugins/assets.md
+++ b/content/sensu-go/6.6/plugins/assets.md
@@ -586,7 +586,7 @@ dbfd4a714c0c51c57f77daeb62f4a21141665ae71440951399be2d899bf44b3634dad2e6f2516fff
 
 From here, you can host your dynamic runtime asset wherever you’d like.
 To make the asset available via [Bonsai][16], you’ll need to host it on GitHub.
-Learn more in [The “Hello World” of Sensu Assets][18] on Discourse.
+Learn more in [The “Hello World” of Sensu Assets][18] at the Sensu Community Forum on Discourse.
 
 To host your dynamic runtime asset on a different platform like Gitlab or Bitbucket, upload your asset there.
 You can also use Artifactory or even Apache or NGINX to serve your asset.

--- a/content/sensu-go/6.6/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.6/plugins/use-assets-to-install-plugins.md
@@ -53,7 +53,7 @@ You can also open the **Release Assets** tab on asset pages in [Bonsai][3] to do
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
+Read the [asset reference](../assets#dynamic-runtime-asset-builds) for more information about asset builds.
 {{% /notice %}}
 
 ## Adjust the asset definition

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -1306,7 +1306,7 @@ All [commercial features][95] are available for free in the packaged Sensu Go di
 You will receive a warning when you approach the 100-entity limit (at 75%).
 
 If your Sensu instance includes more than 100 entities, [contact us][90] to learn how to upgrade your installation and increase your limit.
-Read [the blog announcement][91] for more information about our usage policy.
+Read the [blog announcement][91] for more information about our usage policy.
 
 **NEW FEATURES:**
 

--- a/content/sensu-go/6.6/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.6/sensuctl/sensuctl-bonsai.md
@@ -53,7 +53,7 @@ sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 --rename influxdb-handler
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read [the asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
+Read the [asset reference](../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Check your Sensu backend for outdated dynamic runtime assets


### PR DESCRIPTION
## Description
Moves 'the' out of linked text

e.g. changes:
`Read [the blog announcement][7]`

to:
`Read the [blog announcement][7]`

Also replaces a couple instances of non-specific link text like "the Discourse post" to use the title of the thing being linked to.


