### PR TITLE
Alphabetize specification tables

### DIFF
--- a/content/sensu-go/6.4/api/core/events.md
+++ b/content/sensu-go/6.4/api/core/events.md
@@ -2004,7 +2004,7 @@ output         | {{< code shell >}}
 [5]: #eventsentitycheck-put-parameters
 [6]: ../../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../../observability-pipeline/observe-schedule/checks#check-specification
-[8]: ../../../observability-pipeline/observe-events/events/#events-specification
+[8]: ../../../observability-pipeline/observe-events/events/#event-specification
 [9]: ../../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -607,22 +607,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
-required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Entity
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Entity"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For entities in this version of Sensu, this attribute should always be `core/v2`.
@@ -836,37 +820,46 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-hostname
+type: Entity
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-hostname"
+  "type": "Entity"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+<a id="annotations-attribute"></a>
+
+| annotations |     |
 -------------|------
-description  | [Sensu RBAC namespace][5] that this entity belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
+**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
+{{% /notice %}}
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -911,33 +904,75 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="annotations-attribute"></a>
-
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
-**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
-{{% /notice %}}
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-hostname
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-hostname"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | [Sensu RBAC namespace][5] that this entity belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
+
+deregister   | 
+-------------|------ 
+description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
+required     | false 
+type         | Boolean 
+default      | `false`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregister: false
+{{< /code >}}
+{{< code json >}}
+{
+  "deregister": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+deregistration  | 
+-------------|------ 
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregistration:
+  handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "deregistration": {
+    "handler": "email-handler"
+  }
+}{{< /code >}}
+{{< /language-toggle >}}
 
 entity_class |     |
 -------------|------ 
@@ -951,6 +986,57 @@ entity_class: agent
 {{< code json >}}
 {
   "entity_class": "agent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+last_seen    | 
+-------------|------ 
+description  | Time at which the entity was last seen. In seconds since the Unix epoch.
+required     | false 
+type         | Integer 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+last_seen: 1522798317
+{{< /code >}}
+{{< code json >}}
+{
+  "last_seen": 1522798317
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+redact       | 
+-------------|------ 
+description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
+required     | false 
+type         | Array 
+default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
+example      | {{< language-toggle >}}
+{{< code yml >}}
+redact:
+- extra_secret_tokens
+{{< /code >}}
+{{< code json >}}
+{
+  "redact": [
+    "extra_secret_tokens"
+  ]
+}{{< /code >}}
+{{< /language-toggle >}}
+
+sensu_agent_version  | 
+---------------------|------
+description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
+required             | true
+type                 | String
+example              | {{< language-toggle >}}
+{{< code yml >}}
+sensu_agent_version: 1.0.0
+{{< /code >}}
+{{< code json >}}
+{
+  "sensu_agent_version": "1.0.0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1090,92 +1176,6 @@ system:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-sensu_agent_version  | 
----------------------|------
-description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
-required             | true
-type                 | String
-example              | {{< language-toggle >}}
-{{< code yml >}}
-sensu_agent_version: 1.0.0
-{{< /code >}}
-{{< code json >}}
-{
-  "sensu_agent_version": "1.0.0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-last_seen    | 
--------------|------ 
-description  | Time at which the entity was last seen. In seconds since the Unix epoch.
-required     | false 
-type         | Integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-last_seen: 1522798317
-{{< /code >}}
-{{< code json >}}
-{
-  "last_seen": 1522798317
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregister   | 
--------------|------ 
-description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
-required     | false 
-type         | Boolean 
-default      | `false`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregister: false
-{{< /code >}}
-{{< code json >}}
-{
-  "deregister": false
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregistration  | 
--------------|------ 
-description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregistration:
-  handler: email-handler
-{{< /code >}}
-{{< code json >}}
-{
-  "deregistration": {
-    "handler": "email-handler"
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-redact       | 
--------------|------ 
-description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
-required     | false 
-type         | Array 
-default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
-example      | {{< language-toggle >}}
-{{< code yml >}}
-redact:
-- extra_secret_tokens
-{{< /code >}}
-{{< code json >}}
-{
-  "redact": [
-    "extra_secret_tokens"
-  ]
-}{{< /code >}}
-{{< /language-toggle >}}
-
 | user |      |
 --------------|------
 description   | [Sensu RBAC username][22] used by the entity. Agent entities require get, list, create, update, and delete permissions for events across all namespaces.
@@ -1192,7 +1192,59 @@ user: agent
 {{< /code >}}
 {{< /language-toggle >}}
 
+### Deregistration attributes
+
+handler      | 
+-------------|------ 
+description  | Name of the handler to call when an agent entity is deregistered.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "handler": "email-handler"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### System attributes
+
+arch         | 
+-------------|------ 
+description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+arch: amd64
+{{< /code >}}
+{{< code json >}}
+{
+  "arch": "amd64"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cloud_provider | 
+---------------|------ 
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
+{{% /notice %}}
+required       | false 
+type           | String 
+example        | {{< language-toggle >}}
+{{< code yml >}}
+"cloud_provider": ""
+{{< /code >}}
+{{< code json >}}
+{
+  "cloud_provider": ""
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 hostname     | 
 -------------|------ 
@@ -1208,6 +1260,65 @@ hostname: example-hostname
   "hostname": "example-hostname"
 }
 {{< /code >}}
+{{< /language-toggle >}}
+
+libc_type    | 
+-------------|------ 
+description  | Entity's libc type. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+libc_type: glibc
+{{< /code >}}
+{{< code json >}}
+{
+  "libc_type": "glibc"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+network     | 
+-------------|------ 
+description  | Entity's network interface list. Read [network attributes][3] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+network:
+  interfaces:
+  - addresses:
+    - 127.0.0.1/8
+    - ::1/128
+    name: lo
+  - addresses:
+    - 93.184.216.34/24
+    - 2606:2800:220:1:248:1893:25c8:1946/10
+    mac: 52:54:00:20:1b:3c
+    name: eth0
+{{< /code >}}
+{{< code json >}}
+{
+  "network": {
+    "interfaces": [
+      {
+        "name": "lo",
+        "addresses": [
+          "127.0.0.1/8",
+          "::1/128"
+        ]
+      },
+      {
+        "name": "eth0",
+        "mac": "52:54:00:20:1b:3c",
+        "addresses": [
+          "93.184.216.34/24",
+          "2606:2800:220:1:248:1893:25c8:1946/10"
+        ]
+      }
+    ]
+  }
+}{{< /code >}}
 {{< /language-toggle >}}
 
 os           | 
@@ -1274,131 +1385,6 @@ platform_version: 16.04
 {{< /code >}}
 {{< /language-toggle >}}
 
-network     | 
--------------|------ 
-description  | Entity's network interface list. Read [network attributes][3] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-network:
-  interfaces:
-  - addresses:
-    - 127.0.0.1/8
-    - ::1/128
-    name: lo
-  - addresses:
-    - 93.184.216.34/24
-    - 2606:2800:220:1:248:1893:25c8:1946/10
-    mac: 52:54:00:20:1b:3c
-    name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "network": {
-    "interfaces": [
-      {
-        "name": "lo",
-        "addresses": [
-          "127.0.0.1/8",
-          "::1/128"
-        ]
-      },
-      {
-        "name": "eth0",
-        "mac": "52:54:00:20:1b:3c",
-        "addresses": [
-          "93.184.216.34/24",
-          "2606:2800:220:1:248:1893:25c8:1946/10"
-        ]
-      }
-    ]
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-arch         | 
--------------|------ 
-description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-arch: amd64
-{{< /code >}}
-{{< code json >}}
-{
-  "arch": "amd64"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-libc_type    | 
--------------|------ 
-description  | Entity's libc type. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-libc_type: glibc
-{{< /code >}}
-{{< code json >}}
-{
-  "libc_type": "glibc"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_system    | 
--------------|------ 
-description  | Entity's virtual machine system. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_system: kvm
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_system": "kvm"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_role      | 
--------------|------ 
-description  | Entity's virtual machine role. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_role: host
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_role": "host"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cloud_provider | 
----------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
-**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
-{{% /notice %}}
-required       | false 
-type           | String 
-example        | {{< language-toggle >}}
-{{< code yml >}}
-"cloud_provider": ""
-{{< /code >}}
-{{< code json >}}
-{
-  "cloud_provider": ""
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. Read [processes attributes][26] for more information.{{% notice note %}}
@@ -1457,13 +1443,45 @@ processes:
 }{{< /code >}}
 {{< /language-toggle >}}
 
+vm_role      | 
+-------------|------ 
+description  | Entity's virtual machine role. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_role: host
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_role": "host"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+vm_system    | 
+-------------|------ 
+description  | Entity's virtual machine system. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_system: kvm
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_system": "kvm"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Network attributes
 
-network_interface         | 
+interfaces   | 
 -------------|------ 
-description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. 
+description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. Read [interfaces attributes][4] for more information.
 required     | false 
-type         | Array [NetworkInterface][4] 
+type         | Array 
 example      | {{< language-toggle >}}
 {{< code yml >}}
 interfaces:
@@ -1499,39 +1517,7 @@ interfaces:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-### NetworkInterface attributes
-
-name         | 
--------------|------ 
-description  | Network interface name.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "eth0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mac          | 
--------------|------ 
-description  | Network interface's MAC address.
-required     | false 
-type         | string 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mac: 52:54:00:20:1b:3c
-{{< /code >}}
-{{< code json >}}
-{
-  "mac": "52:54:00:20:1b:3c"
-}
-{{< /code >}}
-{{< /language-toggle >}}
+### Interfaces attributes
 
 addresses    | 
 -------------|------ 
@@ -1554,20 +1540,34 @@ addresses:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Deregistration attributes
-
-handler      | 
+mac          | 
 -------------|------ 
-description  | Name of the handler to call when an agent entity is deregistered.
+description  | Network interface's MAC address.
+required     | false 
+type         | string 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mac: 52:54:00:20:1b:3c
+{{< /code >}}
+{{< code json >}}
+{
+  "mac": "52:54:00:20:1b:3c"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------ 
+description  | Network interface name.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-handler: email-handler
+name: eth0
 {{< /code >}}
 {{< code json >}}
 {
-  "handler": "email-handler"
+  "name": "eth0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1584,6 +1584,76 @@ For more information, read [Get started with commercial features](../../../comme
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+background   | 
+-------------|------ 
+description  | If `true`, the process is a background process. Otherwise, `false`.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+background: true
+{{< /code >}}
+{{< code json >}}
+{
+  "background": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cpu_percent  | 
+-------------|------ 
+description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
+**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+cpu_percent: 0.12639
+{{< /code >}}
+{{< code json >}}
+{
+  "cpu_percent": 0.12639
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+created      | 
+-------------|------ 
+description  | Time at which the process was created. In seconds since the Unix epoch.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created: 1586138786
+{{< /code >}}
+{{< code json >}}
+{
+  "created": 1586138786
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+memory_percent | 
+-------------|------ 
+description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
+**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+memory_percent: 0.19932
+{{< /code >}}
+{{< code json >}}
+{
+  "memory_percent": 0.19932
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------ 
@@ -1633,38 +1703,6 @@ ppid: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-status       | 
--------------|------ 
-description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-status: Ss
-{{< /code >}}
-{{< code json >}}
-{
-  "status": "Ss"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-background   | 
--------------|------ 
-description  | If `true`, the process is a background process. Otherwise, `false`.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-background: true
-{{< /code >}}
-{{< code json >}}
-{
-  "background": true
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 running      | 
 -------------|------ 
 description  | If `true`, the process is running. Otherwise, `false`.
@@ -1681,56 +1719,18 @@ running: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-created      | 
+status       | 
 -------------|------ 
-description  | Time at which the process was created. In seconds since the Unix epoch.
+description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
 required     | false
-type         | Integer
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-created: 1586138786
+status: Ss
 {{< /code >}}
 {{< code json >}}
 {
-  "created": 1586138786
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-memory_percent | 
--------------|------ 
-description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
-**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-memory_percent: 0.19932
-{{< /code >}}
-{{< code json >}}
-{
-  "memory_percent": 0.19932
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cpu_percent  | 
--------------|------ 
-description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
-**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-cpu_percent: 0.12639
-{{< /code >}}
-{{< code json >}}
-{
-  "cpu_percent": 0.12639
+  "status": "Ss"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1739,7 +1739,7 @@ cpu_percent: 0.12639
 [1]: #system-attributes
 [2]: #deregistration-attributes
 [3]: #network-attributes
-[4]: #networkinterface-attributes
+[4]: #interfaces-attributes
 [5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/

--- a/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-events/events.md
@@ -1014,25 +1014,9 @@ The following table shows the occurrences attributes for a series of example eve
 |10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
 |11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
-## Events specification
+## Event specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
-required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Event
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Event"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -1314,7 +1298,39 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Event
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Event"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created_by: "admin"
+{{< /code >}}
+{{< code json >}}
+{
+  "created_by": "admin"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | namespace  |      |
 -------------|------
@@ -1333,71 +1349,114 @@ namespace: production
 {{< /code >}}
 {{< /language-toggle >}}
 
-| created_by |      |
--------------|------
-description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-created_by: "admin"
-{{< /code >}}
-{{< code json >}}
-{
-  "created_by": "admin"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 ### Spec attributes
 
-|timestamp   |      |
+<a id="check-attribute"></a>
+
+|check       |      |
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
-required     | false
-type         | Integer
-default      | Time that the event occurred
+description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
+type         | Map
+required     | true
 example      | {{< language-toggle >}}
 {{< code yml >}}
-timestamp: 1522099512
+check:
+  check_hooks:
+  command: metrics-curl -u "http://localhost"
+  duration: 0.060790838
+  env_vars:
+  executed: 1552506033
+  handlers: []
+  high_flap_threshold: 0
+  history:
+  - executed: 1552505833
+    status: 0
+  - executed: 1552505843
+    status: 0
+  interval: 10
+  is_silenced: true
+  issued: 1552506033
+  last_ok: 1552506033
+  low_flap_threshold: 0
+  metadata:
+    name: curl_timings
+    namespace: default
+  occurrences: 1
+  occurrences_watermark: 1
+  silenced:
+  - webserver:*
+  output: sensu-go.curl_timings.time_total 0.005
+  output_metric_format: graphite_plaintext
+  output_metric_handlers:
+  - influx-db
+  proxy_entity_name: ''
+  publish: true
+  round_robin: false
+  runtime_assets: []
+  state: passing
+  status: 0
+  stdin: false
+  subdue:
+  subscriptions:
+  - entity:sensu-go-testing
+  timeout: 0
+  total_state_change: 0
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
-  "timestamp": 1522099512
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-id           |      |
--------------|------
-description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-id: 431a0085-96da-4521-863f-c38b480701e9
-{{< /code >}}
-{{< code json >}}
-{
-  "id": "431a0085-96da-4521-863f-c38b480701e9"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-<a id="sequence-attribute"></a>
-
-sequence     |      |
--------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
-required     | false
-type         | Integer
-example      | {{< language-toggle >}}
-{{< code yml >}}
-sequence: 1
-{{< /code >}}
-{{< code json >}}
-{
-  "sequence": 1
+  "check": {
+    "check_hooks": null,
+    "command": "metrics-curl -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "history": [
+      {
+        "executed": 1552505833,
+        "status": 0
+      },
+      {
+        "executed": 1552505843,
+        "status": 0
+      }
+    ],
+    "interval": 10,
+    "is_silenced": true,
+    "issued": 1552506033,
+    "last_ok": 1552506033,
+    "low_flap_threshold": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
+    "occurrences": 1,
+    "occurrences_watermark": 1,
+    "silenced": [
+      "webserver:*"
+    ],
+    "output": "sensu-go.curl_timings.time_total 0.005",
+    "output_metric_format": "graphite_plaintext",
+    "output_metric_handlers": [
+      "influx-db"
+    ],
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "entity:sensu-go-testing"
+    ],
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1508,112 +1567,18 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="checks-attribute"></a>
-
-|check       |      |
+id           |      |
 -------------|------
-description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
-type         | Map
-required     | true
+description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+required     | false
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-check:
-  check_hooks:
-  command: metrics-curl -u "http://localhost"
-  duration: 0.060790838
-  env_vars:
-  executed: 1552506033
-  handlers: []
-  high_flap_threshold: 0
-  history:
-  - executed: 1552505833
-    status: 0
-  - executed: 1552505843
-    status: 0
-  interval: 10
-  is_silenced: true
-  issued: 1552506033
-  last_ok: 1552506033
-  low_flap_threshold: 0
-  metadata:
-    name: curl_timings
-    namespace: default
-  occurrences: 1
-  occurrences_watermark: 1
-  silenced:
-  - webserver:*
-  output: sensu-go.curl_timings.time_total 0.005
-  output_metric_format: graphite_plaintext
-  output_metric_handlers:
-  - influx-db
-  proxy_entity_name: ''
-  publish: true
-  round_robin: false
-  runtime_assets: []
-  state: passing
-  status: 0
-  stdin: false
-  subdue:
-  subscriptions:
-  - entity:sensu-go-testing
-  timeout: 0
-  total_state_change: 0
-  ttl: 0
+id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /code >}}
 {{< code json >}}
 {
-  "check": {
-    "check_hooks": null,
-    "command": "metrics-curl -u \"http://localhost\"",
-    "duration": 0.060790838,
-    "env_vars": null,
-    "executed": 1552506033,
-    "handlers": [],
-    "high_flap_threshold": 0,
-    "history": [
-      {
-        "executed": 1552505833,
-        "status": 0
-      },
-      {
-        "executed": 1552505843,
-        "status": 0
-      }
-    ],
-    "interval": 10,
-    "is_silenced": true,
-    "issued": 1552506033,
-    "last_ok": 1552506033,
-    "low_flap_threshold": 0,
-    "metadata": {
-      "name": "curl_timings",
-      "namespace": "default"
-    },
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "silenced": [
-      "webserver:*"
-    ],
-    "output": "sensu-go.curl_timings.time_total 0.005",
-    "output_metric_format": "graphite_plaintext",
-    "output_metric_handlers": [
-      "influx-db"
-    ],
-    "proxy_entity_name": "",
-    "publish": true,
-    "round_robin": false,
-    "runtime_assets": [],
-    "state": "passing",
-    "status": 0,
-    "stdin": false,
-    "subdue": null,
-    "subscriptions": [
-      "entity:sensu-go-testing"
-    ],
-    "timeout": 0,
-    "total_state_change": 0,
-    "ttl": 0
-  }
+  "id": "431a0085-96da-4521-863f-c38b480701e9"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1661,6 +1626,41 @@ metrics:
       }
     ]
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="sequence-attribute"></a>
+
+sequence     |      |
+-------------|------
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+sequence: 1
+{{< /code >}}
+{{< code json >}}
+{
+  "sequence": 1
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
+required     | false
+type         | Integer
+default      | Time that the event occurred
+example      | {{< language-toggle >}}
+{{< code yml >}}
+timestamp: 1522099512
+{{< /code >}}
+{{< code json >}}
+{
+  "timestamp": 1522099512
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1730,6 +1730,22 @@ history:
 {{< /code >}}
 {{< /language-toggle >}}
 
+is_silenced  | |
+-------------|------
+description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+is_silenced: true
+{{< /code >}}
+{{< code json >}}
+{
+  "is_silenced": "true"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 issued       |      |
 -------------|------
 description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
@@ -1794,18 +1810,18 @@ occurrences_watermark: 1
 {{< /code >}}
 {{< /language-toggle >}}
 
-is_silenced  | |
+output       |      |
 -------------|------
-description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
+description  | Output from the execution of the check command.
 required     | false
-type         | Boolean
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-is_silenced: true
+output: "sensu-go.curl_timings.time_total 0.005
 {{< /code >}}
 {{< code json >}}
 {
-  "is_silenced": "true"
+  "output": "sensu-go.curl_timings.time_total 0.005"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1827,22 +1843,6 @@ silenced:
   "silenced": [
     "webserver:*"
   ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-output       |      |
--------------|------
-description  | Output from the execution of the check command.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-output: "sensu-go.curl_timings.time_total 0.005
-{{< /code >}}
-{{< code json >}}
-{
-  "output": "sensu-go.curl_timings.time_total 0.005"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -552,27 +552,11 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [core/v2/events API]][43].
+The events in the returned array use the same format as responses for the [core/v2/events API][43].
 
 ## Event filter specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
-required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: EventFilter
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "EventFilter"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -649,37 +633,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: filter-weekdays-only
+type: EventFilter
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "filter-weekdays-only"
+  "type": "EventFilter"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -722,24 +711,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: filter-weekdays-only
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "filter-weekdays-only"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -282,22 +282,6 @@ If you do not specify a keepalive handler with the `keepalive-handlers` flag, th
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
-required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Handler
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Handler"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For handlers in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -380,37 +364,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: handler-slack
+type: Handler
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "handler-slack"
+  "type": "Handler"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the handler belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -453,102 +442,40 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: handler-slack
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "handler-slack"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the handler belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
-
-type         | 
--------------|------
-description  | Handler type.
-required     | true
-type         | String
-allowed values | `pipe`, `tcp`, `udp`, and `set`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: pipe
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "pipe"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-filters      | 
--------------|------
-description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-filters:
-- is_incident
-- not_silenced
-- state_change_only
-{{< /code >}}
-{{< code json >}}
-{
-  "filters": [
-    "is_incident",
-    "not_silenced",
-    "state_change_only"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mutator      | 
--------------|------
-description  | Name of the Sensu event mutator to use to mutate event data for the handler.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator: only_check_output
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": "only_check_output"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout     | 
-------------|------
-description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
-required    | false
-type        | Integer
-default     | `60` (for `tcp` and `udp` handlers)
-example     | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 command      | 
 -------------|------
@@ -589,20 +516,25 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-socket       | 
+filters      | 
 -------------|------
-description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
-**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
-{{% /notice %}}
-required     | true (if `type` equals `tcp` or `udp`)
-type         | Hash
+description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.
+required     | false
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-socket: {}
+filters:
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
-  "socket": {}
+  "filters": [
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -628,6 +560,22 @@ handlers:
     "email",
     "ec2"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+mutator      | 
+-------------|------
+description  | Name of the Sensu event mutator to use to mutate event data for the handler.
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator: only_check_output
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": "only_check_output"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -676,6 +624,58 @@ secrets:
       "secret": "sensu-ansible-token"
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+socket       | 
+-------------|------
+description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
+**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+{{% /notice %}}
+required     | true (if `type` equals `tcp` or `udp`)
+type         | Hash
+example      | {{< language-toggle >}}
+{{< code yml >}}
+socket: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "socket": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+timeout     | 
+------------|------
+description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
+required    | false
+type        | Integer
+default     | `60` (for `tcp` and `udp` handlers)
+example     | {{< language-toggle >}}
+{{< code yml >}}
+timeout: 30
+{{< /code >}}
+{{< code json >}}
+{
+  "timeout": 30
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | Handler type.
+required     | true
+type         | String
+allowed values | `pipe`, `tcp`, `udp`, and `set`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: pipe
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "pipe"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1272,7 +1272,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1313,7 +1313,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
@@ -151,22 +151,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
-required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: HookConfig
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "HookConfig"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For hooks in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -239,37 +223,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: process_tree
+type: HookConfig
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "process_tree"
+  "type": "HookConfig"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -312,24 +301,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: process_tree
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "process_tree"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -352,19 +352,21 @@ command: sudo /etc/init.d/nginx start
 {{< /code >}}
 {{< /language-toggle >}}
 
-timeout      | 
+|runtime_assets |   |
 -------------|------
-description  | Hook execution duration timeout (hard stop). In seconds.
+description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
 required     | false
-type         | Integer
-default      | 60
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-timeout: 30
+runtime_assets:
+- log-context
 {{< /code >}}
 {{< code json >}}
 {
-  "timeout": 30
+  "runtime_assets": [
+    "log-context"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -386,21 +388,19 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-|runtime_assets |   |
+timeout      | 
 -------------|------
-description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
+description  | Hook execution duration timeout (hard stop). In seconds.
 required     | false
-type         | Array
+type         | Integer
+default      | 60
 example      | {{< language-toggle >}}
 {{< code yml >}}
-runtime_assets:
-- log-context
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "runtime_assets": [
-    "log-context"
-  ]
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -197,26 +197,9 @@ Both service components can make use of the same rule template at the threshold 
 Service components can reference more than one rule template.
 Sensu evaluates each rule separately, and each rule produces its own event as output.
 
-
 ## Rule template specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
-required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: RuleTemplate
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "RuleTemplate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -500,39 +483,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
+required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: RuleTemplate
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RuleTemplate"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the rule template that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: aggregate
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "aggregate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -590,23 +557,39 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-description  | 
--------------|------ 
-description  | Plain text description of the rule template's behavior.
+name         |      |
+-------------|------
+description  | Name for the rule template that is used internally by Sensu.
 required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+name: aggregate
 {{< /code >}}
 {{< code json >}}
 {
-  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
+  "name": "aggregate"
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
 
 arguments    | 
 -------------|------ 
@@ -694,6 +677,22 @@ arguments:
     },
     "required": null
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+description  | 
+-------------|------ 
+description  | Plain text description of the rule template's behavior.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+{{< /code >}}
+{{< code json >}}
+{
+  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -849,22 +848,6 @@ eval: |2
 
 #### Arguments attributes
 
-required     | 
--------------|------ 
-description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-required: null
-{{< /code >}}
-{{< code json >}}
-{
-  "required": null
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="rule-properties"></a>
 
 properties   | 
@@ -945,6 +928,22 @@ properties:
       "type": "number"
     }
   },
+  "required": null
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+required     | 
+-------------|------ 
+description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+required: null
+{{< /code >}}
+{{< code json >}}
+{
   "required": null
 }
 {{< /code >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/service-components.md
@@ -109,22 +109,6 @@ The rules can emit new events based on the component input.
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
-required     | Required for service component configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: ServiceComponent
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "ServiceComponent"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For service component configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -228,39 +212,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
+required     | Required for service component configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: ServiceComponent
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ServiceComponent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the service component that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: webservers
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "webservers"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -314,6 +282,38 @@ labels:
   "labels": {
     "region": "us-west-1"
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         |      |
+-------------|------
+description  | Name for the service component that is used internally by Sensu.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: webservers
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "webservers"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
@@ -167,22 +167,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
-required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For mutators in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -257,37 +241,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-mutator
+type: Mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-mutator"
+  "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -330,24 +319,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-mutator"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -366,22 +366,6 @@ command: /etc/sensu/plugins/mutated.go
 {{< code json >}}
 {
   "command": "/etc/sensu/plugins/mutated.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout      | 
--------------|------ 
-description  | Mutator execution duration timeout (hard stop). In seconds.
-required     | false 
-type         | integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -449,6 +433,22 @@ secrets:
       "secret": "sensu-ansible-token"
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+timeout      | 
+-------------|------ 
+description  | Mutator execution duration timeout (hard stop). In seconds.
+required     | false 
+type         | integer 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+timeout: 30
+{{< /code >}}
+{{< code json >}}
+{
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/api/core/events.md
+++ b/content/sensu-go/6.5/api/core/events.md
@@ -2105,7 +2105,7 @@ output         | {{< code shell >}}
 [5]: #eventsentitycheck-put-parameters
 [6]: ../../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../../observability-pipeline/observe-schedule/checks#check-specification
-[8]: ../../../observability-pipeline/observe-events/events/#events-specification
+[8]: ../../../observability-pipeline/observe-events/events/#event-specification
 [9]: ../../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -607,22 +607,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
-required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Entity
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Entity"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For entities in this version of Sensu, this attribute should always be `core/v2`.
@@ -836,37 +820,46 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-hostname
+type: Entity
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-hostname"
+  "type": "Entity"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+<a id="annotations-attribute"></a>
+
+| annotations |     |
 -------------|------
-description  | [Sensu RBAC namespace][5] that this entity belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
+**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
+{{% /notice %}}
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -911,33 +904,75 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="annotations-attribute"></a>
-
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
-**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
-{{% /notice %}}
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-hostname
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-hostname"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | [Sensu RBAC namespace][5] that this entity belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
+
+deregister   | 
+-------------|------ 
+description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
+required     | false 
+type         | Boolean 
+default      | `false`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregister: false
+{{< /code >}}
+{{< code json >}}
+{
+  "deregister": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+deregistration  | 
+-------------|------ 
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregistration:
+  handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "deregistration": {
+    "handler": "email-handler"
+  }
+}{{< /code >}}
+{{< /language-toggle >}}
 
 entity_class |     |
 -------------|------ 
@@ -951,6 +986,57 @@ entity_class: agent
 {{< code json >}}
 {
   "entity_class": "agent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+last_seen    | 
+-------------|------ 
+description  | Time at which the entity was last seen. In seconds since the Unix epoch.
+required     | false 
+type         | Integer 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+last_seen: 1522798317
+{{< /code >}}
+{{< code json >}}
+{
+  "last_seen": 1522798317
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+redact       | 
+-------------|------ 
+description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
+required     | false 
+type         | Array 
+default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
+example      | {{< language-toggle >}}
+{{< code yml >}}
+redact:
+- extra_secret_tokens
+{{< /code >}}
+{{< code json >}}
+{
+  "redact": [
+    "extra_secret_tokens"
+  ]
+}{{< /code >}}
+{{< /language-toggle >}}
+
+sensu_agent_version  | 
+---------------------|------
+description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
+required             | true
+type                 | String
+example              | {{< language-toggle >}}
+{{< code yml >}}
+sensu_agent_version: 1.0.0
+{{< /code >}}
+{{< code json >}}
+{
+  "sensu_agent_version": "1.0.0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1090,92 +1176,6 @@ system:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-sensu_agent_version  | 
----------------------|------
-description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
-required             | true
-type                 | String
-example              | {{< language-toggle >}}
-{{< code yml >}}
-sensu_agent_version: 1.0.0
-{{< /code >}}
-{{< code json >}}
-{
-  "sensu_agent_version": "1.0.0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-last_seen    | 
--------------|------ 
-description  | Time at which the entity was last seen. In seconds since the Unix epoch.
-required     | false 
-type         | Integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-last_seen: 1522798317
-{{< /code >}}
-{{< code json >}}
-{
-  "last_seen": 1522798317
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregister   | 
--------------|------ 
-description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
-required     | false 
-type         | Boolean 
-default      | `false`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregister: false
-{{< /code >}}
-{{< code json >}}
-{
-  "deregister": false
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregistration  | 
--------------|------ 
-description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregistration:
-  handler: email-handler
-{{< /code >}}
-{{< code json >}}
-{
-  "deregistration": {
-    "handler": "email-handler"
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-redact       | 
--------------|------ 
-description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
-required     | false 
-type         | Array 
-default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
-example      | {{< language-toggle >}}
-{{< code yml >}}
-redact:
-- extra_secret_tokens
-{{< /code >}}
-{{< code json >}}
-{
-  "redact": [
-    "extra_secret_tokens"
-  ]
-}{{< /code >}}
-{{< /language-toggle >}}
-
 | user |      |
 --------------|------
 description   | [Sensu RBAC username][22] used by the entity. Agent entities require get, list, create, update, and delete permissions for events across all namespaces.
@@ -1192,7 +1192,59 @@ user: agent
 {{< /code >}}
 {{< /language-toggle >}}
 
+### Deregistration attributes
+
+handler      | 
+-------------|------ 
+description  | Name of the handler to call when an agent entity is deregistered.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "handler": "email-handler"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### System attributes
+
+arch         | 
+-------------|------ 
+description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+arch: amd64
+{{< /code >}}
+{{< code json >}}
+{
+  "arch": "amd64"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cloud_provider | 
+---------------|------ 
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
+{{% /notice %}}
+required       | false 
+type           | String 
+example        | {{< language-toggle >}}
+{{< code yml >}}
+"cloud_provider": ""
+{{< /code >}}
+{{< code json >}}
+{
+  "cloud_provider": ""
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 hostname     | 
 -------------|------ 
@@ -1208,6 +1260,65 @@ hostname: example-hostname
   "hostname": "example-hostname"
 }
 {{< /code >}}
+{{< /language-toggle >}}
+
+libc_type    | 
+-------------|------ 
+description  | Entity's libc type. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+libc_type: glibc
+{{< /code >}}
+{{< code json >}}
+{
+  "libc_type": "glibc"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+network     | 
+-------------|------ 
+description  | Entity's network interface list. Read [network attributes][3] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+network:
+  interfaces:
+  - addresses:
+    - 127.0.0.1/8
+    - ::1/128
+    name: lo
+  - addresses:
+    - 93.184.216.34/24
+    - 2606:2800:220:1:248:1893:25c8:1946/10
+    mac: 52:54:00:20:1b:3c
+    name: eth0
+{{< /code >}}
+{{< code json >}}
+{
+  "network": {
+    "interfaces": [
+      {
+        "name": "lo",
+        "addresses": [
+          "127.0.0.1/8",
+          "::1/128"
+        ]
+      },
+      {
+        "name": "eth0",
+        "mac": "52:54:00:20:1b:3c",
+        "addresses": [
+          "93.184.216.34/24",
+          "2606:2800:220:1:248:1893:25c8:1946/10"
+        ]
+      }
+    ]
+  }
+}{{< /code >}}
 {{< /language-toggle >}}
 
 os           | 
@@ -1274,131 +1385,6 @@ platform_version: 16.04
 {{< /code >}}
 {{< /language-toggle >}}
 
-network     | 
--------------|------ 
-description  | Entity's network interface list. Read [network attributes][3] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-network:
-  interfaces:
-  - addresses:
-    - 127.0.0.1/8
-    - ::1/128
-    name: lo
-  - addresses:
-    - 93.184.216.34/24
-    - 2606:2800:220:1:248:1893:25c8:1946/10
-    mac: 52:54:00:20:1b:3c
-    name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "network": {
-    "interfaces": [
-      {
-        "name": "lo",
-        "addresses": [
-          "127.0.0.1/8",
-          "::1/128"
-        ]
-      },
-      {
-        "name": "eth0",
-        "mac": "52:54:00:20:1b:3c",
-        "addresses": [
-          "93.184.216.34/24",
-          "2606:2800:220:1:248:1893:25c8:1946/10"
-        ]
-      }
-    ]
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-arch         | 
--------------|------ 
-description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-arch: amd64
-{{< /code >}}
-{{< code json >}}
-{
-  "arch": "amd64"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-libc_type    | 
--------------|------ 
-description  | Entity's libc type. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-libc_type: glibc
-{{< /code >}}
-{{< code json >}}
-{
-  "libc_type": "glibc"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_system    | 
--------------|------ 
-description  | Entity's virtual machine system. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_system: kvm
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_system": "kvm"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_role      | 
--------------|------ 
-description  | Entity's virtual machine role. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_role: host
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_role": "host"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cloud_provider | 
----------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
-**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
-{{% /notice %}}
-required       | false 
-type           | String 
-example        | {{< language-toggle >}}
-{{< code yml >}}
-"cloud_provider": ""
-{{< /code >}}
-{{< code json >}}
-{
-  "cloud_provider": ""
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. Read [processes attributes][26] for more information.{{% notice note %}}
@@ -1457,13 +1443,45 @@ processes:
 }{{< /code >}}
 {{< /language-toggle >}}
 
+vm_role      | 
+-------------|------ 
+description  | Entity's virtual machine role. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_role: host
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_role": "host"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+vm_system    | 
+-------------|------ 
+description  | Entity's virtual machine system. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_system: kvm
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_system": "kvm"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Network attributes
 
-network_interface         | 
+interfaces   | 
 -------------|------ 
-description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. 
+description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. Read [interfaces attributes][4] for more information.
 required     | false 
-type         | Array [NetworkInterface][4] 
+type         | Array 
 example      | {{< language-toggle >}}
 {{< code yml >}}
 interfaces:
@@ -1499,39 +1517,7 @@ interfaces:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-### NetworkInterface attributes
-
-name         | 
--------------|------ 
-description  | Network interface name.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "eth0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mac          | 
--------------|------ 
-description  | Network interface's MAC address.
-required     | false 
-type         | string 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mac: 52:54:00:20:1b:3c
-{{< /code >}}
-{{< code json >}}
-{
-  "mac": "52:54:00:20:1b:3c"
-}
-{{< /code >}}
-{{< /language-toggle >}}
+### Interfaces attributes
 
 addresses    | 
 -------------|------ 
@@ -1554,20 +1540,34 @@ addresses:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Deregistration attributes
-
-handler      | 
+mac          | 
 -------------|------ 
-description  | Name of the handler to call when an agent entity is deregistered.
+description  | Network interface's MAC address.
+required     | false 
+type         | string 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mac: 52:54:00:20:1b:3c
+{{< /code >}}
+{{< code json >}}
+{
+  "mac": "52:54:00:20:1b:3c"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------ 
+description  | Network interface name.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-handler: email-handler
+name: eth0
 {{< /code >}}
 {{< code json >}}
 {
-  "handler": "email-handler"
+  "name": "eth0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1584,6 +1584,76 @@ For more information, read [Get started with commercial features](../../../comme
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+background   | 
+-------------|------ 
+description  | If `true`, the process is a background process. Otherwise, `false`.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+background: true
+{{< /code >}}
+{{< code json >}}
+{
+  "background": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cpu_percent  | 
+-------------|------ 
+description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
+**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+cpu_percent: 0.12639
+{{< /code >}}
+{{< code json >}}
+{
+  "cpu_percent": 0.12639
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+created      | 
+-------------|------ 
+description  | Time at which the process was created. In seconds since the Unix epoch.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created: 1586138786
+{{< /code >}}
+{{< code json >}}
+{
+  "created": 1586138786
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+memory_percent | 
+-------------|------ 
+description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
+**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+memory_percent: 0.19932
+{{< /code >}}
+{{< code json >}}
+{
+  "memory_percent": 0.19932
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------ 
@@ -1633,38 +1703,6 @@ ppid: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-status       | 
--------------|------ 
-description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-status: Ss
-{{< /code >}}
-{{< code json >}}
-{
-  "status": "Ss"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-background   | 
--------------|------ 
-description  | If `true`, the process is a background process. Otherwise, `false`.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-background: true
-{{< /code >}}
-{{< code json >}}
-{
-  "background": true
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 running      | 
 -------------|------ 
 description  | If `true`, the process is running. Otherwise, `false`.
@@ -1681,56 +1719,18 @@ running: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-created      | 
+status       | 
 -------------|------ 
-description  | Time at which the process was created. In seconds since the Unix epoch.
+description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
 required     | false
-type         | Integer
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-created: 1586138786
+status: Ss
 {{< /code >}}
 {{< code json >}}
 {
-  "created": 1586138786
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-memory_percent | 
--------------|------ 
-description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
-**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-memory_percent: 0.19932
-{{< /code >}}
-{{< code json >}}
-{
-  "memory_percent": 0.19932
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cpu_percent  | 
--------------|------ 
-description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
-**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-cpu_percent: 0.12639
-{{< /code >}}
-{{< code json >}}
-{
-  "cpu_percent": 0.12639
+  "status": "Ss"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1739,7 +1739,7 @@ cpu_percent: 0.12639
 [1]: #system-attributes
 [2]: #deregistration-attributes
 [3]: #network-attributes
-[4]: #networkinterface-attributes
+[4]: #interfaces-attributes
 [5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/

--- a/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-events/events.md
@@ -2126,25 +2126,9 @@ The following table shows the occurrences attributes for a series of example eve
 |10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
 |11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
-## Events specification
+## Event specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
-required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Event
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Event"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -2456,7 +2440,39 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Event
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Event"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created_by: "admin"
+{{< /code >}}
+{{< code json >}}
+{
+  "created_by": "admin"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | namespace  |      |
 -------------|------
@@ -2475,40 +2491,7 @@ namespace: production
 {{< /code >}}
 {{< /language-toggle >}}
 
-| created_by |      |
--------------|------
-description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-created_by: "admin"
-{{< /code >}}
-{{< code json >}}
-{
-  "created_by": "admin"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 ### Pipelines attributes
-
-type         | 
--------------|------
-description  | The [`sensuctl create`][8] resource type for the [pipeline][44]. Sensu automatically populates the pipelines type field when the event is created or updated. Pipeline resources are always type `Pipeline`.
-required     | false
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -2544,55 +2527,128 @@ name: is_incident
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-|timestamp   |      |
+type         | 
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
-required     | false
-type         | Integer
-default      | Time that the event occurred
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timestamp: 1522099512
-{{< /code >}}
-{{< code json >}}
-{
-  "timestamp": 1522099512
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-id           |      |
--------------|------
-description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+description  | The [`sensuctl create`][8] resource type for the [pipeline][44]. Sensu automatically populates the pipelines type field when the event is created or updated. Pipeline resources are always type `Pipeline`.
 required     | false
 type         | String
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-id: 431a0085-96da-4521-863f-c38b480701e9
+type: Pipeline
 {{< /code >}}
 {{< code json >}}
 {
-  "id": "431a0085-96da-4521-863f-c38b480701e9"
+ "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="sequence-attribute"></a>
+### Spec attributes
 
-sequence     |      |
+<a id="check-attribute"></a>
+
+|check       |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
-required     | false
-type         | Integer
+description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
+type         | Map
+required     | true
 example      | {{< language-toggle >}}
 {{< code yml >}}
-sequence: 1
+check:
+  check_hooks:
+  command: metrics-curl -u "http://localhost"
+  duration: 0.060790838
+  env_vars:
+  executed: 1552506033
+  handlers: []
+  high_flap_threshold: 0
+  history:
+  - executed: 1552505833
+    status: 0
+  - executed: 1552505843
+    status: 0
+  interval: 10
+  is_silenced: true
+  processed_by: sensu-go-sandbox
+  issued: 1552506033
+  last_ok: 1552506033
+  low_flap_threshold: 0
+  metadata:
+    name: curl_timings
+    namespace: default
+  occurrences: 1
+  occurrences_watermark: 1
+  silenced:
+  - webserver:*
+  output: sensu-go.curl_timings.time_total 0.005
+  output_metric_format: graphite_plaintext
+  proxy_entity_name: ''
+  publish: true
+  round_robin: false
+  runtime_assets: []
+  state: passing
+  status: 0
+  stdin: false
+  subdue:
+  subscriptions:
+  - entity:sensu-go-testing
+  timeout: 0
+  total_state_change: 0
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
-  "sequence": 1
+  "check": {
+    "check_hooks": null,
+    "command": "metrics-curl -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "history": [
+      {
+        "executed": 1552505833,
+        "status": 0
+      },
+      {
+        "executed": 1552505843,
+        "status": 0
+      }
+    ],
+    "interval": 10,
+    "is_silenced": true,
+    "processed_by": "sensu-go-sandbox",
+    "issued": 1552506033,
+    "last_ok": 1552506033,
+    "low_flap_threshold": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
+    "occurrences": 1,
+    "occurrences_watermark": 1,
+    "silenced": [
+      "webserver:*"
+    ],
+    "output": "sensu-go.curl_timings.time_total 0.005",
+    "output_metric_format": "graphite_plaintext",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "entity:sensu-go-testing"
+    ],
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2703,109 +2759,18 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="checks-attribute"></a>
-
-|check       |      |
+id           |      |
 -------------|------
-description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
-type         | Map
-required     | true
+description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+required     | false
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-check:
-  check_hooks:
-  command: metrics-curl -u "http://localhost"
-  duration: 0.060790838
-  env_vars:
-  executed: 1552506033
-  handlers: []
-  high_flap_threshold: 0
-  history:
-  - executed: 1552505833
-    status: 0
-  - executed: 1552505843
-    status: 0
-  interval: 10
-  is_silenced: true
-  processed_by: sensu-go-sandbox
-  issued: 1552506033
-  last_ok: 1552506033
-  low_flap_threshold: 0
-  metadata:
-    name: curl_timings
-    namespace: default
-  occurrences: 1
-  occurrences_watermark: 1
-  silenced:
-  - webserver:*
-  output: sensu-go.curl_timings.time_total 0.005
-  output_metric_format: graphite_plaintext
-  proxy_entity_name: ''
-  publish: true
-  round_robin: false
-  runtime_assets: []
-  state: passing
-  status: 0
-  stdin: false
-  subdue:
-  subscriptions:
-  - entity:sensu-go-testing
-  timeout: 0
-  total_state_change: 0
-  ttl: 0
+id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /code >}}
 {{< code json >}}
 {
-  "check": {
-    "check_hooks": null,
-    "command": "metrics-curl -u \"http://localhost\"",
-    "duration": 0.060790838,
-    "env_vars": null,
-    "executed": 1552506033,
-    "handlers": [],
-    "high_flap_threshold": 0,
-    "history": [
-      {
-        "executed": 1552505833,
-        "status": 0
-      },
-      {
-        "executed": 1552505843,
-        "status": 0
-      }
-    ],
-    "interval": 10,
-    "is_silenced": true,
-    "processed_by": "sensu-go-sandbox",
-    "issued": 1552506033,
-    "last_ok": 1552506033,
-    "low_flap_threshold": 0,
-    "metadata": {
-      "name": "curl_timings",
-      "namespace": "default"
-    },
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "silenced": [
-      "webserver:*"
-    ],
-    "output": "sensu-go.curl_timings.time_total 0.005",
-    "output_metric_format": "graphite_plaintext",
-    "proxy_entity_name": "",
-    "publish": true,
-    "round_robin": false,
-    "runtime_assets": [],
-    "state": "passing",
-    "status": 0,
-    "stdin": false,
-    "subdue": null,
-    "subscriptions": [
-      "entity:sensu-go-testing"
-    ],
-    "timeout": 0,
-    "total_state_change": 0,
-    "ttl": 0
-  }
+  "id": "431a0085-96da-4521-863f-c38b480701e9"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2848,6 +2813,41 @@ metrics:
       }
     ]
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="sequence-attribute"></a>
+
+sequence     |      |
+-------------|------
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+sequence: 1
+{{< /code >}}
+{{< code json >}}
+{
+  "sequence": 1
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
+required     | false
+type         | Integer
+default      | Time that the event occurred
+example      | {{< language-toggle >}}
+{{< code yml >}}
+timestamp: 1522099512
+{{< /code >}}
+{{< code json >}}
+{
+  "timestamp": 1522099512
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2917,6 +2917,22 @@ history:
 {{< /code >}}
 {{< /language-toggle >}}
 
+is_silenced  | |
+-------------|------
+description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+is_silenced: true
+{{< /code >}}
+{{< code json >}}
+{
+  "is_silenced": "true"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 issued       |      |
 -------------|------
 description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
@@ -2981,43 +2997,6 @@ occurrences_watermark: 1
 {{< /code >}}
 {{< /language-toggle >}}
 
-is_silenced  | |
--------------|------
-description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-is_silenced: true
-{{< /code >}}
-{{< code json >}}
-{
-  "is_silenced": "true"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-<a id="silenced-attribute"></a>
-
-silenced     | |
--------------|------
-description  | Array of silencing entries that match the event. The `silenced` attribute is only present for events if one or more silencing entries matched the event at time of processing. If the `silenced` attribute is not present in an event, the event was not silenced at the time of processing.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-silenced:
-- webserver:*
-{{< /code >}}
-{{< code json >}}
-{
-  "silenced": [
-    "webserver:*"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 output       |      |
 -------------|------
 description  | Output from the execution of the check command.
@@ -3052,6 +3031,27 @@ processed_by: sensu-go-sandbox
 {{< /code >}}
 {{< /language-toggle >}}
 
+<a id="silenced-attribute"></a>
+
+silenced     | |
+-------------|------
+description  | Array of silencing entries that match the event. The `silenced` attribute is only present for events if one or more silencing entries matched the event at time of processing. If the `silenced` attribute is not present in an event, the event was not silenced at the time of processing.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+silenced:
+- webserver:*
+{{< /code >}}
+{{< code json >}}
+{
+  "silenced": [
+    "webserver:*"
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 state         |      |
 -------------|------
 description  | State of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. Use the `low_flap_threshold` and `high_flap_threshold` [check attributes][33] to configure `flapping` state detection.<br><br>Sensu automatically populates the `state` based on the `status`.
@@ -3067,6 +3067,8 @@ state: passing
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+<a id="check-status-attribute"></a>
 
 status       |      |
 -------------|------

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -570,27 +570,11 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [core/v2/events API]][43].
+The events in the returned array use the same format as responses for the [core/v2/events API][43].
 
 ## Event filter specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
-required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: EventFilter
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "EventFilter"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -667,37 +651,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: filter-weekdays-only
+type: EventFilter
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "filter-weekdays-only"
+  "type": "EventFilter"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -740,24 +729,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: filter-weekdays-only
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "filter-weekdays-only"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -291,22 +291,6 @@ If you do not specify a keepalive handler with the `keepalive-handlers` flag, th
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
-required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Handler
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Handler"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For handlers in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -389,37 +373,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: handler-slack
+type: Handler
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "handler-slack"
+  "type": "Handler"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the handler belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -462,108 +451,40 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: handler-slack
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "handler-slack"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the handler belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
-
-type         | 
--------------|------
-description  | Handler type.
-required     | true
-type         | String
-allowed values | `pipe`, `tcp`, `udp`, and `set`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: pipe
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "pipe"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-filters      | 
--------------|------
-description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.{{% notice note %}}
-**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list event filters directly in the pipeline resource definition instead of in handlers.<br><br>
-Pipelines ignore any event filters specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the event filters you want to use in the pipeline workflow.
-{{% /notice %}}
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-filters:
-- is_incident
-- not_silenced
-- state_change_only
-{{< /code >}}
-{{< code json >}}
-{
-  "filters": [
-    "is_incident",
-    "not_silenced",
-    "state_change_only"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mutator      | 
--------------|------
-description  | Name of the Sensu event mutator to use to mutate event data for the handler.{{% notice note %}}
-**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list mutators directly in the pipeline resource definition instead of in handlers.<br><br>
-Pipelines ignore any mutators specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the mutator you want to use in the pipeline workflow.
-{{% /notice %}}
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator: only_check_output
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": "only_check_output"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout     | 
-------------|------
-description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
-required    | false
-type        | Integer
-default     | `60` (for `tcp` and `udp` handlers)
-example     | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 command      | 
 -------------|------
@@ -604,20 +525,28 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-socket       | 
+filters      | 
 -------------|------
-description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
-**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.{{% notice note %}}
+**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list event filters directly in the pipeline resource definition instead of in handlers.<br><br>
+Pipelines ignore any event filters specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the event filters you want to use in the pipeline workflow.
 {{% /notice %}}
-required     | true (if `type` equals `tcp` or `udp`)
-type         | Hash
+required     | false
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-socket: {}
+filters:
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
-  "socket": {}
+  "filters": [
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -644,6 +573,25 @@ handlers:
     "email",
     "ec2"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+mutator      | 
+-------------|------
+description  | Name of the Sensu event mutator to use to mutate event data for the handler.{{% notice note %}}
+**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list mutators directly in the pipeline resource definition instead of in handlers.<br><br>
+Pipelines ignore any mutators specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the mutator you want to use in the pipeline workflow.
+{{% /notice %}}
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator: only_check_output
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": "only_check_output"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -692,6 +640,58 @@ secrets:
       "secret": "sensu-ansible-token"
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+socket       | 
+-------------|------
+description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
+**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+{{% /notice %}}
+required     | true (if `type` equals `tcp` or `udp`)
+type         | Hash
+example      | {{< language-toggle >}}
+{{< code yml >}}
+socket: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "socket": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+timeout     | 
+------------|------
+description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
+required    | false
+type        | Integer
+default     | `60` (for `tcp` and `udp` handlers)
+example     | {{< language-toggle >}}
+{{< code yml >}}
+timeout: 30
+{{< /code >}}
+{{< code json >}}
+{
+  "timeout": 30
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | Handler type.
+required     | true
+type         | String
+allowed values | `pipe`, `tcp`, `udp`, and `set`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: pipe
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "pipe"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -308,22 +308,6 @@ Read [Route alerts with event filters][30] for another pipeline example that inc
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Pipelines should always be type `Pipeline`.
-required     | Required for pipeline definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For pipelines in this version of Sensu, the api_version should always be `core/v2`.
@@ -442,37 +426,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the pipeline. Pipeline names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each pipeline must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Pipelines should always be type `Pipeline`.
+required     | Required for pipeline definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: incident_alerts
+type: Pipeline
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "incident_alerts"
+  "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the pipeline belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: default
+annotations:
+  managed-by: ops
+  slack-channel: "#incidents"
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "default"
+  "annotations": {
+    "managed-by": "ops",
+    "slack-channel": "#incidents"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -515,24 +504,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the pipeline. Pipeline names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each pipeline must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  slack-channel: "#incidents"
+name: incident_alerts
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "slack-channel": "#incidents"
-  }
+  "name": "incident_alerts"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the pipeline belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -649,30 +649,6 @@ filters:
 {{< /code >}}
 {{< /language-toggle >}}
 
-mutator      | 
--------------|------
-description  | Reference for the Sensu mutator to use to mutate event data for the workflow. Each pipeline workflow can reference only one mutator. Read [mutator attributes][9] for details.
-required     | false
-type         | Map of key-value pairs
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator:
-  name: add_labels
-  type: Mutator
-  api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": {
-    "name": "add_labels",
-    "type": "Mutator",
-    "api_version": "core/v2"
-  }
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="handler-pipeline"></a>
 
 handler      | 
@@ -698,7 +674,48 @@ handler:
 {{< /code >}}
 {{< /language-toggle >}}
 
+mutator      | 
+-------------|------
+description  | Reference for the Sensu mutator to use to mutate event data for the workflow. Each pipeline workflow can reference only one mutator. Read [mutator attributes][9] for details.
+required     | false
+type         | Map of key-value pairs
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator:
+  name: add_labels
+  type: Mutator
+  api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": {
+    "name": "add_labels",
+    "type": "Mutator",
+    "api_version": "core/v2"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 #### Filters attributes
+
+api_version  | 
+-------------|------
+description  | The Sensu API group and version for the event filter. For event filters in this version of Sensu, the api_version should always be `core/v2`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------
@@ -734,77 +751,25 @@ type: EventFilter
 {{< /code >}}
 {{< /language-toggle >}}
 
-api_version  | 
--------------|------
-description  | The Sensu API group and version for the event filter. For event filters in this version of Sensu, the api_version should always be `core/v2`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "api_version": "core/v2"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-#### Mutator attributes
-
-name         | 
--------------|------
-description  | Name of the Sensu [mutator][14] to use for the workflow. You can use your existing mutators in pipeline workflows.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: add_labels
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "add_labels"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-type         | 
--------------|------
-description  | The [`sensuctl create`][4] resource type for the mutator. Mutators should always be type `Mutator`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-api_version  | 
--------------|------
-description  | The Sensu API group and version for the mutator. For mutators in this version of Sensu, the api_version should always be `core/v2`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "api_version": "core/v2"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 #### Handler attributes
+
+api_version  | 
+-------------|------
+description  | The Sensu API group and version for the handler.
+required     | true
+type         | String
+allowed values | `core/v2` for a [pipe handler][15], [TCP or UDP handler][16], or [handler set][1]<br><br>`pipeline/v1` for a [TCP stream handler][20] or [Sumo Logic metrics handler][21]
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------
@@ -841,12 +806,13 @@ type: Handler
 {{< /code >}}
 {{< /language-toggle >}}
 
+#### Mutator attributes
+
 api_version  | 
 -------------|------
-description  | The Sensu API group and version for the handler.
+description  | The Sensu API group and version for the mutator. For mutators in this version of Sensu, the api_version should always be `core/v2`.
 required     | true
 type         | String
-allowed values | `core/v2` for a [pipe handler][15], [TCP or UDP handler][16], or [handler set][1]<br><br>`pipeline/v1` for a [TCP stream handler][20] or [Sumo Logic metrics handler][21]
 default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
@@ -855,6 +821,40 @@ api_version: core/v2
 {{< code json >}}
 {
   "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------
+description  | Name of the Sensu [mutator][14] to use for the workflow. You can use your existing mutators in pipeline workflows.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: add_labels
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "add_labels"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | The [`sensuctl create`][4] resource type for the mutator. Mutators should always be type `Mutator`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Mutator
+{{< /code >}}
+{{< code json >}}
+{
+ "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1322,7 +1322,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1363,7 +1363,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
@@ -155,22 +155,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
-required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: HookConfig
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "HookConfig"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For hooks in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -243,37 +227,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: process_tree
+type: HookConfig
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "process_tree"
+  "type": "HookConfig"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -316,24 +305,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: process_tree
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "process_tree"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -356,19 +356,21 @@ command: sudo /etc/init.d/nginx start
 {{< /code >}}
 {{< /language-toggle >}}
 
-timeout      | 
+|runtime_assets |   |
 -------------|------
-description  | Hook execution duration timeout (hard stop). In seconds.
+description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
 required     | false
-type         | Integer
-default      | 60
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-timeout: 30
+runtime_assets:
+- log-context
 {{< /code >}}
 {{< code json >}}
 {
-  "timeout": 30
+  "runtime_assets": [
+    "log-context"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -390,21 +392,19 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-|runtime_assets |   |
+timeout      | 
 -------------|------
-description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
+description  | Hook execution duration timeout (hard stop). In seconds.
 required     | false
-type         | Array
+type         | Integer
+default      | 60
 example      | {{< language-toggle >}}
 {{< code yml >}}
-runtime_assets:
-- log-context
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "runtime_assets": [
-    "log-context"
-  ]
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
@@ -201,22 +201,6 @@ Sensu evaluates each rule separately, and each rule produces its own event as ou
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
-required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: RuleTemplate
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "RuleTemplate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For rule template configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -499,39 +483,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
+required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: RuleTemplate
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RuleTemplate"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the rule template that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: aggregate
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "aggregate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -589,23 +557,39 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-description  | 
--------------|------ 
-description  | Plain text description of the rule template's behavior.
+name         |      |
+-------------|------
+description  | Name for the rule template that is used internally by Sensu.
 required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+name: aggregate
 {{< /code >}}
 {{< code json >}}
 {
-  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
+  "name": "aggregate"
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
 
 arguments    | 
 -------------|------ 
@@ -693,6 +677,22 @@ arguments:
     },
     "required": null
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+description  | 
+-------------|------ 
+description  | Plain text description of the rule template's behavior.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+{{< /code >}}
+{{< code json >}}
+{
+  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -848,22 +848,6 @@ eval: |2
 
 #### Arguments attributes
 
-required     | 
--------------|------ 
-description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-required: null
-{{< /code >}}
-{{< code json >}}
-{
-  "required": null
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="rule-properties"></a>
 
 properties   | 
@@ -944,6 +928,22 @@ properties:
       "type": "number"
     }
   },
+  "required": null
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+required     | 
+-------------|------ 
+description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+required: null
+{{< /code >}}
+{{< code json >}}
+{
   "required": null
 }
 {{< /code >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/service-components.md
@@ -109,22 +109,6 @@ The rules can emit new events based on the component input.
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
-required     | Required for service component configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: ServiceComponent
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "ServiceComponent"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For service component configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -228,39 +212,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
+required     | Required for service component configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: ServiceComponent
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ServiceComponent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the service component that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: webservers
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "webservers"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -314,6 +282,38 @@ labels:
   "labels": {
     "region": "us-west-1"
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         |      |
+-------------|------
+description  | Name for the service component that is used internally by Sensu.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: webservers
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "webservers"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -268,22 +268,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
-required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For mutators in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -362,37 +346,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-mutator
+type: Mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-mutator"
+  "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -435,24 +424,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-mutator"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -473,24 +473,6 @@ command: /etc/sensu/plugins/mutated.go
 {{< code json >}}
 {
   "command": "/etc/sensu/plugins/mutated.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout      | 
--------------|------ 
-description  | Mutator execution duration timeout (hard stop). In seconds.{{% notice warning %}}
-**WARNING**: The timeout attribute is available for [JavaScript mutators](#javascript-mutators) but may not work properly if the mutator is in a loop.
-{{% /notice %}}
-required     | false 
-type         | integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -526,6 +508,26 @@ env_vars:
     "APP_VERSION=2.5.0",
     "SHELL"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="eval-attribute"></a>
+
+eval         | 
+-------------|------ 
+description  | ECMAScript 5 (JavaScript) expression to be executed by the Sensu backend.{{% notice note %}}
+**NOTE**: Pipe mutators require the [command attribute](#spec-attributes) instead of the eval attribute.
+{{% /notice %}}
+required     | true, for [JavaScript mutators][18]
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+eval: 'return JSON.stringify({"some stuff": "is here"});'
+{{< /code >}}
+{{< code json >}}
+{
+  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -578,22 +580,20 @@ secrets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="eval-attribute"></a>
-
-eval         | 
+timeout      | 
 -------------|------ 
-description  | ECMAScript 5 (JavaScript) expression to be executed by the Sensu backend.{{% notice note %}}
-**NOTE**: Pipe mutators require the [command attribute](#spec-attributes) instead of the eval attribute.
+description  | Mutator execution duration timeout (hard stop). In seconds.{{% notice warning %}}
+**WARNING**: The timeout attribute is available for [JavaScript mutators](#javascript-mutators) but may not work properly if the mutator is in a loop.
 {{% /notice %}}
-required     | true, for [JavaScript mutators][18]
-type         | String
+required     | false 
+type         | integer 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-eval: 'return JSON.stringify({"some stuff": "is here"});'
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/api/core/events.md
+++ b/content/sensu-go/6.6/api/core/events.md
@@ -2105,7 +2105,7 @@ output         | {{< code shell >}}
 [5]: #eventsentitycheck-put-parameters
 [6]: ../../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../../observability-pipeline/observe-schedule/checks#check-specification
-[8]: ../../../observability-pipeline/observe-events/events/#events-specification
+[8]: ../../../observability-pipeline/observe-events/events/#event-specification
 [9]: ../../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -607,22 +607,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
-required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Entity
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Entity"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For entities in this version of Sensu, this attribute should always be `core/v2`.
@@ -836,37 +820,46 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-hostname
+type: Entity
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-hostname"
+  "type": "Entity"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+<a id="annotations-attribute"></a>
+
+| annotations |     |
 -------------|------
-description  | [Sensu RBAC namespace][5] that this entity belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
+**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
+{{% /notice %}}
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -911,33 +904,75 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="annotations-attribute"></a>
-
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
-**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
-{{% /notice %}}
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-hostname
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-hostname"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | [Sensu RBAC namespace][5] that this entity belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
+
+deregister   | 
+-------------|------ 
+description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
+required     | false 
+type         | Boolean 
+default      | `false`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregister: false
+{{< /code >}}
+{{< code json >}}
+{
+  "deregister": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+deregistration  | 
+-------------|------ 
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregistration:
+  handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "deregistration": {
+    "handler": "email-handler"
+  }
+}{{< /code >}}
+{{< /language-toggle >}}
 
 entity_class |     |
 -------------|------ 
@@ -951,6 +986,57 @@ entity_class: agent
 {{< code json >}}
 {
   "entity_class": "agent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+last_seen    | 
+-------------|------ 
+description  | Time at which the entity was last seen. In seconds since the Unix epoch.
+required     | false 
+type         | Integer 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+last_seen: 1522798317
+{{< /code >}}
+{{< code json >}}
+{
+  "last_seen": 1522798317
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+redact       | 
+-------------|------ 
+description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
+required     | false 
+type         | Array 
+default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
+example      | {{< language-toggle >}}
+{{< code yml >}}
+redact:
+- extra_secret_tokens
+{{< /code >}}
+{{< code json >}}
+{
+  "redact": [
+    "extra_secret_tokens"
+  ]
+}{{< /code >}}
+{{< /language-toggle >}}
+
+sensu_agent_version  | 
+---------------------|------
+description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
+required             | true
+type                 | String
+example              | {{< language-toggle >}}
+{{< code yml >}}
+sensu_agent_version: 1.0.0
+{{< /code >}}
+{{< code json >}}
+{
+  "sensu_agent_version": "1.0.0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1090,92 +1176,6 @@ system:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-sensu_agent_version  | 
----------------------|------
-description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
-required             | true
-type                 | String
-example              | {{< language-toggle >}}
-{{< code yml >}}
-sensu_agent_version: 1.0.0
-{{< /code >}}
-{{< code json >}}
-{
-  "sensu_agent_version": "1.0.0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-last_seen    | 
--------------|------ 
-description  | Time at which the entity was last seen. In seconds since the Unix epoch.
-required     | false 
-type         | Integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-last_seen: 1522798317
-{{< /code >}}
-{{< code json >}}
-{
-  "last_seen": 1522798317
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregister   | 
--------------|------ 
-description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
-required     | false 
-type         | Boolean 
-default      | `false`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregister: false
-{{< /code >}}
-{{< code json >}}
-{
-  "deregister": false
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregistration  | 
--------------|------ 
-description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregistration:
-  handler: email-handler
-{{< /code >}}
-{{< code json >}}
-{
-  "deregistration": {
-    "handler": "email-handler"
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-redact       | 
--------------|------ 
-description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
-required     | false 
-type         | Array 
-default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
-example      | {{< language-toggle >}}
-{{< code yml >}}
-redact:
-- extra_secret_tokens
-{{< /code >}}
-{{< code json >}}
-{
-  "redact": [
-    "extra_secret_tokens"
-  ]
-}{{< /code >}}
-{{< /language-toggle >}}
-
 | user |      |
 --------------|------
 description   | [Sensu RBAC username][22] used by the entity. Agent entities require get, list, create, update, and delete permissions for events across all namespaces.
@@ -1192,7 +1192,59 @@ user: agent
 {{< /code >}}
 {{< /language-toggle >}}
 
+### Deregistration attributes
+
+handler      | 
+-------------|------ 
+description  | Name of the handler to call when an agent entity is deregistered.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "handler": "email-handler"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### System attributes
+
+arch         | 
+-------------|------ 
+description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+arch: amd64
+{{< /code >}}
+{{< code json >}}
+{
+  "arch": "amd64"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cloud_provider | 
+---------------|------ 
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
+{{% /notice %}}
+required       | false 
+type           | String 
+example        | {{< language-toggle >}}
+{{< code yml >}}
+"cloud_provider": ""
+{{< /code >}}
+{{< code json >}}
+{
+  "cloud_provider": ""
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 hostname     | 
 -------------|------ 
@@ -1208,6 +1260,65 @@ hostname: example-hostname
   "hostname": "example-hostname"
 }
 {{< /code >}}
+{{< /language-toggle >}}
+
+libc_type    | 
+-------------|------ 
+description  | Entity's libc type. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+libc_type: glibc
+{{< /code >}}
+{{< code json >}}
+{
+  "libc_type": "glibc"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+network     | 
+-------------|------ 
+description  | Entity's network interface list. Read [network attributes][3] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+network:
+  interfaces:
+  - addresses:
+    - 127.0.0.1/8
+    - ::1/128
+    name: lo
+  - addresses:
+    - 93.184.216.34/24
+    - 2606:2800:220:1:248:1893:25c8:1946/10
+    mac: 52:54:00:20:1b:3c
+    name: eth0
+{{< /code >}}
+{{< code json >}}
+{
+  "network": {
+    "interfaces": [
+      {
+        "name": "lo",
+        "addresses": [
+          "127.0.0.1/8",
+          "::1/128"
+        ]
+      },
+      {
+        "name": "eth0",
+        "mac": "52:54:00:20:1b:3c",
+        "addresses": [
+          "93.184.216.34/24",
+          "2606:2800:220:1:248:1893:25c8:1946/10"
+        ]
+      }
+    ]
+  }
+}{{< /code >}}
 {{< /language-toggle >}}
 
 os           | 
@@ -1274,131 +1385,6 @@ platform_version: 16.04
 {{< /code >}}
 {{< /language-toggle >}}
 
-network     | 
--------------|------ 
-description  | Entity's network interface list. Read [network attributes][3] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-network:
-  interfaces:
-  - addresses:
-    - 127.0.0.1/8
-    - ::1/128
-    name: lo
-  - addresses:
-    - 93.184.216.34/24
-    - 2606:2800:220:1:248:1893:25c8:1946/10
-    mac: 52:54:00:20:1b:3c
-    name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "network": {
-    "interfaces": [
-      {
-        "name": "lo",
-        "addresses": [
-          "127.0.0.1/8",
-          "::1/128"
-        ]
-      },
-      {
-        "name": "eth0",
-        "mac": "52:54:00:20:1b:3c",
-        "addresses": [
-          "93.184.216.34/24",
-          "2606:2800:220:1:248:1893:25c8:1946/10"
-        ]
-      }
-    ]
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-arch         | 
--------------|------ 
-description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-arch: amd64
-{{< /code >}}
-{{< code json >}}
-{
-  "arch": "amd64"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-libc_type    | 
--------------|------ 
-description  | Entity's libc type. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-libc_type: glibc
-{{< /code >}}
-{{< code json >}}
-{
-  "libc_type": "glibc"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_system    | 
--------------|------ 
-description  | Entity's virtual machine system. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_system: kvm
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_system": "kvm"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_role      | 
--------------|------ 
-description  | Entity's virtual machine role. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_role: host
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_role": "host"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cloud_provider | 
----------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
-**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
-{{% /notice %}}
-required       | false 
-type           | String 
-example        | {{< language-toggle >}}
-{{< code yml >}}
-"cloud_provider": ""
-{{< /code >}}
-{{< code json >}}
-{
-  "cloud_provider": ""
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. Read [processes attributes][26] for more information.{{% notice note %}}
@@ -1457,13 +1443,45 @@ processes:
 }{{< /code >}}
 {{< /language-toggle >}}
 
+vm_role      | 
+-------------|------ 
+description  | Entity's virtual machine role. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_role: host
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_role": "host"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+vm_system    | 
+-------------|------ 
+description  | Entity's virtual machine system. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_system: kvm
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_system": "kvm"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Network attributes
 
-network_interface         | 
+interfaces   | 
 -------------|------ 
-description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. 
+description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. Read [interfaces attributes][4] for more information.
 required     | false 
-type         | Array [NetworkInterface][4] 
+type         | Array 
 example      | {{< language-toggle >}}
 {{< code yml >}}
 interfaces:
@@ -1499,39 +1517,7 @@ interfaces:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-### NetworkInterface attributes
-
-name         | 
--------------|------ 
-description  | Network interface name.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "eth0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mac          | 
--------------|------ 
-description  | Network interface's MAC address.
-required     | false 
-type         | string 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mac: 52:54:00:20:1b:3c
-{{< /code >}}
-{{< code json >}}
-{
-  "mac": "52:54:00:20:1b:3c"
-}
-{{< /code >}}
-{{< /language-toggle >}}
+### Interfaces attributes
 
 addresses    | 
 -------------|------ 
@@ -1554,20 +1540,34 @@ addresses:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Deregistration attributes
-
-handler      | 
+mac          | 
 -------------|------ 
-description  | Name of the handler to call when an agent entity is deregistered.
+description  | Network interface's MAC address.
+required     | false 
+type         | string 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mac: 52:54:00:20:1b:3c
+{{< /code >}}
+{{< code json >}}
+{
+  "mac": "52:54:00:20:1b:3c"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------ 
+description  | Network interface name.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-handler: email-handler
+name: eth0
 {{< /code >}}
 {{< code json >}}
 {
-  "handler": "email-handler"
+  "name": "eth0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1584,6 +1584,76 @@ For more information, read [Get started with commercial features](../../../comme
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+background   | 
+-------------|------ 
+description  | If `true`, the process is a background process. Otherwise, `false`.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+background: true
+{{< /code >}}
+{{< code json >}}
+{
+  "background": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cpu_percent  | 
+-------------|------ 
+description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
+**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+cpu_percent: 0.12639
+{{< /code >}}
+{{< code json >}}
+{
+  "cpu_percent": 0.12639
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+created      | 
+-------------|------ 
+description  | Time at which the process was created. In seconds since the Unix epoch.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created: 1586138786
+{{< /code >}}
+{{< code json >}}
+{
+  "created": 1586138786
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+memory_percent | 
+-------------|------ 
+description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
+**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+memory_percent: 0.19932
+{{< /code >}}
+{{< code json >}}
+{
+  "memory_percent": 0.19932
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------ 
@@ -1633,38 +1703,6 @@ ppid: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-status       | 
--------------|------ 
-description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-status: Ss
-{{< /code >}}
-{{< code json >}}
-{
-  "status": "Ss"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-background   | 
--------------|------ 
-description  | If `true`, the process is a background process. Otherwise, `false`.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-background: true
-{{< /code >}}
-{{< code json >}}
-{
-  "background": true
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 running      | 
 -------------|------ 
 description  | If `true`, the process is running. Otherwise, `false`.
@@ -1681,56 +1719,18 @@ running: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-created      | 
+status       | 
 -------------|------ 
-description  | Time at which the process was created. In seconds since the Unix epoch.
+description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
 required     | false
-type         | Integer
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-created: 1586138786
+status: Ss
 {{< /code >}}
 {{< code json >}}
 {
-  "created": 1586138786
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-memory_percent | 
--------------|------ 
-description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
-**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-memory_percent: 0.19932
-{{< /code >}}
-{{< code json >}}
-{
-  "memory_percent": 0.19932
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cpu_percent  | 
--------------|------ 
-description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
-**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-cpu_percent: 0.12639
-{{< /code >}}
-{{< code json >}}
-{
-  "cpu_percent": 0.12639
+  "status": "Ss"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1739,7 +1739,7 @@ cpu_percent: 0.12639
 [1]: #system-attributes
 [2]: #deregistration-attributes
 [3]: #network-attributes
-[4]: #networkinterface-attributes
+[4]: #interfaces-attributes
 [5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/

--- a/content/sensu-go/6.6/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-events/events.md
@@ -2126,25 +2126,9 @@ The following table shows the occurrences attributes for a series of example eve
 |10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
 |11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
-## Events specification
+## Event specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
-required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Event
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Event"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -2456,7 +2440,39 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Event
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Event"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created_by: "admin"
+{{< /code >}}
+{{< code json >}}
+{
+  "created_by": "admin"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | namespace  |      |
 -------------|------
@@ -2475,40 +2491,7 @@ namespace: production
 {{< /code >}}
 {{< /language-toggle >}}
 
-| created_by |      |
--------------|------
-description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-created_by: "admin"
-{{< /code >}}
-{{< code json >}}
-{
-  "created_by": "admin"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 ### Pipelines attributes
-
-type         | 
--------------|------
-description  | The [`sensuctl create`][8] resource type for the [pipeline][44]. Sensu automatically populates the pipelines type field when the event is created or updated. Pipeline resources are always type `Pipeline`.
-required     | false
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -2544,55 +2527,128 @@ name: is_incident
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-|timestamp   |      |
+type         | 
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
-required     | false
-type         | Integer
-default      | Time that the event occurred
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timestamp: 1522099512
-{{< /code >}}
-{{< code json >}}
-{
-  "timestamp": 1522099512
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-id           |      |
--------------|------
-description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+description  | The [`sensuctl create`][8] resource type for the [pipeline][44]. Sensu automatically populates the pipelines type field when the event is created or updated. Pipeline resources are always type `Pipeline`.
 required     | false
 type         | String
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-id: 431a0085-96da-4521-863f-c38b480701e9
+type: Pipeline
 {{< /code >}}
 {{< code json >}}
 {
-  "id": "431a0085-96da-4521-863f-c38b480701e9"
+ "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="sequence-attribute"></a>
+### Spec attributes
 
-sequence     |      |
+<a id="check-attribute"></a>
+
+|check       |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
-required     | false
-type         | Integer
+description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
+type         | Map
+required     | true
 example      | {{< language-toggle >}}
 {{< code yml >}}
-sequence: 1
+check:
+  check_hooks:
+  command: metrics-curl -u "http://localhost"
+  duration: 0.060790838
+  env_vars:
+  executed: 1552506033
+  handlers: []
+  high_flap_threshold: 0
+  history:
+  - executed: 1552505833
+    status: 0
+  - executed: 1552505843
+    status: 0
+  interval: 10
+  is_silenced: true
+  processed_by: sensu-go-sandbox
+  issued: 1552506033
+  last_ok: 1552506033
+  low_flap_threshold: 0
+  metadata:
+    name: curl_timings
+    namespace: default
+  occurrences: 1
+  occurrences_watermark: 1
+  silenced:
+  - webserver:*
+  output: sensu-go.curl_timings.time_total 0.005
+  output_metric_format: graphite_plaintext
+  proxy_entity_name: ''
+  publish: true
+  round_robin: false
+  runtime_assets: []
+  state: passing
+  status: 0
+  stdin: false
+  subdue:
+  subscriptions:
+  - entity:sensu-go-testing
+  timeout: 0
+  total_state_change: 0
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
-  "sequence": 1
+  "check": {
+    "check_hooks": null,
+    "command": "metrics-curl -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "history": [
+      {
+        "executed": 1552505833,
+        "status": 0
+      },
+      {
+        "executed": 1552505843,
+        "status": 0
+      }
+    ],
+    "interval": 10,
+    "is_silenced": true,
+    "processed_by": "sensu-go-sandbox",
+    "issued": 1552506033,
+    "last_ok": 1552506033,
+    "low_flap_threshold": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
+    "occurrences": 1,
+    "occurrences_watermark": 1,
+    "silenced": [
+      "webserver:*"
+    ],
+    "output": "sensu-go.curl_timings.time_total 0.005",
+    "output_metric_format": "graphite_plaintext",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "entity:sensu-go-testing"
+    ],
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2703,109 +2759,18 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="checks-attribute"></a>
-
-|check       |      |
+id           |      |
 -------------|------
-description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
-type         | Map
-required     | true
+description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+required     | false
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-check:
-  check_hooks:
-  command: metrics-curl -u "http://localhost"
-  duration: 0.060790838
-  env_vars:
-  executed: 1552506033
-  handlers: []
-  high_flap_threshold: 0
-  history:
-  - executed: 1552505833
-    status: 0
-  - executed: 1552505843
-    status: 0
-  interval: 10
-  is_silenced: true
-  processed_by: sensu-go-sandbox
-  issued: 1552506033
-  last_ok: 1552506033
-  low_flap_threshold: 0
-  metadata:
-    name: curl_timings
-    namespace: default
-  occurrences: 1
-  occurrences_watermark: 1
-  silenced:
-  - webserver:*
-  output: sensu-go.curl_timings.time_total 0.005
-  output_metric_format: graphite_plaintext
-  proxy_entity_name: ''
-  publish: true
-  round_robin: false
-  runtime_assets: []
-  state: passing
-  status: 0
-  stdin: false
-  subdue:
-  subscriptions:
-  - entity:sensu-go-testing
-  timeout: 0
-  total_state_change: 0
-  ttl: 0
+id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /code >}}
 {{< code json >}}
 {
-  "check": {
-    "check_hooks": null,
-    "command": "metrics-curl -u \"http://localhost\"",
-    "duration": 0.060790838,
-    "env_vars": null,
-    "executed": 1552506033,
-    "handlers": [],
-    "high_flap_threshold": 0,
-    "history": [
-      {
-        "executed": 1552505833,
-        "status": 0
-      },
-      {
-        "executed": 1552505843,
-        "status": 0
-      }
-    ],
-    "interval": 10,
-    "is_silenced": true,
-    "processed_by": "sensu-go-sandbox",
-    "issued": 1552506033,
-    "last_ok": 1552506033,
-    "low_flap_threshold": 0,
-    "metadata": {
-      "name": "curl_timings",
-      "namespace": "default"
-    },
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "silenced": [
-      "webserver:*"
-    ],
-    "output": "sensu-go.curl_timings.time_total 0.005",
-    "output_metric_format": "graphite_plaintext",
-    "proxy_entity_name": "",
-    "publish": true,
-    "round_robin": false,
-    "runtime_assets": [],
-    "state": "passing",
-    "status": 0,
-    "stdin": false,
-    "subdue": null,
-    "subscriptions": [
-      "entity:sensu-go-testing"
-    ],
-    "timeout": 0,
-    "total_state_change": 0,
-    "ttl": 0
-  }
+  "id": "431a0085-96da-4521-863f-c38b480701e9"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2848,6 +2813,41 @@ metrics:
       }
     ]
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="sequence-attribute"></a>
+
+sequence     |      |
+-------------|------
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+sequence: 1
+{{< /code >}}
+{{< code json >}}
+{
+  "sequence": 1
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
+required     | false
+type         | Integer
+default      | Time that the event occurred
+example      | {{< language-toggle >}}
+{{< code yml >}}
+timestamp: 1522099512
+{{< /code >}}
+{{< code json >}}
+{
+  "timestamp": 1522099512
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2917,6 +2917,22 @@ history:
 {{< /code >}}
 {{< /language-toggle >}}
 
+is_silenced  | |
+-------------|------
+description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+is_silenced: true
+{{< /code >}}
+{{< code json >}}
+{
+  "is_silenced": "true"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 issued       |      |
 -------------|------
 description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
@@ -2981,43 +2997,6 @@ occurrences_watermark: 1
 {{< /code >}}
 {{< /language-toggle >}}
 
-is_silenced  | |
--------------|------
-description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-is_silenced: true
-{{< /code >}}
-{{< code json >}}
-{
-  "is_silenced": "true"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-<a id="silenced-attribute"></a>
-
-silenced     | |
--------------|------
-description  | Array of silencing entries that match the event. The `silenced` attribute is only present for events if one or more silencing entries matched the event at time of processing. If the `silenced` attribute is not present in an event, the event was not silenced at the time of processing.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-silenced:
-- webserver:*
-{{< /code >}}
-{{< code json >}}
-{
-  "silenced": [
-    "webserver:*"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 output       |      |
 -------------|------
 description  | Output from the execution of the check command.
@@ -3052,6 +3031,27 @@ processed_by: sensu-go-sandbox
 {{< /code >}}
 {{< /language-toggle >}}
 
+<a id="silenced-attribute"></a>
+
+silenced     | |
+-------------|------
+description  | Array of silencing entries that match the event. The `silenced` attribute is only present for events if one or more silencing entries matched the event at time of processing. If the `silenced` attribute is not present in an event, the event was not silenced at the time of processing.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+silenced:
+- webserver:*
+{{< /code >}}
+{{< code json >}}
+{
+  "silenced": [
+    "webserver:*"
+  ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 state         |      |
 -------------|------
 description  | State of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`. Use the `low_flap_threshold` and `high_flap_threshold` [check attributes][33] to configure `flapping` state detection.<br><br>Sensu automatically populates the `state` based on the `status`.
@@ -3067,6 +3067,8 @@ state: passing
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+<a id="check-status-attribute"></a>
 
 status       |      |
 -------------|------

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -570,27 +570,11 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [core/v2/events API]][43].
+The events in the returned array use the same format as responses for the [core/v2/events API][43].
 
 ## Event filter specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
-required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: EventFilter
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "EventFilter"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -667,37 +651,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: filter-weekdays-only
+type: EventFilter
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "filter-weekdays-only"
+  "type": "EventFilter"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -740,24 +729,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: filter-weekdays-only
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "filter-weekdays-only"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -291,22 +291,6 @@ If you do not specify a keepalive handler with the `keepalive-handlers` flag, th
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
-required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Handler
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Handler"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For handlers in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -389,37 +373,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: handler-slack
+type: Handler
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "handler-slack"
+  "type": "Handler"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the handler belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -462,108 +451,40 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: handler-slack
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "handler-slack"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the handler belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
-
-type         | 
--------------|------
-description  | Handler type.
-required     | true
-type         | String
-allowed values | `pipe`, `tcp`, `udp`, and `set`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: pipe
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "pipe"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-filters      | 
--------------|------
-description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.{{% notice note %}}
-**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list event filters directly in the pipeline resource definition instead of in handlers.<br><br>
-Pipelines ignore any event filters specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the event filters you want to use in the pipeline workflow.
-{{% /notice %}}
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-filters:
-- is_incident
-- not_silenced
-- state_change_only
-{{< /code >}}
-{{< code json >}}
-{
-  "filters": [
-    "is_incident",
-    "not_silenced",
-    "state_change_only"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mutator      | 
--------------|------
-description  | Name of the Sensu event mutator to use to mutate event data for the handler.{{% notice note %}}
-**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list mutators directly in the pipeline resource definition instead of in handlers.<br><br>
-Pipelines ignore any mutators specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the mutator you want to use in the pipeline workflow.
-{{% /notice %}}
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator: only_check_output
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": "only_check_output"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout     | 
-------------|------
-description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
-required    | false
-type        | Integer
-default     | `60` (for `tcp` and `udp` handlers)
-example     | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 command      | 
 -------------|------
@@ -604,20 +525,28 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-socket       | 
+filters      | 
 -------------|------
-description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
-**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.{{% notice note %}}
+**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list event filters directly in the pipeline resource definition instead of in handlers.<br><br>
+Pipelines ignore any event filters specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the event filters you want to use in the pipeline workflow.
 {{% /notice %}}
-required     | true (if `type` equals `tcp` or `udp`)
-type         | Hash
+required     | false
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-socket: {}
+filters:
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
-  "socket": {}
+  "filters": [
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -644,6 +573,25 @@ handlers:
     "email",
     "ec2"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+mutator      | 
+-------------|------
+description  | Name of the Sensu event mutator to use to mutate event data for the handler.{{% notice note %}}
+**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list mutators directly in the pipeline resource definition instead of in handlers.<br><br>
+Pipelines ignore any mutators specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the mutator you want to use in the pipeline workflow.
+{{% /notice %}}
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator: only_check_output
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": "only_check_output"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -692,6 +640,58 @@ secrets:
       "secret": "sensu-ansible-token"
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+socket       | 
+-------------|------
+description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
+**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+{{% /notice %}}
+required     | true (if `type` equals `tcp` or `udp`)
+type         | Hash
+example      | {{< language-toggle >}}
+{{< code yml >}}
+socket: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "socket": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+timeout     | 
+------------|------
+description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
+required    | false
+type        | Integer
+default     | `60` (for `tcp` and `udp` handlers)
+example     | {{< language-toggle >}}
+{{< code yml >}}
+timeout: 30
+{{< /code >}}
+{{< code json >}}
+{
+  "timeout": 30
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | Handler type.
+required     | true
+type         | String
+allowed values | `pipe`, `tcp`, `udp`, and `set`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: pipe
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "pipe"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
@@ -308,22 +308,6 @@ Read [Route alerts with event filters][30] for another pipeline example that inc
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Pipelines should always be type `Pipeline`.
-required     | Required for pipeline definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For pipelines in this version of Sensu, the api_version should always be `core/v2`.
@@ -442,37 +426,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the pipeline. Pipeline names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each pipeline must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Pipelines should always be type `Pipeline`.
+required     | Required for pipeline definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: incident_alerts
+type: Pipeline
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "incident_alerts"
+  "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the pipeline belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: default
+annotations:
+  managed-by: ops
+  slack-channel: "#incidents"
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "default"
+  "annotations": {
+    "managed-by": "ops",
+    "slack-channel": "#incidents"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -515,24 +504,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the pipeline. Pipeline names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each pipeline must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  slack-channel: "#incidents"
+name: incident_alerts
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "slack-channel": "#incidents"
-  }
+  "name": "incident_alerts"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the pipeline belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -649,30 +649,6 @@ filters:
 {{< /code >}}
 {{< /language-toggle >}}
 
-mutator      | 
--------------|------
-description  | Reference for the Sensu mutator to use to mutate event data for the workflow. Each pipeline workflow can reference only one mutator. Read [mutator attributes][9] for details.
-required     | false
-type         | Map of key-value pairs
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator:
-  name: add_labels
-  type: Mutator
-  api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": {
-    "name": "add_labels",
-    "type": "Mutator",
-    "api_version": "core/v2"
-  }
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="handler-pipeline"></a>
 
 handler      | 
@@ -698,7 +674,48 @@ handler:
 {{< /code >}}
 {{< /language-toggle >}}
 
+mutator      | 
+-------------|------
+description  | Reference for the Sensu mutator to use to mutate event data for the workflow. Each pipeline workflow can reference only one mutator. Read [mutator attributes][9] for details.
+required     | false
+type         | Map of key-value pairs
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator:
+  name: add_labels
+  type: Mutator
+  api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": {
+    "name": "add_labels",
+    "type": "Mutator",
+    "api_version": "core/v2"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 #### Filters attributes
+
+api_version  | 
+-------------|------
+description  | The Sensu API group and version for the event filter. For event filters in this version of Sensu, the api_version should always be `core/v2`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------
@@ -734,77 +751,25 @@ type: EventFilter
 {{< /code >}}
 {{< /language-toggle >}}
 
-api_version  | 
--------------|------
-description  | The Sensu API group and version for the event filter. For event filters in this version of Sensu, the api_version should always be `core/v2`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "api_version": "core/v2"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-#### Mutator attributes
-
-name         | 
--------------|------
-description  | Name of the Sensu [mutator][14] to use for the workflow. You can use your existing mutators in pipeline workflows.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: add_labels
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "add_labels"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-type         | 
--------------|------
-description  | The [`sensuctl create`][4] resource type for the mutator. Mutators should always be type `Mutator`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-api_version  | 
--------------|------
-description  | The Sensu API group and version for the mutator. For mutators in this version of Sensu, the api_version should always be `core/v2`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "api_version": "core/v2"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 #### Handler attributes
+
+api_version  | 
+-------------|------
+description  | The Sensu API group and version for the handler.
+required     | true
+type         | String
+allowed values | `core/v2` for a [pipe handler][15], [TCP or UDP handler][16], or [handler set][1]<br><br>`pipeline/v1` for a [TCP stream handler][20] or [Sumo Logic metrics handler][21]
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------
@@ -841,12 +806,13 @@ type: Handler
 {{< /code >}}
 {{< /language-toggle >}}
 
+#### Mutator attributes
+
 api_version  | 
 -------------|------
-description  | The Sensu API group and version for the handler.
+description  | The Sensu API group and version for the mutator. For mutators in this version of Sensu, the api_version should always be `core/v2`.
 required     | true
 type         | String
-allowed values | `core/v2` for a [pipe handler][15], [TCP or UDP handler][16], or [handler set][1]<br><br>`pipeline/v1` for a [TCP stream handler][20] or [Sumo Logic metrics handler][21]
 default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
@@ -855,6 +821,40 @@ api_version: core/v2
 {{< code json >}}
 {
   "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------
+description  | Name of the Sensu [mutator][14] to use for the workflow. You can use your existing mutators in pipeline workflows.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: add_labels
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "add_labels"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | The [`sensuctl create`][4] resource type for the mutator. Mutators should always be type `Mutator`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Mutator
+{{< /code >}}
+{{< code json >}}
+{
+ "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -1322,7 +1322,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1363,7 +1363,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/hooks.md
@@ -155,22 +155,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
-required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: HookConfig
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "HookConfig"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For hooks in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -243,37 +227,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: process_tree
+type: HookConfig
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "process_tree"
+  "type": "HookConfig"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -316,24 +305,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: process_tree
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "process_tree"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -356,19 +356,21 @@ command: sudo /etc/init.d/nginx start
 {{< /code >}}
 {{< /language-toggle >}}
 
-timeout      | 
+|runtime_assets |   |
 -------------|------
-description  | Hook execution duration timeout (hard stop). In seconds.
+description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
 required     | false
-type         | Integer
-default      | 60
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-timeout: 30
+runtime_assets:
+- log-context
 {{< /code >}}
 {{< code json >}}
 {
-  "timeout": 30
+  "runtime_assets": [
+    "log-context"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -390,21 +392,19 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-|runtime_assets |   |
+timeout      | 
 -------------|------
-description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
+description  | Hook execution duration timeout (hard stop). In seconds.
 required     | false
-type         | Array
+type         | Integer
+default      | 60
 example      | {{< language-toggle >}}
 {{< code yml >}}
-runtime_assets:
-- log-context
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "runtime_assets": [
-    "log-context"
-  ]
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/rule-templates.md
@@ -201,22 +201,6 @@ Sensu evaluates each rule separately, and each rule produces its own event as ou
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
-required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: RuleTemplate
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "RuleTemplate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For rule template configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -499,39 +483,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
+required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: RuleTemplate
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RuleTemplate"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the rule template that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: aggregate
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "aggregate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -589,23 +557,39 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-description  | 
--------------|------ 
-description  | Plain text description of the rule template's behavior.
+name         |      |
+-------------|------
+description  | Name for the rule template that is used internally by Sensu.
 required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+name: aggregate
 {{< /code >}}
 {{< code json >}}
 {
-  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
+  "name": "aggregate"
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
 
 arguments    | 
 -------------|------ 
@@ -693,6 +677,22 @@ arguments:
     },
     "required": null
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+description  | 
+-------------|------ 
+description  | Plain text description of the rule template's behavior.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+{{< /code >}}
+{{< code json >}}
+{
+  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -848,22 +848,6 @@ eval: |2
 
 #### Arguments attributes
 
-required     | 
--------------|------ 
-description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-required: null
-{{< /code >}}
-{{< code json >}}
-{
-  "required": null
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="rule-properties"></a>
 
 properties   | 
@@ -944,6 +928,22 @@ properties:
       "type": "number"
     }
   },
+  "required": null
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+required     | 
+-------------|------ 
+description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+required: null
+{{< /code >}}
+{{< code json >}}
+{
   "required": null
 }
 {{< /code >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/service-components.md
@@ -109,22 +109,6 @@ The rules can emit new events based on the component input.
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
-required     | Required for service component configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: ServiceComponent
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "ServiceComponent"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For service component configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -228,39 +212,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
+required     | Required for service component configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: ServiceComponent
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ServiceComponent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the service component that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: webservers
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "webservers"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -314,6 +282,38 @@ labels:
   "labels": {
     "region": "us-west-1"
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         |      |
+-------------|------
+description  | Name for the service component that is used internally by Sensu.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: webservers
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "webservers"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-transform/mutators.md
@@ -268,22 +268,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
-required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For mutators in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -362,37 +346,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-mutator
+type: Mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-mutator"
+  "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -435,24 +424,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-mutator"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -473,24 +473,6 @@ command: /etc/sensu/plugins/mutated.go
 {{< code json >}}
 {
   "command": "/etc/sensu/plugins/mutated.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout      | 
--------------|------ 
-description  | Mutator execution duration timeout (hard stop). In seconds.{{% notice warning %}}
-**WARNING**: The timeout attribute is available for [JavaScript mutators](#javascript-mutators) but may not work properly if the mutator is in a loop.
-{{% /notice %}}
-required     | false 
-type         | integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -526,6 +508,26 @@ env_vars:
     "APP_VERSION=2.5.0",
     "SHELL"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="eval-attribute"></a>
+
+eval         | 
+-------------|------ 
+description  | ECMAScript 5 (JavaScript) expression to be executed by the Sensu backend.{{% notice note %}}
+**NOTE**: Pipe mutators require the [command attribute](#spec-attributes) instead of the eval attribute.
+{{% /notice %}}
+required     | true, for [JavaScript mutators][18]
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+eval: 'return JSON.stringify({"some stuff": "is here"});'
+{{< /code >}}
+{{< code json >}}
+{
+  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -578,22 +580,20 @@ secrets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="eval-attribute"></a>
-
-eval         | 
+timeout      | 
 -------------|------ 
-description  | ECMAScript 5 (JavaScript) expression to be executed by the Sensu backend.{{% notice note %}}
-**NOTE**: Pipe mutators require the [command attribute](#spec-attributes) instead of the eval attribute.
+description  | Mutator execution duration timeout (hard stop). In seconds.{{% notice warning %}}
+**WARNING**: The timeout attribute is available for [JavaScript mutators](#javascript-mutators) but may not work properly if the mutator is in a loop.
 {{% /notice %}}
-required     | true, for [JavaScript mutators][18]
-type         | String
+required     | false 
+type         | integer 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-eval: 'return JSON.stringify({"some stuff": "is here"});'
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/api/core/events.md
+++ b/content/sensu-go/6.7/api/core/events.md
@@ -2105,7 +2105,7 @@ output         | {{< code shell >}}
 [5]: #eventsentitycheck-put-parameters
 [6]: ../../../observability-pipeline/observe-entities/entities#entities-specification
 [7]: ../../../observability-pipeline/observe-schedule/checks#check-specification
-[8]: ../../../observability-pipeline/observe-events/events/#events-specification
+[8]: ../../../observability-pipeline/observe-events/events/#event-specification
 [9]: ../../../observability-pipeline/observe-events/events#metrics-attribute
 [10]: ../../#response-filtering
 [11]: #eventsentitycheck-put

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
@@ -746,22 +746,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
-required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Entity
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Entity"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For entities in this version of Sensu, this attribute should always be `core/v2`.
@@ -975,37 +959,46 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][12] resource type. Entities should always be type `Entity`.
+required     | Required for entity definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][12].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-hostname
+type: Entity
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-hostname"
+  "type": "Entity"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+<a id="annotations-attribute"></a>
+
+| annotations |     |
 -------------|------
-description  | [Sensu RBAC namespace][5] that this entity belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
+**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
+{{% /notice %}}
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1050,33 +1043,75 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="annotations-attribute"></a>
-
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][6]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][14], [sensuctl response filtering][15], or [web UI views][30].{{% notice note %}}
-**NOTE**: For annotations defined in agent.yml or backend.yml, the keys are automatically modified to use all lower-case letters. For example, if you define the annotation `webhookURL: "https://my-webhook.com"` in agent.yml or backend.yml, it will be listed as `webhookurl: "https://my-webhook.com"` in entity definitions.<br><br>Key cases are **not** modified for annotations you define with a command line flag or an environment variable.
-{{% /notice %}}
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique name of the entity, validated with Go regex [`\A[\w\.\-]+\z`][21].
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-hostname
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-hostname"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | [Sensu RBAC namespace][5] that this entity belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
+
+deregister   | 
+-------------|------ 
+description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
+required     | false 
+type         | Boolean 
+default      | `false`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregister: false
+{{< /code >}}
+{{< code json >}}
+{
+  "deregister": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+deregistration  | 
+-------------|------ 
+description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+deregistration:
+  handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "deregistration": {
+    "handler": "email-handler"
+  }
+}{{< /code >}}
+{{< /language-toggle >}}
 
 entity_class |     |
 -------------|------ 
@@ -1090,6 +1125,57 @@ entity_class: agent
 {{< code json >}}
 {
   "entity_class": "agent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+last_seen    | 
+-------------|------ 
+description  | Time at which the entity was last seen. In seconds since the Unix epoch.
+required     | false 
+type         | Integer 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+last_seen: 1522798317
+{{< /code >}}
+{{< code json >}}
+{
+  "last_seen": 1522798317
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+redact       | 
+-------------|------ 
+description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
+required     | false 
+type         | Array 
+default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
+example      | {{< language-toggle >}}
+{{< code yml >}}
+redact:
+- extra_secret_tokens
+{{< /code >}}
+{{< code json >}}
+{
+  "redact": [
+    "extra_secret_tokens"
+  ]
+}{{< /code >}}
+{{< /language-toggle >}}
+
+sensu_agent_version  | 
+---------------------|------
+description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
+required             | true
+type                 | String
+example              | {{< language-toggle >}}
+{{< code yml >}}
+sensu_agent_version: 1.0.0
+{{< /code >}}
+{{< code json >}}
+{
+  "sensu_agent_version": "1.0.0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1229,92 +1315,6 @@ system:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-sensu_agent_version  | 
----------------------|------
-description          | Sensu Semantic Versioning (SemVer) version of the agent entity.
-required             | true
-type                 | String
-example              | {{< language-toggle >}}
-{{< code yml >}}
-sensu_agent_version: 1.0.0
-{{< /code >}}
-{{< code json >}}
-{
-  "sensu_agent_version": "1.0.0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-last_seen    | 
--------------|------ 
-description  | Time at which the entity was last seen. In seconds since the Unix epoch.
-required     | false 
-type         | Integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-last_seen: 1522798317
-{{< /code >}}
-{{< code json >}}
-{
-  "last_seen": 1522798317
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregister   | 
--------------|------ 
-description  | If the entity should be removed when it stops sending keepalive messages, `true`. Otherwise, `false`.
-required     | false 
-type         | Boolean 
-default      | `false`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregister: false
-{{< /code >}}
-{{< code json >}}
-{
-  "deregister": false
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-deregistration  | 
--------------|------ 
-description  | Map that contains a handler name to use when an agent entity is deregistered. Read [deregistration attributes][2] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-deregistration:
-  handler: email-handler
-{{< /code >}}
-{{< code json >}}
-{
-  "deregistration": {
-    "handler": "email-handler"
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-redact       | 
--------------|------ 
-description  | List of items to redact from log messages. If a value is provided, it overwrites the default list of items to be redacted.
-required     | false 
-type         | Array 
-default      | ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret"]
-example      | {{< language-toggle >}}
-{{< code yml >}}
-redact:
-- extra_secret_tokens
-{{< /code >}}
-{{< code json >}}
-{
-  "redact": [
-    "extra_secret_tokens"
-  ]
-}{{< /code >}}
-{{< /language-toggle >}}
-
 | user |      |
 --------------|------
 description   | [Sensu RBAC username][22] used by the entity. Agent entities require get, list, create, update, and delete permissions for events across all namespaces.
@@ -1331,7 +1331,59 @@ user: agent
 {{< /code >}}
 {{< /language-toggle >}}
 
+### Deregistration attributes
+
+handler      | 
+-------------|------ 
+description  | Name of the handler to call when an agent entity is deregistered.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+handler: email-handler
+{{< /code >}}
+{{< code json >}}
+{
+  "handler": "email-handler"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### System attributes
+
+arch         | 
+-------------|------ 
+description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+arch: amd64
+{{< /code >}}
+{{< code json >}}
+{
+  "arch": "amd64"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cloud_provider | 
+---------------|------ 
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
+{{% /notice %}}
+required       | false 
+type           | String 
+example        | {{< language-toggle >}}
+{{< code yml >}}
+"cloud_provider": ""
+{{< /code >}}
+{{< code json >}}
+{
+  "cloud_provider": ""
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 hostname     | 
 -------------|------ 
@@ -1347,6 +1399,65 @@ hostname: example-hostname
   "hostname": "example-hostname"
 }
 {{< /code >}}
+{{< /language-toggle >}}
+
+libc_type    | 
+-------------|------ 
+description  | Entity's libc type. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+libc_type: glibc
+{{< /code >}}
+{{< code json >}}
+{
+  "libc_type": "glibc"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+network     | 
+-------------|------ 
+description  | Entity's network interface list. Read [network attributes][3] for more information.
+required     | false
+type         | Map
+example      | {{< language-toggle >}}
+{{< code yml >}}
+network:
+  interfaces:
+  - addresses:
+    - 127.0.0.1/8
+    - ::1/128
+    name: lo
+  - addresses:
+    - 93.184.216.34/24
+    - 2606:2800:220:1:248:1893:25c8:1946/10
+    mac: 52:54:00:20:1b:3c
+    name: eth0
+{{< /code >}}
+{{< code json >}}
+{
+  "network": {
+    "interfaces": [
+      {
+        "name": "lo",
+        "addresses": [
+          "127.0.0.1/8",
+          "::1/128"
+        ]
+      },
+      {
+        "name": "eth0",
+        "mac": "52:54:00:20:1b:3c",
+        "addresses": [
+          "93.184.216.34/24",
+          "2606:2800:220:1:248:1893:25c8:1946/10"
+        ]
+      }
+    ]
+  }
+}{{< /code >}}
 {{< /language-toggle >}}
 
 os           | 
@@ -1413,131 +1524,6 @@ platform_version: 16.04
 {{< /code >}}
 {{< /language-toggle >}}
 
-network     | 
--------------|------ 
-description  | Entity's network interface list. Read [network attributes][3] for more information.
-required     | false
-type         | Map
-example      | {{< language-toggle >}}
-{{< code yml >}}
-network:
-  interfaces:
-  - addresses:
-    - 127.0.0.1/8
-    - ::1/128
-    name: lo
-  - addresses:
-    - 93.184.216.34/24
-    - 2606:2800:220:1:248:1893:25c8:1946/10
-    mac: 52:54:00:20:1b:3c
-    name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "network": {
-    "interfaces": [
-      {
-        "name": "lo",
-        "addresses": [
-          "127.0.0.1/8",
-          "::1/128"
-        ]
-      },
-      {
-        "name": "eth0",
-        "mac": "52:54:00:20:1b:3c",
-        "addresses": [
-          "93.184.216.34/24",
-          "2606:2800:220:1:248:1893:25c8:1946/10"
-        ]
-      }
-    ]
-  }
-}{{< /code >}}
-{{< /language-toggle >}}
-
-arch         | 
--------------|------ 
-description  | Entity's system architecture. This value is determined by the Go binary architecture as a function of runtime.GOARCH. An `amd` system running a `386` binary will report the `arch` as `386`.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-arch: amd64
-{{< /code >}}
-{{< code json >}}
-{
-  "arch": "amd64"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-libc_type    | 
--------------|------ 
-description  | Entity's libc type. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-libc_type: glibc
-{{< /code >}}
-{{< code json >}}
-{
-  "libc_type": "glibc"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_system    | 
--------------|------ 
-description  | Entity's virtual machine system. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_system: kvm
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_system": "kvm"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-vm_role      | 
--------------|------ 
-description  | Entity's virtual machine role. Automatically populated upon agent startup.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-vm_role: host
-{{< /code >}}
-{{< code json >}}
-{
-  "vm_role": "host"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cloud_provider | 
----------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
-**NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
-{{% /notice %}}
-required       | false 
-type           | String 
-example        | {{< language-toggle >}}
-{{< code yml >}}
-"cloud_provider": ""
-{{< /code >}}
-{{< code json >}}
-{
-  "cloud_provider": ""
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 processes    | 
 -------------|------ 
 description  | List of processes on the local agent. Read [processes attributes][26] for more information.{{% notice note %}}
@@ -1596,13 +1582,45 @@ processes:
 }{{< /code >}}
 {{< /language-toggle >}}
 
+vm_role      | 
+-------------|------ 
+description  | Entity's virtual machine role. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_role: host
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_role": "host"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+vm_system    | 
+-------------|------ 
+description  | Entity's virtual machine system. Automatically populated upon agent startup.
+required     | false 
+type         | String 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+vm_system: kvm
+{{< /code >}}
+{{< code json >}}
+{
+  "vm_system": "kvm"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Network attributes
 
-network_interface         | 
+interfaces   | 
 -------------|------ 
-description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. 
+description  | List of network interfaces available on the entity, with their associated MAC and IP addresses. Read [interfaces attributes][4] for more information.
 required     | false 
-type         | Array [NetworkInterface][4] 
+type         | Array 
 example      | {{< language-toggle >}}
 {{< code yml >}}
 interfaces:
@@ -1638,39 +1656,7 @@ interfaces:
 }{{< /code >}}
 {{< /language-toggle >}}
 
-### NetworkInterface attributes
-
-name         | 
--------------|------ 
-description  | Network interface name.
-required     | false 
-type         | String 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: eth0
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "eth0"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mac          | 
--------------|------ 
-description  | Network interface's MAC address.
-required     | false 
-type         | string 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mac: 52:54:00:20:1b:3c
-{{< /code >}}
-{{< code json >}}
-{
-  "mac": "52:54:00:20:1b:3c"
-}
-{{< /code >}}
-{{< /language-toggle >}}
+### Interfaces attributes
 
 addresses    | 
 -------------|------ 
@@ -1693,20 +1679,34 @@ addresses:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Deregistration attributes
-
-handler      | 
+mac          | 
 -------------|------ 
-description  | Name of the handler to call when an agent entity is deregistered.
+description  | Network interface's MAC address.
+required     | false 
+type         | string 
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mac: 52:54:00:20:1b:3c
+{{< /code >}}
+{{< code json >}}
+{
+  "mac": "52:54:00:20:1b:3c"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------ 
+description  | Network interface name.
 required     | false 
 type         | String 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-handler: email-handler
+name: eth0
 {{< /code >}}
 {{< code json >}}
 {
-  "handler": "email-handler"
+  "name": "eth0"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1723,6 +1723,76 @@ For more information, read [Get started with commercial features](../../../comme
 New events will not include data in the `processes` attributes.
 Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+background   | 
+-------------|------ 
+description  | If `true`, the process is a background process. Otherwise, `false`.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+background: true
+{{< /code >}}
+{{< code json >}}
+{
+  "background": true
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+cpu_percent  | 
+-------------|------ 
+description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
+**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+cpu_percent: 0.12639
+{{< /code >}}
+{{< code json >}}
+{
+  "cpu_percent": 0.12639
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+created      | 
+-------------|------ 
+description  | Time at which the process was created. In seconds since the Unix epoch.
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created: 1586138786
+{{< /code >}}
+{{< code json >}}
+{
+  "created": 1586138786
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+memory_percent | 
+-------------|------ 
+description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
+**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
+It is not supported on Windows.
+{{% /notice %}}
+required     | false
+type         | float
+example      | {{< language-toggle >}}
+{{< code yml >}}
+memory_percent: 0.19932
+{{< /code >}}
+{{< code json >}}
+{
+  "memory_percent": 0.19932
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------ 
@@ -1772,38 +1842,6 @@ ppid: 0
 {{< /code >}}
 {{< /language-toggle >}}
 
-status       | 
--------------|------ 
-description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-status: Ss
-{{< /code >}}
-{{< code json >}}
-{
-  "status": "Ss"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-background   | 
--------------|------ 
-description  | If `true`, the process is a background process. Otherwise, `false`.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-background: true
-{{< /code >}}
-{{< code json >}}
-{
-  "background": true
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 running      | 
 -------------|------ 
 description  | If `true`, the process is running. Otherwise, `false`.
@@ -1820,56 +1858,18 @@ running: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-created      | 
+status       | 
 -------------|------ 
-description  | Time at which the process was created. In seconds since the Unix epoch.
+description  | Status of the process. Read the [Linux `top` manual page][28] for examples.
 required     | false
-type         | Integer
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-created: 1586138786
+status: Ss
 {{< /code >}}
 {{< code json >}}
 {
-  "created": 1586138786
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-memory_percent | 
--------------|------ 
-description  | Percent of memory the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the memory_percent value 0.19932 equals 19.932%. {{% notice note %}}
-**NOTE**: The `memory_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-memory_percent: 0.19932
-{{< /code >}}
-{{< code json >}}
-{
-  "memory_percent": 0.19932
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-cpu_percent  | 
--------------|------ 
-description  | Percent of CPU the process is using. The value is returned as a floating-point number where 0.0 = 0% and 1.0 = 100%. For example, the cpu_percent value 0.12639 equals 12.639%. {{% notice note %}}
-**NOTE**: The `cpu_percent` attribute is supported on Linux and macOS.
-It is not supported on Windows.
-{{% /notice %}}
-required     | false
-type         | float
-example      | {{< language-toggle >}}
-{{< code yml >}}
-cpu_percent: 0.12639
-{{< /code >}}
-{{< code json >}}
-{
-  "cpu_percent": 0.12639
+  "status": "Ss"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -1878,7 +1878,7 @@ cpu_percent: 0.12639
 [1]: #system-attributes
 [2]: #deregistration-attributes
 [3]: #network-attributes
-[4]: #networkinterface-attributes
+[4]: #interfaces-attributes
 [5]: ../../../operations/control-access/namespaces/
 [6]: ../../observe-filter/filters/
 [7]: ../../observe-schedule/tokens/

--- a/content/sensu-go/6.7/observability-pipeline/observe-events/events.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-events/events.md
@@ -2118,7 +2118,7 @@ The `state` event attribute adds meaning to the check status:
 
 - `passing` means the check status is `0` (OK).
 - `failing` means the check status is non-zero (WARNING or CRITICAL).
-- `flapping` indicates an unsteady state in which the check result status (determined based on per-check [high flap threshold][37] and [low flap threshold][47] attributes is not settling on `passing` or `failing` according to the [flap detection algorithm][39].
+- `flapping` indicates an unsteady state in which the check result status (determined based on per-check [high flap threshold][37] and [low flap threshold][47] attributes) is not settling on `passing` or `failing` according to the [flap detection algorithm][39].
 
 Flapping typically indicates intermittent problems with an entity, provided your low and high flap threshold settings are properly configured.
 Although some teams choose to filter out flapping events to reduce unactionable alerts, we suggest sending flapping events to a designated handler for later review.
@@ -2167,25 +2167,9 @@ The following table shows the occurrences attributes for a series of example eve
 |10. OK event       | `occurrences: 1`| `occurrences_watermark: 4`
 |11. CRITICAL event | `occurrences: 1`| `occurrences_watermark: 1`
 
-## Events specification
+## Event specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
-required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Event
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Event"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -2497,7 +2481,39 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the [`sensuctl create`][8] resource type. Events should always be type `Event`.
+required     | Required for events in `wrapped-json` or `yaml` format for use with [`sensuctl create`][8].
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Event
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "Event"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
+
+| created_by |      |
+-------------|------
+description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+created_by: "admin"
+{{< /code >}}
+{{< code json >}}
+{
+  "created_by": "admin"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 | namespace  |      |
 -------------|------
@@ -2516,40 +2532,7 @@ namespace: production
 {{< /code >}}
 {{< /language-toggle >}}
 
-| created_by |      |
--------------|------
-description  | Username of the Sensu user who created the event or last updated the event. Sensu automatically populates the `created_by` field when the event is created or updated.
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-created_by: "admin"
-{{< /code >}}
-{{< code json >}}
-{
-  "created_by": "admin"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 ### Pipelines attributes
-
-type         | 
--------------|------
-description  | The [`sensuctl create`][8] resource type for the [pipeline][44]. Sensu automatically populates the pipelines type field when the event is created or updated. Pipeline resources are always type `Pipeline`.
-required     | false
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -2585,55 +2568,128 @@ name: is_incident
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-|timestamp   |      |
+type         | 
 -------------|------
-description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
-required     | false
-type         | Integer
-default      | Time that the event occurred
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timestamp: 1522099512
-{{< /code >}}
-{{< code json >}}
-{
-  "timestamp": 1522099512
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-id           |      |
--------------|------
-description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+description  | The [`sensuctl create`][8] resource type for the [pipeline][44]. Sensu automatically populates the pipelines type field when the event is created or updated. Pipeline resources are always type `Pipeline`.
 required     | false
 type         | String
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-id: 431a0085-96da-4521-863f-c38b480701e9
+type: Pipeline
 {{< /code >}}
 {{< code json >}}
 {
-  "id": "431a0085-96da-4521-863f-c38b480701e9"
+ "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="sequence-attribute"></a>
+### Spec attributes
 
-sequence     |      |
+<a id="check-attribute"></a>
+
+|check       |      |
 -------------|------
-description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
-required     | false
-type         | Integer
+description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
+type         | Map
+required     | true
 example      | {{< language-toggle >}}
 {{< code yml >}}
-sequence: 1
+check:
+  check_hooks:
+  command: metrics-curl -u "http://localhost"
+  duration: 0.060790838
+  env_vars:
+  executed: 1552506033
+  handlers: []
+  high_flap_threshold: 0
+  history:
+  - executed: 1552505833
+    status: 0
+  - executed: 1552505843
+    status: 0
+  interval: 10
+  is_silenced: true
+  processed_by: sensu-go-sandbox
+  issued: 1552506033
+  last_ok: 1552506033
+  low_flap_threshold: 0
+  metadata:
+    name: curl_timings
+    namespace: default
+  occurrences: 1
+  occurrences_watermark: 1
+  silenced:
+  - webserver:*
+  output: sensu-go.curl_timings.time_total 0.005
+  output_metric_format: graphite_plaintext
+  proxy_entity_name: ''
+  publish: true
+  round_robin: false
+  runtime_assets: []
+  state: passing
+  status: 0
+  stdin: false
+  subdue:
+  subscriptions:
+  - entity:sensu-go-testing
+  timeout: 0
+  total_state_change: 0
+  ttl: 0
 {{< /code >}}
 {{< code json >}}
 {
-  "sequence": 1
+  "check": {
+    "check_hooks": null,
+    "command": "metrics-curl -u \"http://localhost\"",
+    "duration": 0.060790838,
+    "env_vars": null,
+    "executed": 1552506033,
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "history": [
+      {
+        "executed": 1552505833,
+        "status": 0
+      },
+      {
+        "executed": 1552505843,
+        "status": 0
+      }
+    ],
+    "interval": 10,
+    "is_silenced": true,
+    "processed_by": "sensu-go-sandbox",
+    "issued": 1552506033,
+    "last_ok": 1552506033,
+    "low_flap_threshold": 0,
+    "metadata": {
+      "name": "curl_timings",
+      "namespace": "default"
+    },
+    "occurrences": 1,
+    "occurrences_watermark": 1,
+    "silenced": [
+      "webserver:*"
+    ],
+    "output": "sensu-go.curl_timings.time_total 0.005",
+    "output_metric_format": "graphite_plaintext",
+    "proxy_entity_name": "",
+    "publish": true,
+    "round_robin": false,
+    "runtime_assets": [],
+    "state": "passing",
+    "status": 0,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "entity:sensu-go-testing"
+    ],
+    "timeout": 0,
+    "total_state_change": 0,
+    "ttl": 0
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2744,109 +2800,18 @@ entity:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="checks-attribute"></a>
-
-|check       |      |
+id           |      |
 -------------|------
-description  | [Check definition][1] used to create the event and information about the status and history of the event. The check scope includes attributes described in the [event specification][21] and the [check specification][20].
-type         | Map
-required     | true
+description  | Universally unique identifier (UUID) for the event. Logged as `event_id`.<br><br>Sensu automatically populates the `id` value for the event.
+required     | false
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-check:
-  check_hooks:
-  command: metrics-curl -u "http://localhost"
-  duration: 0.060790838
-  env_vars:
-  executed: 1552506033
-  handlers: []
-  high_flap_threshold: 0
-  history:
-  - executed: 1552505833
-    status: 0
-  - executed: 1552505843
-    status: 0
-  interval: 10
-  is_silenced: true
-  processed_by: sensu-go-sandbox
-  issued: 1552506033
-  last_ok: 1552506033
-  low_flap_threshold: 0
-  metadata:
-    name: curl_timings
-    namespace: default
-  occurrences: 1
-  occurrences_watermark: 1
-  silenced:
-  - webserver:*
-  output: sensu-go.curl_timings.time_total 0.005
-  output_metric_format: graphite_plaintext
-  proxy_entity_name: ''
-  publish: true
-  round_robin: false
-  runtime_assets: []
-  state: passing
-  status: 0
-  stdin: false
-  subdue:
-  subscriptions:
-  - entity:sensu-go-testing
-  timeout: 0
-  total_state_change: 0
-  ttl: 0
+id: 431a0085-96da-4521-863f-c38b480701e9
 {{< /code >}}
 {{< code json >}}
 {
-  "check": {
-    "check_hooks": null,
-    "command": "metrics-curl -u \"http://localhost\"",
-    "duration": 0.060790838,
-    "env_vars": null,
-    "executed": 1552506033,
-    "handlers": [],
-    "high_flap_threshold": 0,
-    "history": [
-      {
-        "executed": 1552505833,
-        "status": 0
-      },
-      {
-        "executed": 1552505843,
-        "status": 0
-      }
-    ],
-    "interval": 10,
-    "is_silenced": true,
-    "processed_by": "sensu-go-sandbox",
-    "issued": 1552506033,
-    "last_ok": 1552506033,
-    "low_flap_threshold": 0,
-    "metadata": {
-      "name": "curl_timings",
-      "namespace": "default"
-    },
-    "occurrences": 1,
-    "occurrences_watermark": 1,
-    "silenced": [
-      "webserver:*"
-    ],
-    "output": "sensu-go.curl_timings.time_total 0.005",
-    "output_metric_format": "graphite_plaintext",
-    "proxy_entity_name": "",
-    "publish": true,
-    "round_robin": false,
-    "runtime_assets": [],
-    "state": "passing",
-    "status": 0,
-    "stdin": false,
-    "subdue": null,
-    "subscriptions": [
-      "entity:sensu-go-testing"
-    ],
-    "timeout": 0,
-    "total_state_change": 0,
-    "ttl": 0
-  }
+  "id": "431a0085-96da-4521-863f-c38b480701e9"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2889,6 +2854,41 @@ metrics:
       }
     ]
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="sequence-attribute"></a>
+
+sequence     |      |
+-------------|------
+description  | Event sequence number. The Sensu agent sets the sequence to 1 at startup, then increments the sequence by 1 for every successive check execution or keepalive event. If the agent restarts or reconnects to another backend, the sequence value resets to 1.<br><br>A sequence value of 0 indicates that an outdated or non-conforming agent generated the event.<br><br>Sensu only increments the sequence for agent-executed events. Sensu does not update the sequence for events created with the [core/v2/events API][35].
+required     | false
+type         | Integer
+example      | {{< language-toggle >}}
+{{< code yml >}}
+sequence: 1
+{{< /code >}}
+{{< code json >}}
+{
+  "sequence": 1
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+|timestamp   |      |
+-------------|------
+description  | Time that the event occurred. In seconds since the Unix epoch.<br><br>Sensu automatically populates the timestamp value for the event. For events created with the [core/v2/events API][35], you can specify a `timestamp` value in the request body.
+required     | false
+type         | Integer
+default      | Time that the event occurred
+example      | {{< language-toggle >}}
+{{< code yml >}}
+timestamp: 1522099512
+{{< /code >}}
+{{< code json >}}
+{
+  "timestamp": 1522099512
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -2958,6 +2958,22 @@ history:
 {{< /code >}}
 {{< /language-toggle >}}
 
+is_silenced  | |
+-------------|------
+description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+is_silenced: true
+{{< /code >}}
+{{< code json >}}
+{
+  "is_silenced": "true"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 issued       |      |
 -------------|------
 description  | Time that the check request was issued. In seconds since the Unix epoch.<br><br>The difference between a request's `issued` and `executed` values is the request latency.<br><br>For agent-executed checks, Sensu automatically populates the `issued` value. For events created with the [core/v2/events API][35], the default `issued` value is `0` unless you specify a value in the request body.
@@ -3022,43 +3038,6 @@ occurrences_watermark: 1
 {{< /code >}}
 {{< /language-toggle >}}
 
-is_silenced  | |
--------------|------
-description  | If `true`, the event was silenced at the time of processing. Otherwise, `false`. If `true`, the event. Check definitions also list the silenced entries that match the event in the `silenced` array.
-required     | false
-type         | Boolean
-example      | {{< language-toggle >}}
-{{< code yml >}}
-is_silenced: true
-{{< /code >}}
-{{< code json >}}
-{
-  "is_silenced": "true"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-<a id="silenced-attribute"></a>
-
-silenced     | |
--------------|------
-description  | Array of silencing entries that match the event. The `silenced` attribute is only present for events if one or more silencing entries matched the event at time of processing. If the `silenced` attribute is not present in an event, the event was not silenced at the time of processing.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-silenced:
-- webserver:*
-{{< /code >}}
-{{< code json >}}
-{
-  "silenced": [
-    "webserver:*"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 output       |      |
 -------------|------
 description  | Output from the execution of the check command.
@@ -3089,6 +3068,27 @@ processed_by: sensu-go-sandbox
 {{< code json >}}
 {
   "processed_by": "sensu-go-sandbox"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="silenced-attribute"></a>
+
+silenced     | |
+-------------|------
+description  | Array of silencing entries that match the event. The `silenced` attribute is only present for events if one or more silencing entries matched the event at time of processing. If the `silenced` attribute is not present in an event, the event was not silenced at the time of processing.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+silenced:
+- webserver:*
+{{< /code >}}
+{{< code json >}}
+{
+  "silenced": [
+    "webserver:*"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -3346,7 +3346,7 @@ value: 0.005
 [19]: ../#status-and-metrics-events
 [20]: ../../observe-schedule/checks#check-specification
 [21]: #check-attributes
-[22]: #metrics-attribute
+[22]: #metrics-attributes
 [23]: ../../observe-filter/reduce-alert-fatigue/
 [24]: ../../observe-filter/filters/
 [25]: ../../observe-schedule/checks/#check-result-specification

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -570,27 +570,11 @@ For example:
 sensu.ListEvents()
 {{< /code >}}
 
-The events in the returned array use the same format as responses for the [core/v2/events API]][43].
+The events in the returned array use the same format as responses for the [core/v2/events API][43].
 
 ## Event filter specification
 
 ### Top-level attributes
-
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
-required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: EventFilter
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "EventFilter"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 api_version  | 
 -------------|------
@@ -667,37 +651,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][33] resource type. Event filters should always be type `EventFilter`.
+required     | Required for filter definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][33].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: filter-weekdays-only
+type: EventFilter
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "filter-weekdays-only"
+  "type": "EventFilter"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -740,24 +729,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with event filters. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][36], [sensuctl response filtering][37], or [web UI views][42].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the event filter. Filter names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][35]). Each filter must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: filter-weekdays-only
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "filter-weekdays-only"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][10] that the event filter belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
@@ -291,22 +291,6 @@ If you do not specify a keepalive handler with the `keepalive-handlers` flag, th
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
-required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Handler
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Handler"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For handlers in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -389,37 +373,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Handlers should always be type `Handler`.
+required     | Required for handler definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: handler-slack
+type: Handler
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "handler-slack"
+  "type": "Handler"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the handler belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -462,108 +451,40 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the handler. Handler names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each handler must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: handler-slack
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "handler-slack"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the handler belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
 ### Spec attributes
-
-type         | 
--------------|------
-description  | Handler type.
-required     | true
-type         | String
-allowed values | `pipe`, `tcp`, `udp`, and `set`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: pipe
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "pipe"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-filters      | 
--------------|------
-description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.{{% notice note %}}
-**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list event filters directly in the pipeline resource definition instead of in handlers.<br><br>
-Pipelines ignore any event filters specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the event filters you want to use in the pipeline workflow.
-{{% /notice %}}
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-filters:
-- is_incident
-- not_silenced
-- state_change_only
-{{< /code >}}
-{{< code json >}}
-{
-  "filters": [
-    "is_incident",
-    "not_silenced",
-    "state_change_only"
-  ]
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-mutator      | 
--------------|------
-description  | Name of the Sensu event mutator to use to mutate event data for the handler.{{% notice note %}}
-**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list mutators directly in the pipeline resource definition instead of in handlers.<br><br>
-Pipelines ignore any mutators specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the mutator you want to use in the pipeline workflow.
-{{% /notice %}}
-required     | false
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator: only_check_output
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": "only_check_output"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout     | 
-------------|------
-description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
-required    | false
-type        | Integer
-default     | `60` (for `tcp` and `udp` handlers)
-example     | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 command      | 
 -------------|------
@@ -604,20 +525,28 @@ env_vars:
 {{< /code >}}
 {{< /language-toggle >}}
 
-socket       | 
+filters      | 
 -------------|------
-description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
-**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+description  | Array of Sensu event filters (by names) to use when filtering events for the handler. Each array item must be a string.{{% notice note %}}
+**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list event filters directly in the pipeline resource definition instead of in handlers.<br><br>
+Pipelines ignore any event filters specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the event filters you want to use in the pipeline workflow.
 {{% /notice %}}
-required     | true (if `type` equals `tcp` or `udp`)
-type         | Hash
+required     | false
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-socket: {}
+filters:
+- is_incident
+- not_silenced
+- state_change_only
 {{< /code >}}
 {{< code json >}}
 {
-  "socket": {}
+  "filters": [
+    "is_incident",
+    "not_silenced",
+    "state_change_only"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -644,6 +573,25 @@ handlers:
     "email",
     "ec2"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+mutator      | 
+-------------|------
+description  | Name of the Sensu event mutator to use to mutate event data for the handler.{{% notice note %}}
+**NOTE**: We recommend using [pipelines](../pipelines/), which allow you to list mutators directly in the pipeline resource definition instead of in handlers.<br><br>
+Pipelines ignore any mutators specified in handler definitions, so you do not need to remove them to use your existing handlers &mdash; just make sure to define the mutator you want to use in the pipeline workflow.
+{{% /notice %}}
+required     | false
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator: only_check_output
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": "only_check_output"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -692,6 +640,58 @@ secrets:
       "secret": "sensu-ansible-token"
     }
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+socket       | 
+-------------|------
+description  | Scope for [`socket` definition][6] used to configure the TCP/UDP handler socket. {{% notice note %}}
+**NOTE**: The `socket` attribute is only supported for TCP/UDP handlers (that is, handlers configured with `"type": "tcp"` or `"type": "udp"`).
+{{% /notice %}}
+required     | true (if `type` equals `tcp` or `udp`)
+type         | Hash
+example      | {{< language-toggle >}}
+{{< code yml >}}
+socket: {}
+{{< /code >}}
+{{< code json >}}
+{
+  "socket": {}
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+timeout     | 
+------------|------
+description | Handler execution duration timeout (hard stop). In seconds. Only used by `pipe`, `tcp`, and `udp` handler types.
+required    | false
+type        | Integer
+default     | `60` (for `tcp` and `udp` handlers)
+example     | {{< language-toggle >}}
+{{< code yml >}}
+timeout: 30
+{{< /code >}}
+{{< code json >}}
+{
+  "timeout": 30
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | Handler type.
+required     | true
+type         | String
+allowed values | `pipe`, `tcp`, `udp`, and `set`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: pipe
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "pipe"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
@@ -308,22 +308,6 @@ Read [Route alerts with event filters][30] for another pipeline example that inc
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Pipelines should always be type `Pipeline`.
-required     | Required for pipeline definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Pipeline
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Pipeline"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For pipelines in this version of Sensu, the api_version should always be `core/v2`.
@@ -442,37 +426,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the pipeline. Pipeline names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each pipeline must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][4] resource type. Pipelines should always be type `Pipeline`.
+required     | Required for pipeline definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][4].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: incident_alerts
+type: Pipeline
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "incident_alerts"
+  "type": "Pipeline"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | Sensu [RBAC namespace][9] that the pipeline belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: default
+annotations:
+  managed-by: ops
+  slack-channel: "#incidents"
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "default"
+  "annotations": {
+    "managed-by": "ops",
+    "slack-channel": "#incidents"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -515,24 +504,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][24]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][28].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the pipeline. Pipeline names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][18]). Each pipeline must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  slack-channel: "#incidents"
+name: incident_alerts
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "slack-channel": "#incidents"
-  }
+  "name": "incident_alerts"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][9] that the pipeline belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -649,30 +649,6 @@ filters:
 {{< /code >}}
 {{< /language-toggle >}}
 
-mutator      | 
--------------|------
-description  | Reference for the Sensu mutator to use to mutate event data for the workflow. Each pipeline workflow can reference only one mutator. Read [mutator attributes][9] for details.
-required     | false
-type         | Map of key-value pairs
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-mutator:
-  name: add_labels
-  type: Mutator
-  api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "mutator": {
-    "name": "add_labels",
-    "type": "Mutator",
-    "api_version": "core/v2"
-  }
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="handler-pipeline"></a>
 
 handler      | 
@@ -698,7 +674,48 @@ handler:
 {{< /code >}}
 {{< /language-toggle >}}
 
+mutator      | 
+-------------|------
+description  | Reference for the Sensu mutator to use to mutate event data for the workflow. Each pipeline workflow can reference only one mutator. Read [mutator attributes][9] for details.
+required     | false
+type         | Map of key-value pairs
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+mutator:
+  name: add_labels
+  type: Mutator
+  api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "mutator": {
+    "name": "add_labels",
+    "type": "Mutator",
+    "api_version": "core/v2"
+  }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 #### Filters attributes
+
+api_version  | 
+-------------|------
+description  | The Sensu API group and version for the event filter. For event filters in this version of Sensu, the api_version should always be `core/v2`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------
@@ -734,77 +751,25 @@ type: EventFilter
 {{< /code >}}
 {{< /language-toggle >}}
 
-api_version  | 
--------------|------
-description  | The Sensu API group and version for the event filter. For event filters in this version of Sensu, the api_version should always be `core/v2`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "api_version": "core/v2"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-#### Mutator attributes
-
-name         | 
--------------|------
-description  | Name of the Sensu [mutator][14] to use for the workflow. You can use your existing mutators in pipeline workflows.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: add_labels
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "add_labels"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-type         | 
--------------|------
-description  | The [`sensuctl create`][4] resource type for the mutator. Mutators should always be type `Mutator`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
- "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-api_version  | 
--------------|------
-description  | The Sensu API group and version for the mutator. For mutators in this version of Sensu, the api_version should always be `core/v2`.
-required     | true
-type         | String
-default      | `null`
-example      | {{< language-toggle >}}
-{{< code yml >}}
-api_version: core/v2
-{{< /code >}}
-{{< code json >}}
-{
-  "api_version": "core/v2"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 #### Handler attributes
+
+api_version  | 
+-------------|------
+description  | The Sensu API group and version for the handler.
+required     | true
+type         | String
+allowed values | `core/v2` for a [pipe handler][15], [TCP or UDP handler][16], or [handler set][1]<br><br>`pipeline/v1` for a [TCP stream handler][20] or [Sumo Logic metrics handler][21]
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+api_version: core/v2
+{{< /code >}}
+{{< code json >}}
+{
+  "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
 
 name         | 
 -------------|------
@@ -841,12 +806,13 @@ type: Handler
 {{< /code >}}
 {{< /language-toggle >}}
 
+#### Mutator attributes
+
 api_version  | 
 -------------|------
-description  | The Sensu API group and version for the handler.
+description  | The Sensu API group and version for the mutator. For mutators in this version of Sensu, the api_version should always be `core/v2`.
 required     | true
 type         | String
-allowed values | `core/v2` for a [pipe handler][15], [TCP or UDP handler][16], or [handler set][1]<br><br>`pipeline/v1` for a [TCP stream handler][20] or [Sumo Logic metrics handler][21]
 default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
@@ -855,6 +821,40 @@ api_version: core/v2
 {{< code json >}}
 {
   "api_version": "core/v2"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         | 
+-------------|------
+description  | Name of the Sensu [mutator][14] to use for the workflow. You can use your existing mutators in pipeline workflows.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: add_labels
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "add_labels"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+type         | 
+-------------|------
+description  | The [`sensuctl create`][4] resource type for the mutator. Mutators should always be type `Mutator`.
+required     | true
+type         | String
+default      | `null`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: Mutator
+{{< /code >}}
+{{< code json >}}
+{
+ "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -1362,7 +1362,7 @@ detect-cloud-provider: false{{< /code >}}
 
 | keepalive-critical-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a critical event. Set to disabled (`0`) by default. If the value is not `0`, it must be greater than or equal to `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-critical-timeout` value to the [`event.check.ttl` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.ttl` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `0`
@@ -1419,7 +1419,7 @@ keepalive-pipelines:
 
 | keepalive-warning-timeout |      |
 --------------------|------
-description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#checks-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
+description         | Number of seconds after a missing keepalive event until the agent is considered unresponsive by the Sensu backend to create a warning event. Value must be lower than the `keepalive-critical-timeout` value. Minimum value is `5`.<br>{{% notice note %}}**NOTE**: The agent maps the `keepalive-warning-timeout` value to the [`event.check.timeout` attribute](../../observe-events/events/#check-attribute) when keepalive events are generated for the Sensu backend to process. The `event.check.timeout` attribute is useful for [creating time-based event filters](../../observe-filter/filters#reduce-alert-fatigue-for-keepalive-events) to reduce alert fatigue for agent keepalive events.
 {{% /notice %}}
 type                | Integer
 default             | `120`

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/hooks.md
@@ -155,22 +155,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
-required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: HookConfig
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "HookConfig"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For hooks in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -243,37 +227,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][1] resource type. Hooks should always be type `HookConfig`.
+required     | Required for hook definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][1].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: process_tree
+type: HookConfig
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "process_tree"
+  "type": "HookConfig"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations |     |
 -------------|------
-description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -316,24 +305,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations |     |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with observation event data that you can access with [event filters][4]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][10], [sensuctl response filtering][11], or [web UI views][13].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the hook. Hook names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][8]). Each hook must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: process_tree
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "process_tree"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | The Sensu [RBAC namespace][3] that this hook belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -356,19 +356,21 @@ command: sudo /etc/init.d/nginx start
 {{< /code >}}
 {{< /language-toggle >}}
 
-timeout      | 
+|runtime_assets |   |
 -------------|------
-description  | Hook execution duration timeout (hard stop). In seconds.
+description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
 required     | false
-type         | Integer
-default      | 60
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
-timeout: 30
+runtime_assets:
+- log-context
 {{< /code >}}
 {{< code json >}}
 {
-  "timeout": 30
+  "runtime_assets": [
+    "log-context"
+  ]
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -390,21 +392,19 @@ stdin: true
 {{< /code >}}
 {{< /language-toggle >}}
 
-|runtime_assets |   |
+timeout      | 
 -------------|------
-description  | Array of [Sensu dynamic runtime assets][5] (by their names) required at runtime for execution of the `command`.
+description  | Hook execution duration timeout (hard stop). In seconds.
 required     | false
-type         | Array
+type         | Integer
+default      | 60
 example      | {{< language-toggle >}}
 {{< code yml >}}
-runtime_assets:
-- log-context
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "runtime_assets": [
-    "log-context"
-  ]
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/rule-templates.md
@@ -201,22 +201,6 @@ Sensu evaluates each rule separately, and each rule produces its own event as ou
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
-required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: RuleTemplate
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "RuleTemplate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For rule template configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -499,39 +483,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For rule template configuration, the type should always be `RuleTemplate`.
+required     | Required for rule template configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: RuleTemplate
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "RuleTemplate"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the rule template that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: aggregate
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "aggregate"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][6] that the rule template belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -589,23 +557,39 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Spec attributes
-
-description  | 
--------------|------ 
-description  | Plain text description of the rule template's behavior.
+name         |      |
+-------------|------
+description  | Name for the rule template that is used internally by Sensu.
 required     | true
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+name: aggregate
 {{< /code >}}
 {{< code json >}}
 {
-  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
+  "name": "aggregate"
 }
 {{< /code >}}
 {{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][6] that the rule template belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+### Spec attributes
 
 arguments    | 
 -------------|------ 
@@ -693,6 +677,22 @@ arguments:
     },
     "required": null
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+description  | 
+-------------|------ 
+description  | Plain text description of the rule template's behavior.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+description: Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
+{{< /code >}}
+{{< code json >}}
+{
+  "description": "Monitor a distributed service - aggregate one or more events into a single event. This BSM rule template allows you to treat the results of multiple disparate check executions – executed across multiple disparate systems – as a single event. This template is extremely useful in dynamic environments and/or environments that have a reasonable tolerance for failure. Use this template when a service can be considered healthy as long as a minimum threshold is satisfied (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?)."
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -848,22 +848,6 @@ eval: |2
 
 #### Arguments attributes
 
-required     | 
--------------|------ 
-description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
-required     | false
-type         | Array
-example      | {{< language-toggle >}}
-{{< code yml >}}
-required: null
-{{< /code >}}
-{{< code json >}}
-{
-  "required": null
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 <a id="rule-properties"></a>
 
 properties   | 
@@ -944,6 +928,22 @@ properties:
       "type": "number"
     }
   },
+  "required": null
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+required     | 
+-------------|------ 
+description  | List of attributes the rule template argument requires. The listed attributes must be configured in the [properties][2] object.
+required     | false
+type         | Array
+example      | {{< language-toggle >}}
+{{< code yml >}}
+required: null
+{{< /code >}}
+{{< code json >}}
+{
   "required": null
 }
 {{< /code >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/service-components.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/service-components.md
@@ -109,22 +109,6 @@ The rules can emit new events based on the component input.
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
-required     | Required for service component configuration in `wrapped-json` or `yaml` format.
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: ServiceComponent
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "ServiceComponent"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For service component configuration in this version of Sensu, the api_version should always be `bsm/v1`.
@@ -228,39 +212,23 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
+type         | 
+-------------|------
+description  | Top-level attribute that specifies the resource type. For service component configuration, the type should always be `ServiceComponent`.
+required     | Required for service component configuration in `wrapped-json` or `yaml` format.
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+type: ServiceComponent
+{{< /code >}}
+{{< code json >}}
+{
+  "type": "ServiceComponent"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
 ### Metadata attributes
-
-name         |      |
--------------|------
-description  | Name for the service component that is used internally by Sensu.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-name: webservers
-{{< /code >}}
-{{< code json >}}
-{
-  "name": "webservers"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-namespace    |      |
--------------|------
-description  | [Sensu RBAC namespace][7] that the service component belongs to.
-required     | true
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-namespace: default
-{{< /code >}}
-{{< code json >}}
-{
-  "namespace": "default"
-}
-{{< /code >}}
-{{< /language-toggle >}}
 
 | annotations |     |
 -------------|------
@@ -314,6 +282,38 @@ labels:
   "labels": {
     "region": "us-west-1"
   }
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+name         |      |
+-------------|------
+description  | Name for the service component that is used internally by Sensu.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+name: webservers
+{{< /code >}}
+{{< code json >}}
+{
+  "name": "webservers"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+namespace    |      |
+-------------|------
+description  | [Sensu RBAC namespace][7] that the service component belongs to.
+required     | true
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: default
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "default"
 }
 {{< /code >}}
 {{< /language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-transform/mutators.md
@@ -268,22 +268,6 @@ spec:
 
 ### Top-level attributes
 
-type         | 
--------------|------
-description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
-required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
-type         | String
-example      | {{< language-toggle >}}
-{{< code yml >}}
-type: Mutator
-{{< /code >}}
-{{< code json >}}
-{
-  "type": "Mutator"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
 api_version  | 
 -------------|------
 description  | Top-level attribute that specifies the Sensu API group and version. For mutators in this version of Sensu, the `api_version` should always be `core/v2`.
@@ -362,37 +346,42 @@ spec:
 {{< /code >}}
 {{< /language-toggle >}}
 
-### Metadata attributes
-
-| name       |      |
+type         | 
 -------------|------
-description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
-required     | true
+description  | Top-level attribute that specifies the [`sensuctl create`][5] resource type. Mutators should always be type `Mutator`.
+required     | Required for mutator definitions in `wrapped-json` or `yaml` format for use with [`sensuctl create`][5].
 type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-name: example-mutator
+type: Mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "name": "example-mutator"
+  "type": "Mutator"
 }
 {{< /code >}}
 {{< /language-toggle >}}
 
-| namespace  |      |
+### Metadata attributes
+
+| annotations | |
 -------------|------
-description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
 required     | false
-type         | String
-default      | `default`
+type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
+default      | `null`
 example      | {{< language-toggle >}}
 {{< code yml >}}
-namespace: production
+annotations:
+  managed-by: ops
+  playbook: www.example.url
 {{< /code >}}
 {{< code json >}}
 {
-  "namespace": "production"
+  "annotations": {
+    "managed-by": "ops",
+    "playbook": "www.example.url"
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -435,24 +424,35 @@ labels:
 {{< /code >}}
 {{< /language-toggle >}}
 
-| annotations | |
+| name       |      |
 -------------|------
-description  | Non-identifying metadata to include with event data that you can access with [event filters][12]. You can use annotations to add data that's meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][8], [sensuctl response filtering][9], or [web UI views][15].
-required     | false
-type         | Map of key-value pairs. Keys and values can be any valid UTF-8 string.
-default      | `null`
+description  | Unique string used to identify the mutator. Mutator names cannot contain special characters or spaces (validated with Go regex [`\A[\w\.\-]+\z`][7]). Each mutator must have a unique name within its namespace.
+required     | true
+type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
-annotations:
-  managed-by: ops
-  playbook: www.example.url
+name: example-mutator
 {{< /code >}}
 {{< code json >}}
 {
-  "annotations": {
-    "managed-by": "ops",
-    "playbook": "www.example.url"
-  }
+  "name": "example-mutator"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+| namespace  |      |
+-------------|------
+description  | Sensu [RBAC namespace][3] that the mutator belongs to.
+required     | false
+type         | String
+default      | `default`
+example      | {{< language-toggle >}}
+{{< code yml >}}
+namespace: production
+{{< /code >}}
+{{< code json >}}
+{
+  "namespace": "production"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -473,24 +473,6 @@ command: /etc/sensu/plugins/mutated.go
 {{< code json >}}
 {
   "command": "/etc/sensu/plugins/mutated.go"
-}
-{{< /code >}}
-{{< /language-toggle >}}
-
-timeout      | 
--------------|------ 
-description  | Mutator execution duration timeout (hard stop). In seconds.{{% notice warning %}}
-**WARNING**: The timeout attribute is available for [JavaScript mutators](#javascript-mutators) but may not work properly if the mutator is in a loop.
-{{% /notice %}}
-required     | false 
-type         | integer 
-example      | {{< language-toggle >}}
-{{< code yml >}}
-timeout: 30
-{{< /code >}}
-{{< code json >}}
-{
-  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -526,6 +508,26 @@ env_vars:
     "APP_VERSION=2.5.0",
     "SHELL"
   ]
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="eval-attribute"></a>
+
+eval         | 
+-------------|------ 
+description  | ECMAScript 5 (JavaScript) expression to be executed by the Sensu backend.{{% notice note %}}
+**NOTE**: Pipe mutators require the [command attribute](#spec-attributes) instead of the eval attribute.
+{{% /notice %}}
+required     | true, for [JavaScript mutators][18]
+type         | String
+example      | {{< language-toggle >}}
+{{< code yml >}}
+eval: 'return JSON.stringify({"some stuff": "is here"});'
+{{< /code >}}
+{{< code json >}}
+{
+  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -578,22 +580,20 @@ secrets:
 {{< /code >}}
 {{< /language-toggle >}}
 
-<a id="eval-attribute"></a>
-
-eval         | 
+timeout      | 
 -------------|------ 
-description  | ECMAScript 5 (JavaScript) expression to be executed by the Sensu backend.{{% notice note %}}
-**NOTE**: Pipe mutators require the [command attribute](#spec-attributes) instead of the eval attribute.
+description  | Mutator execution duration timeout (hard stop). In seconds.{{% notice warning %}}
+**WARNING**: The timeout attribute is available for [JavaScript mutators](#javascript-mutators) but may not work properly if the mutator is in a loop.
 {{% /notice %}}
-required     | true, for [JavaScript mutators][18]
-type         | String
+required     | false 
+type         | integer 
 example      | {{< language-toggle >}}
 {{< code yml >}}
-eval: 'return JSON.stringify({"some stuff": "is here"});'
+timeout: 30
 {{< /code >}}
 {{< code json >}}
 {
-  "eval": "return JSON.stringify({\"some info\": \"is here\"});"
+  "timeout": 30
 }
 {{< /code >}}
 {{< /language-toggle >}}


### PR DESCRIPTION
## Description
Alphabetizes the attributes in the specification tables in references. This PR covers entities through pipelines.

## Motivation and Context
Contributes to https://github.com/sensu/sensu-docs/issues/3739

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>