### PR TITLE
Fix operator and search term order in Catalog search example

### DIFF
--- a/content/sensu-go/6.7/web-ui/sensu-catalog.md
+++ b/content/sensu-go/6.7/web-ui/sensu-catalog.md
@@ -84,7 +84,7 @@ Sensu Catalog search supports two set-based operators:
 | Operator  | Description        | Example                |
 | --------- | ------------------ | ---------------------- |
 | `in`      | Included in        | `ansible in tags`
-| `matches` | Substring matching | `display_name ansible matches`
+| `matches` | Substring matching | `display_name matches ansible`
 
 #### Catalog search metadata
 


### PR DESCRIPTION
## Description
Fixes the order of the "matches" operator and search term in the example in https://docs.sensu.io/sensu-go/latest/web-ui/sensu-catalog/#catalog-search-operators

## Motivation and Context
@lspxxv caught the error!

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>