### PR TITLE
Describe plugin configuration overrides

### DIFF
--- a/content/sensu-go/6.4/plugins/plugins.md
+++ b/content/sensu-go/6.4/plugins/plugins.md
@@ -48,6 +48,13 @@ As a result, executable scripts (for example, plugins) located in `/etc/sensu/pl
 This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
+## Plugin configuration overrides
+
+Many plugins support configuration overrides on a per-entity or per-check basis.
+For example, some plugins allow you to use annotations in individual entities and checks to set arguments that will override any arguments set in a resource command or in backend runtime environment variables for only that entity or check.
+
+Read the [Bonsai][12] documentation for a plugin to learn about any configuration overrides the plugin supports.
+
 ## Go plugin example
 
 The following example shows the structure for a very basic Sensu Go plugin.

--- a/content/sensu-go/6.5/plugins/plugins.md
+++ b/content/sensu-go/6.5/plugins/plugins.md
@@ -48,6 +48,13 @@ As a result, executable scripts (for example, plugins) located in `/etc/sensu/pl
 This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
+## Plugin configuration overrides
+
+Many plugins support configuration overrides on a per-entity or per-check basis.
+For example, some plugins allow you to use annotations in individual entities and checks to set arguments that will override any arguments set in a resource command or in backend runtime environment variables for only that entity or check.
+
+Read the [Bonsai][12] documentation for a plugin to learn about any configuration overrides the plugin supports.
+
 ## Go plugin example
 
 The following example shows the structure for a very basic Sensu Go plugin.

--- a/content/sensu-go/6.6/plugins/plugins.md
+++ b/content/sensu-go/6.6/plugins/plugins.md
@@ -48,6 +48,13 @@ As a result, executable scripts (for example, plugins) located in `/etc/sensu/pl
 This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
+## Plugin configuration overrides
+
+Many plugins support configuration overrides on a per-entity or per-check basis.
+For example, some plugins allow you to use annotations in individual entities and checks to set arguments that will override any arguments set in a resource command or in backend runtime environment variables for only that entity or check.
+
+Read the [Bonsai][12] documentation for a plugin to learn about any configuration overrides the plugin supports.
+
 ## Go plugin example
 
 The following example shows the structure for a very basic Sensu Go plugin.

--- a/content/sensu-go/6.7/plugins/plugins.md
+++ b/content/sensu-go/6.7/plugins/plugins.md
@@ -48,6 +48,13 @@ As a result, executable scripts (for example, plugins) located in `/etc/sensu/pl
 This allows command attributes to use relative paths for Sensu plugin commands, such as `"command": "http-check --url https://sensu.io"`.
 {{% /notice %}}
 
+## Plugin configuration overrides
+
+Many plugins support configuration overrides on a per-entity or per-check basis.
+For example, some plugins allow you to use annotations in individual entities and checks to set arguments that will override any arguments set in a resource command or in backend runtime environment variables for only that entity or check.
+
+Read the [Bonsai][12] documentation for a plugin to learn about any configuration overrides the plugin supports.
+
 ## Go plugin example
 
 The following example shows the structure for a very basic Sensu Go plugin.
@@ -152,3 +159,4 @@ It does not provide functionality.
 [9]: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html
 [10]: https://www.nagios.org/downloads/nagios-plugins/
 [11]: https://exchange.nagios.org/
+[12]: https://bonsai.sensu.io/


### PR DESCRIPTION
## Description
Adds a section in the Plugins reference that describes plugin configuration overrides (for example, using annotations) and explains that users can find plugin-specific information in individual plugin documentation in Bonsai.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3821

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>