### PR TITLE
Update code block formatting in service management section in agent reference

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -488,7 +488,6 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
-
 Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -488,6 +488,7 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
+
 Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -487,9 +487,9 @@ If a Sensu agent fails to send keepalive events over the period specified by the
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.
+**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.
+As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
 
@@ -566,7 +566,7 @@ Keepalive monitoring is more fluid &mdash; it permits agents to reconnect any nu
 As long as the agent can successfully send one event to any backend within the timeout, the keepalive logic is satisfied.
 {{% /notice %}}
 
-## Service management {#operation}
+## Service management
 
 ### Start the service
 
@@ -574,7 +574,7 @@ Use the `sensu-agent` tool to start the agent and apply configuration flags.
 
 {{< platformBlock "Linux" >}}
 
-#### Linux
+**Linux**
 
 To start the agent with [configuration flags][24]:
 
@@ -600,7 +600,7 @@ If you do not provide any configuration flags, the agent loads configuration fro
 
 {{< platformBlock "Windows" >}}
 
-#### Windows
+**Windows**
 
 Run the following command as an admin to install and start the agent:
 
@@ -622,25 +622,17 @@ sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.
 
 To stop the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent stop
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe stop SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Restart the service
 
@@ -648,81 +640,71 @@ You must restart the agent to implement any configuration updates.
 
 To restart the agent using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent restart
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe start SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Enable on boot
 
 To enable the agent to start on system boot:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo systemctl enable sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+The service is configured to start automatically on boot by default.
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent.
+{{% /notice %}}
+
 To disable the agent from starting on system boot:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "Linux" >}}
 sudo systemctl disable sensu-agent
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable the agent.
-{{% /notice %}}
-
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
+{{< code shell "Windows" >}}
 The service is configured to start automatically on boot by default.
+{{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent off` to disable the agent.
+{{% /notice %}}
 
 ### Get service status
 
 To view the status of the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 service sensu-agent status
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe query SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get service version
 
@@ -912,7 +894,7 @@ Flags:
 
 ### Windows
 
-You can specify the agent configuration using a `.yml` file.
+Specify the agent configuration using a `.yml` file.
 Review the [example agent configuration file][5] (also provided with Sensu packages at `%ALLUSERSPROFILE%\sensu\config\agent.yml.example`; default `C:\ProgramData\sensu\config\agent.yml.example`).
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -729,7 +729,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -724,15 +724,19 @@ curl http://127.0.0.1:3031/version
 
 ### Uninstall the service
 
-{{< platformBlock "Windows" >}}
+To uninstall the sensu-agent service, run:
 
-**Windows**
+{{< language-toggle >}}
 
-{{< code text >}}
+{{< code shell "Linux" >}}
+sudo service sensu-agent stop
+{{< /code >}}
+
+{{< code shell "Windows" >}}
 sensu-agent service uninstall
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get help
 

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -1686,7 +1686,7 @@ To get started with Sensu Go:
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
 [40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
-[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#operation
+[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#service-management
 [43]: /sensu-go/5.7/api/#response-filtering
 [44]: https://discourse.sensu.io/t/introducing-usage-limits-in-the-sensu-go-free-tier/1156/
 [45]: /sensu-go/5.8/sensuctl/create-manage-resources/#handle-large-datasets

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -487,9 +487,9 @@ If a Sensu agent fails to send keepalive events over the period specified by the
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.
+**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.
+As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
 
@@ -566,7 +566,7 @@ Keepalive monitoring is more fluid &mdash; it permits agents to reconnect any nu
 As long as the agent can successfully send one event to any backend within the timeout, the keepalive logic is satisfied.
 {{% /notice %}}
 
-## Service management {#operation}
+## Service management
 
 ### Start the service
 
@@ -574,7 +574,7 @@ Use the `sensu-agent` tool to start the agent and apply configuration flags.
 
 {{< platformBlock "Linux" >}}
 
-#### Linux
+**Linux**
 
 To start the agent with [configuration flags][24]:
 
@@ -600,7 +600,7 @@ If you do not provide any configuration flags, the agent loads configuration fro
 
 {{< platformBlock "Windows" >}}
 
-#### Windows
+**Windows**
 
 Run the following command as an admin to install and start the agent:
 
@@ -622,25 +622,17 @@ sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.
 
 To stop the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent stop
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe stop SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Restart the service
 
@@ -648,81 +640,71 @@ You must restart the agent to implement any configuration updates.
 
 To restart the agent using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent restart
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe start SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Enable on boot
 
 To enable the agent to start on system boot:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo systemctl enable sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+The service is configured to start automatically on boot by default.
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent.
+{{% /notice %}}
+
 To disable the agent from starting on system boot:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "Linux" >}}
 sudo systemctl disable sensu-agent
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable the agent.
-{{% /notice %}}
-
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
+{{< code shell "Windows" >}}
 The service is configured to start automatically on boot by default.
+{{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent off` to disable the agent.
+{{% /notice %}}
 
 ### Get service status
 
 To view the status of the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 service sensu-agent status
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe query SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get service version
 
@@ -912,7 +894,7 @@ Flags:
 
 ### Windows
 
-You can specify the agent configuration using a `.yml` file.
+Specify the agent configuration using a `.yml` file.
 Review the [example agent configuration file][5] (also provided with Sensu packages at `%ALLUSERSPROFILE%\sensu\config\agent.yml.example`; default `C:\ProgramData\sensu\config\agent.yml.example`).
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -729,7 +729,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -724,15 +724,19 @@ curl http://127.0.0.1:3031/version
 
 ### Uninstall the service
 
-{{< platformBlock "Windows" >}}
+To uninstall the sensu-agent service, run:
 
-**Windows**
+{{< language-toggle >}}
 
-{{< code text >}}
+{{< code shell "Linux" >}}
+sudo service sensu-agent stop
+{{< /code >}}
+
+{{< code shell "Windows" >}}
 sensu-agent service uninstall
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get help
 

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -1780,7 +1780,7 @@ To get started with Sensu Go:
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
 [40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
-[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#operation
+[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#service-management
 [43]: /sensu-go/5.7/api/#response-filtering
 [44]: https://discourse.sensu.io/t/introducing-usage-limits-in-the-sensu-go-free-tier/1156/
 [45]: /sensu-go/5.8/sensuctl/create-manage-resources/#handle-large-datasets

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -735,7 +735,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -493,9 +493,9 @@ If a Sensu agent fails to send keepalive events over the period specified by the
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.
+**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.
+As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
 
@@ -572,7 +572,7 @@ Keepalive monitoring is more fluid &mdash; it permits agents to reconnect any nu
 As long as the agent can successfully send one event to any backend within the timeout, the keepalive logic is satisfied.
 {{% /notice %}}
 
-## Service management {#operation}
+## Service management
 
 ### Start the service
 
@@ -580,7 +580,7 @@ Use the `sensu-agent` tool to start the agent and apply configuration flags.
 
 {{< platformBlock "Linux" >}}
 
-#### Linux
+**Linux**
 
 To start the agent with [configuration flags][24]:
 
@@ -606,7 +606,7 @@ If you do not provide any configuration flags, the agent loads configuration fro
 
 {{< platformBlock "Windows" >}}
 
-#### Windows
+**Windows**
 
 Run the following command as an admin to install and start the agent:
 
@@ -628,25 +628,17 @@ sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.
 
 To stop the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent stop
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe stop SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Restart the service
 
@@ -654,81 +646,71 @@ You must restart the agent to implement any configuration updates.
 
 To restart the agent using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent restart
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe start SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Enable on boot
 
 To enable the agent to start on system boot:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo systemctl enable sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+The service is configured to start automatically on boot by default.
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent.
+{{% /notice %}}
+
 To disable the agent from starting on system boot:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "Linux" >}}
 sudo systemctl disable sensu-agent
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable the agent.
-{{% /notice %}}
-
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
+{{< code shell "Windows" >}}
 The service is configured to start automatically on boot by default.
+{{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent off` to disable the agent.
+{{% /notice %}}
 
 ### Get service status
 
 To view the status of the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 service sensu-agent status
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe query SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get service version
 
@@ -921,7 +903,7 @@ Flags:
 
 ### Windows
 
-You can specify the agent configuration using a `.yml` file.
+Specify the agent configuration using a `.yml` file.
 Review the [example agent configuration file][5] (also provided with Sensu packages at `%ALLUSERSPROFILE%\sensu\config\agent.yml.example`; default `C:\ProgramData\sensu\config\agent.yml.example`).
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -730,15 +730,19 @@ curl http://127.0.0.1:3031/version
 
 ### Uninstall the service
 
-{{< platformBlock "Windows" >}}
+To uninstall the sensu-agent service, run:
 
-**Windows**
+{{< language-toggle >}}
 
-{{< code text >}}
+{{< code shell "Linux" >}}
+sudo service sensu-agent stop
+{{< /code >}}
+
+{{< code shell "Windows" >}}
 sensu-agent service uninstall
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get help
 

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -1937,7 +1937,7 @@ To get started with Sensu Go:
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
 [40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
-[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#operation
+[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#service-management
 [43]: /sensu-go/5.7/api/#response-filtering
 [44]: https://discourse.sensu.io/t/introducing-usage-limits-in-the-sensu-go-free-tier/1156/
 [45]: /sensu-go/5.8/sensuctl/create-manage-resources/#handle-large-datasets

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -735,7 +735,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -730,15 +730,19 @@ curl http://127.0.0.1:3031/version
 
 ### Uninstall the service
 
-{{< platformBlock "Windows" >}}
+To uninstall the sensu-agent service, run:
 
-**Windows**
+{{< language-toggle >}}
 
-{{< code text >}}
+{{< code shell "Linux" >}}
+sudo service sensu-agent stop
+{{< /code >}}
+
+{{< code shell "Windows" >}}
 sensu-agent service uninstall
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get help
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -572,7 +572,7 @@ Keepalive monitoring is more fluid &mdash; it permits agents to reconnect any nu
 As long as the agent can successfully send one event to any backend within the timeout, the keepalive logic is satisfied.
 {{% /notice %}}
 
-## Service management {#operation}
+## Service management
 
 ### Start the service
 
@@ -580,7 +580,7 @@ Use the `sensu-agent` tool to start the agent and apply configuration flags.
 
 {{< platformBlock "Linux" >}}
 
-#### Linux
+**Linux**
 
 To start the agent with [configuration flags][24]:
 
@@ -606,7 +606,7 @@ If you do not provide any configuration flags, the agent loads configuration fro
 
 {{< platformBlock "Windows" >}}
 
-#### Windows
+**Windows**
 
 Run the following command as an admin to install and start the agent:
 
@@ -628,25 +628,17 @@ sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.
 
 To stop the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent stop
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe stop SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Restart the service
 
@@ -654,81 +646,71 @@ You must restart the agent to implement any configuration updates.
 
 To restart the agent using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo service sensu-agent restart
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe start SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Enable on boot
 
 To enable the agent to start on system boot:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 sudo systemctl enable sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+The service is configured to start automatically on boot by default.
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent.
+{{% /notice %}}
+
 To disable the agent from starting on system boot:
 
-{{< code shell >}}
+{{< language-toggle >}}
+
+{{< code shell "Linux" >}}
 sudo systemctl disable sensu-agent
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent on` to enable the agent and `sudo chkconfig sensu-agent off` to disable the agent.
-{{% /notice %}}
-
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
+{{< code shell "Windows" >}}
 The service is configured to start automatically on boot by default.
+{{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
+
+{{% notice note %}}
+**NOTE**: On older distributions of Linux, use `sudo chkconfig sensu-agent off` to disable the agent.
+{{% /notice %}}
 
 ### Get service status
 
 To view the status of the agent service using a service manager:
 
-{{< platformBlock "Linux" >}}
+{{< language-toggle >}}
 
-**Linux**
-
-{{< code shell >}}
+{{< code shell "Linux" >}}
 service sensu-agent status
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-**Windows**
-
-{{< code text >}}
+{{< code shell "Windows" >}}
 sc.exe query SensuAgent
 {{< /code >}}
 
-{{< platformBlockClose >}}
+{{< /language-toggle >}}
 
 ### Get service version
 
@@ -921,7 +903,7 @@ Flags:
 
 ### Windows
 
-You can specify the agent configuration using a `.yml` file.
+Specify the agent configuration using a `.yml` file.
 Review the [example agent configuration file][5] (also provided with Sensu packages at `%ALLUSERSPROFILE%\sensu\config\agent.yml.example`; default `C:\ProgramData\sensu\config\agent.yml.example`).
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -2085,7 +2085,7 @@ To get started with Sensu Go:
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
 [40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
-[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#operation
+[42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/#service-management
 [43]: /sensu-go/5.7/api/#response-filtering
 [44]: https://discourse.sensu.io/t/introducing-usage-limits-in-the-sensu-go-free-tier/1156/
 [45]: /sensu-go/5.8/sensuctl/create-manage-resources/#handle-large-datasets


### PR DESCRIPTION
## Description
Reformats some of the platform picker content in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/ Service Management section to use language toggle instead.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3723

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>