### PR TITLE
Fix a typo and incorrectly formatted link

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/tokens.md
@@ -32,7 +32,7 @@ This example demonstrates a reusable disk usage check.
 The [check command][5] includes `-w` (warning) and `-c` (critical) arguments with default values for the thresholds (as percentages) for generating warning or critical events.
 The check will compare every subscribed entity's disk space against the default threshold values to determine whether to generate a warning or critical event.
 
-However, the check command also includes token substitution, which means you can add entity labels that correspond to the check commnand tokens to specify different warning and critical values for individual entities.
+However, the check command also includes token substitution, which means you can add entity labels that correspond to the check command tokens to specify different warning and critical values for individual entities.
 Instead of creating a different check for every set of thresholds, you can use the same check to apply the defaults in most cases and the token-substituted values for specific entities.
 
 Follow this example to set up a reusable check for disk usage:

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -32,7 +32,7 @@ This example demonstrates a reusable disk usage check.
 The [check command][5] includes `-w` (warning) and `-c` (critical) arguments with default values for the thresholds (as percentages) for generating warning or critical events.
 The check will compare every subscribed entity's disk space against the default threshold values to determine whether to generate a warning or critical event.
 
-However, the check command also includes token substitution, which means you can add entity labels that correspond to the check commnand tokens to specify different warning and critical values for individual entities.
+However, the check command also includes token substitution, which means you can add entity labels that correspond to the check command tokens to specify different warning and critical values for individual entities.
 Instead of creating a different check for every set of thresholds, you can use the same check to apply the defaults in most cases and the token-substituted values for specific entities.
 
 Follow this example to set up a reusable check for disk usage:

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -32,7 +32,7 @@ This example demonstrates a reusable disk usage check.
 The [check command][5] includes `-w` (warning) and `-c` (critical) arguments with default values for the thresholds (as percentages) for generating warning or critical events.
 The check will compare every subscribed entity's disk space against the default threshold values to determine whether to generate a warning or critical event.
 
-However, the check command also includes token substitution, which means you can add entity labels that correspond to the check commnand tokens to specify different warning and critical values for individual entities.
+However, the check command also includes token substitution, which means you can add entity labels that correspond to the check command tokens to specify different warning and critical values for individual entities.
 Instead of creating a different check for every set of thresholds, you can use the same check to apply the defaults in most cases and the token-substituted values for specific entities.
 
 Follow this example to set up a reusable check for disk usage:

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
@@ -32,7 +32,7 @@ This example demonstrates a reusable disk usage check.
 The [check command][5] includes `-w` (warning) and `-c` (critical) arguments with default values for the thresholds (as percentages) for generating warning or critical events.
 The check will compare every subscribed entity's disk space against the default threshold values to determine whether to generate a warning or critical event.
 
-However, the check command also includes token substitution, which means you can add entity labels that correspond to the check commnand tokens to specify different warning and critical values for individual entities.
+However, the check command also includes token substitution, which means you can add entity labels that correspond to the check command tokens to specify different warning and critical values for individual entities.
 Instead of creating a different check for every set of thresholds, you can use the same check to apply the defaults in most cases and the token-substituted values for specific entities.
 
 Follow this example to set up a reusable check for disk usage:

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
@@ -32,7 +32,7 @@ This example demonstrates a reusable disk usage check.
 The [check command][5] includes `-w` (warning) and `-c` (critical) arguments with default values for the thresholds (as percentages) for generating warning or critical events.
 The check will compare every subscribed entity's disk space against the default threshold values to determine whether to generate a warning or critical event.
 
-However, the check command also includes token substitution, which means you can add entity labels that correspond to the check commnand tokens to specify different warning and critical values for individual entities.
+However, the check command also includes token substitution, which means you can add entity labels that correspond to the check command tokens to specify different warning and critical values for individual entities.
 Instead of creating a different check for every set of thresholds, you can use the same check to apply the defaults in most cases and the token-substituted values for specific entities.
 
 Follow this example to set up a reusable check for disk usage:


### PR DESCRIPTION
## Description
Fixes a typo and an incorrectly formatted link the Tokens reference

## Motivation and Context
Noticed when working on something else
