### PR TITLE
Update env var steps in agent and backend references

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1678,7 +1678,7 @@ Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables: `/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1701,7 +1701,7 @@ All environment variables that control Sensu agent configuration begin with `SEN
      For a custom environment variable, you do not have to prepend `SENSU`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      In this example, the `api-host` flag is configured as an environment variable and set to `"0.0.0.0"`:
      
@@ -1717,7 +1717,7 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-agent service so these settings can take effect.
+4. Restart the sensu-agent service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1363,7 +1363,7 @@ Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables: `/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1386,7 +1386,7 @@ All environment variables that control Sensu backend configuration begin with `S
      For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      For example, to create `api-listen-address` as an environment variable and set it to `192.168.100.20:8080`:
      
@@ -1402,7 +1402,7 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-backend service so these settings can take effect.
+4. Restart the sensu-backend service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1728,7 +1728,7 @@ Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables: `/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1751,7 +1751,7 @@ All environment variables that control Sensu agent configuration begin with `SEN
      For a custom environment variable, you do not have to prepend `SENSU`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      In this example, the `api-host` flag is configured as an environment variable and set to `"0.0.0.0"`:
      
@@ -1767,7 +1767,7 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-agent service so these settings can take effect.
+4. Restart the sensu-agent service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1500,7 +1500,7 @@ Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables: `/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1523,7 +1523,7 @@ All environment variables that control Sensu backend configuration begin with `S
      For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      For example, to create `api-listen-address` as an environment variable and set it to `192.168.100.20:8080`:
      
@@ -1539,7 +1539,7 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-backend service so these settings can take effect.
+4. Restart the sensu-backend service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -1728,7 +1728,7 @@ Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables: `/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1751,7 +1751,7 @@ All environment variables that control Sensu agent configuration begin with `SEN
      For a custom environment variable, you do not have to prepend `SENSU`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      In this example, the `api-host` flag is configured as an environment variable and set to `"0.0.0.0"`:
      
@@ -1767,7 +1767,7 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-agent service so these settings can take effect.
+4. Restart the sensu-agent service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -1514,7 +1514,7 @@ Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables: `/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1537,7 +1537,7 @@ All environment variables that control Sensu backend configuration begin with `S
      For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      For example, to create `api-listen-address` as an environment variable and set it to `192.168.100.20:8080`:
      
@@ -1553,7 +1553,7 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-backend service so these settings can take effect.
+4. Restart the sensu-backend service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -1784,7 +1784,7 @@ Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables: `/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-agent` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1807,7 +1807,7 @@ All environment variables that control Sensu agent configuration begin with `SEN
      For a custom environment variable, you do not have to prepend `SENSU`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-agent` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-agent` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      In this example, the `api-host` flag is configured as an environment variable and set to `"0.0.0.0"`:
      
@@ -1823,7 +1823,7 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-agent service so these settings can take effect.
+4. Restart the sensu-agent service so these settings can take effect:
 
      {{< language-toggle >}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -1540,7 +1540,7 @@ Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
 
-1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables: `/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems.
+1. Create the files from which the `sensu-backend` service configured by our supported packages will read environment variables:
 
      {{< language-toggle >}}
      
@@ -1563,7 +1563,7 @@ All environment variables that control Sensu backend configuration begin with `S
      For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
-3. Add the environment variable to the environment file (`/etc/default/sensu-backend` for Debian/Ubuntu systems or `/etc/sysconfig/sensu-backend` for RHEL/CentOS systems).
+3. Add the environment variable to the environment file.
 
      For example, to create `api-listen-address` as an environment variable and set it to `192.168.100.20:8080`:
      
@@ -1579,7 +1579,7 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< /language-toggle >}}
 
-4. Restart the sensu-backend service so these settings can take effect.
+4. Restart the sensu-backend service so these settings can take effect:
 
      {{< language-toggle >}}
 


### PR DESCRIPTION
## Description
Removes repetitive details from env var setup steps in the agent and backend references

## Motivation and Context
Noticed when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>