### PR TITLE
Remove stray references to pipelines in 6.4 docs

### DIFF
--- a/content/sensu-go/6.4/api/core/roles.md
+++ b/content/sensu-go/6.4/api/core/roles.md
@@ -459,7 +459,6 @@ The example request will result in a successful `HTTP/1.1 200 OK` response and a
           "handlers",
           "hooks",
           "mutators",
-          "pipelines",
           "rolebindings",
           "roles",
           "silenced"
@@ -550,7 +549,6 @@ output         | {{< code text >}}
           "handlers",
           "hooks",
           "mutators",
-          "pipelines",
           "rolebindings",
           "roles",
           "silenced"

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -460,7 +460,7 @@ Next, test your contact filters to make sure they work.
 
 ## Test contact routing
 
-To make sure your contact filters work the way you expect, use the [agent API][13] to create ad hoc events and send them to your Slack pipeline.
+To make sure your contact filters work the way you expect, use the [agent API][13] to create ad hoc events and send them to your Slack handler.
 
 First, create an event without a `contacts` label.
 You may need to modify the URL with your Sensu agent address.

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -240,7 +240,7 @@ You can connect keepalive events to your monitoring workflows using a keepalive 
 Sensu looks for an event handler named `keepalive` and automatically uses it to process keepalive events.
 
 Suppose you want to receive Slack notifications for keepalive alerts, and you already have a [Slack handler set up to process events][15].
-To process keepalive events using the Slack pipeline, create a handler set named `keepalive` and add the `slack` handler to the `handlers` array.
+To process keepalive events using the Slack handler, create a handler set named `keepalive` and add the `slack` handler to the `handlers` array.
 The resulting `keepalive` handler set configuration will look like this example:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -229,7 +229,6 @@ spec:
   output_metric_format: influxdb_line
   output_metric_handlers:
   - influxdb-handler
-  pipelines: []
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -263,7 +262,6 @@ spec:
     "output_metric_handlers": [
       "influxdb-handler"
     ],
-    "pipelines": [],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -199,7 +199,6 @@ spec:
   low_flap_threshold: 0
   output_metric_format: nagios_perfdata
   output_metric_handlers: null
-  pipelines: []
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -231,7 +230,6 @@ spec:
     "low_flap_threshold": 0,
     "output_metric_format": "nagios_perfdata",
     "output_metric_handlers": null,
-    "pipelines": [],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,
@@ -329,8 +327,7 @@ If you add the debug handler and configure the `collect-metrics` check to use it
     "secrets": null,
     "is_silenced": false,
     "scheduler": "memory",
-    "processed_by": "sensu-centos",
-    "pipelines": []
+    "processed_by": "sensu-centos"
   },
   "metrics": {
     "handlers": null,
@@ -372,7 +369,6 @@ If you add the debug handler and configure the `collect-metrics` check to use it
   },
   "id": "d19ee7f9-8cc5-447b-9059-895e89e14667",
   "sequence": 146,
-  "pipelines": null,
   "timestamp": 1635886845,
   "entity": {
     "entity_class": "agent",

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -52,7 +52,6 @@ spec:
   output_metric_format: graphite_plaintext
   output_metric_handlers:
   - graphite-handler
-  pipelines: []
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -88,7 +87,6 @@ spec:
     "output_metric_handlers": [
       "graphite-handler"
     ],
-    "pipelines": [],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,
@@ -117,7 +115,6 @@ The [example metric check][6] will produce events similar to this metric event:
 
 {{< code yml >}}
 ---
-pipelines:
 timestamp: 1635270402
 entity:
   entity_class: agent
@@ -310,7 +307,6 @@ check:
   is_silenced: false
   scheduler: memory
   processed_by: sensu-centos
-  pipelines: []
 metrics:
   handlers:
   - graphite-handler
@@ -471,7 +467,6 @@ sequence: 5
 
 {{< code json >}}
 {
-  "pipelines": null,
   "timestamp": 1635270402,
   "entity": {
     "entity_class": "agent",
@@ -606,8 +601,7 @@ sequence: 5
     "secrets": null,
     "is_silenced": false,
     "scheduler": "memory",
-    "processed_by": "sensu-centos",
-    "pipelines": []
+    "processed_by": "sensu-centos"
   },
   "metrics": {
     "handlers": [

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -397,7 +397,6 @@ spec:
   low_flap_threshold: 0
   output_metric_format: ""
   output_metric_handlers: null
-  pipelines: []
   proxy_entity_name: ""
   publish: true
   round_robin: false
@@ -429,7 +428,6 @@ spec:
     "low_flap_threshold": 0,
     "output_metric_format": "",
     "output_metric_handlers": null,
-    "pipelines": [],
     "proxy_entity_name": "",
     "publish": true,
     "round_robin": false,

--- a/content/sensu-go/6.4/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.4/operations/monitoring-as-code/_index.md
@@ -55,7 +55,6 @@ All resources of each type for each namespace are saved in a single configuratio
       handlers/
       handlersets/
       mutators/
-      pipelines/
 {{< /code >}}
 
 ## Adopt a configuration file strategy

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -254,7 +254,7 @@ Sensu downloads the dynamic runtime asset build on the host system where the ass
 For example, if a check definition references a dynamic runtime asset, the Sensu agent that executes the check will download the asset the first time it executes the check.
 The dynamic runtime asset build the agent downloads will depend on the filter rules associated with each build defined for the asset.
 
-Sensu backends follow a similar process when pipeline elements (filters, mutators, and handlers) request dynamic runtime asset installation as part of operation.
+Sensu backends follow a similar process when filters, mutators, and handlers request dynamic runtime asset installation as part of operation.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime asset builds are not downloaded until they are needed for command execution.


### PR DESCRIPTION
## Description
Removes a few stray mentions of the pipeline resource from 6.4 docs.

## Motivation and Context
Found when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>