### PR TITLE
Add RFC 3339 links

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-process/plan-maintenance.md
@@ -180,7 +180,7 @@ sensuctl silenced create \
 
 {{% notice note %}}
 **NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses RFC3339 with space delimiters and numeric zone offset.
+This example uses [RFC 3339 format][20] with space delimiters and numeric zone offset.
 {{% /notice %}}
 
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
@@ -288,3 +288,4 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [17]: ../send-email-alerts/
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
+[20]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.3/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.3/sensuctl/create-manage-resources.md
@@ -628,9 +628,9 @@ This is useful for setting silences, for example.
 
 Sensuctl supports the following formats:
 
-* RFC3339 with numeric zone offset: `2018-05-10T07:04:00-08:00` or
+* [RFC 3339][42] with numeric zone offset: `2018-05-10T07:04:00-08:00` or
   `2018-05-10T15:04:00Z`
-* RFC3339 with space delimiters and numeric zone offset: `2018-05-10 07:04:00
+* [RFC 3339][42] with space delimiters and numeric zone offset: `2018-05-10 07:04:00
   -08:00`
 * Sensu alpha legacy format with canonical zone ID: `May 10 2018 7:04AM
   America/Vancouver`
@@ -673,3 +673,4 @@ Sensuctl supports the following formats:
 [37]: ../../operations/control-access/oidc-auth/
 [38]: ../../operations/control-access/rbac/#namespaced-resource-types
 [39]: ../../operations/control-access/sso/
+[42]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
@@ -180,7 +180,7 @@ sensuctl silenced create \
 
 {{% notice note %}}
 **NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses RFC3339 with space delimiters and numeric zone offset.
+This example uses [RFC 3339 format][20] with space delimiters and numeric zone offset.
 {{% /notice %}}
 
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
@@ -288,3 +288,4 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [17]: ../send-email-alerts/
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
+[20]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -628,9 +628,9 @@ This is useful for setting silences, for example.
 
 Sensuctl supports the following formats:
 
-* RFC3339 with numeric zone offset: `2018-05-10T07:04:00-08:00` or
+* [RFC 3339][42] with numeric zone offset: `2018-05-10T07:04:00-08:00` or
   `2018-05-10T15:04:00Z`
-* RFC3339 with space delimiters and numeric zone offset: `2018-05-10 07:04:00
+* [RFC 3339][42] with space delimiters and numeric zone offset: `2018-05-10 07:04:00
   -08:00`
 * Sensu alpha legacy format with canonical zone ID: `May 10 2018 7:04AM
   America/Vancouver`
@@ -673,3 +673,4 @@ Sensuctl supports the following formats:
 [37]: ../../operations/control-access/oidc-auth/
 [38]: ../../operations/control-access/rbac/#namespaced-resource-types
 [39]: ../../operations/control-access/sso/
+[42]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
@@ -180,7 +180,7 @@ sensuctl silenced create \
 
 {{% notice note %}}
 **NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses RFC3339 with space delimiters and numeric zone offset.
+This example uses [RFC 3339 format][20] with space delimiters and numeric zone offset.
 {{% /notice %}}
 
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
@@ -288,3 +288,4 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [17]: ../send-email-alerts/
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
+[20]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -623,9 +623,9 @@ This is useful for setting silences, for example.
 
 Sensuctl supports the following formats:
 
-* RFC3339 with numeric zone offset: `2018-05-10T07:04:00-08:00` or
+* [RFC 3339][42] with numeric zone offset: `2018-05-10T07:04:00-08:00` or
   `2018-05-10T15:04:00Z`
-* RFC3339 with space delimiters and numeric zone offset: `2018-05-10 07:04:00
+* [RFC 3339][42] with space delimiters and numeric zone offset: `2018-05-10 07:04:00
   -08:00`
 * Sensu alpha legacy format with canonical zone ID: `May 10 2018 7:04AM
   America/Vancouver`
@@ -671,3 +671,4 @@ Sensuctl supports the following formats:
 [39]: ../../operations/control-access/sso/
 [40]: ../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [41]: ../../observability-pipeline/observe-process/tcp-stream-handlers/
+[42]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
@@ -180,7 +180,7 @@ sensuctl silenced create \
 
 {{% notice note %}}
 **NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses RFC3339 with space delimiters and numeric zone offset.
+This example uses [RFC 3339 format][20] with space delimiters and numeric zone offset.
 {{% /notice %}}
 
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
@@ -288,3 +288,4 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [17]: ../send-email-alerts/
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
+[20]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -623,9 +623,9 @@ This is useful for setting silences, for example.
 
 Sensuctl supports the following formats:
 
-* RFC3339 with numeric zone offset: `2018-05-10T07:04:00-08:00` or
+* [RFC 3339][42] with numeric zone offset: `2018-05-10T07:04:00-08:00` or
   `2018-05-10T15:04:00Z`
-* RFC3339 with space delimiters and numeric zone offset: `2018-05-10 07:04:00
+* [RFC 3339][42] with space delimiters and numeric zone offset: `2018-05-10 07:04:00
   -08:00`
 * Sensu alpha legacy format with canonical zone ID: `May 10 2018 7:04AM
   America/Vancouver`
@@ -671,3 +671,4 @@ Sensuctl supports the following formats:
 [39]: ../../operations/control-access/sso/
 [40]: ../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [41]: ../../observability-pipeline/observe-process/tcp-stream-handlers/
+[42]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
@@ -180,7 +180,7 @@ sensuctl silenced create \
 
 {{% notice note %}}
 **NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses RFC3339 with space delimiters and numeric zone offset.
+This example uses [RFC 3339 format][20] with space delimiters and numeric zone offset.
 {{% /notice %}}
 
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
@@ -288,3 +288,4 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [17]: ../send-email-alerts/
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
+[20]: https://www.ietf.org/rfc/rfc3339.txt

--- a/content/sensu-go/6.7/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.7/sensuctl/create-manage-resources.md
@@ -623,9 +623,9 @@ This is useful for setting silences, for example.
 
 Sensuctl supports the following formats:
 
-* RFC3339 with numeric zone offset: `2018-05-10T07:04:00-08:00` or
+* [RFC 3339][42] with numeric zone offset: `2018-05-10T07:04:00-08:00` or
   `2018-05-10T15:04:00Z`
-* RFC3339 with space delimiters and numeric zone offset: `2018-05-10 07:04:00
+* [RFC 3339][42] with space delimiters and numeric zone offset: `2018-05-10 07:04:00
   -08:00`
 * Sensu alpha legacy format with canonical zone ID: `May 10 2018 7:04AM
   America/Vancouver`
@@ -671,3 +671,4 @@ Sensuctl supports the following formats:
 [39]: ../../operations/control-access/sso/
 [40]: ../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [41]: ../../observability-pipeline/observe-process/tcp-stream-handlers/
+[42]: https://www.ietf.org/rfc/rfc3339.txt


### PR DESCRIPTION
## Description
Updates instances of RFC 3339 to use spaces and link to https://www.ietf.org/rfc/rfc3339.txt

## Motivation and Context
Noticed when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>
