### PR TITLE
Replace service with systemctl in service commands

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/agent.md
@@ -591,7 +591,7 @@ sensu-agent start --help
 To start the agent using a service manager:
 
 {{< code shell >}}
-sudo service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 If you do not provide any configuration flags, the agent loads configuration from the location specified by the `config-file` attribute (default is `/etc/sensu/agent.yml`).
@@ -625,7 +625,7 @@ To stop the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -643,7 +643,7 @@ To restart the agent using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -697,7 +697,7 @@ To view the status of the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-service sensu-agent status
+sudo systemctl sensu-agent status
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -729,7 +729,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-systemctl sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/backend.md
@@ -184,7 +184,7 @@ If you do not provide any configuration flags, the backend loads configuration f
 To start the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend start
+sudo systemctl sensu-backend start
 {{< /code >}}
 
 ### Stop the service
@@ -192,7 +192,7 @@ service sensu-backend start
 To stop the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend stop
+sudo systemctl sensu-backend stop
 {{< /code >}}
 
 ### Restart the service
@@ -202,7 +202,7 @@ You must restart the backend to implement any configuration updates.
 To restart the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 ### Enable on boot
@@ -210,13 +210,13 @@ service sensu-backend restart
 To enable the backend to start on system boot:
 
 {{< code shell >}}
-systemctl enable sensu-backend
+sudo systemctl enable sensu-backend
 {{< /code >}}
 
 To disable the backend from starting on system boot:
 
 {{< code shell >}}
-systemctl disable sensu-backend
+sudo systemctl disable sensu-backend
 {{< /code >}}
 
 {{% notice note %}}
@@ -228,7 +228,7 @@ systemctl disable sensu-backend
 To view the status of the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 ### Get service version

--- a/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.3/operations/deploy-sensu/install-sensu.md
@@ -171,10 +171,10 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -182,10 +182,10 @@ service sensu-backend status
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -434,7 +434,7 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -442,7 +442,7 @@ service sensu-agent start
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code powershell "Windows" >}}

--- a/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/upgrade.md
@@ -26,12 +26,12 @@ sudo systemctl daemon-reload
 
 3. Restart the Sensu agent:
 {{< code shell >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 4. Restart the Sensu backend:
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 5. Run a single upgrade command on one your Sensu backends to migrate the cluster:
@@ -204,7 +204,7 @@ state-dir: "/var/lib/sensu"
 Then restart the backend:
 
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -591,7 +591,7 @@ sensu-agent start --help
 To start the agent using a service manager:
 
 {{< code shell >}}
-sudo service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 If you do not provide any configuration flags, the agent loads configuration from the location specified by the `config-file` attribute (default is `/etc/sensu/agent.yml`).
@@ -625,7 +625,7 @@ To stop the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -643,7 +643,7 @@ To restart the agent using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -697,7 +697,7 @@ To view the status of the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-service sensu-agent status
+sudo systemctl sensu-agent status
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -729,7 +729,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-systemctl sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -216,7 +216,7 @@ If you do not provide any configuration flags, the backend loads configuration f
 To start the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend start
+sudo systemctl sensu-backend start
 {{< /code >}}
 
 ### Stop the service
@@ -224,7 +224,7 @@ service sensu-backend start
 To stop the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend stop
+sudo systemctl sensu-backend stop
 {{< /code >}}
 
 ### Restart the service
@@ -234,7 +234,7 @@ You must restart the backend to implement any configuration updates.
 To restart the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 ### Enable on boot
@@ -242,13 +242,13 @@ service sensu-backend restart
 To enable the backend to start on system boot:
 
 {{< code shell >}}
-systemctl enable sensu-backend
+sudo systemctl enable sensu-backend
 {{< /code >}}
 
 To disable the backend from starting on system boot:
 
 {{< code shell >}}
-systemctl disable sensu-backend
+sudo systemctl disable sensu-backend
 {{< /code >}}
 
 {{% notice note %}}
@@ -260,7 +260,7 @@ systemctl disable sensu-backend
 To view the status of the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 ### Get service version

--- a/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
@@ -171,10 +171,10 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -182,10 +182,10 @@ service sensu-backend status
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -434,7 +434,7 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -442,7 +442,7 @@ service sensu-agent start
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code powershell "Windows" >}}

--- a/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/upgrade.md
@@ -26,12 +26,12 @@ sudo systemctl daemon-reload
 
 3. Restart the Sensu agent:
 {{< code shell >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 4. Restart the Sensu backend:
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 5. Run a single upgrade command on one your Sensu backends to migrate the cluster:
@@ -228,7 +228,7 @@ state-dir: "/var/lib/sensu"
 Then restart the backend:
 
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -597,7 +597,7 @@ sensu-agent start --help
 To start the agent using a service manager:
 
 {{< code shell >}}
-sudo service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 If you do not provide any configuration flags, the agent loads configuration from the location specified by the `config-file` attribute (default is `/etc/sensu/agent.yml`).
@@ -631,7 +631,7 @@ To stop the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -649,7 +649,7 @@ To restart the agent using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -703,7 +703,7 @@ To view the status of the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-service sensu-agent status
+sudo systemctl sensu-agent status
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -735,7 +735,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-systemctl sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -320,7 +320,7 @@ If you do not provide any configuration flags, the backend loads configuration f
 To start the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend start
+sudo systemctl sensu-backend start
 {{< /code >}}
 
 ### Stop the service
@@ -328,7 +328,7 @@ service sensu-backend start
 To stop the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend stop
+sudo systemctl sensu-backend stop
 {{< /code >}}
 
 ### Restart the service
@@ -338,7 +338,7 @@ You must restart the backend to implement any configuration updates.
 To restart the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 ### Enable on boot
@@ -346,13 +346,13 @@ service sensu-backend restart
 To enable the backend to start on system boot:
 
 {{< code shell >}}
-systemctl enable sensu-backend
+sudo systemctl enable sensu-backend
 {{< /code >}}
 
 To disable the backend from starting on system boot:
 
 {{< code shell >}}
-systemctl disable sensu-backend
+sudo systemctl disable sensu-backend
 {{< /code >}}
 
 {{% notice note %}}
@@ -364,7 +364,7 @@ systemctl disable sensu-backend
 To view the status of the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 ### Get service version

--- a/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
@@ -171,10 +171,10 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -182,10 +182,10 @@ service sensu-backend status
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -434,7 +434,7 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -442,7 +442,7 @@ service sensu-agent start
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code powershell "Windows" >}}

--- a/content/sensu-go/6.5/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/upgrade.md
@@ -26,12 +26,12 @@ sudo systemctl daemon-reload
 
 3. Restart the Sensu agent:
 {{< code shell >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 4. Restart the Sensu backend:
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 5. Run a single upgrade command on one your Sensu backends to migrate the cluster:
@@ -233,7 +233,7 @@ state-dir: "/var/lib/sensu"
 Then restart the backend:
 
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -597,7 +597,7 @@ sensu-agent start --help
 To start the agent using a service manager:
 
 {{< code shell >}}
-sudo service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 If you do not provide any configuration flags, the agent loads configuration from the location specified by the `config-file` attribute (default is `/etc/sensu/agent.yml`).
@@ -631,7 +631,7 @@ To stop the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -649,7 +649,7 @@ To restart the agent using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -703,7 +703,7 @@ To view the status of the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-service sensu-agent status
+sudo systemctl sensu-agent status
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -735,7 +735,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-systemctl sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -320,7 +320,7 @@ If you do not provide any configuration flags, the backend loads configuration f
 To start the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend start
+sudo systemctl sensu-backend start
 {{< /code >}}
 
 ### Stop the service
@@ -328,7 +328,7 @@ service sensu-backend start
 To stop the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend stop
+sudo systemctl sensu-backend stop
 {{< /code >}}
 
 ### Restart the service
@@ -338,7 +338,7 @@ You must restart the backend to implement any configuration updates.
 To restart the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 ### Enable on boot
@@ -346,13 +346,13 @@ service sensu-backend restart
 To enable the backend to start on system boot:
 
 {{< code shell >}}
-systemctl enable sensu-backend
+sudo systemctl enable sensu-backend
 {{< /code >}}
 
 To disable the backend from starting on system boot:
 
 {{< code shell >}}
-systemctl disable sensu-backend
+sudo systemctl disable sensu-backend
 {{< /code >}}
 
 {{% notice note %}}
@@ -364,7 +364,7 @@ systemctl disable sensu-backend
 To view the status of the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 ### Get service version

--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -171,10 +171,10 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -182,10 +182,10 @@ service sensu-backend status
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -434,7 +434,7 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -442,7 +442,7 @@ service sensu-agent start
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code powershell "Windows" >}}

--- a/content/sensu-go/6.6/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/upgrade.md
@@ -26,12 +26,12 @@ sudo systemctl daemon-reload
 
 3. Restart the Sensu agent:
 {{< code shell >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 4. Restart the Sensu backend:
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 5. Run a single upgrade command on one your Sensu backends to migrate the cluster:
@@ -233,7 +233,7 @@ state-dir: "/var/lib/sensu"
 Then restart the backend:
 
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -597,7 +597,7 @@ sensu-agent start --help
 To start the agent using a service manager:
 
 {{< code shell >}}
-sudo service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 If you do not provide any configuration flags, the agent loads configuration from the location specified by the `config-file` attribute (default is `/etc/sensu/agent.yml`).
@@ -631,7 +631,7 @@ To stop the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -649,7 +649,7 @@ To restart the agent using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -703,7 +703,7 @@ To view the status of the agent service using a service manager:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-service sensu-agent status
+sudo systemctl sensu-agent status
 {{< /code >}}
 
 {{< code shell "Windows" >}}
@@ -735,7 +735,7 @@ To uninstall the sensu-agent service, run:
 {{< language-toggle >}}
 
 {{< code shell "Linux" >}}
-systemctl sensu-agent stop
+sudo systemctl sensu-agent stop
 {{< /code >}}
 
 {{< code shell "Windows" >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -320,7 +320,7 @@ If you do not provide any configuration flags, the backend loads configuration f
 To start the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend start
+sudo systemctl sensu-backend start
 {{< /code >}}
 
 ### Stop the service
@@ -328,7 +328,7 @@ service sensu-backend start
 To stop the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend stop
+sudo systemctl sensu-backend stop
 {{< /code >}}
 
 ### Restart the service
@@ -338,7 +338,7 @@ You must restart the backend to implement any configuration updates.
 To restart the backend using a service manager:
 
 {{< code shell >}}
-service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 ### Enable on boot
@@ -346,13 +346,13 @@ service sensu-backend restart
 To enable the backend to start on system boot:
 
 {{< code shell >}}
-systemctl enable sensu-backend
+sudo systemctl enable sensu-backend
 {{< /code >}}
 
 To disable the backend from starting on system boot:
 
 {{< code shell >}}
-systemctl disable sensu-backend
+sudo systemctl disable sensu-backend
 {{< /code >}}
 
 {{% notice note %}}
@@ -364,7 +364,7 @@ systemctl disable sensu-backend
 To view the status of the backend service using a service manager:
 
 {{< code shell >}}
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 ### Get service version

--- a/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
@@ -171,10 +171,10 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -182,10 +182,10 @@ service sensu-backend status
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo service sensu-backend start
+sudo systemctl sensu-backend start
 
 # Verify that the backend is running
-service sensu-backend status
+sudo systemctl sensu-backend status
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -434,7 +434,7 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -442,7 +442,7 @@ service sensu-agent start
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-service sensu-agent start
+sudo systemctl sensu-agent start
 {{< /code >}}
 
 {{< code powershell "Windows" >}}

--- a/content/sensu-go/6.7/operations/maintain-sensu/upgrade.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/upgrade.md
@@ -26,12 +26,12 @@ sudo systemctl daemon-reload
 
 3. Restart the Sensu agent:
 {{< code shell >}}
-sudo service sensu-agent restart
+sudo systemctl sensu-agent restart
 {{< /code >}}
 
 4. Restart the Sensu backend:
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 5. Run a single upgrade command on one your Sensu backends to migrate the cluster:
@@ -233,7 +233,7 @@ state-dir: "/var/lib/sensu"
 Then restart the backend:
 
 {{< code shell >}}
-sudo service sensu-backend restart
+sudo systemctl sensu-backend restart
 {{< /code >}}
 
 


### PR DESCRIPTION
## Description
Replaces `service` with `systemctl` in service commands throughout docs

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3731

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>