### PR TITLE
Fix reversed values for latency-related etcd flags

### DIFF
--- a/content/sensu-go/6.3/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/tune.md
@@ -22,7 +22,7 @@ These pages describe common problems and solutions, planning and optimization co
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
 To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
-For example, you might increase `etcd-election-timeout` from 100 to 500 and `etcd-heartbeat-interval` from 1000 to 5000.
+For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 

--- a/content/sensu-go/6.4/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/tune.md
@@ -22,7 +22,7 @@ These pages describe common problems and solutions, planning and optimization co
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
 To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
-For example, you might increase `etcd-election-timeout` from 100 to 500 and `etcd-heartbeat-interval` from 1000 to 5000.
+For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 

--- a/content/sensu-go/6.5/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/tune.md
@@ -22,7 +22,7 @@ These pages describe common problems and solutions, planning and optimization co
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
 To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
-For example, you might increase `etcd-election-timeout` from 100 to 500 and `etcd-heartbeat-interval` from 1000 to 5000.
+For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 

--- a/content/sensu-go/6.6/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/tune.md
@@ -22,7 +22,7 @@ These pages describe common problems and solutions, planning and optimization co
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
 To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
-For example, you might increase `etcd-election-timeout` from 100 to 500 and `etcd-heartbeat-interval` from 1000 to 5000.
+For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 

--- a/content/sensu-go/6.7/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/tune.md
@@ -22,7 +22,7 @@ These pages describe common problems and solutions, planning and optimization co
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
 To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
-For example, you might increase `etcd-election-timeout` from 100 to 500 and `etcd-heartbeat-interval` from 1000 to 5000.
+For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 


### PR DESCRIPTION
## Description
Fixes incorrect (reversed) suggestions for addressing latency with etcd-heartbeat-interval and etcd-election-timeout flags in https://docs.sensu.io/sensu-go/latest/operations/maintain-sensu/tune/#latency-tolerances-for-etcd

## Motivation and Context
https://sumologic.slack.com/archives/C024PCF29KR/p1648631365733849

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>