### PR TITLE
Add API shortcodes to offline folder

### DIFF
--- a/offline/shortcodes/coreapiListing.html
+++ b/offline/shortcodes/coreapiListing.html
@@ -1,0 +1,9 @@
+<ul class="grid-list">
+  {{ range (.Site.Pages.ByParam "core_api_title") }}
+    <!-- Only include pages from the specified version -->
+    <!-- Only include pages with specified frontmatter type "reference" -->
+    {{ if and (eq .Type "core_api") (.IsDescendant $.Page.CurrentSection.Parent) }}
+      <li><a href="{{ .Permalink }}">{{ .Params.core_api_title }}</a></li>
+    {{ end }}
+  {{ end }}
+</ul>

--- a/offline/shortcodes/enterpriseapiListing.html
+++ b/offline/shortcodes/enterpriseapiListing.html
@@ -1,0 +1,9 @@
+<ul class="grid-list">
+  {{ range (.Site.Pages.ByParam "enterprise_api_title") }}
+    <!-- Only include pages from the specified version -->
+    <!-- Only include pages with specified frontmatter type "reference" -->
+    {{ if and (eq .Type "enterprise_api") (.IsDescendant $.Page.CurrentSection.Parent) }}
+      <li><a href="{{ .Permalink }}">{{ .Params.enterprise_api_title }}</a></li>
+    {{ end }}
+  {{ end }}
+</ul>

--- a/offline/shortcodes/otherapiListing.html
+++ b/offline/shortcodes/otherapiListing.html
@@ -1,0 +1,9 @@
+<ul class="grid-list">
+  {{ range (.Site.Pages.ByParam "other_api_title") }}
+    <!-- Only include pages from the specified version -->
+    <!-- Only include pages with specified frontmatter type "reference" -->
+    {{ if and (eq .Type "other_api") (.IsDescendant $.Page.CurrentSection.Parent) }}
+      <li><a href="{{ .Permalink }}">{{ .Params.other_api_title }}</a></li>
+    {{ end }}
+  {{ end }}
+</ul>


### PR DESCRIPTION
## Description
Adds a copy of the shortcodes used to create the lists of API endpoints at https://docs.sensu.io/sensu-go/6.3/api/#available-apis to the `offline` folder

## Motivation and Context
Required to generate offline docs

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>
