### PR TITLE
Minor update to sensuctl configure info in sensuctl section index

### DIFF
--- a/content/sensu-go/6.4/sensuctl/_index.md
+++ b/content/sensu-go/6.4/sensuctl/_index.md
@@ -27,8 +27,8 @@ To set up sensuctl, run `sensuctl configure` to log in to sensuctl and connect t
 sensuctl configure
 {{< /code >}}
 
-This starts the prompts for interactive sensuctl setup.
-When prompted, choose the authentication method you wish to use: username/password or OIDC.
+The `sensuctl configure` command starts the prompts for interactive setup.
+The first prompt is for the authentication method you wish to use: username/password or OIDC.
 
 Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.

--- a/content/sensu-go/6.5/sensuctl/_index.md
+++ b/content/sensu-go/6.5/sensuctl/_index.md
@@ -27,8 +27,8 @@ To set up sensuctl, run `sensuctl configure` to log in to sensuctl and connect t
 sensuctl configure
 {{< /code >}}
 
-This starts the prompts for interactive sensuctl setup.
-When prompted, choose the authentication method you wish to use: username/password or OIDC.
+The `sensuctl configure` command starts the prompts for interactive setup.
+The first prompt is for the authentication method you wish to use: username/password or OIDC.
 
 Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.

--- a/content/sensu-go/6.6/sensuctl/_index.md
+++ b/content/sensu-go/6.6/sensuctl/_index.md
@@ -27,8 +27,8 @@ To set up sensuctl, run `sensuctl configure` to log in to sensuctl and connect t
 sensuctl configure
 {{< /code >}}
 
-This starts the prompts for interactive sensuctl setup.
-When prompted, choose the authentication method you wish to use: username/password or OIDC.
+The `sensuctl configure` command starts the prompts for interactive setup.
+The first prompt is for the authentication method you wish to use: username/password or OIDC.
 
 Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.

--- a/content/sensu-go/6.7/sensuctl/_index.md
+++ b/content/sensu-go/6.7/sensuctl/_index.md
@@ -27,8 +27,8 @@ To set up sensuctl, run `sensuctl configure` to log in to sensuctl and connect t
 sensuctl configure
 {{< /code >}}
 
-This starts the prompts for interactive sensuctl setup.
-When prompted, choose the authentication method you wish to use: username/password or OIDC.
+The `sensuctl configure` command starts the prompts for interactive setup.
+The first prompt is for the authentication method you wish to use: username/password or OIDC.
 
 Sensuctl uses your username and password or OIDC credentials to obtain access and refresh tokens via the Sensu [/auth API][14].
 The access and refresh tokens are HMAC-SHA256 [JSON Web Tokens (JWTs)][16] that Sensu issues to record the details of users' authenticated Sensu sessions.


### PR DESCRIPTION
## Description
Updates a couple of sentences in the sensuctl index page that describe the `sensuctl configure` command.

## Motivation and Context
Fixes some slightly ambiguous explanation

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>