### PR TITLE
Update web UI search page weight

### DIFF
--- a/content/sensu-go/6.3/web-ui/search.md
+++ b/content/sensu-go/6.3/web-ui/search.md
@@ -2,7 +2,7 @@
 title: "Search in the web UI"
 linkTitle: "Search in the Web UI"
 description: "Search and filter in the Sensu web UI and build customized views of your events, entities, silences, checks, handlers, filters, and mutators pages."
-weight: 30
+weight: 35
 version: "6.3"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.4/web-ui/search.md
+++ b/content/sensu-go/6.4/web-ui/search.md
@@ -2,7 +2,7 @@
 title: "Search in the web UI"
 linkTitle: "Search in the Web UI"
 description: "Search and filter in the Sensu web UI and build customized views of your events, entities, silences, checks, handlers, filters, and mutators pages."
-weight: 30
+weight: 35
 version: "6.4"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.5/web-ui/search.md
+++ b/content/sensu-go/6.5/web-ui/search.md
@@ -2,7 +2,7 @@
 title: "Search in the web UI"
 linkTitle: "Search in the Web UI"
 description: "Search and filter in the Sensu web UI and build customized views of your events, entities, silences, checks, handlers, filters, and mutators pages."
-weight: 30
+weight: 35
 version: "6.5"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.6/web-ui/search.md
+++ b/content/sensu-go/6.6/web-ui/search.md
@@ -2,7 +2,7 @@
 title: "Search in the web UI"
 linkTitle: "Search in the Web UI"
 description: "Search and filter in the Sensu web UI and build customized views of your events, entities, silences, checks, handlers, filters, and mutators pages."
-weight: 30
+weight: 35
 version: "6.6"
 product: "Sensu Go"
 platformContent: false

--- a/content/sensu-go/6.7/web-ui/search.md
+++ b/content/sensu-go/6.7/web-ui/search.md
@@ -2,7 +2,7 @@
 title: "Search in the web UI"
 linkTitle: "Search in the Web UI"
 description: "Search and filter in the Sensu web UI and build customized views of your events, entities, silences, checks, handlers, filters, and mutators pages."
-weight: 30
+weight: 35
 version: "6.7"
 product: "Sensu Go"
 platformContent: false


### PR DESCRIPTION
## Description
Updates the page weight on the web UI search guide (not reference) so that it does not conflict with the BSM page

## Motivation and Context
Noticed when working on 6.7 docs

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>