### PR TITLE
Add note to explain deregistration is supported for agent entities

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-entities/entities.md
@@ -1141,7 +1141,7 @@ deregister: false
 
 deregistration  | 
 -------------|------ 
-description  | Map that contains a handler name to use when an entity is deregistered. Read [deregistration attributes][2] for more information.
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -1558,7 +1558,7 @@ addresses:
 
 handler      | 
 -------------|------ 
-description  | Name of the handler to call when an entity is deregistered.
+description  | Name of the handler to call when an agent entity is deregistered.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -488,7 +488,7 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
-Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
+Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
@@ -757,7 +757,7 @@ sensu-agent start --help
 ### Registration, endpoint management, and service discovery
 
 Sensu agents automatically discover and register infrastructure components and the services running on them.
-When an agent process stops, the Sensu backend can automatically create and process a deregistration event.
+When an agent process stops, the Sensu backend can automatically create and process a deregistration event for the agent entities.
 
 In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `name`).
 The [Sensu backend][2] stores this agent registry, and it is accessible via [`sensuctl entity list`][6].
@@ -788,6 +788,11 @@ As with registration events, the Sensu backend can create and process a deregist
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
 To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
 You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+
+{{% notice note %}}
+**NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
+Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
+{{% /notice %}}
 
 ### Cluster
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -1141,7 +1141,7 @@ deregister: false
 
 deregistration  | 
 -------------|------ 
-description  | Map that contains a handler name to use when an entity is deregistered. Read [deregistration attributes][2] for more information.
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -1558,7 +1558,7 @@ addresses:
 
 handler      | 
 -------------|------ 
-description  | Name of the handler to call when an entity is deregistered.
+description  | Name of the handler to call when an agent entity is deregistered.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -488,7 +488,7 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
-Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
+Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
@@ -788,6 +788,11 @@ As with registration events, the Sensu backend can create and process a deregist
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
 To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
 You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+
+{{% notice note %}}
+**NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
+Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
+{{% /notice %}}
 
 ### Cluster
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -757,7 +757,7 @@ sensu-agent start --help
 ### Registration, endpoint management, and service discovery
 
 Sensu agents automatically discover and register infrastructure components and the services running on them.
-When an agent process stops, the Sensu backend can automatically create and process a deregistration event.
+When an agent process stops, the Sensu backend can automatically create and process a deregistration event for the agent entities.
 
 In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `name`).
 The [Sensu backend][2] stores this agent registry, and it is accessible via [`sensuctl entity list`][6].

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -1141,7 +1141,7 @@ deregister: false
 
 deregistration  | 
 -------------|------ 
-description  | Map that contains a handler name to use when an entity is deregistered. Read [deregistration attributes][2] for more information.
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -1558,7 +1558,7 @@ addresses:
 
 handler      | 
 -------------|------ 
-description  | Name of the handler to call when an entity is deregistered.
+description  | Name of the handler to call when an agent entity is deregistered.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -763,7 +763,7 @@ sensu-agent start --help
 ### Registration, endpoint management, and service discovery
 
 Sensu agents automatically discover and register infrastructure components and the services running on them.
-When an agent process stops, the Sensu backend can automatically create and process a deregistration event.
+When an agent process stops, the Sensu backend can automatically create and process a deregistration event for the agent entities.
 
 In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `name`).
 The [Sensu backend][2] stores this agent registry, and it is accessible via [`sensuctl entity list`][6].

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -494,7 +494,7 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
-Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
+Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
@@ -794,6 +794,11 @@ As with registration events, the Sensu backend can create and process a deregist
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
 To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
 You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+
+{{% notice note %}}
+**NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
+Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
+{{% /notice %}}
 
 ### Cluster
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -1141,7 +1141,7 @@ deregister: false
 
 deregistration  | 
 -------------|------ 
-description  | Map that contains a handler name to use when an entity is deregistered. Read [deregistration attributes][2] for more information.
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -1558,7 +1558,7 @@ addresses:
 
 handler      | 
 -------------|------ 
-description  | Name of the handler to call when an entity is deregistered.
+description  | Name of the handler to call when an agent entity is deregistered.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -763,7 +763,7 @@ sensu-agent start --help
 ### Registration, endpoint management, and service discovery
 
 Sensu agents automatically discover and register infrastructure components and the services running on them.
-When an agent process stops, the Sensu backend can automatically create and process a deregistration event.
+When an agent process stops, the Sensu backend can automatically create and process a deregistration event for the agent entities.
 
 In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `name`).
 The [Sensu backend][2] stores this agent registry, and it is accessible via [`sensuctl entity list`][6].

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -494,7 +494,7 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
-Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
+Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
@@ -794,6 +794,11 @@ As with registration events, the Sensu backend can create and process a deregist
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
 To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
 You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+
+{{% notice note %}}
+**NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
+Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
+{{% /notice %}}
 
 ### Cluster
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
@@ -1141,7 +1141,7 @@ deregister: false
 
 deregistration  | 
 -------------|------ 
-description  | Map that contains a handler name to use when an entity is deregistered. Read [deregistration attributes][2] for more information.
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
 required     | false
 type         | Map
 example      | {{< language-toggle >}}
@@ -1558,7 +1558,7 @@ addresses:
 
 handler      | 
 -------------|------ 
-description  | Name of the handler to call when an entity is deregistered.
+description  | Name of the handler to call when an agent entity is deregistered.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -763,7 +763,7 @@ sensu-agent start --help
 ### Registration, endpoint management, and service discovery
 
 Sensu agents automatically discover and register infrastructure components and the services running on them.
-When an agent process stops, the Sensu backend can automatically create and process a deregistration event.
+When an agent process stops, the Sensu backend can automatically create and process a deregistration event for the agent entities.
 
 In practice, agent registration happens when a Sensu backend processes an agent keepalive event for an agent that is not already registered in the Sensu agent registry (based on the configured agent `name`).
 The [Sensu backend][2] stores this agent registry, and it is accessible via [`sensuctl entity list`][6].

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -494,7 +494,7 @@ The value you specify for `keepalive-warning-timeout` must be lower than the val
 
 {{% notice note %}}
 **NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
-Deregistration prevents and clears alerts for failing keepalives &mdash; the backend does not distinguish between intentional shutdown and failure.
+Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
 As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
 If you want to receive alerts for failing keepalives, set the [deregister flag](#ephemeral-agent-configuration-flags) to `false`.
 {{% /notice %}}
@@ -794,6 +794,11 @@ As with registration events, the Sensu backend can create and process a deregist
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
 To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
 You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+
+{{% notice note %}}
+**NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
+Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
+{{% /notice %}}
 
 ### Cluster
 


### PR DESCRIPTION
## Description
Updates agent and entities references to explain that deregistration is supported for agent entities, but not proxy entities.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3740

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>