### PR TITLE
Fix link to events API

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -498,7 +498,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -498,7 +498,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -504,7 +504,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -504,7 +504,7 @@ In addition, the agent maps [`keepalive-critical-timeout` and `keepalive-warning
 
 {{% notice note %}}
 **NOTE**: Automatic keepalive monitoring is not supported for [proxy entities](../../observe-entities/#proxy-entities) because they cannot run a Sensu agent.
-Use the [core/v2/events API](../../../api/core/events/#eventsentitycheck-put) to send manual keepalive events for proxy entities.
+Use the [core/v2/events API](../../../api/core/events/) to send manual keepalive events for proxy entities.
 {{% /notice %}}
 
 ### Handle keepalive events


### PR DESCRIPTION
## Description
Fixes a link to the events API -- updated to link to the events API page rather than the PUT method

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>
