### PR TITLE
Add note about common packages and all packages on platforms page

### DIFF
--- a/content/sensu-go/6.4/platforms.md
+++ b/content/sensu-go/6.4/platforms.md
@@ -16,7 +16,12 @@ Sensu downloads are provided under the [Sensu commercial license][7].
 
 ## Supported packages
 
-Supported packages are available through [sensu/stable][8] on packagecloud and the [downloads page][9].
+This page lists supported packages for the most common platforms.
+Supported packages for common platforms are available from [sensu/stable][8] on packagecloud and the [Sensu downloads page][9].
+
+{{% notice note %}}
+**NOTE**: The [sensu/stable](https://packagecloud.io/sensu/stable/) repository on packagecloud includes packages for every platform Sensu supports, in addition to packages for the common platforms listed on this page.
+{{% /notice %}}
 
 ### Sensu backend
 

--- a/content/sensu-go/6.5/platforms.md
+++ b/content/sensu-go/6.5/platforms.md
@@ -16,7 +16,12 @@ Sensu downloads are provided under the [Sensu commercial license][7].
 
 ## Supported packages
 
-Supported packages are available through [sensu/stable][8] on packagecloud and the [downloads page][9].
+This page lists supported packages for the most common platforms.
+Supported packages for common platforms are available from [sensu/stable][8] on packagecloud and the [Sensu downloads page][9].
+
+{{% notice note %}}
+**NOTE**: The [sensu/stable](https://packagecloud.io/sensu/stable/) repository on packagecloud includes packages for every platform Sensu supports, in addition to packages for the common platforms listed on this page.
+{{% /notice %}}
 
 ### Sensu backend
 

--- a/content/sensu-go/6.6/platforms.md
+++ b/content/sensu-go/6.6/platforms.md
@@ -16,7 +16,12 @@ Sensu downloads are provided under the [Sensu commercial license][7].
 
 ## Supported packages
 
-Supported packages are available through [sensu/stable][8] on packagecloud and the [downloads page][9].
+This page lists supported packages for the most common platforms.
+Supported packages for common platforms are available from [sensu/stable][8] on packagecloud and the [Sensu downloads page][9].
+
+{{% notice note %}}
+**NOTE**: The [sensu/stable](https://packagecloud.io/sensu/stable/) repository on packagecloud includes packages for every platform Sensu supports, in addition to packages for the common platforms listed on this page.
+{{% /notice %}}
 
 ### Sensu backend
 

--- a/content/sensu-go/6.7/platforms.md
+++ b/content/sensu-go/6.7/platforms.md
@@ -16,7 +16,12 @@ Sensu downloads are provided under the [Sensu commercial license][7].
 
 ## Supported packages
 
-Supported packages are available through [sensu/stable][8] on packagecloud and the [downloads page][9].
+This page lists supported packages for the most common platforms.
+Supported packages for common platforms are available from [sensu/stable][8] on packagecloud and the [Sensu downloads page][9].
+
+{{% notice note %}}
+**NOTE**: The [sensu/stable](https://packagecloud.io/sensu/stable/) repository on packagecloud includes packages for every platform Sensu supports, in addition to packages for the common platforms listed on this page.
+{{% /notice %}}
 
 ### Sensu backend
 


### PR DESCRIPTION
## Description
Revises the supported packages content to explain that the platforms and distributions page lists only the most common packages, but users can find all packages we support at packagecloud.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3845

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>