### PR TITLE
Update link used for RBAC entity username references

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -1744,7 +1744,7 @@ status: Ss
 [19]: #proxy-entities-managed
 [20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
-[22]: ../../../operations/control-access/rbac/
+[22]: ../../../operations/control-access/rbac/#agent-user
 [23]: ../../../web-ui/search#search-for-labels
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1952,7 +1952,7 @@ log-level: debug
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags
 [38]: #name
-[39]: ../../../operations/control-access/rbac/
+[39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
 [41]: ../../observe-process/handlers/#send-registration-events
 [42]: #backend-heartbeat-timeout

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -1744,7 +1744,7 @@ status: Ss
 [19]: #proxy-entities-managed
 [20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
-[22]: ../../../operations/control-access/rbac/
+[22]: ../../../operations/control-access/rbac/#agent-user
 [23]: ../../../web-ui/search#search-for-labels
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -2003,7 +2003,7 @@ sensu-agent start --help
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags
 [38]: #name
-[39]: ../../../operations/control-access/rbac/
+[39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
 [41]: ../../observe-process/handlers/#send-registration-events
 [42]: #backend-heartbeat-timeout

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -1744,7 +1744,7 @@ status: Ss
 [19]: #proxy-entities-managed
 [20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
-[22]: ../../../operations/control-access/rbac/
+[22]: ../../../operations/control-access/rbac/#agent-user
 [23]: ../../../web-ui/search#search-for-labels
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -2003,7 +2003,7 @@ sensu-agent start --help
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags
 [38]: #name
-[39]: ../../../operations/control-access/rbac/
+[39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
 [41]: ../../observe-process/handlers/#send-registration-events
 [42]: #backend-heartbeat-timeout

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
@@ -1883,7 +1883,7 @@ status: Ss
 [19]: #proxy-entities-managed
 [20]: #annotations-attribute
 [21]: https://regex101.com/r/zo9mQU/2
-[22]: ../../../operations/control-access/rbac/
+[22]: ../../../operations/control-access/rbac/#agent-user
 [23]: ../../../web-ui/search#search-for-labels
 [24]: ../../observe-schedule/checks#proxy-requests-attributes
 [25]: ../../observe-schedule/agent/#detect-cloud-provider-flag

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -2061,7 +2061,7 @@ sensu-agent start --help
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
 [37]: ../backend#general-configuration-flags
 [38]: #name
-[39]: ../../../operations/control-access/rbac/
+[39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
 [41]: ../../observe-process/handlers/#send-registration-events
 [42]: #backend-heartbeat-timeout


### PR DESCRIPTION
## Description
Fixes entity and agent references that linked to the RBAC reference page instead of directly to the agent user section for references to the RBAC username.

## Motivation and Context
Found when working on https://github.com/sensu/sensu-docs/pull/3911

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>