### PR TITLE
Add offline: true to frontmatter in Sensu Plus doc

### DIFF
--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -3,7 +3,7 @@ title: "Sensu Plus"
 description: "Deploy the Sensu Plus turnkey integration to send metrics to Sumo Logic and extract insights from your Sensu observability data."
 version: "6.5"
 weight: -20
-offline: false
+offline: true
 toc: true
 product: "Sensu Go"
 menu: "sensu-go-6.5"

--- a/content/sensu-go/6.6/sensu-plus.md
+++ b/content/sensu-go/6.6/sensu-plus.md
@@ -3,7 +3,7 @@ title: "Sensu Plus"
 description: "Deploy the Sensu Plus turnkey integration to send metrics to Sumo Logic and extract insights from your Sensu observability data."
 version: "6.6"
 weight: -20
-offline: false
+offline: true
 toc: true
 product: "Sensu Go"
 menu: "sensu-go-6.6"

--- a/content/sensu-go/6.7/sensu-plus.md
+++ b/content/sensu-go/6.7/sensu-plus.md
@@ -3,7 +3,7 @@ title: "Sensu Plus"
 description: "Deploy the Sensu Plus turnkey integration to send metrics to Sumo Logic and extract insights from your Sensu observability data."
 version: "6.7"
 weight: -20
-offline: false
+offline: true
 toc: true
 product: "Sensu Go"
 menu: "sensu-go-6.7"


### PR DESCRIPTION
## Description
In the Sensu Plus page frontmatter, changes `offline: false` to `true` so that the Sensu Plus page will display in the offline docs PDF.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3858

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>