### PR TITLE
Add assetPath section link in token reference

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -266,6 +266,7 @@ With this asset definition, which includes the `.labels.asset_url` token substit
 Handlers and mutators can also include `sensu-go-hello-world` as a dynamic runtime asset, but Sensu Go will use the token subtitution for the backend's entity instead of the agent's entity.
 
 You can also use token substitution to customize dynamic runtime asset headers (for example, to include secure information for authentication).
+Sensu also provides an [`assetPath` function][14] that allows you to substitute a dynamic runtime asset’s local path on disk.
 
 {{% notice note %}}
 **NOTE**: To maintain security, you cannot use token substitution for a dynamic runtime asset's SHA512 value.
@@ -343,3 +344,4 @@ Token substitution **can** be used for alerting thresholds because those values 
 [11]: ../../observe-transform/mutators/
 [12]: ../../../plugins/assets/
 [13]: https://bonsai.sensu.io/assets/sensu/check-disk-usage
+[14]: ../../../plugins/assets/#assetpath-function-for-dynamic-runtime-asset-paths

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -266,6 +266,7 @@ With this asset definition, which includes the `.labels.asset_url` token substit
 Handlers and mutators can also include `sensu-go-hello-world` as a dynamic runtime asset, but Sensu Go will use the token subtitution for the backend's entity instead of the agent's entity.
 
 You can also use token substitution to customize dynamic runtime asset headers (for example, to include secure information for authentication).
+Sensu also provides an [`assetPath` function][14] that allows you to substitute a dynamic runtime asset’s local path on disk.
 
 {{% notice note %}}
 **NOTE**: To maintain security, you cannot use token substitution for a dynamic runtime asset's SHA512 value.
@@ -343,3 +344,4 @@ Token substitution **can** be used for alerting thresholds because those values 
 [11]: ../../observe-transform/mutators/
 [12]: ../../../plugins/assets/
 [13]: https://bonsai.sensu.io/assets/sensu/check-disk-usage
+[14]: ../../../plugins/assets/#assetpath-function-for-dynamic-runtime-asset-paths

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
@@ -266,6 +266,7 @@ With this asset definition, which includes the `.labels.asset_url` token substit
 Handlers and mutators can also include `sensu-go-hello-world` as a dynamic runtime asset, but Sensu Go will use the token subtitution for the backend's entity instead of the agent's entity.
 
 You can also use token substitution to customize dynamic runtime asset headers (for example, to include secure information for authentication).
+Sensu also provides an [`assetPath` function][14] that allows you to substitute a dynamic runtime asset’s local path on disk.
 
 {{% notice note %}}
 **NOTE**: To maintain security, you cannot use token substitution for a dynamic runtime asset's SHA512 value.
@@ -343,3 +344,4 @@ Token substitution **can** be used for alerting thresholds because those values 
 [11]: ../../observe-transform/mutators/
 [12]: ../../../plugins/assets/
 [13]: https://bonsai.sensu.io/assets/sensu/check-disk-usage
+[14]: ../../../plugins/assets/#assetpath-function-for-dynamic-runtime-asset-paths

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
@@ -266,6 +266,7 @@ With this asset definition, which includes the `.labels.asset_url` token substit
 Handlers and mutators can also include `sensu-go-hello-world` as a dynamic runtime asset, but Sensu Go will use the token subtitution for the backend's entity instead of the agent's entity.
 
 You can also use token substitution to customize dynamic runtime asset headers (for example, to include secure information for authentication).
+Sensu also provides an [`assetPath` function][14] that allows you to substitute a dynamic runtime asset’s local path on disk.
 
 {{% notice note %}}
 **NOTE**: To maintain security, you cannot use token substitution for a dynamic runtime asset's SHA512 value.
@@ -343,3 +344,4 @@ Token substitution **can** be used for alerting thresholds because those values 
 [11]: ../../observe-transform/mutators/
 [12]: ../../../plugins/assets/
 [13]: https://bonsai.sensu.io/assets/sensu/check-disk-usage
+[14]: ../../../plugins/assets/#assetpath-function-for-dynamic-runtime-asset-paths


### PR DESCRIPTION
## Description
Adds a link to the asset reference's assetPath section to the token reference discussion of token substitution options.

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>