### PR TITLE
Update install-sensu.md

### DIFF
--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -171,10 +171,10 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo systemctl sensu-backend start
+sudo systemctl start sensu-backend 
 
 # Verify that the backend is running
-sudo systemctl sensu-backend status
+sudo systemctl status sensu-backend 
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -182,10 +182,10 @@ sudo systemctl sensu-backend status
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
 # Start sensu-backend using a service manager
-sudo systemctl sensu-backend start
+sudo systemctl start sensu-backend 
 
 # Verify that the backend is running
-sudo systemctl sensu-backend status
+sudo systemctl status sensu-backend 
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -434,7 +434,7 @@ volumes:
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-sudo systemctl sensu-agent start
+sudo systemctl start sensu-agent 
 {{< /code >}}
 
 {{< code shell "RHEL/CentOS" >}}
@@ -442,7 +442,7 @@ sudo systemctl sensu-agent start
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
 # Start sensu-agent using a service manager
-sudo systemctl sensu-agent start
+sudo systemctl start sensu-agent 
 {{< /code >}}
 
 {{< code powershell "Windows" >}}


### PR DESCRIPTION
Update: corrected systemctl command for start and status check of sensu services. It should systemctl <start/stop/status> <application>

<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/main/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> Systemctl command specified in the document doest work in any linux based system. Command supposed to be in this format "systemctl <start/stop/status> <application>"
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->

## Review Instructions
<!--- Optional -->
systemctl man page for reference https://man7.org/linux/man-pages/man1/systemctl.1.html 
