### PR TITLE
Update statement about subdue in Migrate guide

### DIFF
--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Sensu Go checks do not include the `subdue` attribute.
+Check subdues are not yet implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Sensu Go checks do not include the `subdue` attribute.
+Check subdues are not yet implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Sensu Go checks do not include the `subdue` attribute.
+Check subdues are not yet implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Sensu Go checks do not include the `subdue` attribute.
+Check subdues are not yet implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Sensu Go checks do not include the `subdue` attribute.
+Check subdues are not yet implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks


### PR DESCRIPTION
## Description
Updates incorrect statement in Migrate guide: Sensu Go checks do include the subdue attribute, but it's nonfunctional

## Motivation and Context
Found when working on subdues doc for 6.7

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>