### PR TITLE
Remove capitalization and code formatting from stdin, stdout, and stderr

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -444,7 +444,7 @@ For more information about event attributes, read the [event reference][28].
 `event.check.runtime_assets`         | array   | Sensu [dynamic runtime assets][17] used by the check
 `event.check.state`                  | string  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`
 `event.check.status`                 | integer | Exit status code produced by the check: `0` (OK), `1` (warning), `2` (critical), or other status (unknown or custom status)
-`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ STDIN
+`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ stdin
 `event.check.subscriptions`          | array   | Subscriptions that the check belongs to
 `event.check.timeout`                | integer | The check execution duration timeout in seconds
 `event.check.total_state_change`     | integer | The total state change percentage for the check’s history

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handler-templates.md
@@ -82,7 +82,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
-The template toolkit command uses event data you supply via STDIN in JSON format.
+The template toolkit command uses event data you supply via stdin in JSON format.
 
 Add the Sensu template toolkit command asset to Sensu:
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -19,7 +19,7 @@ Handlers are actions the Sensu backend executes on events.
 Several types of handlers are available.
 The most common are `pipe` handlers, which work similarly to [checks][1] and enable Sensu to interact with almost any computer program via [standard streams][2].
 
-- **Pipe handlers** send observation data (events) into arbitrary commands via `STDIN`
+- **Pipe handlers** send observation data (events) into arbitrary commands via stdin
 - **TCP/UDP handlers** send observation data (events) to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
@@ -30,7 +30,7 @@ Read [Use dynamic runtime assets to install plugins][23] to get started.
 
 ## Pipe handlers
 
-Pipe handlers are external commands that can consume [event][3] data via STDIN.
+Pipe handlers are external commands that can consume [event][3] data via stdin.
 
 ### Pipe handler example
 
@@ -479,7 +479,7 @@ namespace: production
 
 command      | 
 -------------|------
-description  | Handler command to be executed. The event data is passed to the process via `STDIN`. {{% notice note %}}
+description  | Handler command to be executed. The event data is passed to the process via stdin. {{% notice note %}}
 **NOTE**: The `command` attribute is only supported for pipe handlers (that is, handlers configured with `"type": "pipe"`).
 {{% /notice %}}
 required     | true (if `type` equals `pipe`)

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -90,7 +90,7 @@ Commands must be executable files that are discoverable on the Sensu agent syste
 
 Although Sensu agents attempt to execute any command defined for a check, successful check result processing requires adherence to a simple specification.
 
-- Result data is output to [STDOUT or STDERR][3].
+- Result data is output to [stdout or stderr][3].
     - For service checks, this output is typically a human-readable message.
     - For metric checks, this output contains the measurements gathered by the
       check.
@@ -1268,7 +1268,7 @@ silenced:
 
 |stdin       |      |
 -------------|------
-description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ STDIN. The command must expect the JSON data via STDIN, read it, and close STDIN. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close STDIN.
+description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ stdin. The command must expect the JSON data via stdin, read it, and close stdin. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/hooks.md
@@ -16,7 +16,7 @@ menu:
 Hooks are reusable commands the agent executes in response to a check result before creating an observability event.
 You can create, manage, and reuse hooks independently of checks.
 Hooks enrich observability event context by gathering relevant information based on the exit status code of a check (ex: `1`).
-Hook commands can also receive JSON serialized Sensu client data via `STDIN`.
+Hook commands can also receive JSON serialized Sensu client data via stdin.
 
 ## Hook example
 
@@ -375,7 +375,7 @@ runtime_assets:
 
 stdin        | 
 -------------|------
-description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process `STDIN`. Otherwise, `false`. The command must expect the JSON data via STDIN, read it, and close STDIN. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close STDIN.
+description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process stdin. Otherwise, `false`. The command must expect the JSON data via stdin, read it, and close stdin. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -237,7 +237,7 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ### Validate the CPU check
 
 The Sensu agent uses WebSocket to communicate with the Sensu backend, sending event data as JSON messages.
-As your checks run, the Sensu agent captures check standard output (`STDOUT`) or standard error (`STDERR`).
+As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.

--- a/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-transform/mutators.md
@@ -25,8 +25,8 @@ If the mutator executes successfully (returns an exit status code of `0`), the m
 Exit codes other than `0` indicate failure.
 If the mutator fails to execute (returns a non-zero exit status code or fails to complete within its configured timeout), an error is logged and the handler will not execute.
 
-Mutators accept input/data via `STDIN` and can parse JSON event data.
-They output JSON data (modified event data) to `STDOUT` or `STDERR`.
+Mutators accept input/data via stdin and can parse JSON event data.
+They output JSON data (modified event data) to stdout or stderr.
 
 ## Mutator examples
 

--- a/content/sensu-go/6.4/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.4/operations/monitoring-as-code/_index.md
@@ -184,7 +184,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json > resource.json
 
 {{< /language-toggle >}}
 
-- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in STDOUT:
+- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in stdout:
 
   {{< language-toggle >}}
 
@@ -212,7 +212,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json >> resource.json
 
 {{< /language-toggle >}}
 
-- Append the resource defintion to an existing file and show the resource definition in STDOUT:
+- Append the resource defintion to an existing file and show the resource definition in stdout:
 
   {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/plugins/featured-integrations/prometheus.md
+++ b/content/sensu-go/6.4/plugins/featured-integrations/prometheus.md
@@ -19,7 +19,7 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Sensu Prometheus Collector
 
-The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to STDOUT in Influx, Graphite, or JSON format.
+The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to stdout in Influx, Graphite, or JSON format.
 
 ### Features
 

--- a/content/sensu-go/6.4/plugins/plugins.md
+++ b/content/sensu-go/6.4/plugins/plugins.md
@@ -15,9 +15,9 @@ menu:
 Sensu plugins provide executable scripts or other programs that you can use as Sensu checks, handlers, and mutators.
 Sensu plugins must comply with the following specification:
 
-- Accept input/data via `STDIN` (handler and mutator plugins only)
+- Accept input/data via stdin (handler and mutator plugins only)
   - Optionally able to parse a JSON data payload (that is, observation data in an event)
-- Output data to `STDOUT` or `STDERR`
+- Output data to stdout or stderr
 - Produce an exit status code to indicate state:
   - `0` indicates `OK`
   - `1` indicates `WARNING`
@@ -132,13 +132,13 @@ The following example demonstrates a very basic Sensu plugin in the Ruby program
 #
 require 'json'
 
-# Read the incoming JSON data from STDIN
-event = JSON.parse(STDIN.read, :symbolize_names => true)
+# Read the incoming JSON data from stdin
+event = JSON.parse(stdin.read, :symbolize_names => true)
 
 # Create an output object using Ruby string interpolation
 output = "The check named #{event[:check][:name]} generated the following output: #{event[:output]}"
 
-# Convert the mutated event data back to JSON and output it to STDOUT
+# Convert the mutated event data back to JSON and output it to stdout
 puts output
 {{< /code >}}
 

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -457,7 +457,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL errors could cause the backend to panic.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL would refuse to store event with a negative check status.
 - The backend will no longer start if the web UI TLS configuration is not fully specified.
-- The agent entity is now included in data passed to the STDIN for the command process.
+- The agent entity is now included in data passed to the stdin for the command process.
 - Improved check scheduling to prevent stale proxy entity data when using cron or round robin schedulers.
 - Fixed a bug that resulted in incorrect entity listings for agent entities created via the API instead of sensu-agent.
 - When downloading assets, Sensu now closes the response body after reading from it.
@@ -1065,7 +1065,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.14.1.
 - ([Commercial feature][79]) Sensuctl will not incorrectly warn of entity limits for unlimited licenses.
 - ([Commercial feature][79]) `oidc` authentication providers will now properly load on start-up.
 - When opening a Bolt database that is already open, `sensu-agent` will not hang indefinitely.
-- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to `STDOUT` instead of the specified file.
+- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to stdout instead of the specified file.
 - Fixed a crash in sensu-backend (panic: send on closed channel).
 
 ## 5.14.0 release notes
@@ -1099,7 +1099,7 @@ This can help in the rare case that something in the persisted state is leading 
 - ([Commercial feature][79]) `sensuctl` on Windows can now create Postgres resources.
 - ([Commercial feature][79]) Fixed a bug that resulted in event metrics being ignored when using the Postgres store.
 - Fixed a bug that caused checks to stop executing after a network error.
-- Fixed a bug that prevented `sensuctl create` with `stdin` from working.
+- Fixed a bug that prevented `sensuctl create` with stdin from working.
 - Splayed proxy checks are executed every interval (instead of every interval + interval * splay_coverage).
 - Proxy entity labels and annotations are now redacted in the web UI as expected.
 - Fixed a bug in the ring that prevented round robin schedules from recovering after quorum loss.
@@ -1177,7 +1177,7 @@ Read the [installation guide][16] for the latest download links.
 - Operators can now authenticate to Sensu via OpenID Direct Connect (OIDC) using sensuctl.
 Read the [authentication documentation][17] for details.
 - Added sensu-agent and sensuctl binary builds for FreeBSD.
-- Added sensuctl dump command to output resources to a file or STDOUT, making it easier to back up your Sensu backends.
+- Added sensuctl dump command to output resources to a file or stdout, making it easier to back up your Sensu backends.
 - Agents can now be configured with a list of executables that are allowed to run as check and hook commands.
 Read the [agent reference][78] for more information.
 
@@ -1205,7 +1205,7 @@ The system will refer to the namespace in the request URL.
 - Requesting events from the `GET /events/:entity` API endpoint now returns events only for the specified entity.
 - Running sensuctl config view without configuration no longer causes a crash.
 - Creating an entity via sensuctl with the `--interactive` flag now prompts for the entity name when it is not provided on the command line.
-- Check hooks with `stdin: true` now receive actual event data on STDIN instead of an empty event.
+- Check hooks with `stdin: true` now receive actual event data on stdin instead of an empty event.
 - Some issues with check scheduling and updating have been fixed by refactoring the backend's watcher implementation.
 
 **KNOWN ISSUES:**

--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
@@ -46,7 +46,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or JSON format:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from stdin or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 Review the [list of supported resource types][3] `for sensuctl create`.
 Read the [reference docs][6] for information about creating resource definitions.
@@ -252,7 +252,7 @@ sensuctl create --file pagerduty.json
 
 ## Delete resources
 
-The `sensuctl delete` command allows you to delete resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl delete` command allows you to delete resources by reading from stdin or a flag configured file (`-f`).
 The `delete` command accepts Sensu resource definitions in `wrapped-json` and `yaml` formats and uses the same [resource types][3] as `sensuctl create`.
 To be deleted successfully, resources provided to the `delete` command must match the name and namespace of an existing resource.
 
@@ -480,7 +480,7 @@ Read the [RBAC reference][22] for information about local user management with s
 For more information, read [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
+The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or stdin.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -462,7 +462,7 @@ For more information about event attributes, read the [event reference][28].
 `event.check.runtime_assets`         | array   | Sensu [dynamic runtime assets][17] used by the check
 `event.check.state`                  | string  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`
 `event.check.status`                 | integer | Exit status code produced by the check: `0` (OK), `1` (warning), `2` (critical), or other status (unknown or custom status)
-`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ STDIN
+`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ stdin
 `event.check.subscriptions`          | array   | Subscriptions that the check belongs to
 `event.check.timeout`                | integer | The check execution duration timeout in seconds
 `event.check.total_state_change`     | integer | The total state change percentage for the check’s history

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handler-templates.md
@@ -82,7 +82,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
-The template toolkit command uses event data you supply via STDIN in JSON format.
+The template toolkit command uses event data you supply via stdin in JSON format.
 
 Add the Sensu template toolkit command asset to Sensu:
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -19,7 +19,7 @@ Handlers are actions the Sensu backend executes on events.
 Several types of handlers are available.
 The most common are `pipe` handlers, which work similarly to [checks][1] and enable Sensu to interact with almost any computer program via [standard streams][2].
 
-- **Pipe handlers** send observation data (events) into arbitrary commands via `STDIN`
+- **Pipe handlers** send observation data (events) into arbitrary commands via stdin
 - **TCP/UDP handlers** send observation data (events) to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
@@ -30,7 +30,7 @@ Read [Use dynamic runtime assets to install plugins][23] to get started.
 
 ## Pipe handlers
 
-Pipe handlers are external commands that can consume [event][3] data via STDIN.
+Pipe handlers are external commands that can consume [event][3] data via stdin.
 
 ### Pipe handler example
 
@@ -488,7 +488,7 @@ namespace: production
 
 command      | 
 -------------|------
-description  | Handler command to be executed. The event data is passed to the process via `STDIN`. {{% notice note %}}
+description  | Handler command to be executed. The event data is passed to the process via stdin. {{% notice note %}}
 **NOTE**: The `command` attribute is only supported for pipe handlers (that is, handlers configured with `"type": "pipe"`).
 {{% /notice %}}
 required     | true (if `type` equals `pipe`)

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -90,7 +90,7 @@ Commands must be executable files that are discoverable on the Sensu agent syste
 
 Although Sensu agents attempt to execute any command defined for a check, successful check result processing requires adherence to a simple specification.
 
-- Result data is output to [STDOUT or STDERR][3].
+- Result data is output to [stdout or stderr][3].
     - For service checks, this output is typically a human-readable message.
     - For metric checks, this output contains the measurements gathered by the
       check.
@@ -1310,7 +1310,7 @@ silenced:
 
 |stdin       |      |
 -------------|------
-description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ STDIN. The command must expect the JSON data via STDIN, read it, and close STDIN. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close STDIN.
+description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ stdin. The command must expect the JSON data via stdin, read it, and close stdin. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/hooks.md
@@ -16,7 +16,7 @@ menu:
 Hooks are reusable commands the agent executes in response to a check result before creating an observability event.
 You can create, manage, and reuse hooks independently of checks.
 Hooks enrich observability event context by gathering relevant information based on the exit status code of a check (ex: `1`).
-Hook commands can also receive JSON serialized Sensu client data via `STDIN`.
+Hook commands can also receive JSON serialized Sensu client data via stdin.
 
 ## Hook example
 
@@ -379,7 +379,7 @@ runtime_assets:
 
 stdin        | 
 -------------|------
-description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process `STDIN`. Otherwise, `false`. The command must expect the JSON data via STDIN, read it, and close STDIN. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close STDIN.
+description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process stdin. Otherwise, `false`. The command must expect the JSON data via stdin, read it, and close stdin. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -243,7 +243,7 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ### Validate the CPU check
 
 The Sensu agent uses WebSocket to communicate with the Sensu backend, sending event data as JSON messages.
-As your checks run, the Sensu agent captures check standard output (`STDOUT`) or standard error (`STDERR`).
+As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.

--- a/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-transform/mutators.md
@@ -18,8 +18,8 @@ Sensu executes mutators during the **[transform][16]** stage of the [observabili
 [Pipelines][27] can specify a mutator to execute and transform observability event data before any handlers are applied.
 When the Sensu backend processes an event, it checks the pipeline for the presence of a mutator and executes that mutator before executing the handler.
 
-Mutators accept input/data via `STDIN` and can parse JSON event data.
-They output JSON data (modified event data) to `STDOUT` or `STDERR`.
+Mutators accept input/data via stdin and can parse JSON event data.
+They output JSON data (modified event data) to stdout or stderr.
 
 There are two types of mutators: [pipe][21] and [JavaScript][18].
 

--- a/content/sensu-go/6.5/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.5/operations/monitoring-as-code/_index.md
@@ -195,7 +195,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json > resource.json
 
 {{< /language-toggle >}}
 
-- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in STDOUT:
+- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in stdout:
 
   {{< language-toggle >}}
 
@@ -223,7 +223,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json >> resource.json
 
 {{< /language-toggle >}}
 
-- Append the resource defintion to an existing file and show the resource definition in STDOUT:
+- Append the resource defintion to an existing file and show the resource definition in stdout:
 
   {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/plugins/featured-integrations/prometheus.md
+++ b/content/sensu-go/6.5/plugins/featured-integrations/prometheus.md
@@ -19,7 +19,7 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Sensu Prometheus Collector
 
-The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to STDOUT in Influx, Graphite, or JSON format.
+The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to stdout in Influx, Graphite, or JSON format.
 
 ### Features
 

--- a/content/sensu-go/6.5/plugins/plugins.md
+++ b/content/sensu-go/6.5/plugins/plugins.md
@@ -15,9 +15,9 @@ menu:
 Sensu plugins provide executable scripts or other programs that you can use as Sensu checks, handlers, and mutators.
 Sensu plugins must comply with the following specification:
 
-- Accept input/data via `STDIN` (handler and mutator plugins only)
+- Accept input/data via stdin (handler and mutator plugins only)
   - Optionally able to parse a JSON data payload (that is, observation data in an event)
-- Output data to `STDOUT` or `STDERR`
+- Output data to stdout or stderr
 - Produce an exit status code to indicate state:
   - `0` indicates `OK`
   - `1` indicates `WARNING`
@@ -132,13 +132,13 @@ The following example demonstrates a very basic Sensu plugin in the Ruby program
 #
 require 'json'
 
-# Read the incoming JSON data from STDIN
-event = JSON.parse(STDIN.read, :symbolize_names => true)
+# Read the incoming JSON data from stdin
+event = JSON.parse(stdin.read, :symbolize_names => true)
 
 # Create an output object using Ruby string interpolation
 output = "The check named #{event[:check][:name]} generated the following output: #{event[:output]}"
 
-# Convert the mutated event data back to JSON and output it to STDOUT
+# Convert the mutated event data back to JSON and output it to stdout
 puts output
 {{< /code >}}
 

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -614,7 +614,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL errors could cause the backend to panic.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL would refuse to store event with a negative check status.
 - The backend will no longer start if the web UI TLS configuration is not fully specified.
-- The agent entity is now included in data passed to the STDIN for the command process.
+- The agent entity is now included in data passed to the stdin for the command process.
 - Improved check scheduling to prevent stale proxy entity data when using cron or round robin schedulers.
 - Fixed a bug that resulted in incorrect entity listings for agent entities created via the API instead of sensu-agent.
 - When downloading assets, Sensu now closes the response body after reading from it.
@@ -1222,7 +1222,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.14.1.
 - ([Commercial feature][79]) Sensuctl will not incorrectly warn of entity limits for unlimited licenses.
 - ([Commercial feature][79]) `oidc` authentication providers will now properly load on start-up.
 - When opening a Bolt database that is already open, `sensu-agent` will not hang indefinitely.
-- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to `STDOUT` instead of the specified file.
+- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to stdout instead of the specified file.
 - Fixed a crash in sensu-backend (panic: send on closed channel).
 
 ## 5.14.0 release notes
@@ -1256,7 +1256,7 @@ This can help in the rare case that something in the persisted state is leading 
 - ([Commercial feature][79]) `sensuctl` on Windows can now create Postgres resources.
 - ([Commercial feature][79]) Fixed a bug that resulted in event metrics being ignored when using the Postgres store.
 - Fixed a bug that caused checks to stop executing after a network error.
-- Fixed a bug that prevented `sensuctl create` with `stdin` from working.
+- Fixed a bug that prevented `sensuctl create` with stdin from working.
 - Splayed proxy checks are executed every interval (instead of every interval + interval * splay_coverage).
 - Proxy entity labels and annotations are now redacted in the web UI as expected.
 - Fixed a bug in the ring that prevented round robin schedules from recovering after quorum loss.
@@ -1334,7 +1334,7 @@ Read the [installation guide][16] for the latest download links.
 - Operators can now authenticate to Sensu via OpenID Direct Connect (OIDC) using sensuctl.
 Read the [authentication documentation][17] for details.
 - Added sensu-agent and sensuctl binary builds for FreeBSD.
-- Added sensuctl dump command to output resources to a file or STDOUT, making it easier to back up your Sensu backends.
+- Added sensuctl dump command to output resources to a file or stdout, making it easier to back up your Sensu backends.
 - Agents can now be configured with a list of executables that are allowed to run as check and hook commands.
 Read the [agent reference][78] for more information.
 
@@ -1362,7 +1362,7 @@ The system will refer to the namespace in the request URL.
 - Requesting events from the `GET /events/:entity` API endpoint now returns events only for the specified entity.
 - Running sensuctl config view without configuration no longer causes a crash.
 - Creating an entity via sensuctl with the `--interactive` flag now prompts for the entity name when it is not provided on the command line.
-- Check hooks with `stdin: true` now receive actual event data on STDIN instead of an empty event.
+- Check hooks with `stdin: true` now receive actual event data on stdin instead of an empty event.
 - Some issues with check scheduling and updating have been fixed by refactoring the backend's watcher implementation.
 
 **KNOWN ISSUES:**

--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
@@ -46,7 +46,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or JSON format:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from stdin or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 Review the [list of supported resource types][3] `for sensuctl create`.
 Read the [reference docs][6] for information about creating resource definitions.
@@ -243,7 +243,7 @@ sensuctl create --file pagerduty.json
 
 ## Delete resources
 
-The `sensuctl delete` command allows you to delete resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl delete` command allows you to delete resources by reading from stdin or a flag configured file (`-f`).
 The `delete` command accepts Sensu resource definitions in `wrapped-json` and `yaml` formats and uses the same [resource types][3] as `sensuctl create`.
 To be deleted successfully, resources provided to the `delete` command must match the name and namespace of an existing resource.
 
@@ -472,7 +472,7 @@ Read the [RBAC reference][22] for information about local user management with s
 For more information, read [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
+The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or stdin.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -462,7 +462,7 @@ For more information about event attributes, read the [event reference][28].
 `event.check.runtime_assets`         | array   | Sensu [dynamic runtime assets][17] used by the check
 `event.check.state`                  | string  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`
 `event.check.status`                 | integer | Exit status code produced by the check: `0` (OK), `1` (warning), `2` (critical), or other status (unknown or custom status)
-`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ STDIN
+`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ stdin
 `event.check.subscriptions`          | array   | Subscriptions that the check belongs to
 `event.check.timeout`                | integer | The check execution duration timeout in seconds
 `event.check.total_state_change`     | integer | The total state change percentage for the check’s history

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handler-templates.md
@@ -82,7 +82,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
-The template toolkit command uses event data you supply via STDIN in JSON format.
+The template toolkit command uses event data you supply via stdin in JSON format.
 
 Add the Sensu template toolkit command asset to Sensu:
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -19,7 +19,7 @@ Handlers are actions the Sensu backend executes on events.
 Several types of handlers are available.
 The most common are `pipe` handlers, which work similarly to [checks][1] and enable Sensu to interact with almost any computer program via [standard streams][2].
 
-- **Pipe handlers** send observation data (events) into arbitrary commands via `STDIN`
+- **Pipe handlers** send observation data (events) into arbitrary commands via stdin
 - **TCP/UDP handlers** send observation data (events) to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
@@ -30,7 +30,7 @@ Read [Use dynamic runtime assets to install plugins][23] to get started.
 
 ## Pipe handlers
 
-Pipe handlers are external commands that can consume [event][3] data via STDIN.
+Pipe handlers are external commands that can consume [event][3] data via stdin.
 
 ### Pipe handler example
 
@@ -488,7 +488,7 @@ namespace: production
 
 command      | 
 -------------|------
-description  | Handler command to be executed. The event data is passed to the process via `STDIN`. {{% notice note %}}
+description  | Handler command to be executed. The event data is passed to the process via stdin. {{% notice note %}}
 **NOTE**: The `command` attribute is only supported for pipe handlers (that is, handlers configured with `"type": "pipe"`).
 {{% /notice %}}
 required     | true (if `type` equals `pipe`)

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -90,7 +90,7 @@ Commands must be executable files that are discoverable on the Sensu agent syste
 
 Although Sensu agents attempt to execute any command defined for a check, successful check result processing requires adherence to a simple specification.
 
-- Result data is output to [STDOUT or STDERR][3].
+- Result data is output to [stdout or stderr][3].
     - For service checks, this output is typically a human-readable message.
     - For metric checks, this output contains the measurements gathered by the
       check.
@@ -1310,7 +1310,7 @@ silenced:
 
 |stdin       |      |
 -------------|------
-description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ STDIN. The command must expect the JSON data via STDIN, read it, and close STDIN. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close STDIN.
+description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ stdin. The command must expect the JSON data via stdin, read it, and close stdin. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/hooks.md
@@ -16,7 +16,7 @@ menu:
 Hooks are reusable commands the agent executes in response to a check result before creating an observability event.
 You can create, manage, and reuse hooks independently of checks.
 Hooks enrich observability event context by gathering relevant information based on the exit status code of a check (ex: `1`).
-Hook commands can also receive JSON serialized Sensu client data via `STDIN`.
+Hook commands can also receive JSON serialized Sensu client data via stdin.
 
 ## Hook example
 
@@ -379,7 +379,7 @@ runtime_assets:
 
 stdin        | 
 -------------|------
-description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process `STDIN`. Otherwise, `false`. The command must expect the JSON data via STDIN, read it, and close STDIN. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close STDIN.
+description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process stdin. Otherwise, `false`. The command must expect the JSON data via stdin, read it, and close stdin. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -243,7 +243,7 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ### Validate the CPU check
 
 The Sensu agent uses WebSocket to communicate with the Sensu backend, sending event data as JSON messages.
-As your checks run, the Sensu agent captures check standard output (`STDOUT`) or standard error (`STDERR`).
+As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.

--- a/content/sensu-go/6.6/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-transform/mutators.md
@@ -18,8 +18,8 @@ Sensu executes mutators during the **[transform][16]** stage of the [observabili
 [Pipelines][27] can specify a mutator to execute and transform observability event data before any handlers are applied.
 When the Sensu backend processes an event, it checks the pipeline for the presence of a mutator and executes that mutator before executing the handler.
 
-Mutators accept input/data via `STDIN` and can parse JSON event data.
-They output JSON data (modified event data) to `STDOUT` or `STDERR`.
+Mutators accept input/data via stdin and can parse JSON event data.
+They output JSON data (modified event data) to stdout or stderr.
 
 There are two types of mutators: [pipe][21] and [JavaScript][18].
 

--- a/content/sensu-go/6.6/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.6/operations/monitoring-as-code/_index.md
@@ -195,7 +195,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json > resource.json
 
 {{< /language-toggle >}}
 
-- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in STDOUT:
+- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in stdout:
 
   {{< language-toggle >}}
 
@@ -223,7 +223,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json >> resource.json
 
 {{< /language-toggle >}}
 
-- Append the resource defintion to an existing file and show the resource definition in STDOUT:
+- Append the resource defintion to an existing file and show the resource definition in stdout:
 
   {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/plugins/featured-integrations/prometheus.md
+++ b/content/sensu-go/6.6/plugins/featured-integrations/prometheus.md
@@ -19,7 +19,7 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Sensu Prometheus Collector
 
-The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to STDOUT in Influx, Graphite, or JSON format.
+The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to stdout in Influx, Graphite, or JSON format.
 
 ### Features
 

--- a/content/sensu-go/6.6/plugins/plugins.md
+++ b/content/sensu-go/6.6/plugins/plugins.md
@@ -15,9 +15,9 @@ menu:
 Sensu plugins provide executable scripts or other programs that you can use as Sensu checks, handlers, and mutators.
 Sensu plugins must comply with the following specification:
 
-- Accept input/data via `STDIN` (handler and mutator plugins only)
+- Accept input/data via stdin (handler and mutator plugins only)
   - Optionally able to parse a JSON data payload (that is, observation data in an event)
-- Output data to `STDOUT` or `STDERR`
+- Output data to stdout or stderr
 - Produce an exit status code to indicate state:
   - `0` indicates `OK`
   - `1` indicates `WARNING`
@@ -132,13 +132,13 @@ The following example demonstrates a very basic Sensu plugin in the Ruby program
 #
 require 'json'
 
-# Read the incoming JSON data from STDIN
-event = JSON.parse(STDIN.read, :symbolize_names => true)
+# Read the incoming JSON data from stdin
+event = JSON.parse(stdin.read, :symbolize_names => true)
 
 # Create an output object using Ruby string interpolation
 output = "The check named #{event[:check][:name]} generated the following output: #{event[:output]}"
 
-# Convert the mutated event data back to JSON and output it to STDOUT
+# Convert the mutated event data back to JSON and output it to stdout
 puts output
 {{< /code >}}
 

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -762,7 +762,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL errors could cause the backend to panic.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL would refuse to store event with a negative check status.
 - The backend will no longer start if the web UI TLS configuration is not fully specified.
-- The agent entity is now included in data passed to the STDIN for the command process.
+- The agent entity is now included in data passed to the stdin for the command process.
 - Improved check scheduling to prevent stale proxy entity data when using cron or round robin schedulers.
 - Fixed a bug that resulted in incorrect entity listings for agent entities created via the API instead of sensu-agent.
 - When downloading assets, Sensu now closes the response body after reading from it.
@@ -1370,7 +1370,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.14.1.
 - ([Commercial feature][79]) Sensuctl will not incorrectly warn of entity limits for unlimited licenses.
 - ([Commercial feature][79]) `oidc` authentication providers will now properly load on start-up.
 - When opening a Bolt database that is already open, `sensu-agent` will not hang indefinitely.
-- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to `STDOUT` instead of the specified file.
+- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to stdout instead of the specified file.
 - Fixed a crash in sensu-backend (panic: send on closed channel).
 
 ## 5.14.0 release notes
@@ -1404,7 +1404,7 @@ This can help in the rare case that something in the persisted state is leading 
 - ([Commercial feature][79]) `sensuctl` on Windows can now create Postgres resources.
 - ([Commercial feature][79]) Fixed a bug that resulted in event metrics being ignored when using the Postgres store.
 - Fixed a bug that caused checks to stop executing after a network error.
-- Fixed a bug that prevented `sensuctl create` with `stdin` from working.
+- Fixed a bug that prevented `sensuctl create` with stdin from working.
 - Splayed proxy checks are executed every interval (instead of every interval + interval * splay_coverage).
 - Proxy entity labels and annotations are now redacted in the web UI as expected.
 - Fixed a bug in the ring that prevented round robin schedules from recovering after quorum loss.
@@ -1482,7 +1482,7 @@ Read the [installation guide][16] for the latest download links.
 - Operators can now authenticate to Sensu via OpenID Direct Connect (OIDC) using sensuctl.
 Read the [authentication documentation][17] for details.
 - Added sensu-agent and sensuctl binary builds for FreeBSD.
-- Added sensuctl dump command to output resources to a file or STDOUT, making it easier to back up your Sensu backends.
+- Added sensuctl dump command to output resources to a file or stdout, making it easier to back up your Sensu backends.
 - Agents can now be configured with a list of executables that are allowed to run as check and hook commands.
 Read the [agent reference][78] for more information.
 
@@ -1510,7 +1510,7 @@ The system will refer to the namespace in the request URL.
 - Requesting events from the `GET /events/:entity` API endpoint now returns events only for the specified entity.
 - Running sensuctl config view without configuration no longer causes a crash.
 - Creating an entity via sensuctl with the `--interactive` flag now prompts for the entity name when it is not provided on the command line.
-- Check hooks with `stdin: true` now receive actual event data on STDIN instead of an empty event.
+- Check hooks with `stdin: true` now receive actual event data on stdin instead of an empty event.
 - Some issues with check scheduling and updating have been fixed by refactoring the backend's watcher implementation.
 
 **KNOWN ISSUES:**

--- a/content/sensu-go/6.6/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.6/sensuctl/back-up-recover.md
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
@@ -46,7 +46,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or JSON format:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from stdin or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 Review the [list of supported resource types][3] `for sensuctl create`.
 Read the [reference docs][6] for information about creating resource definitions.
@@ -243,7 +243,7 @@ sensuctl create --file pagerduty.json
 
 ## Delete resources
 
-The `sensuctl delete` command allows you to delete resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl delete` command allows you to delete resources by reading from stdin or a flag configured file (`-f`).
 The `delete` command accepts Sensu resource definitions in `wrapped-json` and `yaml` formats and uses the same [resource types][3] as `sensuctl create`.
 To be deleted successfully, resources provided to the `delete` command must match the name and namespace of an existing resource.
 
@@ -472,7 +472,7 @@ Read the [RBAC reference][22] for information about local user management with s
 For more information, read [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
+The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or stdin.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -462,7 +462,7 @@ For more information about event attributes, read the [event reference][28].
 `event.check.runtime_assets`         | array   | Sensu [dynamic runtime assets][17] used by the check
 `event.check.state`                  | string  | The state of the check: `passing` (status `0`), `failing` (status other than `0`), or `flapping`
 `event.check.status`                 | integer | Exit status code produced by the check: `0` (OK), `1` (warning), `2` (critical), or other status (unknown or custom status)
-`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ STDIN
+`event.check.stdin`                  | Boolean | Whether the Sensu agent writes JSON-serialized entity and check data to the command process’ stdin
 `event.check.subscriptions`          | array   | Subscriptions that the check belongs to
 `event.check.timeout`                | integer | The check execution duration timeout in seconds
 `event.check.total_state_change`     | integer | The total state change percentage for the check’s history

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handler-templates.md
@@ -82,7 +82,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
-The template toolkit command uses event data you supply via STDIN in JSON format.
+The template toolkit command uses event data you supply via stdin in JSON format.
 
 Add the Sensu template toolkit command asset to Sensu:
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
@@ -19,7 +19,7 @@ Handlers are actions the Sensu backend executes on events.
 Several types of handlers are available.
 The most common are `pipe` handlers, which work similarly to [checks][1] and enable Sensu to interact with almost any computer program via [standard streams][2].
 
-- **Pipe handlers** send observation data (events) into arbitrary commands via `STDIN`
+- **Pipe handlers** send observation data (events) into arbitrary commands via stdin
 - **TCP/UDP handlers** send observation data (events) to a remote socket
 - **Handler sets** group event handlers and streamline groups of actions to execute for certain types of events (also called "set handlers")
 
@@ -30,7 +30,7 @@ Read [Use dynamic runtime assets to install plugins][23] to get started.
 
 ## Pipe handlers
 
-Pipe handlers are external commands that can consume [event][3] data via STDIN.
+Pipe handlers are external commands that can consume [event][3] data via stdin.
 
 ### Pipe handler example
 
@@ -488,7 +488,7 @@ namespace: production
 
 command      | 
 -------------|------
-description  | Handler command to be executed. The event data is passed to the process via `STDIN`. {{% notice note %}}
+description  | Handler command to be executed. The event data is passed to the process via stdin. {{% notice note %}}
 **NOTE**: The `command` attribute is only supported for pipe handlers (that is, handlers configured with `"type": "pipe"`).
 {{% /notice %}}
 required     | true (if `type` equals `pipe`)

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
@@ -90,7 +90,7 @@ Commands must be executable files that are discoverable on the Sensu agent syste
 
 Although Sensu agents attempt to execute any command defined for a check, successful check result processing requires adherence to a simple specification.
 
-- Result data is output to [STDOUT or STDERR][3].
+- Result data is output to [stdout or stderr][3].
     - For service checks, this output is typically a human-readable message.
     - For metric checks, this output contains the measurements gathered by the
       check.
@@ -1641,7 +1641,7 @@ silenced:
 
 |stdin       |      |
 -------------|------
-description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ STDIN. The command must expect the JSON data via STDIN, read it, and close STDIN. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close STDIN.
+description  | `true` if the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ stdin. The command must expect the JSON data via stdin, read it, and close stdin. Otherwise, `false`. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the check process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/hooks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/hooks.md
@@ -16,7 +16,7 @@ menu:
 Hooks are reusable commands the agent executes in response to a check result before creating an observability event.
 You can create, manage, and reuse hooks independently of checks.
 Hooks enrich observability event context by gathering relevant information based on the exit status code of a check (ex: `1`).
-Hook commands can also receive JSON serialized Sensu client data via `STDIN`.
+Hook commands can also receive JSON serialized Sensu client data via stdin.
 
 ## Hook example
 
@@ -379,7 +379,7 @@ runtime_assets:
 
 stdin        | 
 -------------|------
-description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process `STDIN`. Otherwise, `false`. The command must expect the JSON data via STDIN, read it, and close STDIN. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close STDIN.
+description  | If `true`, the Sensu agent writes JSON serialized Sensu entity and check data to the command process stdin. Otherwise, `false`. The command must expect the JSON data via stdin, read it, and close stdin. This attribute cannot be used with existing Sensu check plugins or Nagios plugins because the Sensu agent will wait indefinitely for the hook process to read and close stdin.
 required     | false
 type         | Boolean
 default      | `false`

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -243,7 +243,7 @@ If you want to share, reuse, and maintain this check just like you would code, y
 ### Validate the CPU check
 
 The Sensu agent uses WebSocket to communicate with the Sensu backend, sending event data as JSON messages.
-As your checks run, the Sensu agent captures check standard output (`STDOUT`) or standard error (`STDERR`).
+As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
 It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.

--- a/content/sensu-go/6.7/observability-pipeline/observe-transform/mutators.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-transform/mutators.md
@@ -18,8 +18,8 @@ Sensu executes mutators during the **[transform][16]** stage of the [observabili
 [Pipelines][27] can specify a mutator to execute and transform observability event data before any handlers are applied.
 When the Sensu backend processes an event, it checks the pipeline for the presence of a mutator and executes that mutator before executing the handler.
 
-Mutators accept input/data via `STDIN` and can parse JSON event data.
-They output JSON data (modified event data) to `STDOUT` or `STDERR`.
+Mutators accept input/data via stdin and can parse JSON event data.
+They output JSON data (modified event data) to stdout or stderr.
 
 There are two types of mutators: [pipe][21] and [JavaScript][18].
 

--- a/content/sensu-go/6.7/operations/monitoring-as-code/_index.md
+++ b/content/sensu-go/6.7/operations/monitoring-as-code/_index.md
@@ -195,7 +195,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json > resource.json
 
 {{< /language-toggle >}}
 
-- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in STDOUT:
+- Copy the resource defintion to a new file (or overwrite an existing file with the same name) and show the resource definition in stdout:
 
   {{< language-toggle >}}
 
@@ -223,7 +223,7 @@ sensuctl <resource> info <resource_name> --format wrapped-json >> resource.json
 
 {{< /language-toggle >}}
 
-- Append the resource defintion to an existing file and show the resource definition in STDOUT:
+- Append the resource defintion to an existing file and show the resource definition in stdout:
 
   {{< language-toggle >}}
 

--- a/content/sensu-go/6.7/plugins/featured-integrations/prometheus.md
+++ b/content/sensu-go/6.7/plugins/featured-integrations/prometheus.md
@@ -19,7 +19,7 @@ To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.s
 
 ## Sensu Prometheus Collector
 
-The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to STDOUT in Influx, Graphite, or JSON format.
+The [Sensu Prometheus Collector plugin][6] is a Sensu [check][8] that collects metrics from a Prometheus exporter or the Prometheus query API and outputs the metrics to stdout in Influx, Graphite, or JSON format.
 
 ### Features
 

--- a/content/sensu-go/6.7/plugins/plugins.md
+++ b/content/sensu-go/6.7/plugins/plugins.md
@@ -15,9 +15,9 @@ menu:
 Sensu plugins provide executable scripts or other programs that you can use as Sensu checks, handlers, and mutators.
 Sensu plugins must comply with the following specification:
 
-- Accept input/data via `STDIN` (handler and mutator plugins only)
+- Accept input/data via stdin (handler and mutator plugins only)
   - Optionally able to parse a JSON data payload (that is, observation data in an event)
-- Output data to `STDOUT` or `STDERR`
+- Output data to stdout or stderr
 - Produce an exit status code to indicate state:
   - `0` indicates `OK`
   - `1` indicates `WARNING`
@@ -132,13 +132,13 @@ The following example demonstrates a very basic Sensu plugin in the Ruby program
 #
 require 'json'
 
-# Read the incoming JSON data from STDIN
-event = JSON.parse(STDIN.read, :symbolize_names => true)
+# Read the incoming JSON data from stdin
+event = JSON.parse(stdin.read, :symbolize_names => true)
 
 # Create an output object using Ruby string interpolation
 output = "The check named #{event[:check][:name]} generated the following output: #{event[:output]}"
 
-# Convert the mutated event data back to JSON and output it to STDOUT
+# Convert the mutated event data back to JSON and output it to stdout
 puts output
 {{< /code >}}
 

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -844,7 +844,7 @@ SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL errors could cause the backend to panic.
 - ([Commercial feature][172]) Fixed a bug where PostgreSQL would refuse to store event with a negative check status.
 - The backend will no longer start if the web UI TLS configuration is not fully specified.
-- The agent entity is now included in data passed to the STDIN for the command process.
+- The agent entity is now included in data passed to the stdin for the command process.
 - Improved check scheduling to prevent stale proxy entity data when using cron or round robin schedulers.
 - Fixed a bug that resulted in incorrect entity listings for agent entities created via the API instead of sensu-agent.
 - When downloading assets, Sensu now closes the response body after reading from it.
@@ -1452,7 +1452,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.14.1.
 - ([Commercial feature][79]) Sensuctl will not incorrectly warn of entity limits for unlimited licenses.
 - ([Commercial feature][79]) `oidc` authentication providers will now properly load on start-up.
 - When opening a Bolt database that is already open, `sensu-agent` will not hang indefinitely.
-- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to `STDOUT` instead of the specified file.
+- Running [`sensuctl dump`][84] for multiple resource types with the output format as YAML will not result in separators being printed to stdout instead of the specified file.
 - Fixed a crash in sensu-backend (panic: send on closed channel).
 
 ## 5.14.0 release notes
@@ -1486,7 +1486,7 @@ This can help in the rare case that something in the persisted state is leading 
 - ([Commercial feature][79]) `sensuctl` on Windows can now create Postgres resources.
 - ([Commercial feature][79]) Fixed a bug that resulted in event metrics being ignored when using the Postgres store.
 - Fixed a bug that caused checks to stop executing after a network error.
-- Fixed a bug that prevented `sensuctl create` with `stdin` from working.
+- Fixed a bug that prevented `sensuctl create` with stdin from working.
 - Splayed proxy checks are executed every interval (instead of every interval + interval * splay_coverage).
 - Proxy entity labels and annotations are now redacted in the web UI as expected.
 - Fixed a bug in the ring that prevented round robin schedules from recovering after quorum loss.
@@ -1564,7 +1564,7 @@ Read the [installation guide][16] for the latest download links.
 - Operators can now authenticate to Sensu via OpenID Direct Connect (OIDC) using sensuctl.
 Read the [authentication documentation][17] for details.
 - Added sensu-agent and sensuctl binary builds for FreeBSD.
-- Added sensuctl dump command to output resources to a file or STDOUT, making it easier to back up your Sensu backends.
+- Added sensuctl dump command to output resources to a file or stdout, making it easier to back up your Sensu backends.
 - Agents can now be configured with a list of executables that are allowed to run as check and hook commands.
 Read the [agent reference][78] for more information.
 
@@ -1592,7 +1592,7 @@ The system will refer to the namespace in the request URL.
 - Requesting events from the `GET /events/:entity` API endpoint now returns events only for the specified entity.
 - Running sensuctl config view without configuration no longer causes a crash.
 - Creating an entity via sensuctl with the `--interactive` flag now prompts for the entity name when it is not provided on the command line.
-- Check hooks with `stdin: true` now receive actual event data on STDIN instead of an empty event.
+- Check hooks with `stdin: true` now receive actual event data on stdin instead of an empty event.
 - Some issues with check scheduling and updating have been fixed by refactoring the backend's watcher implementation.
 
 **KNOWN ISSUES:**

--- a/content/sensu-go/6.7/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.7/sensuctl/back-up-recover.md
@@ -11,7 +11,7 @@ menu:
     parent: sensuctl
 ---
 
-The sensuctl dump command allows you to export your [resources][6] to standard out (STDOUT) or to a file.
+The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
@@ -46,7 +46,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to STDOUT in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or JSON format:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.7/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.7/sensuctl/create-manage-resources.md
@@ -16,7 +16,7 @@ Sensuctl works by calling Sensu’s underlying API to create, read, update, and 
 
 ## Create resources
 
-The `sensuctl create` command allows you to create or update resources by reading from STDIN or a [flag][36] configured file (`-f`).
+The `sensuctl create` command allows you to create or update resources by reading from stdin or a [flag][36] configured file (`-f`).
 The `create` command accepts Sensu resource definitions in [`yaml` or `wrapped-json` formats][4], which wrap the contents of the resource in `spec` and identify the resource `type` and `api_version`.
 Review the [list of supported resource types][3] `for sensuctl create`.
 Read the [reference docs][6] for information about creating resource definitions.
@@ -243,7 +243,7 @@ sensuctl create --file pagerduty.json
 
 ## Delete resources
 
-The `sensuctl delete` command allows you to delete resources by reading from STDIN or a flag configured file (`-f`).
+The `sensuctl delete` command allows you to delete resources by reading from stdin or a flag configured file (`-f`).
 The `delete` command accepts Sensu resource definitions in `wrapped-json` and `yaml` formats and uses the same [resource types][3] as `sensuctl create`.
 To be deleted successfully, resources provided to the `delete` command must match the name and namespace of an existing resource.
 
@@ -472,7 +472,7 @@ Read the [RBAC reference][22] for information about local user management with s
 For more information, read [Get started with commercial features](../../commercial/).
 {{% /notice %}}
 
-The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or STDIN.
+The `sensuctl prune` subcommand allows you to delete resources that do not appear in a given set of Sensu objects (called a "configuration") from a from a file, URL, or stdin.
 For example, you can use `sensuctl create` to to apply a new configuration, then use `sensuctl prune` to prune unneeded resources, resources that were created by a specific user or that include a specific label selector, and more.
 
 {{% notice note %}}


### PR DESCRIPTION
## Description
Removes capitalization and code formatting from stdin, stdout, and stderr throughout the docs

## Motivation and Context
Found when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>