### PR TITLE
Replaces /u0026 with & in BSM code examples

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -171,7 +171,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -271,13 +271,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/rule-templates.md
@@ -300,7 +300,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -400,13 +400,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;
@@ -705,7 +705,7 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 eval: |2
-  if (events \u0026\u0026 events.length == 0) {
+  if (events && events.length == 0) {
       event.check.output = "WARNING: No events selected for aggregate
   ";
       event.check.status = 1;
@@ -805,13 +805,13 @@ eval: |2
           }
       }
   }
-  if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+  if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
       event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 2;
       return event;
   }
-  if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+  if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
       event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 1;

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -171,7 +171,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -271,13 +271,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/rule-templates.md
@@ -300,7 +300,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -400,13 +400,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;
@@ -705,7 +705,7 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 eval: |2
-  if (events \u0026\u0026 events.length == 0) {
+  if (events && events.length == 0) {
       event.check.output = "WARNING: No events selected for aggregate
   ";
       event.check.status = 1;
@@ -805,13 +805,13 @@ eval: |2
           }
       }
   }
-  if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+  if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
       event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 2;
       return event;
   }
-  if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+  if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
       event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 1;

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -171,7 +171,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -271,13 +271,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/rule-templates.md
@@ -300,7 +300,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -400,13 +400,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;
@@ -705,7 +705,7 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 eval: |2
-  if (events \u0026\u0026 events.length == 0) {
+  if (events && events.length == 0) {
       event.check.output = "WARNING: No events selected for aggregate
   ";
       event.check.status = 1;
@@ -805,13 +805,13 @@ eval: |2
           }
       }
   }
-  if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+  if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
       event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 2;
       return event;
   }
-  if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+  if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
       event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 1;

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/business-service-monitoring.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/business-service-monitoring.md
@@ -171,7 +171,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -271,13 +271,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/rule-templates.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/rule-templates.md
@@ -300,7 +300,7 @@ spec:
     a service can be considered healthy as long as a minimum threshold is satisfied
     (e.g. at least 5 healthy web servers? at least 70% of N processes healthy?).
   eval: |2
-    if (events \u0026\u0026 events.length == 0) {
+    if (events && events.length == 0) {
         event.check.output = "WARNING: No events selected for aggregate
     ";
         event.check.status = 1;
@@ -400,13 +400,13 @@ spec:
             }
         }
     }
-    if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+    if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
         event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 2;
         return event;
     }
-    if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+    if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
         event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
     ";
         event.check.status = 1;
@@ -705,7 +705,7 @@ type         | String
 example      | {{< language-toggle >}}
 {{< code yml >}}
 eval: |2
-  if (events \u0026\u0026 events.length == 0) {
+  if (events && events.length == 0) {
       event.check.output = "WARNING: No events selected for aggregate
   ";
       event.check.status = 1;
@@ -805,13 +805,13 @@ eval: |2
           }
       }
   }
-  if (!!args["critical_threshold"] \u0026\u0026 percentOK \u003c= args["critical_threshold"]) {
+  if (!!args["critical_threshold"] && percentOK \u003c= args["critical_threshold"]) {
       event.check.output = "CRITICAL: Less than " + args["critical_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 2;
       return event;
   }
-  if (!!args["warning_threshold"] \u0026\u0026 percentOK \u003c= args["warning_threshold"]) {
+  if (!!args["warning_threshold"] && percentOK \u003c= args["warning_threshold"]) {
       event.check.output = "WARNING: Less than " + args["warning_threshold"].toString() + "% of selected events are OK (" + percentOK.toString() + "%)
   ";
       event.check.status = 1;


### PR DESCRIPTION
## Description
In BSM examples, replaces `/u0026/u026` with `&&`

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3918

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>