### PR TITLE
Place references and guides together within categories

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/filters.md
@@ -4,7 +4,7 @@ linkTitle: "Event Filter Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."
-weight: 10
+weight: 20
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -4,7 +4,7 @@ linkTitle: "Reduce Alert Fatigue"
 guide_title: "Reduce alert fatigue with event filters"
 type: "guide"
 description: "Here’s how to reduce alert fatigue with Sensu. Learn about Sensu filters, how they reduce alert fatigue, and how to put them into action."
-weight: 20
+weight: 60
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-filter/route-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Route Alerts"
 guide_title: "Route alerts with event filters"
 type: "guide"
 description: "Alert the right people using their preferred contact method with Sensu's contact routing and reduce mean time to response and recovery."
-weight: 30
+weight: 80
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -4,7 +4,7 @@ linkTitle: "Aggregate StatsD Metrics"
 guide_title: "Aggregate metrics with the Sensu StatsD listener"
 type: "guide"
 description: "Sensu agents include a StatsD listener you can use to send application performance, CPU, I/O, and network utilization metrics to your observability pipeline."
-weight: 40
+weight: 100
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 55
+weight: 120
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
 description: "Read this reference to learn to use handlers, the actions the Sensu backend executes on events, in your automated monitoring and observability workflows."
-weight: 10
+weight: 20
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
@@ -4,7 +4,7 @@ linkTitle: "Plan Maintenance Windows"
 guide_title: "Plan maintenance windows with silencing"
 type: "guide"
 description: "Use Sensu's silencing feature to suppress event handling during system maintenance so you can coordinate and perform maintenance without getting alerts."
-weight: 70
+weight: 140
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -4,7 +4,7 @@ linkTitle: "Populate Metrics in InfluxDB"
 guide_title: "Populate metrics in InfluxDB with handlers"
 type: "guide"
 description: "Follow this guide to populate Sensu metrics into the time-series database InfluxDB with a handler, an action the Sensu backend executes when an event occurs."
-weight: 50
+weight: 160
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -4,7 +4,7 @@ linkTitle: "Send Data to Sumo Logic"
 guide_title: "Send data to Sumo Logic with Sensu"
 type: "guide"
 description: "Put Sensu's observability pipeline into action. Follow this guide to configure a handler to send Sensu data to Sumo Logic for long-term log and metrics storage."
-weight: 19
+weight: 180
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-email-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Email Alerts"
 guide_title: "Send email alerts with the Sensu Go Email Handler"
 type: "guide"
 description: "Send notifications based on Sensu Go observability event data to an email address to alert you of incidents and help you resolve them more quickly."
-weight: 20
+weight: 200
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send PagerDuty Alerts"
 guide_title: "Send PagerDuty alerts with Sensu"
 type: "guide"
 description: "Follow this guide to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events."
-weight: 25
+weight: 220
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Augment Event Data"
 guide_title: "Augment event data with check hooks"
 type: "guide"
 description: "Free up precious operator time: use Sensu check hooks to automate data collection that operators would otherwise perform manually to investigate alerts."
-weight: 90
+weight: 140
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -2,7 +2,7 @@
 title: "Business service monitoring SDK"
 linkTitle: "Business Service Monitoring SDK"
 description: "Use Sensu's business service monitoring SDK of JavaScript-based expressions to add functionality for Sensu rule templates that evaluate service components."
-weight: 75
+weight: 130
 version: "6.3"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -5,7 +5,7 @@ type: "guide"
 description: "Use Sensu's business service monitoring (BSM) to monitor every component in your system with a top-down approach that produces meaningful information."
 product: "Sensu Go"
 version: "6.3"
-weight: 55
+weight: 200
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Service Metrics"
 guide_title: "Collect service metrics with Sensu checks"
 type: "guide"
 description: "Collect service metrics for an NGINX webserver with a Sensu check and output the metrics data in Nagios Performance Data format."
-weight: 50
+weight: 180
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Hooks Reference"
 reference_title: "Hooks"
 type: "reference"
 description: "Read this reference to free up precious operator time with hooks, which allow you to automate data collection that operators would typically perform manually."
-weight: 80
+weight: 40
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Metrics Reference"
 reference_title: "Metrics"
 type: "reference"
 description: "Read this reference to collect service and time-series metrics for your infrastructure and process extracted metrics with the Sensu observability pipeline."
-weight: 33
+weight: 50
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -4,7 +4,7 @@ linkTitle: "Monitor Server Resources"
 guide_title: "Monitor server resources with checks"
 type: "guide"
 description: "Sensu lets you monitor server resources with checks. Read this guide to learn about Sensu checks and how to use checks to monitor servers."
-weight: 40
+weight: 220
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Prometheus Metrics"
 guide_title: "Collect Prometheus metrics with Sensu"
 type: "guide"
 description: "Use the Sensu Prometheus Collector integration to collect Prometheus metrics so Sensu can route the collected metrics to a time-series database like InfluxDB."
-weight: 55
+weight: 160
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/service-components.md
@@ -4,7 +4,7 @@ linkTitle: "Service Components Reference"
 reference_title: "Service components"
 type: "reference"
 description: "Service components are meaningful selections of Sensu events, like database monitoring events, that allow you to define and manage business service elements."
-weight: 70
+weight: 80
 version: "6.3"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/subscriptions.md
@@ -4,7 +4,7 @@ linkTitle: "Subscriptions Reference"
 reference_title: "Subscriptions"
 type: "reference"
 description: "Use Sensu subscriptions to configure checks in a one-to-many model and write checks even if you don't know the names of the entities that should run the checks."
-weight: 35
+weight: 100
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -4,7 +4,7 @@ linkTitle: "Tokens Reference"
 reference_title: "Tokens"
 type: "reference"
 description: "Use tokens in Sensu checks as placeholders that agents replace with entity data to fine-tune check attributes while reusing check definitions."
-weight: 100
+weight: 120
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/plugins/assets.md
+++ b/content/sensu-go/6.3/plugins/assets.md
@@ -4,7 +4,7 @@ linkTitle: "Assets Reference"
 reference_title: "Assets"
 type: "reference"
 description: "Use Sensu's dynamic runtime assets to provide the plugins, libraries, and runtimes you need to create automated monitoring and observability workflows."
-weight: 60
+weight: 20
 version: "6.3"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.3/plugins/install-plugins.md
+++ b/content/sensu-go/6.3/plugins/install-plugins.md
@@ -2,7 +2,7 @@
 title: "Install Sensu plugins"
 linkTitle: "Install Plugins"
 description: "Learn how to install plugins to extend Sensu's functionality with executables for performing checks, mutators, and handlers."
-weight: 20
+weight: 60
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/plugins/plugins.md
+++ b/content/sensu-go/6.3/plugins/plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Plugins Reference"
 reference_title: "Plugins"
 type: "reference"
 description: "Read this reference for information about Sensu plugins, which provide executables that you can use as a Sensu check, handler, or mutator command."
-weight: 80
+weight: 40
 version: "6.3"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.3/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.3/plugins/supported-integrations/_index.md
@@ -3,7 +3,7 @@ title: "Supported Integrations"
 description: "Use Sensu plugins to integrate Sensu with your existing workflows for Sumo Logic, PagerDuty, Ansible, Chef, Jira, Elasticsearch, InfluxDB, and more."
 product: "Sensu Go"
 version: "6.3"
-weight: 80
+weight: 100
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.3/plugins/use-assets-to-install-plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Use Assets to Install Plugins"
 guide_title: "Use dynamic runtime assets to install plugins"
 type: "guide"
 description: "Use Sensu's shareable, reusable dynamic runtime assets to deploy the plugins, libraries, and runtimes you need for your monitoring and observability workflows."
-weight: 40
+weight: 80
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -4,7 +4,7 @@ linkTitle: "Event Filter Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."
-weight: 10
+weight: 20
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -4,7 +4,7 @@ linkTitle: "Reduce Alert Fatigue"
 guide_title: "Reduce alert fatigue with event filters"
 type: "guide"
 description: "Here’s how to reduce alert fatigue with Sensu. Learn about Sensu filters, how they reduce alert fatigue, and how to put them into action."
-weight: 20
+weight: 60
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Route Alerts"
 guide_title: "Route alerts with event filters"
 type: "guide"
 description: "Alert the right people using their preferred contact method with Sensu's contact routing and reduce mean time to response and recovery."
-weight: 30
+weight: 80
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -4,7 +4,7 @@ linkTitle: "Aggregate StatsD Metrics"
 guide_title: "Aggregate metrics with the Sensu StatsD listener"
 type: "guide"
 description: "Sensu agents include a StatsD listener you can use to send application performance, CPU, I/O, and network utilization metrics to your observability pipeline."
-weight: 40
+weight: 100
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 55
+weight: 120
 version: "6.4"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
 description: "Read this reference to learn to use handlers, the actions the Sensu backend executes on events, in your automated monitoring and observability workflows."
-weight: 10
+weight: 20
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
@@ -4,7 +4,7 @@ linkTitle: "Plan Maintenance Windows"
 guide_title: "Plan maintenance windows with silencing"
 type: "guide"
 description: "Use Sensu's silencing feature to suppress event handling during system maintenance so you can coordinate and perform maintenance without getting alerts."
-weight: 70
+weight: 140
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -4,7 +4,7 @@ linkTitle: "Populate Metrics in InfluxDB"
 guide_title: "Populate metrics in InfluxDB with handlers"
 type: "guide"
 description: "Follow this guide to populate Sensu metrics into the time-series database InfluxDB with a handler, an action the Sensu backend executes when an event occurs."
-weight: 50
+weight: 160
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -4,7 +4,7 @@ linkTitle: "Send Data to Sumo Logic"
 guide_title: "Send data to Sumo Logic with Sensu"
 type: "guide"
 description: "Put Sensu's observability pipeline into action. Follow this guide to configure a handler to send Sensu data to Sumo Logic for long-term log and metrics storage."
-weight: 19
+weight: 180
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Email Alerts"
 guide_title: "Send email alerts with the Sensu Go Email Handler"
 type: "guide"
 description: "Send notifications based on Sensu Go observability event data to an email address to alert you of incidents and help you resolve them more quickly."
-weight: 20
+weight: 200
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send PagerDuty Alerts"
 guide_title: "Send PagerDuty alerts with Sensu"
 type: "guide"
 description: "Follow this guide to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events."
-weight: 25
+weight: 220
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Augment Event Data"
 guide_title: "Augment event data with check hooks"
 type: "guide"
 description: "Free up precious operator time: use Sensu check hooks to automate data collection that operators would otherwise perform manually to investigate alerts."
-weight: 90
+weight: 140
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -2,7 +2,7 @@
 title: "Business service monitoring SDK"
 linkTitle: "Business Service Monitoring SDK"
 description: "Use Sensu's business service monitoring SDK of JavaScript-based expressions to add functionality for Sensu rule templates that evaluate service components."
-weight: 75
+weight: 130
 version: "6.4"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -5,7 +5,7 @@ type: "guide"
 description: "Use Sensu's business service monitoring (BSM) to monitor every component in your system with a top-down approach that produces meaningful information."
 product: "Sensu Go"
 version: "6.4"
-weight: 55
+weight: 200
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Service Metrics"
 guide_title: "Collect service metrics with Sensu checks"
 type: "guide"
 description: "Collect service metrics for an NGINX webserver with a Sensu check and output the metrics data in Nagios Performance Data format."
-weight: 50
+weight: 180
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Hooks Reference"
 reference_title: "Hooks"
 type: "reference"
 description: "Read this reference to free up precious operator time with hooks, which allow you to automate data collection that operators would typically perform manually."
-weight: 80
+weight: 40
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Metrics Reference"
 reference_title: "Metrics"
 type: "reference"
 description: "Read this reference to collect service and time-series metrics for your infrastructure and process extracted metrics with the Sensu observability pipeline."
-weight: 33
+weight: 50
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -4,7 +4,7 @@ linkTitle: "Monitor Server Resources"
 guide_title: "Monitor server resources with checks"
 type: "guide"
 description: "Sensu lets you monitor server resources with checks. Read this guide to learn about Sensu checks and how to use checks to monitor servers."
-weight: 40
+weight: 220
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Prometheus Metrics"
 guide_title: "Collect Prometheus metrics with Sensu"
 type: "guide"
 description: "Use the Sensu Prometheus Collector integration to collect Prometheus metrics so Sensu can route the collected metrics to a time-series database like InfluxDB."
-weight: 55
+weight: 160
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -4,7 +4,7 @@ linkTitle: "Service Components Reference"
 reference_title: "Service components"
 type: "reference"
 description: "Service components are meaningful selections of Sensu events, like database monitoring events, that allow you to define and manage business service elements."
-weight: 70
+weight: 80
 version: "6.4"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/subscriptions.md
@@ -4,7 +4,7 @@ linkTitle: "Subscriptions Reference"
 reference_title: "Subscriptions"
 type: "reference"
 description: "Use Sensu subscriptions to configure checks in a one-to-many model and write checks even if you don't know the names of the entities that should run the checks."
-weight: 35
+weight: 100
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -4,7 +4,7 @@ linkTitle: "Tokens Reference"
 reference_title: "Tokens"
 type: "reference"
 description: "Use tokens in Sensu checks as placeholders that agents replace with entity data to fine-tune check attributes while reusing check definitions."
-weight: 100
+weight: 120
 version: "6.4"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -4,7 +4,7 @@ linkTitle: "Assets Reference"
 reference_title: "Assets"
 type: "reference"
 description: "Use Sensu's dynamic runtime assets to provide the plugins, libraries, and runtimes you need to create automated monitoring and observability workflows."
-weight: 60
+weight: 20
 version: "6.4"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.4/plugins/install-plugins.md
+++ b/content/sensu-go/6.4/plugins/install-plugins.md
@@ -2,7 +2,7 @@
 title: "Install Sensu plugins"
 linkTitle: "Install Plugins"
 description: "Learn how to install plugins to extend Sensu's functionality with executables for performing checks, mutators, and handlers."
-weight: 20
+weight: 60
 version: "6.4"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.4/plugins/plugins.md
+++ b/content/sensu-go/6.4/plugins/plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Plugins Reference"
 reference_title: "Plugins"
 type: "reference"
 description: "Read this reference for information about Sensu plugins, which provide executables that you can use as a Sensu check, handler, or mutator command."
-weight: 80
+weight: 40
 version: "6.4"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.4/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.4/plugins/supported-integrations/_index.md
@@ -3,7 +3,7 @@ title: "Supported Integrations"
 description: "Use Sensu plugins to integrate Sensu with your existing workflows for Sumo Logic, PagerDuty, Ansible, Chef, Jira, Elasticsearch, InfluxDB, and more."
 product: "Sensu Go"
 version: "6.4"
-weight: 80
+weight: 100
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.4/plugins/use-assets-to-install-plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Use Assets to Install Plugins"
 guide_title: "Use dynamic runtime assets to install plugins"
 type: "guide"
 description: "Use Sensu's shareable, reusable dynamic runtime assets to deploy the plugins, libraries, and runtimes you need for your monitoring and observability workflows."
-weight: 40
+weight: 80
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -4,7 +4,7 @@ linkTitle: "Event Filter Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."
-weight: 10
+weight: 20
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -4,7 +4,7 @@ linkTitle: "Reduce Alert Fatigue"
 guide_title: "Reduce alert fatigue with event filters"
 type: "guide"
 description: "Here’s how to reduce alert fatigue with Sensu. Learn about Sensu filters, how they reduce alert fatigue, and how to put them into action."
-weight: 20
+weight: 60
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Route Alerts"
 guide_title: "Route alerts with event filters"
 type: "guide"
 description: "Alert the right people using their preferred contact method with Sensu's contact routing and reduce mean time to response and recovery."
-weight: 30
+weight: 80
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -4,7 +4,7 @@ linkTitle: "Aggregate StatsD Metrics"
 guide_title: "Aggregate metrics with the Sensu StatsD listener"
 type: "guide"
 description: "Sensu agents include a StatsD listener you can use to send application performance, CPU, I/O, and network utilization metrics to your observability pipeline."
-weight: 40
+weight: 100
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 55
+weight: 120
 version: "6.5"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
 description: "Read this reference to learn to use handlers, the actions the Sensu backend executes on events, in your automated monitoring and observability workflows."
-weight: 10
+weight: 20
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -4,7 +4,7 @@ linkTitle: "Pipeline Reference"
 reference_title: "Pipeline"
 type: "reference"
 description: "Pipelines are observation event processing workflows made up of filters, mutators, and handlers. Read the reference doc to learn about pipelines."
-weight: 15
+weight: 40
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
@@ -4,7 +4,7 @@ linkTitle: "Plan Maintenance Windows"
 guide_title: "Plan maintenance windows with silencing"
 type: "guide"
 description: "Use Sensu's silencing feature to suppress event handling during system maintenance so you can coordinate and perform maintenance without getting alerts."
-weight: 70
+weight: 140
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -4,7 +4,7 @@ linkTitle: "Populate Metrics in InfluxDB"
 guide_title: "Populate metrics in InfluxDB with handlers"
 type: "guide"
 description: "Follow this guide to populate Sensu metrics into the time-series database InfluxDB with a handler, an action the Sensu backend executes when an event occurs."
-weight: 50
+weight: 160
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -4,7 +4,7 @@ linkTitle: "Send Data to Sumo Logic"
 guide_title: "Send data to Sumo Logic with Sensu"
 type: "guide"
 description: "Put Sensu's observability pipeline into action. Follow this guide to configure a handler to send Sensu data to Sumo Logic for long-term log and metrics storage."
-weight: 19
+weight: 180
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Email Alerts"
 guide_title: "Send email alerts with a pipeline"
 type: "guide"
 description: "Send notifications based on Sensu Go observability event data to an email address to alert you of incidents and help you resolve them more quickly."
-weight: 20
+weight: 200
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send PagerDuty Alerts"
 guide_title: "Send PagerDuty alerts with Sensu"
 type: "guide"
 description: "Follow this guide to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events."
-weight: 25
+weight: 220
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Slack Alerts"
 guide_title: "Send Slack alerts with a pipeline"
 type: "guide"
 description: "Send alerts to Slack with Sensu pipelines, which allow you to send events to alert you of incidents and help you resolve them more quickly."
-weight: 30
+weight: 240
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Sumo Logic Metrics Handlers Reference"
 reference_title: "Sumo Logic metrics handlers"
 type: "reference"
 description: "Read this reference to learn about Sumo Logic metrics handlers, which provide a persistent connection for sending Sensu data to Sumo Logic."
-weight: 16
+weight: 80
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers.md
@@ -4,7 +4,7 @@ linkTitle: "TCP Stream Handlers Reference"
 reference_title: "TCP stream handlers"
 type: "reference"
 description: "Read this reference to use TCP stream handlers to send observability data to TCP sockets without the data bottlenecks of traditional TCP handlers."
-weight: 17
+weight: 90
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Augment Event Data"
 guide_title: "Augment event data with check hooks"
 type: "guide"
 description: "Free up precious operator time: use Sensu check hooks to automate data collection that operators would otherwise perform manually to investigate alerts."
-weight: 90
+weight: 140
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -2,7 +2,7 @@
 title: "Business service monitoring SDK"
 linkTitle: "Business Service Monitoring SDK"
 description: "Use Sensu's business service monitoring SDK of JavaScript-based expressions to add functionality for Sensu rule templates that evaluate service components."
-weight: 75
+weight: 130
 version: "6.5"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -5,7 +5,7 @@ type: "guide"
 description: "Use Sensu's business service monitoring (BSM) to monitor every component in your system with a top-down approach that produces meaningful information."
 product: "Sensu Go"
 version: "6.5"
-weight: 55
+weight: 200
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Service Metrics"
 guide_title: "Collect service metrics with Sensu checks"
 type: "guide"
 description: "Collect service metrics for an NGINX webserver with a Sensu check and output the metrics data in Nagios Performance Data format."
-weight: 50
+weight: 180
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Hooks Reference"
 reference_title: "Hooks"
 type: "reference"
 description: "Read this reference to free up precious operator time with hooks, which allow you to automate data collection that operators would typically perform manually."
-weight: 80
+weight: 40
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Metrics Reference"
 reference_title: "Metrics"
 type: "reference"
 description: "Read this reference to collect service and time-series metrics for your infrastructure and process extracted metrics with the Sensu observability pipeline."
-weight: 33
+weight: 50
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -4,7 +4,7 @@ linkTitle: "Monitor Server Resources"
 guide_title: "Monitor server resources with checks"
 type: "guide"
 description: "Sensu lets you monitor server resources with checks. Read this guide to learn about Sensu checks and how to use checks to monitor servers."
-weight: 40
+weight: 220
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Prometheus Metrics"
 guide_title: "Collect Prometheus metrics with Sensu"
 type: "guide"
 description: "Use the Sensu Prometheus Collector integration to collect Prometheus metrics so Sensu can route the collected metrics to a time-series database like InfluxDB."
-weight: 55
+weight: 160
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
@@ -4,7 +4,7 @@ linkTitle: "Service Components Reference"
 reference_title: "Service components"
 type: "reference"
 description: "Service components are meaningful selections of Sensu events, like database monitoring events, that allow you to define and manage business service elements."
-weight: 70
+weight: 80
 version: "6.5"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/subscriptions.md
@@ -4,7 +4,7 @@ linkTitle: "Subscriptions Reference"
 reference_title: "Subscriptions"
 type: "reference"
 description: "Use Sensu subscriptions to configure checks in a one-to-many model and write checks even if you don't know the names of the entities that should run the checks."
-weight: 35
+weight: 100
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -4,7 +4,7 @@ linkTitle: "Tokens Reference"
 reference_title: "Tokens"
 type: "reference"
 description: "Use tokens in Sensu checks as placeholders that agents replace with entity data to fine-tune check attributes while reusing check definitions."
-weight: 100
+weight: 120
 version: "6.5"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -4,7 +4,7 @@ linkTitle: "Assets Reference"
 reference_title: "Assets"
 type: "reference"
 description: "Use Sensu's dynamic runtime assets to provide the plugins, libraries, and runtimes you need to create automated monitoring and observability workflows."
-weight: 60
+weight: 20
 version: "6.5"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.5/plugins/install-plugins.md
+++ b/content/sensu-go/6.5/plugins/install-plugins.md
@@ -2,7 +2,7 @@
 title: "Install Sensu plugins"
 linkTitle: "Install Plugins"
 description: "Learn how to install plugins to extend Sensu's functionality with executables for performing checks, mutators, and handlers."
-weight: 20
+weight: 60
 version: "6.5"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.5/plugins/plugins.md
+++ b/content/sensu-go/6.5/plugins/plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Plugins Reference"
 reference_title: "Plugins"
 type: "reference"
 description: "Read this reference for information about Sensu plugins, which provide executables that you can use as a Sensu check, handler, or mutator command."
-weight: 80
+weight: 40
 version: "6.5"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.5/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.5/plugins/supported-integrations/_index.md
@@ -3,7 +3,7 @@ title: "Supported Integrations"
 description: "Use Sensu plugins to integrate Sensu with your existing workflows for Sumo Logic, PagerDuty, Ansible, Chef, Jira, Elasticsearch, InfluxDB, and more."
 product: "Sensu Go"
 version: "6.5"
-weight: 80
+weight: 100
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.5/plugins/use-assets-to-install-plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Use Assets to Install Plugins"
 guide_title: "Use dynamic runtime assets to install plugins"
 type: "guide"
 description: "Use Sensu's shareable, reusable dynamic runtime assets to deploy the plugins, libraries, and runtimes you need for your monitoring and observability workflows."
-weight: 40
+weight: 80
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -4,7 +4,7 @@ linkTitle: "Event Filter Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."
-weight: 10
+weight: 20
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -4,7 +4,7 @@ linkTitle: "Reduce Alert Fatigue"
 guide_title: "Reduce alert fatigue with event filters"
 type: "guide"
 description: "Here’s how to reduce alert fatigue with Sensu. Learn about Sensu filters, how they reduce alert fatigue, and how to put them into action."
-weight: 20
+weight: 60
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Route Alerts"
 guide_title: "Route alerts with event filters"
 type: "guide"
 description: "Alert the right people using their preferred contact method with Sensu's contact routing and reduce mean time to response and recovery."
-weight: 30
+weight: 80
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -4,7 +4,7 @@ linkTitle: "Aggregate StatsD Metrics"
 guide_title: "Aggregate metrics with the Sensu StatsD listener"
 type: "guide"
 description: "Sensu agents include a StatsD listener you can use to send application performance, CPU, I/O, and network utilization metrics to your observability pipeline."
-weight: 40
+weight: 100
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 55
+weight: 120
 version: "6.6"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
 description: "Read this reference to learn to use handlers, the actions the Sensu backend executes on events, in your automated monitoring and observability workflows."
-weight: 10
+weight: 20
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
@@ -4,7 +4,7 @@ linkTitle: "Pipeline Reference"
 reference_title: "Pipeline"
 type: "reference"
 description: "Pipelines are observation event processing workflows made up of filters, mutators, and handlers. Read the reference doc to learn about pipelines."
-weight: 15
+weight: 40
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
@@ -4,7 +4,7 @@ linkTitle: "Plan Maintenance Windows"
 guide_title: "Plan maintenance windows with silencing"
 type: "guide"
 description: "Use Sensu's silencing feature to suppress event handling during system maintenance so you can coordinate and perform maintenance without getting alerts."
-weight: 70
+weight: 140
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -4,7 +4,7 @@ linkTitle: "Populate Metrics in InfluxDB"
 guide_title: "Populate metrics in InfluxDB with handlers"
 type: "guide"
 description: "Follow this guide to populate Sensu metrics into the time-series database InfluxDB with a handler, an action the Sensu backend executes when an event occurs."
-weight: 50
+weight: 160
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -4,7 +4,7 @@ linkTitle: "Send Data to Sumo Logic"
 guide_title: "Send data to Sumo Logic with Sensu"
 type: "guide"
 description: "Put Sensu's observability pipeline into action. Follow this guide to configure a handler to send Sensu data to Sumo Logic for long-term log and metrics storage."
-weight: 19
+weight: 180
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Email Alerts"
 guide_title: "Send email alerts with a pipeline"
 type: "guide"
 description: "Send notifications based on Sensu Go observability event data to an email address to alert you of incidents and help you resolve them more quickly."
-weight: 20
+weight: 200
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send PagerDuty Alerts"
 guide_title: "Send PagerDuty alerts with Sensu"
 type: "guide"
 description: "Follow this guide to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events."
-weight: 25
+weight: 220
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Slack Alerts"
 guide_title: "Send Slack alerts with a pipeline"
 type: "guide"
 description: "Send alerts to Slack with Sensu pipelines, which allow you to send events to alert you of incidents and help you resolve them more quickly."
-weight: 30
+weight: 240
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Sumo Logic Metrics Handlers Reference"
 reference_title: "Sumo Logic metrics handlers"
 type: "reference"
 description: "Read this reference to learn about Sumo Logic metrics handlers, which provide a persistent connection for sending Sensu data to Sumo Logic."
-weight: 16
+weight: 80
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/tcp-stream-handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/tcp-stream-handlers.md
@@ -4,7 +4,7 @@ linkTitle: "TCP Stream Handlers Reference"
 reference_title: "TCP stream handlers"
 type: "reference"
 description: "Read this reference to use TCP stream handlers to send observability data to TCP sockets without the data bottlenecks of traditional TCP handlers."
-weight: 17
+weight: 90
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Augment Event Data"
 guide_title: "Augment event data with check hooks"
 type: "guide"
 description: "Free up precious operator time: use Sensu check hooks to automate data collection that operators would otherwise perform manually to investigate alerts."
-weight: 90
+weight: 140
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -2,7 +2,7 @@
 title: "Business service monitoring SDK"
 linkTitle: "Business Service Monitoring SDK"
 description: "Use Sensu's business service monitoring SDK of JavaScript-based expressions to add functionality for Sensu rule templates that evaluate service components."
-weight: 75
+weight: 130
 version: "6.6"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -5,7 +5,7 @@ type: "guide"
 description: "Use Sensu's business service monitoring (BSM) to monitor every component in your system with a top-down approach that produces meaningful information."
 product: "Sensu Go"
 version: "6.6"
-weight: 55
+weight: 200
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Service Metrics"
 guide_title: "Collect service metrics with Sensu checks"
 type: "guide"
 description: "Collect service metrics for an NGINX webserver with a Sensu check and output the metrics data in Nagios Performance Data format."
-weight: 50
+weight: 180
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Hooks Reference"
 reference_title: "Hooks"
 type: "reference"
 description: "Read this reference to free up precious operator time with hooks, which allow you to automate data collection that operators would typically perform manually."
-weight: 80
+weight: 40
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Metrics Reference"
 reference_title: "Metrics"
 type: "reference"
 description: "Read this reference to collect service and time-series metrics for your infrastructure and process extracted metrics with the Sensu observability pipeline."
-weight: 33
+weight: 50
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -4,7 +4,7 @@ linkTitle: "Monitor Server Resources"
 guide_title: "Monitor server resources with checks"
 type: "guide"
 description: "Sensu lets you monitor server resources with checks. Read this guide to learn about Sensu checks and how to use checks to monitor servers."
-weight: 40
+weight: 220
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Prometheus Metrics"
 guide_title: "Collect Prometheus metrics with Sensu"
 type: "guide"
 description: "Use the Sensu Prometheus Collector integration to collect Prometheus metrics so Sensu can route the collected metrics to a time-series database like InfluxDB."
-weight: 55
+weight: 160
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/service-components.md
@@ -4,7 +4,7 @@ linkTitle: "Service Components Reference"
 reference_title: "Service components"
 type: "reference"
 description: "Service components are meaningful selections of Sensu events, like database monitoring events, that allow you to define and manage business service elements."
-weight: 70
+weight: 80
 version: "6.6"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/subscriptions.md
@@ -4,7 +4,7 @@ linkTitle: "Subscriptions Reference"
 reference_title: "Subscriptions"
 type: "reference"
 description: "Use Sensu subscriptions to configure checks in a one-to-many model and write checks even if you don't know the names of the entities that should run the checks."
-weight: 35
+weight: 100
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
@@ -4,7 +4,7 @@ linkTitle: "Tokens Reference"
 reference_title: "Tokens"
 type: "reference"
 description: "Use tokens in Sensu checks as placeholders that agents replace with entity data to fine-tune check attributes while reusing check definitions."
-weight: 100
+weight: 120
 version: "6.6"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.6/plugins/assets.md
+++ b/content/sensu-go/6.6/plugins/assets.md
@@ -4,7 +4,7 @@ linkTitle: "Assets Reference"
 reference_title: "Assets"
 type: "reference"
 description: "Use Sensu's dynamic runtime assets to provide the plugins, libraries, and runtimes you need to create automated monitoring and observability workflows."
-weight: 60
+weight: 20
 version: "6.6"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.6/plugins/install-plugins.md
+++ b/content/sensu-go/6.6/plugins/install-plugins.md
@@ -2,7 +2,7 @@
 title: "Install Sensu plugins"
 linkTitle: "Install Plugins"
 description: "Learn how to install plugins to extend Sensu's functionality with executables for performing checks, mutators, and handlers."
-weight: 20
+weight: 60
 version: "6.6"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.6/plugins/plugins.md
+++ b/content/sensu-go/6.6/plugins/plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Plugins Reference"
 reference_title: "Plugins"
 type: "reference"
 description: "Read this reference for information about Sensu plugins, which provide executables that you can use as a Sensu check, handler, or mutator command."
-weight: 80
+weight: 40
 version: "6.6"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.6/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.6/plugins/supported-integrations/_index.md
@@ -3,7 +3,7 @@ title: "Supported Integrations"
 description: "Use Sensu plugins to integrate Sensu with your existing workflows for Sumo Logic, PagerDuty, Ansible, Chef, Jira, Elasticsearch, InfluxDB, and more."
 product: "Sensu Go"
 version: "6.6"
-weight: 80
+weight: 100
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.6/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.6/plugins/use-assets-to-install-plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Use Assets to Install Plugins"
 guide_title: "Use dynamic runtime assets to install plugins"
 type: "guide"
 description: "Use Sensu's shareable, reusable dynamic runtime assets to deploy the plugins, libraries, and runtimes you need for your monitoring and observability workflows."
-weight: 40
+weight: 80
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -4,7 +4,7 @@ linkTitle: "Event Filter Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."
-weight: 10
+weight: 20
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -4,7 +4,7 @@ linkTitle: "Reduce Alert Fatigue"
 guide_title: "Reduce alert fatigue with event filters"
 type: "guide"
 description: "Here’s how to reduce alert fatigue with Sensu. Learn about Sensu filters, how they reduce alert fatigue, and how to put them into action."
-weight: 20
+weight: 60
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Route Alerts"
 guide_title: "Route alerts with event filters"
 type: "guide"
 description: "Alert the right people using their preferred contact method with Sensu's contact routing and reduce mean time to response and recovery."
-weight: 30
+weight: 80
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -4,7 +4,7 @@ linkTitle: "Aggregate StatsD Metrics"
 guide_title: "Aggregate metrics with the Sensu StatsD listener"
 type: "guide"
 description: "Sensu agents include a StatsD listener you can use to send application performance, CPU, I/O, and network utilization metrics to your observability pipeline."
-weight: 40
+weight: 100
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handler-templates.md
@@ -4,7 +4,7 @@ linkTitle: "Create Handler Templates"
 guide_title: "Create handler templates"
 type: "guide"
 description: "Add meaningful, actionable context to alerts with event-based templating for your handlers. Read this guide to learn how to create handler templates."
-weight: 55
+weight: 120
 version: "6.7"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Handlers Reference"
 reference_title: "Handlers"
 type: "reference"
 description: "Read this reference to learn to use handlers, the actions the Sensu backend executes on events, in your automated monitoring and observability workflows."
-weight: 10
+weight: 20
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
@@ -4,7 +4,7 @@ linkTitle: "Pipeline Reference"
 reference_title: "Pipeline"
 type: "reference"
 description: "Pipelines are observation event processing workflows made up of filters, mutators, and handlers. Read the reference doc to learn about pipelines."
-weight: 15
+weight: 40
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
@@ -4,7 +4,7 @@ linkTitle: "Plan Maintenance Windows"
 guide_title: "Plan maintenance windows with silencing"
 type: "guide"
 description: "Use Sensu's silencing feature to suppress event handling during system maintenance so you can coordinate and perform maintenance without getting alerts."
-weight: 70
+weight: 140
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -4,7 +4,7 @@ linkTitle: "Populate Metrics in InfluxDB"
 guide_title: "Populate metrics in InfluxDB with handlers"
 type: "guide"
 description: "Follow this guide to populate Sensu metrics into the time-series database InfluxDB with a handler, an action the Sensu backend executes when an event occurs."
-weight: 50
+weight: 160
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -4,7 +4,7 @@ linkTitle: "Send Data to Sumo Logic"
 guide_title: "Send data to Sumo Logic with Sensu"
 type: "guide"
 description: "Put Sensu's observability pipeline into action. Follow this guide to configure a handler to send Sensu data to Sumo Logic for long-term log and metrics storage."
-weight: 19
+weight: 180
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Email Alerts"
 guide_title: "Send email alerts with a pipeline"
 type: "guide"
 description: "Send notifications based on Sensu Go observability event data to an email address to alert you of incidents and help you resolve them more quickly."
-weight: 20
+weight: 200
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send PagerDuty Alerts"
 guide_title: "Send PagerDuty alerts with Sensu"
 type: "guide"
 description: "Follow this guide to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events."
-weight: 25
+weight: 220
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
@@ -4,7 +4,7 @@ linkTitle: "Send Slack Alerts"
 guide_title: "Send Slack alerts with a pipeline"
 type: "guide"
 description: "Send alerts to Slack with Sensu pipelines, which allow you to send events to alert you of incidents and help you resolve them more quickly."
-weight: 30
+weight: 240
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/sumo-logic-metrics-handlers.md
@@ -4,7 +4,7 @@ linkTitle: "Sumo Logic Metrics Handlers Reference"
 reference_title: "Sumo Logic metrics handlers"
 type: "reference"
 description: "Read this reference to learn about Sumo Logic metrics handlers, which provide a persistent connection for sending Sensu data to Sumo Logic."
-weight: 16
+weight: 80
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/tcp-stream-handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/tcp-stream-handlers.md
@@ -4,7 +4,7 @@ linkTitle: "TCP Stream Handlers Reference"
 reference_title: "TCP stream handlers"
 type: "reference"
 description: "Read this reference to use TCP stream handlers to send observability data to TCP sockets without the data bottlenecks of traditional TCP handlers."
-weight: 17
+weight: 90
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Augment Event Data"
 guide_title: "Augment event data with check hooks"
 type: "guide"
 description: "Free up precious operator time: use Sensu check hooks to automate data collection that operators would otherwise perform manually to investigate alerts."
-weight: 90
+weight: 140
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/business-service-monitoring-sdk.md
@@ -2,7 +2,7 @@
 title: "Business service monitoring SDK"
 linkTitle: "Business Service Monitoring SDK"
 description: "Use Sensu's business service monitoring SDK of JavaScript-based expressions to add functionality for Sensu rule templates that evaluate service components."
-weight: 75
+weight: 130
 version: "6.7"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -5,7 +5,7 @@ type: "guide"
 description: "Use Sensu's business service monitoring (BSM) to monitor every component in your system with a top-down approach that produces meaningful information."
 product: "Sensu Go"
 version: "6.7"
-weight: 55
+weight: 200
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Service Metrics"
 guide_title: "Collect service metrics with Sensu checks"
 type: "guide"
 description: "Collect service metrics for an NGINX webserver with a Sensu check and output the metrics data in Nagios Performance Data format."
-weight: 50
+weight: 180
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/hooks.md
@@ -4,7 +4,7 @@ linkTitle: "Hooks Reference"
 reference_title: "Hooks"
 type: "reference"
 description: "Read this reference to free up precious operator time with hooks, which allow you to automate data collection that operators would typically perform manually."
-weight: 80
+weight: 40
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Metrics Reference"
 reference_title: "Metrics"
 type: "reference"
 description: "Read this reference to collect service and time-series metrics for your infrastructure and process extracted metrics with the Sensu observability pipeline."
-weight: 33
+weight: 50
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -4,7 +4,7 @@ linkTitle: "Monitor Server Resources"
 guide_title: "Monitor server resources with checks"
 type: "guide"
 description: "Sensu lets you monitor server resources with checks. Read this guide to learn about Sensu checks and how to use checks to monitor servers."
-weight: 40
+weight: 220
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -4,7 +4,7 @@ linkTitle: "Collect Prometheus Metrics"
 guide_title: "Collect Prometheus metrics with Sensu"
 type: "guide"
 description: "Use the Sensu Prometheus Collector integration to collect Prometheus metrics so Sensu can route the collected metrics to a time-series database like InfluxDB."
-weight: 55
+weight: 160
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/service-components.md
@@ -4,7 +4,7 @@ linkTitle: "Service Components Reference"
 reference_title: "Service components"
 type: "reference"
 description: "Service components are meaningful selections of Sensu events, like database monitoring events, that allow you to define and manage business service elements."
-weight: 70
+weight: 80
 version: "6.7"
 product: "Sensu Go"
 menu: 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/subscriptions.md
@@ -4,7 +4,7 @@ linkTitle: "Subscriptions Reference"
 reference_title: "Subscriptions"
 type: "reference"
 description: "Use Sensu subscriptions to configure checks in a one-to-many model and write checks even if you don't know the names of the entities that should run the checks."
-weight: 35
+weight: 100
 version: "6.7"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
@@ -4,7 +4,7 @@ linkTitle: "Tokens Reference"
 reference_title: "Tokens"
 type: "reference"
 description: "Use tokens in Sensu checks as placeholders that agents replace with entity data to fine-tune check attributes while reusing check definitions."
-weight: 100
+weight: 120
 version: "6.7"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.7/plugins/assets.md
+++ b/content/sensu-go/6.7/plugins/assets.md
@@ -4,7 +4,7 @@ linkTitle: "Assets Reference"
 reference_title: "Assets"
 type: "reference"
 description: "Use Sensu's dynamic runtime assets to provide the plugins, libraries, and runtimes you need to create automated monitoring and observability workflows."
-weight: 60
+weight: 20
 version: "6.7"
 product: "Sensu Go"
 platformContent: false 

--- a/content/sensu-go/6.7/plugins/install-plugins.md
+++ b/content/sensu-go/6.7/plugins/install-plugins.md
@@ -2,7 +2,7 @@
 title: "Install Sensu plugins"
 linkTitle: "Install Plugins"
 description: "Learn how to install plugins to extend Sensu's functionality with executables for performing checks, mutators, and handlers."
-weight: 20
+weight: 60
 version: "6.7"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.7/plugins/plugins.md
+++ b/content/sensu-go/6.7/plugins/plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Plugins Reference"
 reference_title: "Plugins"
 type: "reference"
 description: "Read this reference for information about Sensu plugins, which provide executables that you can use as a Sensu check, handler, or mutator command."
-weight: 80
+weight: 40
 version: "6.7"
 product: "Sensu Go"
 menu:

--- a/content/sensu-go/6.7/plugins/supported-integrations/_index.md
+++ b/content/sensu-go/6.7/plugins/supported-integrations/_index.md
@@ -3,7 +3,7 @@ title: "Supported Integrations"
 description: "Use Sensu plugins to integrate Sensu with your existing workflows for Sumo Logic, PagerDuty, Ansible, Chef, Jira, Elasticsearch, InfluxDB, and more."
 product: "Sensu Go"
 version: "6.7"
-weight: 80
+weight: 100
 layout: "single"
 toc: true
 menu:

--- a/content/sensu-go/6.7/plugins/use-assets-to-install-plugins.md
+++ b/content/sensu-go/6.7/plugins/use-assets-to-install-plugins.md
@@ -4,7 +4,7 @@ linkTitle: "Use Assets to Install Plugins"
 guide_title: "Use dynamic runtime assets to install plugins"
 type: "guide"
 description: "Use Sensu's shareable, reusable dynamic runtime assets to deploy the plugins, libraries, and runtimes you need for your monitoring and observability workflows."
-weight: 40
+weight: 80
 version: "6.7"
 product: "Sensu Go"
 platformContent: false


### PR DESCRIPTION
## Description
Updates the weights for pages within the observability pipeline and plugins categories so that references and guides stay grouped together and listed alphabetically within categories and sub-categories

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3747

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>