### PR TITLE
Remove references to Env as 'built in'

### DIFF
--- a/content/sensu-go/6.3/api/core/users.md
+++ b/content/sensu-go/6.3/api/core/users.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 {{% notice note %}}
-**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-auth-api-endpoints).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.3/api/enterprise/secrets.md
+++ b/content/sensu-go/6.3/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/api/other/auth.md
+++ b/content/sensu-go/6.3/api/other/auth.md
@@ -54,7 +54,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/).
 {{% /notice %}}
  

--- a/content/sensu-go/6.3/commercial.md
+++ b/content/sensu-go/6.3/commercial.md
@@ -29,7 +29,7 @@ For more information, read [Get started with commercial features](../commercial/
 Use [business service monitoring (BSM)][23] to monitor your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
 - **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Protect your sensitive information** with [secrets management][22].
-Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's `Env` secrets provider.
 - **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
 Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
 - **Use powerful search capabilities** designed for large installations to search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes.

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -149,8 +149,8 @@ The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
 
 {{% notice note %}}
-**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's built-in `Env` secrets provider.
-Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about [using the Env secrets provider](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management).
+**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's `Env` secrets provider.
+Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about using the `Env` secrets provider.
 {{% /notice %}}
 
 ### Configure the SUMOLOGIC_URL environment variable

--- a/content/sensu-go/6.3/operations/_index.md
+++ b/content/sensu-go/6.3/operations/_index.md
@@ -33,7 +33,7 @@ You'll also find guides for scaling your implementation with Sensu's [Enterprise
 [Control Access][2] explains how Sensu administrators control access by authentication (verifying user identities) and authorization (establishing and managing user permissions for Sensu resources).
 
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-Use Sensu’s [built-in basic authentication provider][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
+Use Sensu’s [built-in basic authentication][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
 
 Next, learn to configure authorization for your authenticated Sensu users with [role-based access control (RBAC)][19] and set up user permissions for interacting with Sensu resources.
 

--- a/content/sensu-go/6.3/operations/control-access/_index.md
+++ b/content/sensu-go/6.3/operations/control-access/_index.md
@@ -16,7 +16,7 @@ Sensu administrators control access by authentication and authorization.
 
 Authentication verifies user identities to confirm that users are who they say they are.
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-You can use Sensu's [built-in basic authentication provider][14] or configure [external authentication providers][15].
+You can use Sensu's [built-in basic authentication][14] or configure [external authentication providers][15].
 
 {{% notice note %}}
 **NOTE**: For API-specific authentication, read the [API overview](../../api/#access-control) and [Use API keys to authenticate to Sensu](use-apikeys/).
@@ -27,13 +27,13 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.3/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ad-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.

--- a/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.3/operations/control-access/create-limited-service-accounts.md
@@ -213,7 +213,7 @@ You will also need the API key for the `ec2-service` user.
 {{% notice note %}}
 **NOTE**: Use [secrets management](../../manage-secrets/secrets-management/) to configure environment variables for your AWS access and secret keys and the `ec2-service` user's API key.
 Do not expose this sensitive information by listing it directly in the handler definition.<br><br>
-The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's built-in [`env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
+The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's [`Env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
 {{% /notice %}}
 
 In the following code, replace these bracketed placeholders with valid values:

--- a/content/sensu-go/6.3/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/ldap-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 

--- a/content/sensu-go/6.3/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.3/operations/control-access/oidc-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
 For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].

--- a/content/sensu-go/6.3/operations/control-access/rbac.md
+++ b/content/sensu-go/6.3/operations/control-access/rbac.md
@@ -175,7 +175,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../ldap-auth/), [Active Directory (AD)](../ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../oidc-auth/). 
 {{% /notice %}}
 

--- a/content/sensu-go/6.3/operations/control-access/sso.md
+++ b/content/sensu-go/6.3/operations/control-access/sso.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][3], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
 
 This guide describes general information for configuring an authentication provider for SSO.
 Read the [LDAP][8], [AD][6], or [OIDC][7] reference documentation for provider-specific examples and specifications.

--- a/content/sensu-go/6.3/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/_index.md
@@ -15,7 +15,7 @@ menu:
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 Secrets management is available for Sensu handler, mutator, and check resources.
 
-[Use secrets management in Sensu][1] explains how to use Sensu's built-in secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
+[Use secrets management in Sensu][1] explains how to use Sensu's secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
 Follow this guide to set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend will be able to execute the handler with any check.
 
@@ -28,7 +28,7 @@ The [secrets reference][3] includes the specification, sensuctl configuration su
 
 ## Secrets providers
 
-The [Sensu Go commercial distribution][2] includes a built-in secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
+The [Sensu Go commercial distribution][2] includes a secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration.
 
 The [secrets providers reference][4] includes the resource specification, instructions for retrieving your secrets providers configuration via the Sensu API, and examples.

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-management.md
@@ -3,7 +3,7 @@ title: "Use secrets management in Sensu"
 linkTitle: "Use Secrets Management"
 guide_title: "Use secrets management in Sensu"
 type: "guide"
-description: "Follow this guide to use Sensu's built-in secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
+description: "Follow this guide to use Sensu's Env secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
 weight: 10
 version: "6.3"
 product: "Sensu Go"
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
-In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
+In this guide, you'll learn how to use Sensu's `Env` secrets provider or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
 You'll set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend can then execute the handler with any check.
 
@@ -52,12 +52,12 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
 
-To use the built-in `Env` secrets provider, you will add your secret as a backend environment variable.
+To use the `Env` secrets provider, add your secret as a backend environment variable.
 
 First, make sure you have created the files you need to store [backend environment variables][21]. 
 

--- a/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.3/operations/manage-secrets/secrets-providers.md
@@ -30,7 +30,7 @@ Unencrypted connections must not transmit privileged information.
 For checks, hooks, and dynamic runtime assets, you must [enable mutual TLS (mTLS)][13].
 Sensu will not transmit secrets to agents that do not use mTLS.
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration's [token auth method][10] or [TLS certificate auth method][11].
 
 You can configure any number of `VaultProvider` secrets providers.
@@ -94,7 +94,7 @@ spec:
 
 ## Env secrets provider example
 
-Sensu's built-in `Env` secrets provider exposes secrets from [backend environment variables][4].
+Sensu's `Env` secrets provider exposes secrets from [backend environment variables][4].
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 Using the `Env` secrets provider may require you to synchronize environment variables in Sensu backend clusters.
@@ -147,7 +147,7 @@ The [secrets providers examples](#env-example) section includes an example for t
 
 type         | 
 -------------|------
-description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's built-in secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
+description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.3/release-notes.md
+++ b/content/sensu-go/6.3/release-notes.md
@@ -803,7 +803,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with a built-in `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
+- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
 - Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**

--- a/content/sensu-go/6.3/sensuctl/_index.md
+++ b/content/sensu-go/6.3/sensuctl/_index.md
@@ -196,7 +196,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../operations/control-access/#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../operations/control-access/#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../operations/control-access/ldap-auth/), [Active Directory (AD)](../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../operations/control-access/oidc-auth/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/api/core/users.md
+++ b/content/sensu-go/6.4/api/core/users.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 {{% notice note %}}
-**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-auth-api-endpoints).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.4/api/enterprise/secrets.md
+++ b/content/sensu-go/6.4/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/api/other/auth.md
+++ b/content/sensu-go/6.4/api/other/auth.md
@@ -54,7 +54,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/).
 {{% /notice %}}
  

--- a/content/sensu-go/6.4/commercial.md
+++ b/content/sensu-go/6.4/commercial.md
@@ -30,7 +30,7 @@ Create customized [global default settings][26] for page size and theme, [page-s
 Use [business service monitoring (BSM)][23] to monitor your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
 - **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Protect your sensitive information** with [secrets management][22].
-Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's `Env` secrets provider.
 - **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
 Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
 - **Use powerful search capabilities** designed for large installations to search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes.

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -149,8 +149,8 @@ The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
 
 {{% notice note %}}
-**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's built-in `Env` secrets provider.
-Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about [using the Env secrets provider](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management).
+**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's `Env` secrets provider.
+Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about using the `Env` secrets provider.
 {{% /notice %}}
 
 ### Configure the SUMOLOGIC_URL environment variable

--- a/content/sensu-go/6.4/operations/_index.md
+++ b/content/sensu-go/6.4/operations/_index.md
@@ -33,7 +33,7 @@ You'll also find guides for scaling your implementation with Sensu's [Enterprise
 [Control Access][2] explains how Sensu administrators control access by authentication (verifying user identities) and authorization (establishing and managing user permissions for Sensu resources).
 
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-Use Sensu’s [built-in basic authentication provider][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
+Use Sensu’s [built-in basic authentication][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
 
 Next, learn to configure authorization for your authenticated Sensu users with [role-based access control (RBAC)][19] and set up user permissions for interacting with Sensu resources.
 

--- a/content/sensu-go/6.4/operations/control-access/_index.md
+++ b/content/sensu-go/6.4/operations/control-access/_index.md
@@ -16,7 +16,7 @@ Sensu administrators control access by authentication and authorization.
 
 Authentication verifies user identities to confirm that users are who they say they are.
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-You can use Sensu's [built-in basic authentication provider][14] or configure [external authentication providers][15].
+You can use Sensu's [built-in basic authentication][14] or configure [external authentication providers][15].
 
 {{% notice note %}}
 **NOTE**: For API-specific authentication, read the [API overview](../../api/#access-control) and [Use API keys to authenticate to Sensu](use-apikeys/).
@@ -27,13 +27,13 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.4/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ad-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -213,7 +213,7 @@ You will also need the API key for the `ec2-service` user.
 {{% notice note %}}
 **NOTE**: Use [secrets management](../../manage-secrets/secrets-management/) to configure environment variables for your AWS access and secret keys and the `ec2-service` user's API key.
 Do not expose this sensitive information by listing it directly in the handler definition.<br><br>
-The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's built-in [`env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
+The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's [`Env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
 {{% /notice %}}
 
 In the following code, replace these bracketed placeholders with valid values:

--- a/content/sensu-go/6.4/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ldap-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 

--- a/content/sensu-go/6.4/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/oidc-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
 For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -175,7 +175,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../ldap-auth/), [Active Directory (AD)](../ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../oidc-auth/). 
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/operations/control-access/sso.md
+++ b/content/sensu-go/6.4/operations/control-access/sso.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][3], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
 
 This guide describes general information for configuring an authentication provider for SSO.
 Read the [LDAP][8], [AD][6], or [OIDC][7] reference documentation for provider-specific examples and specifications.

--- a/content/sensu-go/6.4/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/_index.md
@@ -15,7 +15,7 @@ menu:
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 Secrets management is available for Sensu handler, mutator, and check resources.
 
-[Use secrets management in Sensu][1] explains how to use Sensu's built-in secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
+[Use secrets management in Sensu][1] explains how to use Sensu's secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
 Follow this guide to set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend will be able to execute the handler with any check.
 
@@ -28,7 +28,7 @@ The [secrets reference][3] includes the specification, sensuctl configuration su
 
 ## Secrets providers
 
-The [Sensu Go commercial distribution][2] includes a built-in secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
+The [Sensu Go commercial distribution][2] includes a secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration.
 
 The [secrets providers reference][4] includes the resource specification, instructions for retrieving your secrets providers configuration via the Sensu API, and examples.

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
@@ -3,7 +3,7 @@ title: "Use secrets management in Sensu"
 linkTitle: "Use Secrets Management"
 guide_title: "Use secrets management in Sensu"
 type: "guide"
-description: "Follow this guide to use Sensu's built-in secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
+description: "Follow this guide to use Sensu's Env secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
 weight: 10
 version: "6.4"
 product: "Sensu Go"
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
-In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
+In this guide, you'll learn how to use Sensu's `Env` secrets provider or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
 You'll set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend can then execute the handler with any check.
 
@@ -52,12 +52,12 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
 
-To use the built-in `Env` secrets provider, you will add your secret as a backend environment variable.
+To use the `Env` secrets provider, add your secret as a backend environment variable.
 
 First, make sure you have created the files you need to store [backend environment variables][21]. 
 

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-providers.md
@@ -30,7 +30,7 @@ Unencrypted connections must not transmit privileged information.
 For checks, hooks, and dynamic runtime assets, you must [enable mutual TLS (mTLS)][13].
 Sensu will not transmit secrets to agents that do not use mTLS.
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration's [token auth method][10] or [TLS certificate auth method][11].
 
 You can configure any number of `VaultProvider` secrets providers.
@@ -94,7 +94,7 @@ spec:
 
 ## Env secrets provider example
 
-Sensu's built-in `Env` secrets provider exposes secrets from [backend environment variables][4].
+Sensu's `Env` secrets provider exposes secrets from [backend environment variables][4].
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 Using the `Env` secrets provider may require you to synchronize environment variables in Sensu backend clusters.
@@ -147,7 +147,7 @@ The [secrets providers examples](#env-example) section includes an example for t
 
 type         | 
 -------------|------
-description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's built-in secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
+description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -897,7 +897,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with a built-in `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
+- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
 - Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**

--- a/content/sensu-go/6.4/sensuctl/_index.md
+++ b/content/sensu-go/6.4/sensuctl/_index.md
@@ -196,7 +196,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../operations/control-access/#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../operations/control-access/#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../operations/control-access/ldap-auth/), [Active Directory (AD)](../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../operations/control-access/oidc-auth/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/api/core/users.md
+++ b/content/sensu-go/6.5/api/core/users.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 {{% notice note %}}
-**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-auth-api-endpoints).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.5/api/enterprise/secrets.md
+++ b/content/sensu-go/6.5/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/api/other/auth.md
+++ b/content/sensu-go/6.5/api/other/auth.md
@@ -54,7 +54,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/).
 {{% /notice %}}
  

--- a/content/sensu-go/6.5/commercial.md
+++ b/content/sensu-go/6.5/commercial.md
@@ -31,7 +31,7 @@ Create customized [global default settings][26] for page size and theme, [page-s
 Use [business service monitoring (BSM)][23] to monitor your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
 - **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Protect your sensitive information** with [secrets management][22].
-Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's `Env` secrets provider.
 - **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
 Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
 - **Use powerful search capabilities** designed for large installations to search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes.

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -149,8 +149,8 @@ The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
 
 {{% notice note %}}
-**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's built-in `Env` secrets provider.
-Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about [using the Env secrets provider](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management).
+**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's `Env` secrets provider.
+Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about using the `Env` secrets provider.
 {{% /notice %}}
 
 ### Configure the SUMOLOGIC_URL environment variable

--- a/content/sensu-go/6.5/operations/_index.md
+++ b/content/sensu-go/6.5/operations/_index.md
@@ -33,7 +33,7 @@ You'll also find guides for scaling your implementation with Sensu's [Enterprise
 [Control Access][2] explains how Sensu administrators control access by authentication (verifying user identities) and authorization (establishing and managing user permissions for Sensu resources).
 
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-Use Sensu’s [built-in basic authentication provider][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
+Use Sensu’s [built-in basic authentication][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
 
 Next, learn to configure authorization for your authenticated Sensu users with [role-based access control (RBAC)][19] and set up user permissions for interacting with Sensu resources.
 

--- a/content/sensu-go/6.5/operations/control-access/_index.md
+++ b/content/sensu-go/6.5/operations/control-access/_index.md
@@ -16,7 +16,7 @@ Sensu administrators control access by authentication and authorization.
 
 Authentication verifies user identities to confirm that users are who they say they are.
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-You can use Sensu's [built-in basic authentication provider][14] or configure [external authentication providers][15].
+You can use Sensu's [built-in basic authentication][14] or configure [external authentication providers][15].
 
 {{% notice note %}}
 **NOTE**: For API-specific authentication, read the [API overview](../../api/#access-control) and [Use API keys to authenticate to Sensu](use-apikeys/).
@@ -27,13 +27,13 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.5/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.5/operations/control-access/ad-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -213,7 +213,7 @@ You will also need the API key for the `ec2-service` user.
 {{% notice note %}}
 **NOTE**: Use [secrets management](../../manage-secrets/secrets-management/) to configure environment variables for your AWS access and secret keys and the `ec2-service` user's API key.
 Do not expose this sensitive information by listing it directly in the handler definition.<br><br>
-The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's built-in [`env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
+The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's [`Env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
 {{% /notice %}}
 
 In the following code, replace these bracketed placeholders with valid values:

--- a/content/sensu-go/6.5/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.5/operations/control-access/ldap-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 

--- a/content/sensu-go/6.5/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.5/operations/control-access/oidc-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
 For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -178,7 +178,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../ldap-auth/), [Active Directory (AD)](../ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../oidc-auth/). 
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/operations/control-access/sso.md
+++ b/content/sensu-go/6.5/operations/control-access/sso.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][3], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
 
 This guide describes general information for configuring an authentication provider for SSO.
 Read the [LDAP][8], [AD][6], or [OIDC][7] reference documentation for provider-specific examples and specifications.

--- a/content/sensu-go/6.5/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/_index.md
@@ -15,7 +15,7 @@ menu:
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 Secrets management is available for Sensu handler, mutator, and check resources.
 
-[Use secrets management in Sensu][1] explains how to use Sensu's built-in secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
+[Use secrets management in Sensu][1] explains how to use Sensu's secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
 Follow this guide to set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend will be able to execute the handler with any check.
 
@@ -28,7 +28,7 @@ The [secrets reference][3] includes the specification, sensuctl configuration su
 
 ## Secrets providers
 
-The [Sensu Go commercial distribution][2] includes a built-in secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
+The [Sensu Go commercial distribution][2] includes a secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration.
 
 The [secrets providers reference][4] includes the resource specification, instructions for retrieving your secrets providers configuration via the Sensu API, and examples.

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -3,7 +3,7 @@ title: "Use secrets management in Sensu"
 linkTitle: "Use Secrets Management"
 guide_title: "Use secrets management in Sensu"
 type: "guide"
-description: "Follow this guide to use Sensu's built-in secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
+description: "Follow this guide to use Sensu's Env secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
 weight: 10
 version: "6.5"
 product: "Sensu Go"
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
-In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
+In this guide, you'll learn how to use Sensu's `Env` secrets provider or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
 You'll set up your PagerDuty Integration Key as a secret, create a PagerDuty handler definition that requires the secret, and configure a pipeline that includes the PagerDuty handler.
 Your Sensu backend can then execute the pipeline with any check.
 
@@ -52,12 +52,12 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
 
-To use the built-in `Env` secrets provider, you will add your secret as a backend environment variable.
+To use the `Env` secrets provider, add your secret as a backend environment variable.
 
 First, make sure you have created the files you need to store [backend environment variables][21]. 
 

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
@@ -30,7 +30,7 @@ Unencrypted connections must not transmit privileged information.
 For checks, hooks, and dynamic runtime assets, you must [enable mutual TLS (mTLS)][13].
 Sensu will not transmit secrets to agents that do not use mTLS.
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration's [token auth method][10] or [TLS certificate auth method][11].
 
 You can configure any number of `VaultProvider` secrets providers.
@@ -94,7 +94,7 @@ spec:
 
 ## Env secrets provider example
 
-Sensu's built-in `Env` secrets provider exposes secrets from [backend environment variables][4].
+Sensu's `Env` secrets provider exposes secrets from [backend environment variables][4].
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 Using the `Env` secrets provider may require you to synchronize environment variables in Sensu backend clusters.
@@ -147,7 +147,7 @@ The [secrets providers examples](#env-example) section includes an example for t
 
 type         | 
 -------------|------
-description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's built-in secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
+description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -1054,7 +1054,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with a built-in `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
+- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
 - Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**

--- a/content/sensu-go/6.5/sensuctl/_index.md
+++ b/content/sensu-go/6.5/sensuctl/_index.md
@@ -196,7 +196,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../operations/control-access/#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../operations/control-access/#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../operations/control-access/ldap-auth/), [Active Directory (AD)](../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../operations/control-access/oidc-auth/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/api/core/users.md
+++ b/content/sensu-go/6.6/api/core/users.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 {{% notice note %}}
-**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-auth-api-endpoints).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.6/api/enterprise/secrets.md
+++ b/content/sensu-go/6.6/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/api/other/auth.md
+++ b/content/sensu-go/6.6/api/other/auth.md
@@ -54,7 +54,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/).
 {{% /notice %}}
  

--- a/content/sensu-go/6.6/commercial.md
+++ b/content/sensu-go/6.6/commercial.md
@@ -31,7 +31,7 @@ Create customized [global default settings][26] for page size and theme, [page-s
 Use [business service monitoring (BSM)][23] to monitor your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
 - **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Protect your sensitive information** with [secrets management][22].
-Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's `Env` secrets provider.
 - **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
 Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
 - **Use powerful search capabilities** designed for large installations to search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes.

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -149,8 +149,8 @@ The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
 
 {{% notice note %}}
-**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's built-in `Env` secrets provider.
-Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about [using the Env secrets provider](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management).
+**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's `Env` secrets provider.
+Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about using the `Env` secrets provider.
 {{% /notice %}}
 
 ### Configure the SUMOLOGIC_URL environment variable

--- a/content/sensu-go/6.6/operations/_index.md
+++ b/content/sensu-go/6.6/operations/_index.md
@@ -33,7 +33,7 @@ You'll also find guides for scaling your implementation with Sensu's [Enterprise
 [Control Access][2] explains how Sensu administrators control access by authentication (verifying user identities) and authorization (establishing and managing user permissions for Sensu resources).
 
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-Use Sensu’s [built-in basic authentication provider][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
+Use Sensu’s [built-in basic authentication][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
 
 Next, learn to configure authorization for your authenticated Sensu users with [role-based access control (RBAC)][19] and set up user permissions for interacting with Sensu resources.
 

--- a/content/sensu-go/6.6/operations/control-access/_index.md
+++ b/content/sensu-go/6.6/operations/control-access/_index.md
@@ -16,7 +16,7 @@ Sensu administrators control access by authentication and authorization.
 
 Authentication verifies user identities to confirm that users are who they say they are.
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-You can use Sensu's [built-in basic authentication provider][14] or configure [external authentication providers][15].
+You can use Sensu's [built-in basic authentication][14] or configure [external authentication providers][15].
 
 {{% notice note %}}
 **NOTE**: For API-specific authentication, read the [API overview](../../api/#access-control) and [Use API keys to authenticate to Sensu](use-apikeys/).
@@ -27,13 +27,13 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.6/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ad-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.

--- a/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
@@ -213,7 +213,7 @@ You will also need the API key for the `ec2-service` user.
 {{% notice note %}}
 **NOTE**: Use [secrets management](../../manage-secrets/secrets-management/) to configure environment variables for your AWS access and secret keys and the `ec2-service` user's API key.
 Do not expose this sensitive information by listing it directly in the handler definition.<br><br>
-The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's built-in [`env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
+The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's [`Env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
 {{% /notice %}}
 
 In the following code, replace these bracketed placeholders with valid values:

--- a/content/sensu-go/6.6/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ldap-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 

--- a/content/sensu-go/6.6/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/oidc-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
 For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].

--- a/content/sensu-go/6.6/operations/control-access/rbac.md
+++ b/content/sensu-go/6.6/operations/control-access/rbac.md
@@ -178,7 +178,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../ldap-auth/), [Active Directory (AD)](../ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../oidc-auth/). 
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/operations/control-access/sso.md
+++ b/content/sensu-go/6.6/operations/control-access/sso.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][3], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
 
 This guide describes general information for configuring an authentication provider for SSO.
 Read the [LDAP][8], [AD][6], or [OIDC][7] reference documentation for provider-specific examples and specifications.

--- a/content/sensu-go/6.6/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/_index.md
@@ -15,7 +15,7 @@ menu:
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 Secrets management is available for Sensu handler, mutator, and check resources.
 
-[Use secrets management in Sensu][1] explains how to use Sensu's built-in secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
+[Use secrets management in Sensu][1] explains how to use Sensu's secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
 Follow this guide to set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend will be able to execute the handler with any check.
 
@@ -28,7 +28,7 @@ The [secrets reference][3] includes the specification, sensuctl configuration su
 
 ## Secrets providers
 
-The [Sensu Go commercial distribution][2] includes a built-in secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
+The [Sensu Go commercial distribution][2] includes a secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration.
 
 The [secrets providers reference][4] includes the resource specification, instructions for retrieving your secrets providers configuration via the Sensu API, and examples.

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
@@ -3,7 +3,7 @@ title: "Use secrets management in Sensu"
 linkTitle: "Use Secrets Management"
 guide_title: "Use secrets management in Sensu"
 type: "guide"
-description: "Follow this guide to use Sensu's built-in secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
+description: "Follow this guide to use Sensu's Env secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
 weight: 10
 version: "6.6"
 product: "Sensu Go"
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
-In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
+In this guide, you'll learn how to use Sensu's `Env` secrets provider or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
 You'll set up your PagerDuty Integration Key as a secret, create a PagerDuty handler definition that requires the secret, and configure a pipeline that includes the PagerDuty handler.
 Your Sensu backend can then execute the pipeline with any check.
 
@@ -54,12 +54,12 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
 
-To use the built-in `Env` secrets provider, you will add your secret as a backend environment variable.
+To use the `Env` secrets provider, add your secret as a backend environment variable.
 
 First, make sure you have created the files you need to store [backend environment variables][21]. 
 

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-providers.md
@@ -30,7 +30,7 @@ Unencrypted connections must not transmit privileged information.
 For checks, hooks, and dynamic runtime assets, you must [enable mutual TLS (mTLS)][13].
 Sensu will not transmit secrets to agents that do not use mTLS.
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration's [token auth method][10] or [TLS certificate auth method][11].
 
 You can configure any number of `VaultProvider` secrets providers.
@@ -94,7 +94,7 @@ spec:
 
 ## Env secrets provider example
 
-Sensu's built-in `Env` secrets provider exposes secrets from [backend environment variables][4].
+Sensu's `Env` secrets provider exposes secrets from [backend environment variables][4].
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 Using the `Env` secrets provider may require you to synchronize environment variables in Sensu backend clusters.
@@ -147,7 +147,7 @@ The [secrets providers examples](#env-example) section includes an example for t
 
 type         | 
 -------------|------
-description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's built-in secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
+description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -1202,7 +1202,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with a built-in `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
+- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
 - Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**

--- a/content/sensu-go/6.6/sensuctl/_index.md
+++ b/content/sensu-go/6.6/sensuctl/_index.md
@@ -196,7 +196,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../operations/control-access/#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../operations/control-access/#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../operations/control-access/ldap-auth/), [Active Directory (AD)](../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../operations/control-access/oidc-auth/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/api/core/users.md
+++ b/content/sensu-go/6.7/api/core/users.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 {{% notice note %}}
-**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `core/v2/users` API endpoints allow you to create and manage user credentials with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 To configure user credentials with an external provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth/), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/), use Sensu's [enterprise/authentication/v2 API endpoints](../../enterprise/authproviders/).<br><br>
 Requests to `core/v2/users` API endpoints require you to authenticate with a Sensu [API key](../../#configure-an-environment-variable-for-api-key-authentication) or [access token](../../#authenticate-with-auth-api-endpoints).
 The code examples in this document use the [environment variable](../../#configure-an-environment-variable-for-api-key-authentication) `$SENSU_API_KEY` to represent a valid API key in API requests.

--- a/content/sensu-go/6.7/api/enterprise/secrets.md
+++ b/content/sensu-go/6.7/api/enterprise/secrets.md
@@ -61,7 +61,7 @@ http://127.0.0.1:8080/api/enterprise/secrets/v1/providers \
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes a built-in `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/api/other/auth.md
+++ b/content/sensu-go/6.7/api/other/auth.md
@@ -54,7 +54,7 @@ response codes       | <ul><li>**Valid credentials**: 200 (OK)</li><li> **Invali
 The `/auth/test` API endpoint provides HTTP GET access to test basic authentication user credentials that were created with Sensu's built-in [basic authentication][1].
 
 {{% notice note %}}
-**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication provider](../../../operations/control-access#use-built-in-basic-authentication).
+**NOTE**: The `/auth/test` endpoint only tests user credentials created with Sensu's built-in [basic authentication](../../../operations/control-access#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../../../operations/control-access/ldap-auth), [Active Directory (AD)](../../../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../../../operations/control-access/oidc-auth/).
 {{% /notice %}}
  

--- a/content/sensu-go/6.7/commercial.md
+++ b/content/sensu-go/6.7/commercial.md
@@ -31,7 +31,7 @@ Create customized [global default settings][26] for page size and theme, [page-s
 Use [business service monitoring (BSM)][23] to monitor your system with a top-down approach that produces meaningful alerts, prevents alert fatigue, and helps you focus on your core business services.
 - **Use mutual transport layer security (mTLS) authentication** to [provide two-way verification of your Sensu agents and backend connections][21].
 - **Protect your sensitive information** with [secrets management][22].
-Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's built-in environment variable secrets provider.
+Avoid exposing usernames, passwords, and access keys in your Sensu configuration by integrating with HashiCorp Vault or using Sensu's `Env` secrets provider.
 - **Manage your monitoring resources across multiple data centers, cloud regions, or providers** and mirror changes to follower clusters with [federation][20].
 Federation affords visibility into the health of your infrastructure and services across multiple distinct Sensu instances within a single web UI.
 - **Use powerful search capabilities** designed for large installations to search [Sensu API][4] responses, [sensuctl][5] outputs, and Sensu [web UI][6] views using custom labels and a wide range of resource attributes.

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -149,8 +149,8 @@ The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
 
 {{% notice note %}}
-**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's built-in `Env` secrets provider.
-Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about [using the Env secrets provider](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management).
+**NOTE**: This example shows how to set your Sumo Logic HTTP Source Address URL as an environment variable and use it as a secret with Sensu's `Env` secrets provider.
+Read [Use secrets management in Sensu](../../../operations/manage-secrets/secrets-management/) for more information about using the `Env` secrets provider.
 {{% /notice %}}
 
 ### Configure the SUMOLOGIC_URL environment variable

--- a/content/sensu-go/6.7/operations/_index.md
+++ b/content/sensu-go/6.7/operations/_index.md
@@ -33,7 +33,7 @@ You'll also find guides for scaling your implementation with Sensu's [Enterprise
 [Control Access][2] explains how Sensu administrators control access by authentication (verifying user identities) and authorization (establishing and managing user permissions for Sensu resources).
 
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-Use Sensu’s [built-in basic authentication provider][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
+Use Sensu’s [built-in basic authentication][15] or configure external authentication providers via [Lightweight Directory Access Protocol (LDAP)][16], [Active Directory (AD)][17], or [OpenID Connect 1.0 protocol (OIDC)][18] to authenticate your Sensu users.
 
 Next, learn to configure authorization for your authenticated Sensu users with [role-based access control (RBAC)][19] and set up user permissions for interacting with Sensu resources.
 

--- a/content/sensu-go/6.7/operations/control-access/_index.md
+++ b/content/sensu-go/6.7/operations/control-access/_index.md
@@ -16,7 +16,7 @@ Sensu administrators control access by authentication and authorization.
 
 Authentication verifies user identities to confirm that users are who they say they are.
 Sensu requires username and password authentication to access the web UI, API, and sensuctl command line tool.
-You can use Sensu's [built-in basic authentication provider][14] or configure [external authentication providers][15].
+You can use Sensu's [built-in basic authentication][14] or configure [external authentication providers][15].
 
 {{% notice note %}}
 **NOTE**: For API-specific authentication, read the [API overview](../../api/#access-control) and [Use API keys to authenticate to Sensu](use-apikeys/).
@@ -27,13 +27,13 @@ Configure authorization with [role-based access control (RBAC)][4] to exercise f
 
 ## Authentication
 
-Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication provider][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
+Sensu web UI and sensuctl command line tool users can authenticate via [built-in basic authentication][14] or Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) when the administrator configures [external single sign-on (SSO) authentication providers][15].
 
 Sensu agents authenticate to the Sensu backend using either [basic][14] or [mutual transport layer security (TLS)][20] authentication.
 
 ### Use built-in basic authentication
 
-Sensu's built-in basic authentication provider allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
+Sensu's built-in basic authentication allows you to create and manage user credentials (usernames and passwords) with [core/v2/users API endpoints][53], either directly or using [sensuctl][2].
 The basic authentication provider does not depend on external services and is not configurable.
 
 Sensu hashes user passwords using the [bcrypt][26] algorithm and records the basic authentication credentials in [etcd][54].

--- a/content/sensu-go/6.7/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ad-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for using Microsoft Active Directory (AD) for single sign-on (SSO) authentication.
 The AD authentication provider is based on the [LDAP authentication provider][44].
 
 To use AD authentication for Azure, follow Microsoft's tutorial to [set up secure LDAP in your Azure account][10] and create the host and certificates you need.

--- a/content/sensu-go/6.7/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.7/operations/control-access/create-limited-service-accounts.md
@@ -213,7 +213,7 @@ You will also need the API key for the `ec2-service` user.
 {{% notice note %}}
 **NOTE**: Use [secrets management](../../manage-secrets/secrets-management/) to configure environment variables for your AWS access and secret keys and the `ec2-service` user's API key.
 Do not expose this sensitive information by listing it directly in the handler definition.<br><br>
-The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's built-in [`env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
+The [Sensu Go EC2 Handler's Bonsai page](https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler#environment-variables) includes an example for configuring secrets definitions with Sensu's [`Env` secrets provider](../../manage-secrets/secrets-providers/#env-secrets-provider-example).
 {{% /notice %}}
 
 In the following code, replace these bracketed placeholders with valid values:

--- a/content/sensu-go/6.7/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ldap-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][6] for a standards-compliant Lightweight Directory Access Protocol (LDAP) tool for single sign-on (SSO) authentication.
 The Sensu LDAP authentication provider is tested with [OpenLDAP][7].
 If you're using AD, head to the [AD section][37].
 

--- a/content/sensu-go/6.7/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/oidc-auth.md
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][8], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
+In addition to the [built-in basic authentication][7], Sensu offers [commercial support][6] for single sign-on (SSO) authentication using the OpenID Connect 1.0 protocol (OIDC) on top of the OAuth 2.0 protocol.
 The Sensu OIDC provider is tested with [Okta][51] and [PingFederate][52].
 
 For general information about configuring authentication providers, read [Configure single sign-on (SSO) authentication][12].

--- a/content/sensu-go/6.7/operations/control-access/rbac.md
+++ b/content/sensu-go/6.7/operations/control-access/rbac.md
@@ -178,7 +178,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../ldap-auth/), [Active Directory (AD)](../ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../oidc-auth/). 
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/operations/control-access/sso.md
+++ b/content/sensu-go/6.7/operations/control-access/sso.md
@@ -17,7 +17,7 @@ For more information, read [Get started with commercial features](../../../comme
 
 Sensu requires username and password authentication to access the [web UI][1], [API][3], and [sensuctl][2] command line tool.
 
-In addition to the [built-in basic authentication provider][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
+In addition to the [built-in basic authentication][4], Sensu offers [commercial support][5] for using Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC) for single sign-on (SSO) authentication.
 
 This guide describes general information for configuring an authentication provider for SSO.
 Read the [LDAP][8], [AD][6], or [OIDC][7] reference documentation for provider-specific examples and specifications.

--- a/content/sensu-go/6.7/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/_index.md
@@ -15,7 +15,7 @@ menu:
 Sensu's secrets management eliminates the need to expose secrets like usernames, passwords, and access keys in your Sensu configuration.
 Secrets management is available for Sensu handler, mutator, and check resources.
 
-[Use secrets management in Sensu][1] explains how to use Sensu's built-in secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
+[Use secrets management in Sensu][1] explains how to use Sensu's secrets provider (`Env`) or HashiCorp Vault as your external secrets provider and authenticate without exposing your secrets.
 Follow this guide to set up your PagerDuty Integration Key as a secret and create a PagerDuty handler definition that requires the secret.
 Your Sensu backend will be able to execute the handler with any check.
 
@@ -28,7 +28,7 @@ The [secrets reference][3] includes the specification, sensuctl configuration su
 
 ## Secrets providers
 
-The [Sensu Go commercial distribution][2] includes a built-in secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
+The [Sensu Go commercial distribution][2] includes a secrets provider, `Env`, that exposes secrets from environment variables on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration.
 
 The [secrets providers reference][4] includes the resource specification, instructions for retrieving your secrets providers configuration via the Sensu API, and examples.

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
@@ -3,7 +3,7 @@ title: "Use secrets management in Sensu"
 linkTitle: "Use Secrets Management"
 guide_title: "Use secrets management in Sensu"
 type: "guide"
-description: "Follow this guide to use Sensu's built-in secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
+description: "Follow this guide to use Sensu's Env secrets provider or HashiCorp Vault to avoid exposing sensitive information in your Sensu configuration."
 weight: 10
 version: "6.7"
 product: "Sensu Go"
@@ -19,7 +19,7 @@ For more information, read [Get started with commercial features](../../../comme
 {{% /notice %}}
 
 Sensu's secrets management allows you to avoid exposing secrets like usernames, passwords, and access keys in your Sensu configuration.
-In this guide, you'll learn how to use Sensu's built-in secrets provider, `Env`, or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
+In this guide, you'll learn how to use Sensu's `Env` secrets provider or [HashiCorp Vault][1] as your external [secrets provider][2] and authenticate without exposing your secrets.
 You'll set up your PagerDuty Integration Key as a secret, create a PagerDuty handler definition that requires the secret, and configure a pipeline that includes the PagerDuty handler.
 Your Sensu backend can then execute the pipeline with any check.
 
@@ -54,12 +54,12 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
 
-To use the built-in `Env` secrets provider, you will add your secret as a backend environment variable.
+To use the `Env` secrets provider, add your secret as a backend environment variable.
 
 First, make sure you have created the files you need to store [backend environment variables][21]. 
 

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets-providers.md
@@ -30,7 +30,7 @@ Unencrypted connections must not transmit privileged information.
 For checks, hooks, and dynamic runtime assets, you must [enable mutual TLS (mTLS)][13].
 Sensu will not transmit secrets to agents that do not use mTLS.
 
-The [Sensu Go commercial distribution][1] includes a built-in secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][4] on your Sensu backend nodes.
 You can also use the secrets provider `VaultProvider` to authenticate via the HashiCorp Vault integration's [token auth method][10] or [TLS certificate auth method][11].
 
 You can configure any number of `VaultProvider` secrets providers.
@@ -94,7 +94,7 @@ spec:
 
 ## Env secrets provider example
 
-Sensu's built-in `Env` secrets provider exposes secrets from [backend environment variables][4].
+Sensu's `Env` secrets provider exposes secrets from [backend environment variables][4].
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 Using the `Env` secrets provider may require you to synchronize environment variables in Sensu backend clusters.
@@ -147,7 +147,7 @@ The [secrets providers examples](#env-example) section includes an example for t
 
 type         | 
 -------------|------
-description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's built-in secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
+description  | Top-level attribute that specifies the resource type. May be either `Env` (if you are using Sensu's secrets provider) or `VaultProvider` (if you are using HashiCorp Vault as the secrets provider).
 required     | Required for secrets configuration in `wrapped-json` or `yaml` format.
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -1202,7 +1202,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with a built-in `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
+- ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
 - Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**

--- a/content/sensu-go/6.7/sensu-plus.md
+++ b/content/sensu-go/6.7/sensu-plus.md
@@ -113,7 +113,7 @@ EOF
 
 {{< /language-toggle >}}
 
-If you prefer, you can configure your Sumo Logic HTTP Logs and Metrics Source URL as a [secret][6] with Sensu's built-in [`env` secrets provider][7] to avoid exposing the URL in your handler definition.
+If you prefer, you can configure your Sumo Logic HTTP Logs and Metrics Source URL as a [secret][6] with Sensu's [`Env` secrets provider][7] to avoid exposing the URL in your handler definition.
 This example shows the same definition with the URL referenced as a secret instead:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.7/sensuctl/_index.md
+++ b/content/sensu-go/6.7/sensuctl/_index.md
@@ -196,7 +196,7 @@ An empty response indicates valid credentials.
 A `request-unauthorized` response indicates invalid credentials.
 
 {{% notice note %}}
-**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication provider](../operations/control-access/#use-built-in-basic-authentication).
+**NOTE**: The `sensuctl user test-creds` command tests passwords for users created with Sensu's built-in [basic authentication](../operations/control-access/#use-built-in-basic-authentication).
 It does not test user credentials defined via an authentication provider like [Lightweight Directory Access Protocol (LDAP)](../operations/control-access/ldap-auth/), [Active Directory (AD)](../operations/control-access/ad-auth/), or [OpenID Connect 1.0 protocol (OIDC)](../operations/control-access/oidc-auth/).
 {{% /notice %}}
 


### PR DESCRIPTION
## Description
Removes "built-in" from references to Env, with rephrasing as needed.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3748

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>