### PR TITLE
Fix broken link on namespaces API page

### DIFF
--- a/content/sensu-go/6.4/api/core/namespaces.md
+++ b/content/sensu-go/6.4/api/core/namespaces.md
@@ -207,7 +207,7 @@ output         | {{< code text >}}
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the `/user-namespaces` API endpoint in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../commercial/).
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 The `/user-namespaces` API endpoint provides HTTP GET access to the namespaces the current user can access.

--- a/content/sensu-go/6.5/api/core/namespaces.md
+++ b/content/sensu-go/6.5/api/core/namespaces.md
@@ -207,7 +207,7 @@ output         | {{< code text >}}
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the `/user-namespaces` API endpoint in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../commercial/).
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 The `/user-namespaces` API endpoint provides HTTP GET access to the namespaces the current user can access.

--- a/content/sensu-go/6.6/api/core/namespaces.md
+++ b/content/sensu-go/6.6/api/core/namespaces.md
@@ -207,7 +207,7 @@ output         | {{< code text >}}
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the `/user-namespaces` API endpoint in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../commercial/).
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 The `/user-namespaces` API endpoint provides HTTP GET access to the namespaces the current user can access.

--- a/content/sensu-go/6.7/api/core/namespaces.md
+++ b/content/sensu-go/6.7/api/core/namespaces.md
@@ -207,7 +207,7 @@ output         | {{< code text >}}
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the `/user-namespaces` API endpoint in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../commercial/).
+For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 The `/user-namespaces` API endpoint provides HTTP GET access to the namespaces the current user can access.


### PR DESCRIPTION
## Description
Fixes a broken link to the commercial features page in the namespace API page

## Motivation and Context
Found with monthly linkchecker run

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>
