### PR TITLE
Update package.json so that yarn works up to node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hugo-cli": "^0.11.0"
   },
   "engines": {
-    "node": ">= 12 < 15"
+    "node": ">= 12 <= 18"
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
## Description
Updates package.json with `"engines": {"node": ">= 12 <= 18"}` so that yarn works on systems with node versions 12 through 18 installed.

Tested with node 16.15.0 (LTS) and 18.1.0 (current).

## Motivation and Context
https://sumologic.slack.com/archives/C024PCF29KR/p1651697136865779

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>