### PR TITLE
Change note to commercial feature statement for sensuctl namespace list

### DIFF
--- a/content/sensu-go/6.4/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.4/operations/control-access/namespaces.md
@@ -81,8 +81,9 @@ Use [sensuctl][2] to view all namespaces within Sensu:
 sensuctl namespace list
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, `sensuctl namespace list` lists only the namespaces for which the current user has access.
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 ### Create namespaces

--- a/content/sensu-go/6.5/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.5/operations/control-access/namespaces.md
@@ -81,8 +81,9 @@ Use [sensuctl][2] to view all namespaces within Sensu:
 sensuctl namespace list
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, `sensuctl namespace list` lists only the namespaces for which the current user has access.
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 ### Create namespaces

--- a/content/sensu-go/6.6/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.6/operations/control-access/namespaces.md
@@ -81,8 +81,9 @@ Use [sensuctl][2] to view all namespaces within Sensu:
 sensuctl namespace list
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, `sensuctl namespace list` lists only the namespaces for which the current user has access.
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 ### Create namespaces

--- a/content/sensu-go/6.7/operations/control-access/namespaces.md
+++ b/content/sensu-go/6.7/operations/control-access/namespaces.md
@@ -87,8 +87,9 @@ Use [sensuctl][2] to view all namespaces within Sensu:
 sensuctl namespace list
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: For users on supported Sensu Go distributions, `sensuctl namespace list` lists only the namespaces that the current user has access to.
+{{% notice commercial %}}
+**COMMERCIAL FEATURE**: In the packaged Sensu Go distribution, `sensuctl namespace list` lists only the namespaces for which the current user has access.
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 ### Create namespaces


### PR DESCRIPTION
## Description
Rewrites the note in https://docs.sensu.io/sensu-go/latest/operations/control-access/namespaces/#view-namespaces to use the commercial feature notice formatting instead

## Motivation and Context
Noticed when working on updates in API doc

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>
