### PR TITLE
Improved check spec example in check reference

### DIFF
--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -690,9 +690,7 @@ spec:
     ],
     "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
     "env_vars": null,
-    "handlers":
-    - pagerduty
-    - slack
+    "handlers": null,
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,

--- a/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.3/observability-pipeline/observe-schedule/checks.md
@@ -249,7 +249,6 @@ spec:
 
 {{< /language-toggle >}}
 
-
 Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the `cron` attribute:
 
 {{< language-toggle >}}
@@ -572,22 +571,6 @@ Learn how to use check hooks with the [Sensu hooks reference documentation][6].
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][41] resource type. Checks should always be type `CheckConfig`.
-required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: CheckConfig
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "CheckConfig"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
@@ -612,25 +595,31 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
-  name: collect-metrics
-  namespace: default
+  name: sensu-site-perf
+  namespace: development
   created_by: admin
   labels:
     region: us-west-1
+    environment: dev
   annotations:
     slack-channel: "#monitoring"
+    managed-by: ops
+    playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "metadata": {
-    "name": "collect-metrics",
-    "namespace": "default",
+    "name": "sensu-site-perf",
+    "namespace": "development",
     "created_by": "admin",
     "labels": {
-      "region": "us-west-1"
+      "region": "us-west-1",
+      "environment": "dev"
     },
     "annotations": {
-      "slack-channel": "#monitoring"
+      "slack-channel": "#monitoring",
+      "managed-by": "ops",
+      "playbooks": "www.playbooks-example.url"
     }
   }
 }
@@ -645,22 +634,116 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 spec:
-  command: "/etc/sensu/plugins/check-chef-client.go"
-  interval: 10
+  check_hooks:
+  - '1':
+    - playbook-warning
+    - collect-diagnostics
+  - critical:
+    - playbook-critical
+    - collect-diagnostics
+    - process-tree
+  command: http-perf --url https://sensu.io --warning 1s --critical 2s
+  env_vars: null
+  handlers: null
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: "nagios_perfdata"
+  output_metric_handlers: null
+  output_metric_tags:
+  - name: instance
+    value: "{{ .name }}"
+  - name: region
+    value: "{{ .labels.region }}"
+  proxy_entity_name: ""
   publish: true
+  round_robin: false
+  runtime_assets:
+  - http-checks
+  secrets:
+  - name: PAGERDUTY_TOKEN
+    secret: sensu-pagerduty-token
+  stdin: false
+  subdue: null
   subscriptions:
-  - production
+  - system
+  timeout: 30
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
   "spec": {
-    "command": "/etc/sensu/plugins/check-chef-client.go",
-    "interval": 10,
+    "check_hooks": [
+      {
+        "1": [
+          "playbook-warning",
+          "collect-diagnostics"
+        ]
+      },
+      {
+        "critical": [
+          "playbook-critical",
+          "collect-diagnostics",
+          "process-tree"
+        ]
+      }
+    ],
+    "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
+    "env_vars": null,
+    "handlers":
+    - pagerduty
+    - slack
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "nagios_perfdata",
+    "output_metric_handlers": null,
+    "output_metric_tags": [
+      {
+        "name": "instance",
+        "value": "{{ .name }}"
+      },
+      {
+        "name": "region",
+        "value": "{{ .labels.region }}"
+      }
+    ],
+    "proxy_entity_name": "",
     "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "http-checks"
+    ],
+    "secrets": [
+      {
+        "name": "PAGERDUTY_TOKEN",
+        "secret": "sensu-pagerduty-token"
+      }
+    ],
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "production"
-    ]
+      "system"
+    ],
+    "timeout": 30,
+    "ttl": 0
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the [`sensuctl create`][41] resource type. Checks should always be type `CheckConfig`.
+required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: CheckConfig
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "CheckConfig"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -676,14 +759,16 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 annotations:
+  slack-channel: "#monitoring"
   managed-by: ops
-  playbook: www.example.url
+  playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "annotations": {
+    "slack-channel": "#monitoring",
     "managed-by": "ops",
-    "playbook": "www.example.url"
+    "playbooks": "www.playbooks-example.url"
   }
 }
 {{< /code >}}
@@ -714,14 +799,14 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 labels:
-  environment: development
-  region: us-west-2
+  region: us-west-1
+  environment: dev
 {{< /code >}}
 {{< code json >}}
 {
   "labels": {
-    "environment": "development",
-    "region": "us-west-2"
+    "region": "us-west-1",
+    "environment": "dev"
   }
 }
 {{< /code >}}
@@ -734,11 +819,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: check-cpu
+name: sensu-site-perf
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "check-cpu"
+  "name": "sensu-site-perf"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -751,11 +836,11 @@ type         | String
 default      | `default`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+namespace: development
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "namespace": "development"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -777,28 +862,28 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 check_hooks:
-- '0':
-  - passing-hook
-  - always-run-this-hook
-- critical:
-  - failing-hook
+- '1':
+  - playbook-warning
   - collect-diagnostics
-  - always-run-this-hook
+- critical:
+  - playbook-critical
+  - collect-diagnostics
+  - process-tree
 {{< /code >}}
 {{< code json >}}
 {
   "check_hooks": [
     {
-      "0": [
-        "passing-hook",
-        "always-run-this-hook"
+      "1": [
+        "playbook-warning",
+        "collect-diagnostics"
       ]
     },
     {
       "critical": [
-        "failing-hook",
+        "playbook-critical",
         "collect-diagnostics",
-        "always-run-this-hook"
+        "process-tree"
       ]
     }
   ]
@@ -813,11 +898,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-command: /etc/sensu/plugins/check-chef-client.go
+command: http-perf --url https://sensu.io --warning 1s --critical 2s
 {{< /code >}}
 {{< code json >}}
 {
-  "command": "/etc/sensu/plugins/check-chef-client.go"
+  "command": "http-perf --url https://sensu.io --warning 1s --critical 2s"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -874,13 +959,13 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 handlers:
 - pagerduty
-- email
+- slack
 {{< /code >}}
 {{< code json >}}
 {
   "handlers": [
     "pagerduty",
-    "email"
+    "slack"
   ]
 }
 {{< /code >}}
@@ -948,12 +1033,12 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 output_metric_format:
-- graphite_plaintext
+- nagios_perfdata
 {{< /code >}}
 {{< code json >}}
 {
   "output_metric_format": [
-    "graphite_plaintext"
+    "nagios_perfdata"
   ]
 }
 {{< /code >}}
@@ -992,10 +1077,8 @@ example      | {{< language-toggle >}}
 output_metric_tags:
 - name: instance
   value: "{{ .name }}"
-- name: prometheus_type
-  value: gauge
-- name: service
-  value: "{{ .labels.service }}"
+- name: region
+  value: "{{ .labels.region }}"
 {{< /code >}}
 {{< code json >}}
 {
@@ -1005,12 +1088,8 @@ output_metric_tags:
       "value": "{{ .name }}"
     },
     {
-      "name": "prometheus_type",
-      "value": "gauge"
-    },
-    {
-      "name": "service",
-      "value": "{{ .labels.service }}"
+      "name": "region",
+      "value": "{{ .labels.region }}"
     }
   ]
 }
@@ -1040,7 +1119,7 @@ proxy_entity_name: switch-dc-01
 
 |proxy_requests|    |
 -------------|------
-description  | Assigns a check to run for multiple entities according to their `entity_attributes`. In the example below, the check executes for all entities with entity class `proxy` and the custom proxy type label `website`. Proxy requests are a great way to reuse check definitions for a group of entities. For more information, review the [proxy requests specification][10] and [Monitor external resources][28].
+description  | Assigns a check to run for multiple entities according to their `entity_attributes`. In the example below, the check executes for all entities with entity class `proxy` and the custom proxy type label `website`. Proxy requests are a great way to reuse check definitions for a group of entities. For more information, review the [proxy requests attributes][10] and read [Monitor external resources][28].
 required     | false
 type         | Hash
 example      | {{< language-toggle >}}
@@ -1051,7 +1130,6 @@ proxy_requests:
   - entity.labels.proxy_type == 'website'
   splay: true
   splay_coverage: 90
-
 {{< /code >}}
 {{< code json >}}
 {
@@ -1077,11 +1155,11 @@ type         | Boolean
 default      | `false`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-publish: false
+publish: true
 {{< /code >}}
 {{< code json >}}
 {
-  "publish": false
+  "publish": true
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1113,12 +1191,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- metric-check
+- http-checks
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "metric-check"
+    "http-checks"
   ]
 }
 {{< /code >}}
@@ -1150,21 +1228,15 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 secrets:
-- name: ANSIBLE_HOST
-  secret: sensu-ansible-host
-- name: ANSIBLE_TOKEN
-  secret: sensu-ansible-token
+- name: PAGERDUTY_TOKEN
+  secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
   "secrets": [
     {
-      "name": "ANSIBLE_HOST",
-      "secret": "sensu-ansible-host"
-    },
-    {
-      "name": "ANSIBLE_TOKEN",
-      "secret": "sensu-ansible-token"
+      "name": "PAGERDUTY_TOKEN",
+      "secret": "sensu-pagerduty-token"
     }
   ]
 }
@@ -1230,12 +1302,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subscriptions:
-- production
+- system
 {{< /code >}}
 {{< code json >}}
 {
   "subscriptions": [
-    "production"
+    "system"
   ]
 }
 {{< /code >}}
@@ -1414,11 +1486,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: ANSIBLE_HOST
+name: PAGERDUTY_TOKEN
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "ANSIBLE_HOST"
+  "name": "PAGERDUTY_TOKEN"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1430,11 +1502,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-secret: sensu-ansible-host
+secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
-  "secret": "sensu-ansible-host"
+  "secret": "sensu-pagerduty-token"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1460,13 +1532,12 @@ spec:
   command: collect.sh
   discard_output: true
   env_vars: null
-  handlers: []
+  handlers:
+  - influx-db
   high_flap_threshold: 0
   interval: 10
   low_flap_threshold: 0
   output_metric_format: nagios_perfdata
-  output_metric_handlers:
-  - prometheus_gateway
   output_metric_tags:
   - name: instance
     value: '{{ .name }}'
@@ -1490,35 +1561,26 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "collect-metrics",
+    "annotations": {
+      "slack-channel": "#monitoring"
+    },
     "labels": {
       "region": "us-west-1"
     },
-    "annotations": {
-      "slack-channel" : "#monitoring"
-    }
+    "name": "collect-metrics"
   },
   "spec": {
+    "check_hooks": null,
     "command": "collect.sh",
-    "handlers": [],
+    "discard_output": true,
+    "env_vars": null,
+    "handlers": [
+      "influx-db"
+    ],
     "high_flap_threshold": 0,
     "interval": 10,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": null,
-    "subscriptions": [
-      "system"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "round_robin": false,
     "output_metric_format": "nagios_perfdata",
-    "output_metric_handlers": [
-      "prometheus_gateway"
-    ],
     "output_metric_tags": [
       {
         "name": "instance",
@@ -1533,8 +1595,16 @@ spec:
         "value": "{{ .labels.service }}"
       }
     ],
-    "env_vars": null,
-    "discard_output": true
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": null,
+    "stdin": false,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
   }
 }
 {{< /code >}}
@@ -1602,9 +1672,9 @@ spec:
   command: powershell.exe -f c:\\users\\tester\\test.ps1
   subscriptions:
   - system
+  interval: 60
   handlers:
   - slack
-  interval: 60
   publish: true
 {{< /code >}}
 
@@ -1616,10 +1686,14 @@ spec:
     "name": "interval_test"
   },
   "spec": {
-    "command": "powershell.exe -f c:\\users\\tester\\test.ps1",
-    "subscriptions": ["system"],
-    "handlers": ["slack"],
+    "command": "powershell.exe -f c:\\\\users\\\\tester\\\\test.ps1",
+    "subscriptions": [
+      "system"
+    ],
     "interval": 60,
+    "handlers": [
+      "slack"
+    ],
     "publish": true
   }
 }

--- a/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.3/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Check subdues are not yet implemented in Sensu Go.
+check subdues are not implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -690,9 +690,7 @@ spec:
     ],
     "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
     "env_vars": null,
-    "handlers":
-    - pagerduty
-    - slack
+    "handlers": null,
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -249,7 +249,6 @@ spec:
 
 {{< /language-toggle >}}
 
-
 Use a prefix of `TZ=` or `CRON_TZ=` to set a [timezone][30] for the `cron` attribute:
 
 {{< language-toggle >}}
@@ -572,22 +571,6 @@ Learn how to use check hooks with the [Sensu hooks reference documentation][6].
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][41] resource type. Checks should always be type `CheckConfig`.
-required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: CheckConfig
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "CheckConfig"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For checks in this version of Sensu, this attribute should always be `core/v2`.
@@ -612,25 +595,31 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
-  name: collect-metrics
-  namespace: default
+  name: sensu-site-perf
+  namespace: development
   created_by: admin
   labels:
     region: us-west-1
+    environment: dev
   annotations:
     slack-channel: "#monitoring"
+    managed-by: ops
+    playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "metadata": {
-    "name": "collect-metrics",
-    "namespace": "default",
+    "name": "sensu-site-perf",
+    "namespace": "development",
     "created_by": "admin",
     "labels": {
-      "region": "us-west-1"
+      "region": "us-west-1",
+      "environment": "dev"
     },
     "annotations": {
-      "slack-channel": "#monitoring"
+      "slack-channel": "#monitoring",
+      "managed-by": "ops",
+      "playbooks": "www.playbooks-example.url"
     }
   }
 }
@@ -645,22 +634,116 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 spec:
-  command: "/etc/sensu/plugins/check-chef-client.go"
-  interval: 10
+  check_hooks:
+  - '1':
+    - playbook-warning
+    - collect-diagnostics
+  - critical:
+    - playbook-critical
+    - collect-diagnostics
+    - process-tree
+  command: http-perf --url https://sensu.io --warning 1s --critical 2s
+  env_vars: null
+  handlers: null
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: "nagios_perfdata"
+  output_metric_handlers: null
+  output_metric_tags:
+  - name: instance
+    value: "{{ .name }}"
+  - name: region
+    value: "{{ .labels.region }}"
+  proxy_entity_name: ""
   publish: true
+  round_robin: false
+  runtime_assets:
+  - http-checks
+  secrets:
+  - name: PAGERDUTY_TOKEN
+    secret: sensu-pagerduty-token
+  stdin: false
+  subdue: null
   subscriptions:
-  - production
+  - system
+  timeout: 30
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
   "spec": {
-    "command": "/etc/sensu/plugins/check-chef-client.go",
-    "interval": 10,
+    "check_hooks": [
+      {
+        "1": [
+          "playbook-warning",
+          "collect-diagnostics"
+        ]
+      },
+      {
+        "critical": [
+          "playbook-critical",
+          "collect-diagnostics",
+          "process-tree"
+        ]
+      }
+    ],
+    "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
+    "env_vars": null,
+    "handlers":
+    - pagerduty
+    - slack
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "nagios_perfdata",
+    "output_metric_handlers": null,
+    "output_metric_tags": [
+      {
+        "name": "instance",
+        "value": "{{ .name }}"
+      },
+      {
+        "name": "region",
+        "value": "{{ .labels.region }}"
+      }
+    ],
+    "proxy_entity_name": "",
     "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "http-checks"
+    ],
+    "secrets": [
+      {
+        "name": "PAGERDUTY_TOKEN",
+        "secret": "sensu-pagerduty-token"
+      }
+    ],
+    "stdin": false,
+    "subdue": null,
     "subscriptions": [
-      "production"
-    ]
+      "system"
+    ],
+    "timeout": 30,
+    "ttl": 0
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the [`sensuctl create`][41] resource type. Checks should always be type `CheckConfig`.
+required     | Required for check definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][41].
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: CheckConfig
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "CheckConfig"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -676,14 +759,16 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 annotations:
+  slack-channel: "#monitoring"
   managed-by: ops
-  playbook: www.example.url
+  playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "annotations": {
+    "slack-channel": "#monitoring",
     "managed-by": "ops",
-    "playbook": "www.example.url"
+    "playbooks": "www.playbooks-example.url"
   }
 }
 {{< /code >}}
@@ -714,14 +799,14 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 labels:
-  environment: development
-  region: us-west-2
+  region: us-west-1
+  environment: dev
 {{< /code >}}
 {{< code json >}}
 {
   "labels": {
-    "environment": "development",
-    "region": "us-west-2"
+    "region": "us-west-1",
+    "environment": "dev"
   }
 }
 {{< /code >}}
@@ -734,11 +819,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: check-cpu
+name: sensu-site-perf
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "check-cpu"
+  "name": "sensu-site-perf"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -751,11 +836,11 @@ type         | String
 default      | `default`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+namespace: development
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "namespace": "development"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -777,28 +862,28 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 check_hooks:
-- '0':
-  - passing-hook
-  - always-run-this-hook
-- critical:
-  - failing-hook
+- '1':
+  - playbook-warning
   - collect-diagnostics
-  - always-run-this-hook
+- critical:
+  - playbook-critical
+  - collect-diagnostics
+  - process-tree
 {{< /code >}}
 {{< code json >}}
 {
   "check_hooks": [
     {
-      "0": [
-        "passing-hook",
-        "always-run-this-hook"
+      "1": [
+        "playbook-warning",
+        "collect-diagnostics"
       ]
     },
     {
       "critical": [
-        "failing-hook",
+        "playbook-critical",
         "collect-diagnostics",
-        "always-run-this-hook"
+        "process-tree"
       ]
     }
   ]
@@ -813,11 +898,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-command: /etc/sensu/plugins/check-chef-client.go
+command: http-perf --url https://sensu.io --warning 1s --critical 2s
 {{< /code >}}
 {{< code json >}}
 {
-  "command": "/etc/sensu/plugins/check-chef-client.go"
+  "command": "http-perf --url https://sensu.io --warning 1s --critical 2s"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -874,13 +959,13 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 handlers:
 - pagerduty
-- email
+- slack
 {{< /code >}}
 {{< code json >}}
 {
   "handlers": [
     "pagerduty",
-    "email"
+    "slack"
   ]
 }
 {{< /code >}}
@@ -948,12 +1033,12 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 output_metric_format:
-- graphite_plaintext
+- nagios_perfdata
 {{< /code >}}
 {{< code json >}}
 {
   "output_metric_format": [
-    "graphite_plaintext"
+    "nagios_perfdata"
   ]
 }
 {{< /code >}}
@@ -992,10 +1077,8 @@ example      | {{< language-toggle >}}
 output_metric_tags:
 - name: instance
   value: "{{ .name }}"
-- name: prometheus_type
-  value: gauge
-- name: service
-  value: "{{ .labels.service }}"
+- name: region
+  value: "{{ .labels.region }}"
 {{< /code >}}
 {{< code json >}}
 {
@@ -1005,12 +1088,8 @@ output_metric_tags:
       "value": "{{ .name }}"
     },
     {
-      "name": "prometheus_type",
-      "value": "gauge"
-    },
-    {
-      "name": "service",
-      "value": "{{ .labels.service }}"
+      "name": "region",
+      "value": "{{ .labels.region }}"
     }
   ]
 }
@@ -1040,7 +1119,7 @@ proxy_entity_name: switch-dc-01
 
 |proxy_requests|    |
 -------------|------
-description  | Assigns a check to run for multiple entities according to their `entity_attributes`. In the example below, the check executes for all entities with entity class `proxy` and the custom proxy type label `website`. Proxy requests are a great way to reuse check definitions for a group of entities. For more information, review the [proxy requests specification][10] and [Monitor external resources][28].
+description  | Assigns a check to run for multiple entities according to their `entity_attributes`. In the example below, the check executes for all entities with entity class `proxy` and the custom proxy type label `website`. Proxy requests are a great way to reuse check definitions for a group of entities. For more information, review the [proxy requests attributes][10] and read [Monitor external resources][28].
 required     | false
 type         | Hash
 example      | {{< language-toggle >}}
@@ -1051,7 +1130,6 @@ proxy_requests:
   - entity.labels.proxy_type == 'website'
   splay: true
   splay_coverage: 90
-
 {{< /code >}}
 {{< code json >}}
 {
@@ -1077,11 +1155,11 @@ type         | Boolean
 default      | `false`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-publish: false
+publish: true
 {{< /code >}}
 {{< code json >}}
 {
-  "publish": false
+  "publish": true
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1113,12 +1191,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- metric-check
+- http-checks
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "metric-check"
+    "http-checks"
   ]
 }
 {{< /code >}}
@@ -1150,21 +1228,15 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 secrets:
-- name: ANSIBLE_HOST
-  secret: sensu-ansible-host
-- name: ANSIBLE_TOKEN
-  secret: sensu-ansible-token
+- name: PAGERDUTY_TOKEN
+  secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
   "secrets": [
     {
-      "name": "ANSIBLE_HOST",
-      "secret": "sensu-ansible-host"
-    },
-    {
-      "name": "ANSIBLE_TOKEN",
-      "secret": "sensu-ansible-token"
+      "name": "PAGERDUTY_TOKEN",
+      "secret": "sensu-pagerduty-token"
     }
   ]
 }
@@ -1230,12 +1302,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subscriptions:
-- production
+- system
 {{< /code >}}
 {{< code json >}}
 {
   "subscriptions": [
-    "production"
+    "system"
   ]
 }
 {{< /code >}}
@@ -1414,11 +1486,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: ANSIBLE_HOST
+name: PAGERDUTY_TOKEN
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "ANSIBLE_HOST"
+  "name": "PAGERDUTY_TOKEN"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1430,11 +1502,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-secret: sensu-ansible-host
+secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
-  "secret": "sensu-ansible-host"
+  "secret": "sensu-pagerduty-token"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1460,13 +1532,12 @@ spec:
   command: collect.sh
   discard_output: true
   env_vars: null
-  handlers: []
+  handlers:
+  - influx-db
   high_flap_threshold: 0
   interval: 10
   low_flap_threshold: 0
   output_metric_format: nagios_perfdata
-  output_metric_handlers:
-  - prometheus_gateway
   output_metric_tags:
   - name: instance
     value: '{{ .name }}'
@@ -1490,35 +1561,26 @@ spec:
   "type": "CheckConfig",
   "api_version": "core/v2",
   "metadata": {
-    "name": "collect-metrics",
+    "annotations": {
+      "slack-channel": "#monitoring"
+    },
     "labels": {
       "region": "us-west-1"
     },
-    "annotations": {
-      "slack-channel" : "#monitoring"
-    }
+    "name": "collect-metrics"
   },
   "spec": {
+    "check_hooks": null,
     "command": "collect.sh",
-    "handlers": [],
+    "discard_output": true,
+    "env_vars": null,
+    "handlers": [
+      "influx-db"
+    ],
     "high_flap_threshold": 0,
     "interval": 10,
     "low_flap_threshold": 0,
-    "publish": true,
-    "runtime_assets": null,
-    "subscriptions": [
-      "system"
-    ],
-    "proxy_entity_name": "",
-    "check_hooks": null,
-    "stdin": false,
-    "ttl": 0,
-    "timeout": 0,
-    "round_robin": false,
     "output_metric_format": "nagios_perfdata",
-    "output_metric_handlers": [
-      "prometheus_gateway"
-    ],
     "output_metric_tags": [
       {
         "name": "instance",
@@ -1533,8 +1595,16 @@ spec:
         "value": "{{ .labels.service }}"
       }
     ],
-    "env_vars": null,
-    "discard_output": true
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": null,
+    "stdin": false,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 0,
+    "ttl": 0
   }
 }
 {{< /code >}}
@@ -1602,9 +1672,9 @@ spec:
   command: powershell.exe -f c:\\users\\tester\\test.ps1
   subscriptions:
   - system
+  interval: 60
   handlers:
   - slack
-  interval: 60
   publish: true
 {{< /code >}}
 
@@ -1616,10 +1686,14 @@ spec:
     "name": "interval_test"
   },
   "spec": {
-    "command": "powershell.exe -f c:\\users\\tester\\test.ps1",
-    "subscriptions": ["system"],
-    "handlers": ["slack"],
+    "command": "powershell.exe -f c:\\\\users\\\\tester\\\\test.ps1",
+    "subscriptions": [
+      "system"
+    ],
     "interval": 60,
+    "handlers": [
+      "slack"
+    ],
     "publish": true
   }
 }

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Check subdues are not yet implemented in Sensu Go.
+check subdues are not implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -595,25 +595,31 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
-  name: collect-metrics
-  namespace: default
+  name: sensu-site-perf
+  namespace: development
   created_by: admin
   labels:
     region: us-west-1
+    environment: dev
   annotations:
     slack-channel: "#monitoring"
+    managed-by: ops
+    playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "metadata": {
-    "name": "collect-metrics",
-    "namespace": "default",
+    "name": "sensu-site-perf",
+    "namespace": "development",
     "created_by": "admin",
     "labels": {
-      "region": "us-west-1"
+      "region": "us-west-1",
+      "environment": "dev"
     },
     "annotations": {
-      "slack-channel": "#monitoring"
+      "slack-channel": "#monitoring",
+      "managed-by": "ops",
+      "playbooks": "www.playbooks-example.url"
     }
   }
 }
@@ -628,24 +634,81 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 spec:
-  command: "/etc/sensu/plugins/check-chef-client.go"
-  interval: 10
-  publish: true
-  subscriptions:
-  - production
+  check_hooks:
+  - '1':
+    - playbook-warning
+    - collect-diagnostics
+  - critical:
+    - playbook-critical
+    - collect-diagnostics
+    - process-tree
+  command: http-perf --url https://sensu.io --warning 1s --critical 2s
+  env_vars: null
+  handlers: null
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: "nagios_perfdata"
+  output_metric_handlers: null
+  output_metric_tags:
+  - name: instance
+    value: "{{ .name }}"
+  - name: region
+    value: "{{ .labels.region }}"
   pipelines:
   - type: Pipeline
     api_version: core/v2
     name: incident_alerts
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - http-checks
+  secrets:
+  - name: PAGERDUTY_TOKEN
+    secret: sensu-pagerduty-token
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 30
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
   "spec": {
-    "command": "/etc/sensu/plugins/check-chef-client.go",
-    "interval": 10,
-    "publish": true,
-    "subscriptions": [
-      "production"
+    "check_hooks": [
+      {
+        "1": [
+          "playbook-warning",
+          "collect-diagnostics"
+        ]
+      },
+      {
+        "critical": [
+          "playbook-critical",
+          "collect-diagnostics",
+          "process-tree"
+        ]
+      }
+    ],
+    "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
+    "env_vars": null,
+    "handlers": null,
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "nagios_perfdata",
+    "output_metric_handlers": null,
+    "output_metric_tags": [
+      {
+        "name": "instance",
+        "value": "{{ .name }}"
+      },
+      {
+        "name": "region",
+        "value": "{{ .labels.region }}"
+      }
     ],
     "pipelines": [
       {
@@ -653,7 +716,26 @@ spec:
         "api_version": "core/v2",
         "name": "incident_alerts"
       }
-    ]
+    ],
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "http-checks"
+    ],
+    "secrets": [
+      {
+        "name": "PAGERDUTY_TOKEN",
+        "secret": "sensu-pagerduty-token"
+      }
+    ],
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 30,
+    "ttl": 0
   }
 }
 {{< /code >}}
@@ -686,14 +768,16 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 annotations:
+  slack-channel: "#monitoring"
   managed-by: ops
-  playbook: www.example.url
+  playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "annotations": {
+    "slack-channel": "#monitoring",
     "managed-by": "ops",
-    "playbook": "www.example.url"
+    "playbooks": "www.playbooks-example.url"
   }
 }
 {{< /code >}}
@@ -724,14 +808,14 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 labels:
-  environment: development
-  region: us-west-2
+  region: us-west-1
+  environment: dev
 {{< /code >}}
 {{< code json >}}
 {
   "labels": {
-    "environment": "development",
-    "region": "us-west-2"
+    "region": "us-west-1",
+    "environment": "dev"
   }
 }
 {{< /code >}}
@@ -744,11 +828,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: check-cpu
+name: sensu-site-perf
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "check-cpu"
+  "name": "sensu-site-perf"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -761,11 +845,11 @@ type         | String
 default      | `default`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+namespace: development
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "namespace": "development"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -777,22 +861,6 @@ namespace: production
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 
-|command     |      |
--------------|------
-description  | Check command to be executed.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-command: /etc/sensu/plugins/check-chef-client.go
-{{< /code >}}
-{{< code json >}}
-{
-  "command": "/etc/sensu/plugins/check-chef-client.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
@@ -803,31 +871,47 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 check_hooks:
-- '0':
-  - passing-hook
-  - always-run-this-hook
-- critical:
-  - failing-hook
+- '1':
+  - playbook-warning
   - collect-diagnostics
-  - always-run-this-hook
+- critical:
+  - playbook-critical
+  - collect-diagnostics
+  - process-tree
 {{< /code >}}
 {{< code json >}}
 {
   "check_hooks": [
     {
-      "0": [
-        "passing-hook",
-        "always-run-this-hook"
+      "1": [
+        "playbook-warning",
+        "collect-diagnostics"
       ]
     },
     {
       "critical": [
-        "failing-hook",
+        "playbook-critical",
         "collect-diagnostics",
-        "always-run-this-hook"
+        "process-tree"
       ]
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|command     |      |
+-------------|------
+description  | Check command to be executed.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+command: http-perf --url https://sensu.io --warning 1s --critical 2s
+{{< /code >}}
+{{< code json >}}
+{
+  "command": "http-perf --url https://sensu.io --warning 1s --critical 2s"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -888,13 +972,13 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 handlers:
 - pagerduty
-- email
+- slack
 {{< /code >}}
 {{< code json >}}
 {
   "handlers": [
     "pagerduty",
-    "email"
+    "slack"
   ]
 }
 {{< /code >}}
@@ -962,12 +1046,12 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 output_metric_format:
-- graphite_plaintext
+- nagios_perfdata
 {{< /code >}}
 {{< code json >}}
 {
   "output_metric_format": [
-    "graphite_plaintext"
+    "nagios_perfdata"
   ]
 }
 {{< /code >}}
@@ -1006,10 +1090,8 @@ example      | {{< language-toggle >}}
 output_metric_tags:
 - name: instance
   value: "{{ .name }}"
-- name: prometheus_type
-  value: gauge
-- name: service
-  value: "{{ .labels.service }}"
+- name: region
+  value: "{{ .labels.region }}"
 {{< /code >}}
 {{< code json >}}
 {
@@ -1019,12 +1101,8 @@ output_metric_tags:
       "value": "{{ .name }}"
     },
     {
-      "name": "prometheus_type",
-      "value": "gauge"
-    },
-    {
-      "name": "service",
-      "value": "{{ .labels.service }}"
+      "name": "region",
+      "value": "{{ .labels.region }}"
     }
   ]
 }
@@ -1092,7 +1170,6 @@ proxy_requests:
   - entity.labels.proxy_type == 'website'
   splay: true
   splay_coverage: 90
-
 {{< /code >}}
 {{< code json >}}
 {
@@ -1118,11 +1195,11 @@ type         | Boolean
 default      | `false`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-publish: false
+publish: true
 {{< /code >}}
 {{< code json >}}
 {
-  "publish": false
+  "publish": true
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1154,12 +1231,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- metric-check
+- http-checks
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "metric-check"
+    "http-checks"
   ]
 }
 {{< /code >}}
@@ -1191,21 +1268,15 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 secrets:
-- name: ANSIBLE_HOST
-  secret: sensu-ansible-host
-- name: ANSIBLE_TOKEN
-  secret: sensu-ansible-token
+- name: PAGERDUTY_TOKEN
+  secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
   "secrets": [
     {
-      "name": "ANSIBLE_HOST",
-      "secret": "sensu-ansible-host"
-    },
-    {
-      "name": "ANSIBLE_TOKEN",
-      "secret": "sensu-ansible-token"
+      "name": "PAGERDUTY_TOKEN",
+      "secret": "sensu-pagerduty-token"
     }
   ]
 }
@@ -1249,7 +1320,7 @@ stdin: true
 
 |subdue      |      |
 -------------|------
-description  | Check subdues are not yet implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
+description  | check subdues are not implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subdue: null
@@ -1271,12 +1342,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subscriptions:
-- production
+- system
 {{< /code >}}
 {{< code json >}}
 {
   "subscriptions": [
-    "production"
+    "system"
   ]
 }
 {{< /code >}}
@@ -1320,23 +1391,6 @@ ttl: 100
 
 #### Pipelines attributes
 
-type         | 
--------------|------
-description  | The [`sensuctl create`][41] resource type for the [pipeline][69]. Pipelines should always be type `Pipeline`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | The Sensu API group and version for the [pipeline][69]. For pipelines in this version of Sensu, the api_version should always be `core/v2`.
@@ -1362,11 +1416,28 @@ type         | String
 default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: is_incident
+name: incident_alerts
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "is_incident"
+  "name": "incident_alerts"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | The [`sensuctl create`][41] resource type for the [pipeline][69]. Pipelines should always be type `Pipeline`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Pipeline
+{{< /code >}}
+{{< code json >}}
+{
+ "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1433,22 +1504,6 @@ splay_coverage: 90
 
 #### Check output truncation attributes
 
-|max_output_size  | |
--------------|-------
-description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.
-required     | false
-type         | Integer
-example      | {{< language-toggle >}}
-{{< code yml >}}
-max_output_size: 1024
-{{< /code >}}
-{{< code json >}}
-{
-  "max_output_size": 1024
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 |discard_output  | |
 -------------|------
 description  | If `true`, discard check output after extracting metrics. No check output will be sent to the Sensu backend. Otherwise, `false`.
@@ -1461,6 +1516,22 @@ discard_output: true
 {{< code json >}}
 {
   "discard_output": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|max_output_size  | |
+-------------|-------
+description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+max_output_size: 1024
+{{< /code >}}
+{{< code json >}}
+{
+  "max_output_size": 1024
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1508,11 +1579,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: ANSIBLE_HOST
+name: PAGERDUTY_TOKEN
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "ANSIBLE_HOST"
+  "name": "PAGERDUTY_TOKEN"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1524,11 +1595,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-secret: sensu-ansible-host
+secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
-  "secret": "sensu-ansible-host"
+  "secret": "sensu-pagerduty-token"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Check subdues are not yet implemented in Sensu Go.
+check subdues are not implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -595,25 +595,31 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
-  name: collect-metrics
-  namespace: default
+  name: sensu-site-perf
+  namespace: development
   created_by: admin
   labels:
     region: us-west-1
+    environment: dev
   annotations:
     slack-channel: "#monitoring"
+    managed-by: ops
+    playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "metadata": {
-    "name": "collect-metrics",
-    "namespace": "default",
+    "name": "sensu-site-perf",
+    "namespace": "development",
     "created_by": "admin",
     "labels": {
-      "region": "us-west-1"
+      "region": "us-west-1",
+      "environment": "dev"
     },
     "annotations": {
-      "slack-channel": "#monitoring"
+      "slack-channel": "#monitoring",
+      "managed-by": "ops",
+      "playbooks": "www.playbooks-example.url"
     }
   }
 }
@@ -628,24 +634,81 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 spec:
-  command: "/etc/sensu/plugins/check-chef-client.go"
-  interval: 10
-  publish: true
-  subscriptions:
-  - production
+  check_hooks:
+  - '1':
+    - playbook-warning
+    - collect-diagnostics
+  - critical:
+    - playbook-critical
+    - collect-diagnostics
+    - process-tree
+  command: http-perf --url https://sensu.io --warning 1s --critical 2s
+  env_vars: null
+  handlers: null
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: "nagios_perfdata"
+  output_metric_handlers: null
+  output_metric_tags:
+  - name: instance
+    value: "{{ .name }}"
+  - name: region
+    value: "{{ .labels.region }}"
   pipelines:
   - type: Pipeline
     api_version: core/v2
     name: incident_alerts
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - http-checks
+  secrets:
+  - name: PAGERDUTY_TOKEN
+    secret: sensu-pagerduty-token
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 30
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
   "spec": {
-    "command": "/etc/sensu/plugins/check-chef-client.go",
-    "interval": 10,
-    "publish": true,
-    "subscriptions": [
-      "production"
+    "check_hooks": [
+      {
+        "1": [
+          "playbook-warning",
+          "collect-diagnostics"
+        ]
+      },
+      {
+        "critical": [
+          "playbook-critical",
+          "collect-diagnostics",
+          "process-tree"
+        ]
+      }
+    ],
+    "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
+    "env_vars": null,
+    "handlers": null,
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "nagios_perfdata",
+    "output_metric_handlers": null,
+    "output_metric_tags": [
+      {
+        "name": "instance",
+        "value": "{{ .name }}"
+      },
+      {
+        "name": "region",
+        "value": "{{ .labels.region }}"
+      }
     ],
     "pipelines": [
       {
@@ -653,7 +716,26 @@ spec:
         "api_version": "core/v2",
         "name": "incident_alerts"
       }
-    ]
+    ],
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "http-checks"
+    ],
+    "secrets": [
+      {
+        "name": "PAGERDUTY_TOKEN",
+        "secret": "sensu-pagerduty-token"
+      }
+    ],
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 30,
+    "ttl": 0
   }
 }
 {{< /code >}}
@@ -686,14 +768,16 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 annotations:
+  slack-channel: "#monitoring"
   managed-by: ops
-  playbook: www.example.url
+  playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "annotations": {
+    "slack-channel": "#monitoring",
     "managed-by": "ops",
-    "playbook": "www.example.url"
+    "playbooks": "www.playbooks-example.url"
   }
 }
 {{< /code >}}
@@ -724,14 +808,14 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 labels:
-  environment: development
-  region: us-west-2
+  region: us-west-1
+  environment: dev
 {{< /code >}}
 {{< code json >}}
 {
   "labels": {
-    "environment": "development",
-    "region": "us-west-2"
+    "region": "us-west-1",
+    "environment": "dev"
   }
 }
 {{< /code >}}
@@ -744,11 +828,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: check-cpu
+name: sensu-site-perf
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "check-cpu"
+  "name": "sensu-site-perf"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -761,11 +845,11 @@ type         | String
 default      | `default`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+namespace: development
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "namespace": "development"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -777,22 +861,6 @@ namespace: production
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 
-|command     |      |
--------------|------
-description  | Check command to be executed.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-command: /etc/sensu/plugins/check-chef-client.go
-{{< /code >}}
-{{< code json >}}
-{
-  "command": "/etc/sensu/plugins/check-chef-client.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
@@ -803,31 +871,47 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 check_hooks:
-- '0':
-  - passing-hook
-  - always-run-this-hook
-- critical:
-  - failing-hook
+- '1':
+  - playbook-warning
   - collect-diagnostics
-  - always-run-this-hook
+- critical:
+  - playbook-critical
+  - collect-diagnostics
+  - process-tree
 {{< /code >}}
 {{< code json >}}
 {
   "check_hooks": [
     {
-      "0": [
-        "passing-hook",
-        "always-run-this-hook"
+      "1": [
+        "playbook-warning",
+        "collect-diagnostics"
       ]
     },
     {
       "critical": [
-        "failing-hook",
+        "playbook-critical",
         "collect-diagnostics",
-        "always-run-this-hook"
+        "process-tree"
       ]
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|command     |      |
+-------------|------
+description  | Check command to be executed.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+command: http-perf --url https://sensu.io --warning 1s --critical 2s
+{{< /code >}}
+{{< code json >}}
+{
+  "command": "http-perf --url https://sensu.io --warning 1s --critical 2s"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -888,13 +972,13 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 handlers:
 - pagerduty
-- email
+- slack
 {{< /code >}}
 {{< code json >}}
 {
   "handlers": [
     "pagerduty",
-    "email"
+    "slack"
   ]
 }
 {{< /code >}}
@@ -962,12 +1046,12 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 output_metric_format:
-- graphite_plaintext
+- nagios_perfdata
 {{< /code >}}
 {{< code json >}}
 {
   "output_metric_format": [
-    "graphite_plaintext"
+    "nagios_perfdata"
   ]
 }
 {{< /code >}}
@@ -1006,10 +1090,8 @@ example      | {{< language-toggle >}}
 output_metric_tags:
 - name: instance
   value: "{{ .name }}"
-- name: prometheus_type
-  value: gauge
-- name: service
-  value: "{{ .labels.service }}"
+- name: region
+  value: "{{ .labels.region }}"
 {{< /code >}}
 {{< code json >}}
 {
@@ -1019,12 +1101,8 @@ output_metric_tags:
       "value": "{{ .name }}"
     },
     {
-      "name": "prometheus_type",
-      "value": "gauge"
-    },
-    {
-      "name": "service",
-      "value": "{{ .labels.service }}"
+      "name": "region",
+      "value": "{{ .labels.region }}"
     }
   ]
 }
@@ -1092,7 +1170,6 @@ proxy_requests:
   - entity.labels.proxy_type == 'website'
   splay: true
   splay_coverage: 90
-
 {{< /code >}}
 {{< code json >}}
 {
@@ -1118,11 +1195,11 @@ type         | Boolean
 default      | `false`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-publish: false
+publish: true
 {{< /code >}}
 {{< code json >}}
 {
-  "publish": false
+  "publish": true
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1154,12 +1231,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- metric-check
+- http-checks
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "metric-check"
+    "http-checks"
   ]
 }
 {{< /code >}}
@@ -1191,21 +1268,15 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 secrets:
-- name: ANSIBLE_HOST
-  secret: sensu-ansible-host
-- name: ANSIBLE_TOKEN
-  secret: sensu-ansible-token
+- name: PAGERDUTY_TOKEN
+  secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
   "secrets": [
     {
-      "name": "ANSIBLE_HOST",
-      "secret": "sensu-ansible-host"
-    },
-    {
-      "name": "ANSIBLE_TOKEN",
-      "secret": "sensu-ansible-token"
+      "name": "PAGERDUTY_TOKEN",
+      "secret": "sensu-pagerduty-token"
     }
   ]
 }
@@ -1249,7 +1320,7 @@ stdin: true
 
 |subdue      |      |
 -------------|------
-description  | Check subdues are not yet implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
+description  | check subdues are not implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subdue: null
@@ -1271,12 +1342,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subscriptions:
-- production
+- system
 {{< /code >}}
 {{< code json >}}
 {
   "subscriptions": [
-    "production"
+    "system"
   ]
 }
 {{< /code >}}
@@ -1320,23 +1391,6 @@ ttl: 100
 
 #### Pipelines attributes
 
-type         | 
--------------|------
-description  | The [`sensuctl create`][41] resource type for the [pipeline][69]. Pipelines should always be type `Pipeline`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | The Sensu API group and version for the [pipeline][69]. For pipelines in this version of Sensu, the api_version should always be `core/v2`.
@@ -1362,11 +1416,28 @@ type         | String
 default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: is_incident
+name: incident_alerts
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "is_incident"
+  "name": "incident_alerts"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | The [`sensuctl create`][41] resource type for the [pipeline][69]. Pipelines should always be type `Pipeline`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Pipeline
+{{< /code >}}
+{{< code json >}}
+{
+ "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1433,22 +1504,6 @@ splay_coverage: 90
 
 #### Check output truncation attributes
 
-|max_output_size  | |
--------------|-------
-description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.
-required     | false
-type         | Integer
-example      | {{< language-toggle >}}
-{{< code yml >}}
-max_output_size: 1024
-{{< /code >}}
-{{< code json >}}
-{
-  "max_output_size": 1024
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 |discard_output  | |
 -------------|------
 description  | If `true`, discard check output after extracting metrics. No check output will be sent to the Sensu backend. Otherwise, `false`.
@@ -1461,6 +1516,22 @@ discard_output: true
 {{< code json >}}
 {
   "discard_output": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|max_output_size  | |
+-------------|-------
+description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+max_output_size: 1024
+{{< /code >}}
+{{< code json >}}
+{
+  "max_output_size": 1024
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1508,11 +1579,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: ANSIBLE_HOST
+name: PAGERDUTY_TOKEN
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "ANSIBLE_HOST"
+  "name": "PAGERDUTY_TOKEN"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1524,11 +1595,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-secret: sensu-ansible-host
+secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
-  "secret": "sensu-ansible-host"
+  "secret": "sensu-pagerduty-token"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Check subdues are not yet implemented in Sensu Go.
+check subdues are not implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
@@ -595,25 +595,31 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
-  name: collect-metrics
-  namespace: default
+  name: sensu-site-perf
+  namespace: development
   created_by: admin
   labels:
     region: us-west-1
+    environment: dev
   annotations:
     slack-channel: "#monitoring"
+    managed-by: ops
+    playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "metadata": {
-    "name": "collect-metrics",
-    "namespace": "default",
+    "name": "sensu-site-perf",
+    "namespace": "development",
     "created_by": "admin",
     "labels": {
-      "region": "us-west-1"
+      "region": "us-west-1",
+      "environment": "dev"
     },
     "annotations": {
-      "slack-channel": "#monitoring"
+      "slack-channel": "#monitoring",
+      "managed-by": "ops",
+      "playbooks": "www.playbooks-example.url"
     }
   }
 }
@@ -628,24 +634,81 @@ type         | Map of key-value pairs
 example      | {{< language-toggle >}}
 {{< code yml >}}
 spec:
-  command: "/etc/sensu/plugins/check-chef-client.go"
-  interval: 10
-  publish: true
-  subscriptions:
-  - production
+  check_hooks:
+  - '1':
+    - playbook-warning
+    - collect-diagnostics
+  - critical:
+    - playbook-critical
+    - collect-diagnostics
+    - process-tree
+  command: http-perf --url https://sensu.io --warning 1s --critical 2s
+  env_vars: null
+  handlers: null
+  high_flap_threshold: 0
+  interval: 60
+  low_flap_threshold: 0
+  output_metric_format: "nagios_perfdata"
+  output_metric_handlers: null
+  output_metric_tags:
+  - name: instance
+    value: "{{ .name }}"
+  - name: region
+    value: "{{ .labels.region }}"
   pipelines:
   - type: Pipeline
     api_version: core/v2
     name: incident_alerts
+  proxy_entity_name: ""
+  publish: true
+  round_robin: false
+  runtime_assets:
+  - http-checks
+  secrets:
+  - name: PAGERDUTY_TOKEN
+    secret: sensu-pagerduty-token
+  stdin: false
+  subdue: null
+  subscriptions:
+  - system
+  timeout: 30
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
   "spec": {
-    "command": "/etc/sensu/plugins/check-chef-client.go",
-    "interval": 10,
-    "publish": true,
-    "subscriptions": [
-      "production"
+    "check_hooks": [
+      {
+        "1": [
+          "playbook-warning",
+          "collect-diagnostics"
+        ]
+      },
+      {
+        "critical": [
+          "playbook-critical",
+          "collect-diagnostics",
+          "process-tree"
+        ]
+      }
+    ],
+    "command": "http-perf --url https://sensu.io --warning 1s --critical 2s",
+    "env_vars": null,
+    "handlers": null,
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "output_metric_format": "nagios_perfdata",
+    "output_metric_handlers": null,
+    "output_metric_tags": [
+      {
+        "name": "instance",
+        "value": "{{ .name }}"
+      },
+      {
+        "name": "region",
+        "value": "{{ .labels.region }}"
+      }
     ],
     "pipelines": [
       {
@@ -653,7 +716,26 @@ spec:
         "api_version": "core/v2",
         "name": "incident_alerts"
       }
-    ]
+    ],
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [
+      "http-checks"
+    ],
+    "secrets": [
+      {
+        "name": "PAGERDUTY_TOKEN",
+        "secret": "sensu-pagerduty-token"
+      }
+    ],
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "system"
+    ],
+    "timeout": 30,
+    "ttl": 0
   }
 }
 {{< /code >}}
@@ -686,14 +768,16 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 annotations:
+  slack-channel: "#monitoring"
   managed-by: ops
-  playbook: www.example.url
+  playbooks: www.playbooks-example.url
 {{< /code >}}
 {{< code json >}}
 {
   "annotations": {
+    "slack-channel": "#monitoring",
     "managed-by": "ops",
-    "playbook": "www.example.url"
+    "playbooks": "www.playbooks-example.url"
   }
 }
 {{< /code >}}
@@ -724,14 +808,14 @@ default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
 labels:
-  environment: development
-  region: us-west-2
+  region: us-west-1
+  environment: dev
 {{< /code >}}
 {{< code json >}}
 {
   "labels": {
-    "environment": "development",
-    "region": "us-west-2"
+    "region": "us-west-1",
+    "environment": "dev"
   }
 }
 {{< /code >}}
@@ -744,11 +828,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: check-cpu
+name: sensu-site-perf
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "check-cpu"
+  "name": "sensu-site-perf"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -761,11 +845,11 @@ type         | String
 default      | `default`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+namespace: development
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "namespace": "development"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -777,22 +861,6 @@ namespace: production
 When doing so, the spec attributes are listed as individual [top-level attributes](#top-level-attributes) in the check definition instead.
 {{% /notice %}}
 
-|command     |      |
--------------|------
-description  | Check command to be executed.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-command: /etc/sensu/plugins/check-chef-client.go
-{{< /code >}}
-{{< code json >}}
-{
-  "command": "/etc/sensu/plugins/check-chef-client.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="check-hooks-attribute"></a>
 
 |check_hooks |      |
@@ -803,31 +871,47 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 check_hooks:
-- '0':
-  - passing-hook
-  - always-run-this-hook
-- critical:
-  - failing-hook
+- '1':
+  - playbook-warning
   - collect-diagnostics
-  - always-run-this-hook
+- critical:
+  - playbook-critical
+  - collect-diagnostics
+  - process-tree
 {{< /code >}}
 {{< code json >}}
 {
   "check_hooks": [
     {
-      "0": [
-        "passing-hook",
-        "always-run-this-hook"
+      "1": [
+        "playbook-warning",
+        "collect-diagnostics"
       ]
     },
     {
       "critical": [
-        "failing-hook",
+        "playbook-critical",
         "collect-diagnostics",
-        "always-run-this-hook"
+        "process-tree"
       ]
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|command     |      |
+-------------|------
+description  | Check command to be executed.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+command: http-perf --url https://sensu.io --warning 1s --critical 2s
+{{< /code >}}
+{{< code json >}}
+{
+  "command": "http-perf --url https://sensu.io --warning 1s --critical 2s"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -888,13 +972,13 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 handlers:
 - pagerduty
-- email
+- slack
 {{< /code >}}
 {{< code json >}}
 {
   "handlers": [
     "pagerduty",
-    "email"
+    "slack"
   ]
 }
 {{< /code >}}
@@ -962,12 +1046,12 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 output_metric_format:
-- graphite_plaintext
+- nagios_perfdata
 {{< /code >}}
 {{< code json >}}
 {
   "output_metric_format": [
-    "graphite_plaintext"
+    "nagios_perfdata"
   ]
 }
 {{< /code >}}
@@ -1006,10 +1090,8 @@ example      | {{< language-toggle >}}
 output_metric_tags:
 - name: instance
   value: "{{ .name }}"
-- name: prometheus_type
-  value: gauge
-- name: service
-  value: "{{ .labels.service }}"
+- name: region
+  value: "{{ .labels.region }}"
 {{< /code >}}
 {{< code json >}}
 {
@@ -1019,12 +1101,8 @@ output_metric_tags:
       "value": "{{ .name }}"
     },
     {
-      "name": "prometheus_type",
-      "value": "gauge"
-    },
-    {
-      "name": "service",
-      "value": "{{ .labels.service }}"
+      "name": "region",
+      "value": "{{ .labels.region }}"
     }
   ]
 }
@@ -1092,7 +1170,6 @@ proxy_requests:
   - entity.labels.proxy_type == 'website'
   splay: true
   splay_coverage: 90
-
 {{< /code >}}
 {{< code json >}}
 {
@@ -1118,11 +1195,11 @@ type         | Boolean
 default      | `false`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-publish: false
+publish: true
 {{< /code >}}
 {{< code json >}}
 {
-  "publish": false
+  "publish": true
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1154,12 +1231,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 runtime_assets:
-- metric-check
+- http-checks
 {{< /code >}}
 {{< code json >}}
 {
   "runtime_assets": [
-    "metric-check"
+    "http-checks"
   ]
 }
 {{< /code >}}
@@ -1191,21 +1268,15 @@ type           | Array
 example        | {{< language-toggle >}}
 {{< code yml >}}
 secrets:
-- name: ANSIBLE_HOST
-  secret: sensu-ansible-host
-- name: ANSIBLE_TOKEN
-  secret: sensu-ansible-token
+- name: PAGERDUTY_TOKEN
+  secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
   "secrets": [
     {
-      "name": "ANSIBLE_HOST",
-      "secret": "sensu-ansible-host"
-    },
-    {
-      "name": "ANSIBLE_TOKEN",
-      "secret": "sensu-ansible-token"
+      "name": "PAGERDUTY_TOKEN",
+      "secret": "sensu-pagerduty-token"
     }
   ]
 }
@@ -1249,7 +1320,7 @@ stdin: true
 
 |subdue      |      |
 -------------|------
-description  | Check subdues are not yet implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
+description  | check subdues are not implemented in Sensu Go. Although the `subdue` attribute appears in check definitions by default, it is a placeholder and should not be modified.
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subdue: null
@@ -1271,12 +1342,12 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subscriptions:
-- production
+- system
 {{< /code >}}
 {{< code json >}}
 {
   "subscriptions": [
-    "production"
+    "system"
   ]
 }
 {{< /code >}}
@@ -1320,23 +1391,6 @@ ttl: 100
 
 #### Pipelines attributes
 
-type         | 
--------------|------
-description  | The [`sensuctl create`][41] resource type for the [pipeline][69]. Pipelines should always be type `Pipeline`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | The Sensu API group and version for the [pipeline][69]. For pipelines in this version of Sensu, the api_version should always be `core/v2`.
@@ -1362,11 +1416,28 @@ type         | String
 default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: is_incident
+name: incident_alerts
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "is_incident"
+  "name": "incident_alerts"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | The [`sensuctl create`][41] resource type for the [pipeline][69]. Pipelines should always be type `Pipeline`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Pipeline
+{{< /code >}}
+{{< code json >}}
+{
+ "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1433,22 +1504,6 @@ splay_coverage: 90
 
 #### Check output truncation attributes
 
-|max_output_size  | |
--------------|-------
-description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.
-required     | false
-type         | Integer
-example      | {{< language-toggle >}}
-{{< code yml >}}
-max_output_size: 1024
-{{< /code >}}
-{{< code json >}}
-{
-  "max_output_size": 1024
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 |discard_output  | |
 -------------|------
 description  | If `true`, discard check output after extracting metrics. No check output will be sent to the Sensu backend. Otherwise, `false`.
@@ -1461,6 +1516,22 @@ discard_output: true
 {{< code json >}}
 {
   "discard_output": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|max_output_size  | |
+-------------|-------
+description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+max_output_size: 1024
+{{< /code >}}
+{{< code json >}}
+{
+  "max_output_size": 1024
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1508,11 +1579,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: ANSIBLE_HOST
+name: PAGERDUTY_TOKEN
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "ANSIBLE_HOST"
+  "name": "PAGERDUTY_TOKEN"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1524,11 +1595,11 @@ required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-secret: sensu-ansible-host
+secret: sensu-pagerduty-token
 {{< /code >}}
 {{< code json >}}
 {
-  "secret": "sensu-ansible-host"
+  "secret": "sensu-pagerduty-token"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -107,7 +107,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 
 ### Subdue
 
-Check subdues are not yet implemented in Sensu Go.
+check subdues are not implemented in Sensu Go.
 Instead, use [cron scheduling][99] in Sensu Go checks to specify when checks should be executed.
 
 ### Standalone checks


### PR DESCRIPTION
## Description
Improves the example spec in the check reference specification tables. The existing example didn't include enough of the available attributes.

edit: also removes "yet" from the subdue explanation in migrate

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3770

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>