### PR TITLE
Clarify explanation and add link for proxy_requests in splay section

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -488,10 +488,10 @@ spec:
 
 Use the [`splay`][72] and [`splay_coverage`][73] attributes to distribute proxy check executions across the check interval.
 
-To continue the [example `proxy_requests` check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
+To continue the [example proxy_check_proxy_requests check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
 Use the `splay` and `splay_coverage` attributes to distribute the three check executions over the specified check interval instead of all at the same time.
 
-The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the `proxy_requests` scope.
+The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the [`proxy_requests` object][74].
 With this addition, instead of three check executions in a single burst every 60 seconds, Sensu will distribute the three check executions evenly across a 54-second period (90% of the 60-second interval):
 
 {{< language-toggle >}}
@@ -1701,3 +1701,4 @@ The dynamic runtime asset reference includes an [example check definition that u
 [71]: #example-proxy-check-using-proxy_requests
 [72]: #splay
 [73]: #splay-coverage
+[74]: #proxy-requests-top-level

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -488,10 +488,10 @@ spec:
 
 Use the [`splay`][72] and [`splay_coverage`][73] attributes to distribute proxy check executions across the check interval.
 
-To continue the [example `proxy_requests` check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
+To continue the [example proxy_check_proxy_requests check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
 Use the `splay` and `splay_coverage` attributes to distribute the three check executions over the specified check interval instead of all at the same time.
 
-The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the `proxy_requests` scope.
+The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the [`proxy_requests` object][74].
 With this addition, instead of three check executions in a single burst every 60 seconds, Sensu will distribute the three check executions evenly across a 54-second period (90% of the 60-second interval):
 
 {{< language-toggle >}}
@@ -1701,3 +1701,4 @@ The dynamic runtime asset reference includes an [example check definition that u
 [71]: #example-proxy-check-using-proxy_requests
 [72]: #splay
 [73]: #splay-coverage
+[74]: #proxy-requests-top-level

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -487,10 +487,10 @@ spec:
 
 Use the [`splay`][72] and [`splay_coverage`][73] attributes to distribute proxy check executions across the check interval.
 
-To continue the [example `proxy_requests` check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
+To continue the [example proxy_check_proxy_requests check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
 Use the `splay` and `splay_coverage` attributes to distribute the three check executions over the specified check interval instead of all at the same time.
 
-The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the `proxy_requests` scope.
+The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the [`proxy_requests` object][74].
 With this addition, instead of three check executions in a single burst every 60 seconds, Sensu will distribute the three check executions evenly across a 54-second period (90% of the 60-second interval):
 
 {{< language-toggle >}}
@@ -1813,3 +1813,4 @@ The dynamic runtime asset reference includes an [example check definition that u
 [71]: #example-proxy-check-using-proxy_requests
 [72]: #splay
 [73]: #splay-coverage
+[74]: #proxy-requests-top-level

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -487,10 +487,10 @@ spec:
 
 Use the [`splay`][72] and [`splay_coverage`][73] attributes to distribute proxy check executions across the check interval.
 
-To continue the [example `proxy_requests` check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
+To continue the [example proxy_check_proxy_requests check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
 Use the `splay` and `splay_coverage` attributes to distribute the three check executions over the specified check interval instead of all at the same time.
 
-The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the `proxy_requests` scope.
+The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the [`proxy_requests` object][74].
 With this addition, instead of three check executions in a single burst every 60 seconds, Sensu will distribute the three check executions evenly across a 54-second period (90% of the 60-second interval):
 
 {{< language-toggle >}}
@@ -1813,3 +1813,4 @@ The dynamic runtime asset reference includes an [example check definition that u
 [71]: #example-proxy-check-using-proxy_requests
 [72]: #splay
 [73]: #splay-coverage
+[74]: #proxy-requests-top-level

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
@@ -487,10 +487,10 @@ spec:
 
 Use the [`splay`][72] and [`splay_coverage`][73] attributes to distribute proxy check executions across the check interval.
 
-To continue the [example `proxy_requests` check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
+To continue the [example proxy_check_proxy_requests check][71], if the check matches three proxy entities, you will get a single burst of three check executions (with the resulting events) every 60 seconds.
 Use the `splay` and `splay_coverage` attributes to distribute the three check executions over the specified check interval instead of all at the same time.
 
-The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the `proxy_requests` scope.
+The following example adds `splay` set to `true` and `splay_coverage` set to `90` within the [`proxy_requests` object][74].
 With this addition, instead of three check executions in a single burst every 60 seconds, Sensu will distribute the three check executions evenly across a 54-second period (90% of the 60-second interval):
 
 {{< language-toggle >}}
@@ -1813,3 +1813,4 @@ The dynamic runtime asset reference includes an [example check definition that u
 [71]: #example-proxy-check-using-proxy_requests
 [72]: #splay
 [73]: #splay-coverage
+[74]: #proxy-requests-top-level


### PR DESCRIPTION
## Description
In the check reference, in the section describing splay and splay_coverage settings, clarifies that these two attributes are set within the proxy_requests **object** (rather than **scope**). Also updated to use the correct example check name.

## Motivation and Context
https://sumologic.slack.com/archives/C024XK35Z3Q/p1648542706276509

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>