### PR TITLE
Remove code owners in .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,3 @@
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
 
-# Sensu Plugins documentation.
-
-/content/sensu-go/*/plugins/*      @sensu/plugin-docs


### PR DESCRIPTION
## Description
Removes sensu/plugin-docs from `.github/CODEOWNERS`. We no longer need to auto-request the plugins docs org review.

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>