### PR TITLE
Explain in intro that Monitor external resources covers two methods for configuring website monitoring

### DIFF
--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -17,7 +17,12 @@ Proxy entities allow Sensu to monitor external resources on systems and devices 
 You can create [proxy entities][1] with [sensuctl][8], the [Sensu API][9], and the [`proxy_entity_name` check attribute][2].
 When executing checks that include a `proxy_entity_name` or `proxy_requests` attribute, Sensu agents report the resulting event under the proxy entity instead of the agent entity.
 
-This guide explains how to use a proxy entity to monitor website status, as well as how to use the [proxy checks][3] to monitor a group of websites.
+This guide explains how to use a proxy entity to monitor website status and includes two methods for configuring the required Sensu resources:
+
+- Follow the [Sensu Catalog integration method][27] to configure the resources you need directly in Sensu web UI.
+- Follow the [command line configuration method][28] to manually create the Sensu resources you need.
+
+This guide also explains how to use [proxy checks to monitor a group of websites][29], with command line configuration instructions.
 
 To follow this guide, you’ll need to [install][19] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
 
@@ -581,3 +586,6 @@ Follow any of these guides to learn how to configure event filters, handlers, an
 [24]: https://sensu.io
 [25]: ../../../web-ui/sensu-catalog/
 [26]: ../../../web-ui/view-manage-resources/#manage-entities
+[27]: #use-a-proxy-entity-to-monitor-a-website-sensu-catalog-configuration
+[28]: #use-a-proxy-entity-to-monitor-a-website-command-line-configuration
+[29]: #use-proxy-requests-to-monitor-a-group-of-websites-command-line-configuration


### PR DESCRIPTION
## Description
Updates the intro in Monitor external resources to explain that the guide covers two methods for configuring website monitoring via proxy entities, with links to each method as well as the third part of the guide, which covers proxy requests.

## Motivation and Context
Idea from 1:1

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>