### PR TITLE
Update links and verbiage on Sensu Plus pages

### DIFF
--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -70,7 +70,7 @@ To send your Sensu observability data to your new Sumo Logic HTTP Logs and Metri
 
 {{% notice note %}}
 **NOTE**: Sumo Logic metrics handlers only accept metrics events.
-To send status events, use the [Sensu Sumo Logic Handler integration](../../../plugins/supported-integrations/sumologic/) instead.
+To send status events, use the [Sensu Sumo Logic Handler integration](../plugins/supported-integrations/sumologic/) instead.
 {{% /notice %}}
 
 For a Sumo Logic metrics handler, the resource definition must use the URL you copied in the last step of setting up your HTTP Logs and Metrics Source as the value for the `url` attribute.
@@ -113,7 +113,7 @@ EOF
 
 {{< /language-toggle >}}
 
-If you prefer, you can configure your Sumo Logic HTTP Logs and Metrics Source URL as a [secret][6] with Sensu's built-in [`env` secrets provider][7] to avoid exposing the URL in your handler definition.
+If you prefer, you can configure your Sumo Logic HTTP Logs and Metrics Source URL as a [secret][6] with Sensu's [`env` secrets provider][7] to avoid exposing the URL in your handler definition.
 This example shows the same definition with the URL referenced as a secret instead:
 
 {{< language-toggle >}}
@@ -350,7 +350,7 @@ This check will collect baseline system metrics in Prometheus format for all ent
 
 {{% notice note %}}
 **NOTE**: Sumo Logic metrics handlers only accept metrics events, so you must use a check that produces metrics.
-If your check produces status events, use the [Sensu Sumo Logic Handler integration](../../../plugins/supported-integrations/sumologic/) to create a traditional Sensu handler rather than the Sumo Logic metrics handler.
+If your check produces status events, use the [Sensu Sumo Logic Handler integration](../plugins/supported-integrations/sumologic/) to create a traditional Sensu handler rather than the Sumo Logic metrics handler.
 {{% /notice %}}
 
 ## Import Sumo Logic dashboards

--- a/content/sensu-go/6.6/sensu-plus.md
+++ b/content/sensu-go/6.6/sensu-plus.md
@@ -70,7 +70,7 @@ To send your Sensu observability data to your new Sumo Logic HTTP Logs and Metri
 
 {{% notice note %}}
 **NOTE**: Sumo Logic metrics handlers only accept metrics events.
-To send status events, use the [Sensu Sumo Logic Handler integration](../../../plugins/supported-integrations/sumologic/) instead.
+To send status events, use the [Sensu Sumo Logic Handler integration](../plugins/supported-integrations/sumologic/) instead.
 {{% /notice %}}
 
 For a Sumo Logic metrics handler, the resource definition must use the URL you copied in the last step of setting up your HTTP Logs and Metrics Source as the value for the `url` attribute.
@@ -113,7 +113,7 @@ EOF
 
 {{< /language-toggle >}}
 
-If you prefer, you can configure your Sumo Logic HTTP Logs and Metrics Source URL as a [secret][6] with Sensu's built-in [`env` secrets provider][7] to avoid exposing the URL in your handler definition.
+If you prefer, you can configure your Sumo Logic HTTP Logs and Metrics Source URL as a [secret][6] with Sensu's [`env` secrets provider][7] to avoid exposing the URL in your handler definition.
 This example shows the same definition with the URL referenced as a secret instead:
 
 {{< language-toggle >}}
@@ -350,7 +350,7 @@ This check will collect baseline system metrics in Prometheus format for all ent
 
 {{% notice note %}}
 **NOTE**: Sumo Logic metrics handlers only accept metrics events, so you must use a check that produces metrics.
-If your check produces status events, use the [Sensu Sumo Logic Handler integration](../../../plugins/supported-integrations/sumologic/) to create a traditional Sensu handler rather than the Sumo Logic metrics handler.
+If your check produces status events, use the [Sensu Sumo Logic Handler integration](../plugins/supported-integrations/sumologic/) to create a traditional Sensu handler rather than the Sumo Logic metrics handler.
 {{% /notice %}}
 
 ## Import Sumo Logic dashboards

--- a/content/sensu-go/6.7/sensu-plus.md
+++ b/content/sensu-go/6.7/sensu-plus.md
@@ -70,7 +70,7 @@ To send your Sensu observability data to your new Sumo Logic HTTP Logs and Metri
 
 {{% notice note %}}
 **NOTE**: Sumo Logic metrics handlers only accept metrics events.
-To send status events, use the [Sensu Sumo Logic Handler integration](../../../plugins/supported-integrations/sumologic/) instead.
+To send status events, use the [Sensu Sumo Logic Handler integration](../plugins/supported-integrations/sumologic/) instead.
 {{% /notice %}}
 
 For a Sumo Logic metrics handler, the resource definition must use the URL you copied in the last step of setting up your HTTP Logs and Metrics Source as the value for the `url` attribute.
@@ -350,7 +350,7 @@ This check will collect baseline system metrics in Prometheus format for all ent
 
 {{% notice note %}}
 **NOTE**: Sumo Logic metrics handlers only accept metrics events, so you must use a check that produces metrics.
-If your check produces status events, use the [Sensu Sumo Logic Handler integration](../../../plugins/supported-integrations/sumologic/) to create a traditional Sensu handler rather than the Sumo Logic metrics handler.
+If your check produces status events, use the [Sensu Sumo Logic Handler integration](../plugins/supported-integrations/sumologic/) to create a traditional Sensu handler rather than the Sumo Logic metrics handler.
 {{% /notice %}}
 
 ## Import Sumo Logic dashboards


### PR DESCRIPTION
## Description
Fixes a couple broken links to the Sumo Logic handler plugin page and removes a "built-in" reference to env.

## Motivation and Context
Found when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>