### PR TITLE
Add Windows path for agent env vars

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -616,7 +616,7 @@ By default, the agent loads configuration from `%ALLUSERSPROFILE%\sensu\config\a
 Configure the configuration file and log file locations using the `config-file` and `log-file` flags:
 
 {{< code shell >}}
-sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.yml' --log-file 'C:\\monitoring\\sensu\\log\\sensu-agent.log'
+sensu-agent service install --config-file 'C:\\ProgramData\\sensu\\config\\agent.yml' --log-file 'C:\\ProgramData\\sensu\\log\\sensu-agent.log'
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -1689,6 +1689,14 @@ sudo touch /etc/default/sensu-agent
 {{< code shell "RHEL/CentOS" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
+
+{{< code shell "Windows" >}}
+# By default, the agent loads configuration from %ALLUSERSPROFILE%\sensu\config\agent.yml.
+# If you did not change the location for the configuration #file during installation,
+# the sensu-agent configuration file path is:
+
+C:\ProgramData\sensu\config\agent.yml
+{{< /code >}}
      
      {{< /language-toggle >}}
 
@@ -1715,6 +1723,13 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+# Save the following environment variable in the configuration file
+# at C:\ProgramData\sensu\config\agent.yml:
+
+SENSU_API_HOST="0.0.0.0"
+{{< /code >}}
+
      {{< /language-toggle >}}
 
 4. Restart the sensu-agent service so these settings can take effect:
@@ -1727,6 +1742,10 @@ sudo systemctl restart sensu-agent
 
 {{< code shell "RHEL/CentOS" >}}
 sudo systemctl restart sensu-agent
+{{< /code >}}
+
+{{< code shell "Windows" >}}
+sc.exe start SensuAgent
 {{< /code >}}
 
      {{< /language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -622,7 +622,7 @@ By default, the agent loads configuration from `%ALLUSERSPROFILE%\sensu\config\a
 Configure the configuration file and log file locations using the `config-file` and `log-file` flags:
 
 {{< code shell >}}
-sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.yml' --log-file 'C:\\monitoring\\sensu\\log\\sensu-agent.log'
+sensu-agent service install --config-file 'C:\\ProgramData\\sensu\\config\\agent.yml' --log-file 'C:\\ProgramData\\sensu\\log\\sensu-agent.log'
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -1739,6 +1739,14 @@ sudo touch /etc/default/sensu-agent
 {{< code shell "RHEL/CentOS" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
+
+{{< code shell "Windows" >}}
+# By default, the agent loads configuration from %ALLUSERSPROFILE%\sensu\config\agent.yml.
+# If you did not change the location for the configuration #file during installation,
+# the sensu-agent configuration file path is:
+
+C:\ProgramData\sensu\config\agent.yml
+{{< /code >}}
      
      {{< /language-toggle >}}
 
@@ -1765,6 +1773,13 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+# Save the following environment variable in the configuration file
+# at C:\ProgramData\sensu\config\agent.yml:
+
+SENSU_API_HOST="0.0.0.0"
+{{< /code >}}
+
      {{< /language-toggle >}}
 
 4. Restart the sensu-agent service so these settings can take effect:
@@ -1777,6 +1792,10 @@ sudo systemctl restart sensu-agent
 
 {{< code shell "RHEL/CentOS" >}}
 sudo systemctl restart sensu-agent
+{{< /code >}}
+
+{{< code shell "Windows" >}}
+sc.exe start SensuAgent
 {{< /code >}}
 
      {{< /language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -622,7 +622,7 @@ By default, the agent loads configuration from `%ALLUSERSPROFILE%\sensu\config\a
 Configure the configuration file and log file locations using the `config-file` and `log-file` flags:
 
 {{< code shell >}}
-sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.yml' --log-file 'C:\\monitoring\\sensu\\log\\sensu-agent.log'
+sensu-agent service install --config-file 'C:\\ProgramData\\sensu\\config\\agent.yml' --log-file 'C:\\ProgramData\\sensu\\log\\sensu-agent.log'
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -1739,6 +1739,14 @@ sudo touch /etc/default/sensu-agent
 {{< code shell "RHEL/CentOS" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
+
+{{< code shell "Windows" >}}
+# By default, the agent loads configuration from %ALLUSERSPROFILE%\sensu\config\agent.yml.
+# If you did not change the location for the configuration #file during installation,
+# the sensu-agent configuration file path is:
+
+C:\ProgramData\sensu\config\agent.yml
+{{< /code >}}
      
      {{< /language-toggle >}}
 
@@ -1765,6 +1773,13 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+# Save the following environment variable in the configuration file
+# at C:\ProgramData\sensu\config\agent.yml:
+
+SENSU_API_HOST="0.0.0.0"
+{{< /code >}}
+
      {{< /language-toggle >}}
 
 4. Restart the sensu-agent service so these settings can take effect:
@@ -1777,6 +1792,10 @@ sudo systemctl restart sensu-agent
 
 {{< code shell "RHEL/CentOS" >}}
 sudo systemctl restart sensu-agent
+{{< /code >}}
+
+{{< code shell "Windows" >}}
+sc.exe start SensuAgent
 {{< /code >}}
 
      {{< /language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -647,7 +647,7 @@ By default, the agent loads configuration from `%ALLUSERSPROFILE%\sensu\config\a
 Configure the configuration file and log file locations using the `config-file` and `log-file` flags:
 
 {{< code shell >}}
-sensu-agent service install --config-file 'C:\\monitoring\\sensu\\config\\agent.yml' --log-file 'C:\\monitoring\\sensu\\log\\sensu-agent.log'
+sensu-agent service install --config-file 'C:\\ProgramData\\sensu\\config\\agent.yml' --log-file 'C:\\ProgramData\\sensu\\log\\sensu-agent.log'
 {{< /code >}}
 
 {{< platformBlockClose >}}
@@ -1795,6 +1795,14 @@ sudo touch /etc/default/sensu-agent
 {{< code shell "RHEL/CentOS" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
+
+{{< code shell "Windows" >}}
+# By default, the agent loads configuration from %ALLUSERSPROFILE%\sensu\config\agent.yml.
+# If you did not change the location for the configuration #file during installation,
+# the sensu-agent configuration file path is:
+
+C:\ProgramData\sensu\config\agent.yml
+{{< /code >}}
      
      {{< /language-toggle >}}
 
@@ -1821,6 +1829,13 @@ echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
+{{< code shell "Windows" >}}
+# Save the following environment variable in the configuration file
+# at C:\ProgramData\sensu\config\agent.yml:
+
+SENSU_API_HOST="0.0.0.0"
+{{< /code >}}
+
      {{< /language-toggle >}}
 
 4. Restart the sensu-agent service so these settings can take effect:
@@ -1833,6 +1848,10 @@ sudo systemctl restart sensu-agent
 
 {{< code shell "RHEL/CentOS" >}}
 sudo systemctl restart sensu-agent
+{{< /code >}}
+
+{{< code shell "Windows" >}}
+sc.exe start SensuAgent
 {{< /code >}}
 
      {{< /language-toggle >}}


### PR DESCRIPTION
## Description
Adds Windows path and instructions for agent environment variable setup steps (https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#configuration-via-environment-variables) 

## Motivation and Context
https://sensucommunity.slack.com/archives/C6ARWHC2W/p1653057875731969

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>