### PR TITLE
6.7.0: Removes 6.6.x notes throught 6.7 docset

### DIFF
--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -1079,9 +1079,7 @@ etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-log-level  |      |
 -------------|------
-description  | Logging level for the internal etcd client: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`. {{% notice note %}}
-**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.6.3 to use the etcd-client-log-level backend configuration flag.
-{{% /notice %}}
+description  | Logging level for the internal etcd client: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
 type         | String
 default      | `error`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_LOG_LEVEL`

--- a/content/sensu-go/6.7/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/datastore.md
@@ -446,9 +446,7 @@ pool_size: 20
 
 strict       |      |
 -------------|------
-description  | If `true`, when the PostgresConfig resource is created, configuration validation will include connecting to the PostgreSQL database and executing a query to confirm whether the connected user has permission to create database tables. Otherwise, `false`.<br><br>We recommend setting `strict: true` in most cases. If the connection fails or the user does not have permission to create database tables, resource configuration will fail and the configuration will not be persisted. This extended configuration is useful for debugging when you are not sure whether the configuration is correct or the database is working properly.{{% notice note %}}
-**NOTE**: As of Sensu Go 6.6.6, if `strict: true`, sensu-backend will try to connect to PostgreSQL indefinitely at 5-second intervals instead of reverting to etcd after 3 attempts.
-{{% /notice %}}
+description  | If `true`, when the PostgresConfig resource is created, configuration validation will include connecting to the PostgreSQL database and executing a query to confirm whether the connected user has permission to create database tables. Otherwise, `false`.<br><br>If `strict: true`, sensu-backend will try to connect to PostgreSQL indefinitely at 5-second intervals instead of reverting to etcd after 3 attempts.<br><br>We recommend setting `strict: true` in most cases. If the connection fails or the user does not have permission to create database tables, resource configuration will fail and the configuration will not be persisted. This extended configuration is useful for debugging when you are not sure whether the configuration is correct or the database is working properly.
 required     | false
 default     | false
 type         | Boolean

--- a/content/sensu-go/6.7/web-ui/search.md
+++ b/content/sensu-go/6.7/web-ui/search.md
@@ -25,31 +25,19 @@ You can also [save your favorite searches][8].
 
 ## Events and entities search limits
 
-In Sensu Go 6.6.3 and subsequent versions, if you use etcd for event storage, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
+If you use etcd for event storage, web UI search queries on the events and entities pages will stop after returning a certain number of matches.
 Without these limits, the search operation can diminish cluster health.
 
-In Sensu Go 6.6.5, if a web UI search reaches the limit for the events or entities page, the results count at the bottom-right corner of the page will indicate that the total number of matches exceeds the number of results listed.
-
-{{% notice note %}}
-**NOTE**: The search limits on events and entities do not apply to Sensu Go versions prior to 6.6.3.
-{{% /notice %}}
+If a web UI search reaches the limit for the events or entities page, the results count at the bottom-right corner of the page will indicate that the total number of matches exceeds the number of results listed.
 
 ### Events search limit
 
-On the events page, if you use etcd for event storage, search queries will stop after returning a certain number of events:
-
-- In Sensu Go 6.6.3 and 6.6.4, search queries will return a maximum of 25,000 events.
-- In Sensu Go 6.6.5, search queries will return a maximum of 50,000 events.
-
-For example, in Sensu Go 6.6.5, if you use etcd for event storage and you search in a namespace that has more than 50,000 matching events, the search results will not include matching events beyond the first 50,000.
-
-{{% notice note %}}
-**NOTE**: [Upgrade](../../operations/maintain-sensu/upgrade/) to Sensu Go 6.6.5 to retrieve up to 50,000 results in web UI events searches.
-{{% /notice %}}
+On the events page, if you use etcd for event storage, search queries will return a maximum of 50,000 events.
+For example, if you use etcd for event storage and you search in a namespace that has more than 50,000 matching events, the search results will not include matching events beyond the first 50,000.
 
 ### Entities search limit
 
-Starting with Sensu Go 6.6.3, if you use etcd for event storage, search queries on the entities page will stop after retrieving approximately 500 matches.
+If you use etcd for event storage, search queries on the entities page will stop after retrieving approximately 500 matches.
 As a result, if your search matches more than 500 entities, the total results count at the bottom-right corner of the entities page will not accurately reflect the number of matching entities.
 
 ## Search operators


### PR DESCRIPTION
Signed-off-by: Hillary Fraley <hfraley@sumologic.com>

## Description
Removes notes about features in 6.6.x patch releases throughout the 6.7 docset.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3554