### PR TITLE
Standardize references to asset names

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -35,10 +35,10 @@ Use sensuctl to add the `run_proxies` subscription to the entity the Sensu agent
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -54,10 +54,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ### Register dynamic runtime asset
 
-To power the check, you'll use the [http-checks][16] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][15] will rely on.
+To power the check, you'll use the [sensu/http-checks][16] dynamic runtime asset.
+This community-tier asset includes the http status check command that [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Use [`sensuctl asset add`][21] to register the dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
@@ -84,7 +84,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -104,7 +104,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ### Create the check
 
-Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the `http-checks` dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
+Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the [sensu/http-checks][16] dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
 
 The check includes the [`round_robin` attribute][18] set to `true` to distribute the check execution across all agents subscribed to the `run_proxies` subscription and avoid duplicate events.
 
@@ -422,9 +422,9 @@ The response should include the `check-http` check:
 
 ### Validate the check
 
-Before you validate the check, make sure that you've [registered the `http-checks` dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
+Before you validate the check, make sure that you've [registered the sensu/http-checks dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
 
-Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http`, returning a status of `0` (OK):
+Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http` check, returning a status of `0` (OK):
 
 {{< code shell >}}
 sensuctl event list

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -168,7 +168,7 @@ spec:
 
 ### Filter dynamic runtime assets
 
-Sensu event filters can have dynamic runtime assets that are included in their execution context.
+Sensu event filters can include dynamic runtime assets in their execution context.
 When valid dynamic runtime assets are associated with an event filter, Sensu evaluates any files it finds that have a `.js` extension before executing the filter.
 The result of evaluating the scripts is cached for a given asset set for the sake of performance.
 For an example of how to implement an event filter as an asset, read [Reduce alert fatigue][30].

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -34,7 +34,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The examples in this guide use a check that includes the subscription `system`.
 Use [sensuctl][12] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -42,7 +42,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -225,7 +225,7 @@ This will help you understand what dynamic runtime assets are and how they are u
 
 In this approach, the first step is to obtain an event filter dynamic runtime asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use `sensuctl asset add` to register the [fatigue check filter][8] dynamic runtime asset:
+Use `sensuctl asset add` to register the [sensu/sensu-go-fatigue-check-filter][8] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-fatigue-check-filter:0.8.1 -r fatigue-filter

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -40,7 +40,7 @@ For an agent to execute a specific check, you must specify the same subscription
 This guide uses an example check that includes the subscription `system`.
 Use [sensuctl][7] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find an entity's name, run `sensuctl entity list`.
@@ -48,7 +48,7 @@ The `ID` is the name of the entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -64,9 +64,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Configure contact routing
 
-### 1. Register the has-contact filter dynamic runtime asset
+### 1. Register the sensu/sensu-go-has-contact-filter dynamic runtime asset
 
-Contact routing is powered by the [has-contact filter dynamic runtime asset][12].
+Contact routing is powered by the [sensu/sensu-go-has-contact-filter][12] dynamic runtime asset.
 To add the has-contact dynamic runtime asset to Sensu, use [`sensuctl asset add`][14]:
 
 {{< code shell >}}
@@ -97,7 +97,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ### 2. Create contact filters
 
-The [Bonsai][12] documentation for the asset explains that the has-contact dynamic runtime asset supports two functions:
+The [Bonsai][12] documentation explains that the sensu/sensu-go-has-contact-filter dynamic runtime asset supports two functions:
 
 - `has_contact`, which takes the Sensu event and the contact name as arguments
 - `no_contact`, which is available as a fallback in the absence of contact labels and takes only the event as an argument
@@ -225,7 +225,7 @@ The response should list the new `contact_ops`, `contact_dev`, and `contact_fall
 ### 3. Create a handler for each contact
 
 With your contact filters in place, you can create a handler for each contact: ops, dev, and fallback.
-If you haven't already, add the [Slack handler dynamic runtime asset][8] to Sensu with sensuctl:
+If you haven't already, add the [sensu/sensu-slack-handler][8] dynamic runtime asset to Sensu with sensuctl:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -255,8 +255,8 @@ In each handler definition, you will specify:
 
 Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Replace `<alert-ops>`, `<alert-dev>`, and `<alert-all>` with the names of the channels you want to use to receive alerts in your Slack instance.
-- Replace `<slack_webhook_url>` with your Slack webhook URL.
+- Replace `<ALERT_OPS>`, `<ALERT_DEV>`, and `<ALERT_ALL>` with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace `<SLACK_WEBHOOK_URL>` with your Slack webhook URL.
 
 After you update the code to use your preferred Slack channels and webhook URL, run:
 
@@ -269,9 +269,9 @@ api_version: core/v2
 metadata:
   name: slack_ops
 spec:
-  command: sensu-slack-handler --channel "#<alert-ops>"
+  command: sensu-slack-handler --channel "#<ALERT_OPS>"
   env_vars:
-  - SLACK_WEBHOOK_URL=<slack_webhook_url>
+  - SLACK_WEBHOOK_URL=<SLACK_WEBHOOK_URL>
   filters:
   - is_incident
   - not_silenced
@@ -285,9 +285,9 @@ api_version: core/v2
 metadata:
   name: slack_dev
 spec:
-  command: sensu-slack-handler --channel "#<alert-dev>"
+  command: sensu-slack-handler --channel "#<ALERT_DEV>"
   env_vars:
-  - SLACK_WEBHOOK_URL=<slack_webhook_url>
+  - SLACK_WEBHOOK_URL=<SLACK_WEBHOOK_URL>
   filters:
   - is_incident
   - not_silenced
@@ -301,9 +301,9 @@ api_version: core/v2
 metadata:
   name: slack_fallback
 spec:
-  command: sensu-slack-handler --channel "#<alert-all>"
+  command: sensu-slack-handler --channel "#<ALERT_ALL>"
   env_vars:
-  - SLACK_WEBHOOK_URL=<slack_webhook_url>
+  - SLACK_WEBHOOK_URL=<SLACK_WEBHOOK_URL>
   filters:
   - is_incident
   - not_silenced
@@ -321,9 +321,9 @@ echo '{
     "name": "slack_ops"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel "#<alert-ops>",
+    "command": "sensu-slack-handler --channel "#<ALERT_OPS>",
     "env_vars": [
-      "SLACK_WEBHOOK_URL=<slack_webhook_url>
+      "SLACK_WEBHOOK_URL=<SLACK_WEBHOOK_URL>
     ],
     "filters": [
       "is_incident",
@@ -343,9 +343,9 @@ echo '{
     "name": "slack_dev"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel "#<alert-dev>",
+    "command": "sensu-slack-handler --channel "#<ALERT_DEV>",
     "env_vars": [
-      "SLACK_WEBHOOK_URL=<slack_webhook_url>
+      "SLACK_WEBHOOK_URL=<SLACK_WEBHOOK_URL>
     ],
     "filters": [
       "is_incident",
@@ -365,9 +365,9 @@ echo '{
     "name": "slack_fallback"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel "#<alert-all>",
+    "command": "sensu-slack-handler --channel "#<ALERT_ALL>",
     "env_vars": [
-      "SLACK_WEBHOOK_URL=<slack_webhook_url>
+      "SLACK_WEBHOOK_URL=<SLACK_WEBHOOK_URL>
     ],
     "filters": [
       "is_incident",
@@ -397,9 +397,9 @@ The response should list the new `slack_ops`, `slack_dev`, and `slack_fallback` 
 {{< code shell >}}
        Name        Type   Timeout                    Filters                    Mutator                        Execute                                                Environment Variables                                    Assets         
  ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ─────────────────────────────────────────────────── ────────────────────────────────────────────────────────────────────────── ───────────────────── 
-  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
-  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
-  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#<ALERT_DEV>"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#<ALERT_ALL>"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#<ALERT_OPS>"    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX      sensu-slack-handler
 {{< /code >}}
 
 ### 4. Create a handler set
@@ -449,9 +449,9 @@ The updated output should include the `slack` handler set:
        Name        Type   Timeout                    Filters                    Mutator                       Execute                                                Environment Variables                                  Assets         
  ──────────────── ────── ───────── ─────────────────────────────────────────── ───────── ────────────────────────────────────────────────── ──────────────────────────────────────────────────────────────────────── ───────────────────── 
   slack            set          0                                                         CALL: slack_ops,slack_dev,slack_fallback                                                                                                         
-  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#alert-dev"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
-  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#alert-all"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
-  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#alert-ops"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_dev        pipe         0   is_incident,not_silenced,contact_dev                  RUN:  sensu-slack-handler --channel "#<ALERT_DEV>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_fallback   pipe         0   is_incident,not_silenced,contact_fallback             RUN:  sensu-slack-handler --channel "#<ALERT_ALL>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
+  slack_ops        pipe         0   is_incident,not_silenced,contact_ops                  RUN:  sensu-slack-handler --channel "#<ALERT_OPS>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX   sensu-slack-handler  
 {{< /code >}}
 
 Congratulations!
@@ -653,7 +653,7 @@ spec:
 
 {{< /language-toggle >}}
 
-Now when the `check_cpu` check generates an incident, Sensu will filter the event according to the `contact_ops` and `contact_dev` event filters and send alerts to #alert-ops and #alert-dev accordingly.
+Now when the `check_cpu` check generates an incident, Sensu will filter the event according to the `contact_ops` and `contact_dev` event filters and send alerts to #<ALERT_OPS> and #<ALERT_DEV> accordingly.
 
 {{< figure src="/images/go/route_alerts/contact_routing_old_dev_ops_teams.png" alt="Diagram that shows an event generated with a check label for the dev and ops teams, matched to the dev team and ops team handlers using contact filters, and routed to the Slack channels for dev and ops" link="/images/go/route_alerts/contact_routing_old_dev_ops_teams.png" target="_blank" >}}
 <!-- Diagram source: https://www.lucidchart.com/documents/edit/3cbd2ad3-92ed-48cc-bbaa-a97f53dae1ba -->
@@ -664,7 +664,7 @@ You can also specify contacts using an entity label.
 For more information about managing entity labels, read the [entity reference][10].
 
 If contact labels are present in both the check and entity, the check contacts override the entity contacts.
-In this example, the `dev` label in the check configuration overrides the `ops` label in the agent definition, resulting in an alert sent to #alert-dev but not to #alert-ops or #alert-all.
+In this example, the `dev` label in the check configuration overrides the `ops` label in the agent definition, resulting in an alert sent to #<ALERT_DEV> but not to #<ALERT_OPS> or #<ALERT_ALL>.
 
 {{< figure src="/images/go/route_alerts/old_label_overrides.png" alt="Diagram that shows that check labels override entity labels when both are present in an event" link="/images/go/route_alerts/old_label_overrides.png" target="_blank" >}}
 <!-- Diagram source: https://www.lucidchart.com/documents/edit/da41741f-15c5-47f8-b2b4-9197593a67d8/0 -->

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handler-templates.md
@@ -80,7 +80,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 ## Template toolkit command
 
-The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
+The [sensu/template-toolkit-command][8] dynamic runtime asset provides a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
 The template toolkit command uses event data you supply via stdin in JSON format.
 
@@ -222,12 +222,12 @@ Sensu<br>
 
 {{< /code >}}
 
-The Sensu Email Handler plugin also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
-Read the [Sensu Email Handler Bonsai page][9] for details.
+The sensu/sensu-email-handler dynamic runtime asset also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
+Read the [sensu/sensu-email-handler Bonsai page][9] for details.
 
 ## Sensu PagerDuty Handler example
 
-The [Sensu PagerDuty Handler plugin][10] includes a basic template for the PagerDuty alert summary:
+The [sensu/sensu-pagerduty-handler][10] dynamic runtime asset includes a basic template for the PagerDuty alert summary:
 
 {{< code shell >}}
 "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}"

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -228,9 +228,11 @@ With these event filters and handlers configured, you can create a [handler set]
 You can also list the three handlers in the [handlers array][33] in your check definition instead.
 
 {{% notice protip %}}
+{{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
-For example, you can use the `is_incident` event filter in conjunction with the [Sensu Go Fatigue Check Filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
-Sensu's [Ansible](../../../plugins/featured-integrations/ansible/), [Rundeck](../../../plugins/featured-integrations/rundeck/), and [Saltstack](../../../plugins/featured-integrations/saltstack/) auto-remediation integrations and the [Sensu Remediation Handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
+The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+{{% /notice %}}
 {{% /notice %}}
 
 ## Keepalive event handlers
@@ -751,7 +753,7 @@ secret: sensu-ansible-host
 ## Send Slack alerts
 
 This handler will send alerts to a channel named `monitoring` with the configured webhook URL, using the `handler-slack` executable command.
-The handler uses the [Sensu Slack Handler][34] dynamic runtime asset.
+The handler uses the [sensu/sensu-slack-handler][34] dynamic runtime asset.
 Read [Send Slack alerts with handlers][35] for detailed instructions for adding the required asset and configuring this handler.
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -228,11 +228,9 @@ With these event filters and handlers configured, you can create a [handler set]
 You can also list the three handlers in the [handlers array][33] in your check definition instead.
 
 {{% notice protip %}}
-{{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
 For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
 The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
-{{% /notice %}}
 {{% /notice %}}
 
 ## Keepalive event handlers

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/plan-maintenance.md
@@ -36,10 +36,10 @@ Use sensuctl to add the `website` subscription to an entity the Sensu agent is o
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,10 +55,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [http-checks][12] dynamic runtime asset.
+To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
 This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
 
-Register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -73,7 +73,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -28,7 +28,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The example in this guide uses the `prometheus_metrics` check from [Collect Prometheus metrics with Sensu][10], which includes the subscription `app_tier`.
 Use [sensuctl][15] to add an `app_tier` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -36,7 +36,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -53,9 +53,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][12] are shareable, reusable packages that make it easier to deploy Sensu plugins.
-This example uses the [Sensu InfluxDB Handler][13] dynamic runtime asset to power an InfluxDB handler.
+This example uses the [sensu/sensu-influxdb-handler][13] dynamic runtime asset to power an InfluxDB handler.
 
-Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynamic runtime asset:
+Use [`sensuctl asset add`][5] to register the [sensu/sensu-influxdb-handler][13] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -85,7 +85,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create the handler
 
-Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
+Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the sensu/sensu-influxdb-handler dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
 For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -38,11 +38,11 @@ sensuctl entity list
 The `ID` in the response is the entity name.
 Select one of the listed entities.
 
-Before you run the following sensuctl command, replace `<entity_name>` with the name of your entity.
+Before you run the following sensuctl command, replace `<ENTITY_NAME>` with the name of your entity.
 Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -58,9 +58,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu Sumo Logic Handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
+The [sensu/sensu-sumologic-handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
 
-To add the Sumo Logic handler asset, run:
+To add the sensu/sensu-sumologic-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-sumologic-handler:0.3.0 -r sumologic-handler
@@ -85,7 +85,7 @@ To confirm that the asset was added to your Sensu backend, run:
 sensuctl asset info sumologic-handler
 {{< /code >}}
 
-The response will list the available builds for the Sensu Sumo Logic Handler dynamic runtime asset.
+The response will list the available builds for the sensu/sensu-sumologic-handler dynamic runtime asset.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -143,7 +143,7 @@ You will use this URL in the next step as the `SUMOLOGIC_URL` value for the secr
 
 ## Add the Sumo Logic handler
 
-Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [Sensu Sumo Logic Handler asset][8] to send observability data to Sumo Logic.
+Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [sensu/sensu-sumologic-handler][8] dynamic runtime asset to send observability data to Sumo Logic.
 
 The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
@@ -502,7 +502,7 @@ You have a successful workflow that sends Sensu observability data to your Sumo 
 
 To share and reuse the check and handler like code, [save them to files][6] and start building a [monitoring as code repository][7].
 
-Learn more about the [Sensu Sumo Logic Handler][19] dynamic runtime asset.
+Learn more about the [sensu/sensu-sumologic-handler][19] dynamic runtime asset.
 You can also configure a [Sumo Logic dashboard][10] to search, view, and analyze the Sensu data you're sending to your Sumo Logic HTTP Logs and Metrics Source.
 
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-email-alerts.md
@@ -27,9 +27,9 @@ You'll also add an [event filter][5] to make sure you only receive a notificatio
 ## Add the email handler dynamic runtime asset
 
 [Dynamic runtime assets][8] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Go Email Handler][3] dynamic runtime asset to power an `email` handler.
+In this guide, you'll use the [sensu/sensu-email-handler][3] dynamic runtime asset to power an `email` handler.
 
-Use the following sensuctl example to register the [Sensu Go Email Handler][3] dynamic runtime asset:
+Use the following sensuctl example to register the [sensu/sensu-email-handler][3] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler -r email-handler
@@ -64,7 +64,7 @@ For a detailed list of everything related to the asset that Sensu added automati
 sensuctl asset info email-handler
 {{< /code >}}
 
-The dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
+The sensu/sensu-email-handler dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -131,7 +131,7 @@ EOF
 
 ## Create the email handler definition
 
-After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
+After you add an event filter, create the email handler definition to specify the email address where the handler will send notifications.
 In the handler definition's `command` value, you'll need to change a few things:
 
 - `<sender@example.com>`: Replace with the email address you want to use to send email alerts.

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -34,11 +34,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][12] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][12] command below.
 Then run the command to add the `system` [subscription][13] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -182,9 +182,9 @@ In the next step, you'll configure your workflow for sending Sensu alerts to you
 
 ## Add the PagerDuty handler
 
-The [Sensu PagerDuty Handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
+The [sensu/sensu-pagerduty-handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
 
-To add the PagerDuty handler asset, run:
+To add the sensu/sensu-pagerduty-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler
@@ -201,7 +201,7 @@ The response will list the available builds for the PagerDuty handler dynamic ru
 Now that you've added the Sensu PagerDuty Handler dynamic runtime asset, you can create a [handler][9] that uses the asset to send non-OK events to PagerDuty.
 This requires you to update the handler command by adding your PagerDuty API key.
 
-In the following command, replace `<pagerduty_key>` with your [PagerDuty API integration key][1].
+In the following command, replace `<PAGERDUTY_KEY>` with your [PagerDuty API integration key][1].
 Then run the updated command:
 
 {{< code shell >}}
@@ -209,7 +209,7 @@ sensuctl handler create pagerduty \
 --type pipe \
 --filters is_incident,not_silenced \
 --runtime-assets sensu/sensu-pagerduty-handler \
---command "sensu-pagerduty-handler -t <pagerduty_key>"
+--command "sensu-pagerduty-handler -t <PAGERDUTY_KEY>"
 {{< /code >}}
 
 {{% notice note %}}
@@ -241,7 +241,7 @@ api_version: core/v2
 metadata:
   name: pagerduty
 spec:
-  command: sensu-pagerduty-handler -t <pagerduty_key>
+  command: sensu-pagerduty-handler -t <PAGERDUTY_KEY>
   env_vars: null
   filters:
   - is_incident
@@ -262,7 +262,7 @@ spec:
     "name": "pagerduty"
   },
   "spec": {
-    "command": "sensu-pagerduty-handler -t <pagerduty_key>",
+    "command": "sensu-pagerduty-handler -t <PAGERDUTY_KEY>",
     "env_vars": null,
     "filters": [
       "is_incident",

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/send-slack-alerts.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][20] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
 Then run the command to add the `system` [subscription][21] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -56,9 +56,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Slack Handler][14] dynamic runtime asset to power a `slack` handler.
+In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic runtime asset:
+Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.0.3 -r sensu-slack-handler
@@ -99,7 +99,7 @@ After saving, you can find your webhook URL under Integration Settings.
 
 ## Create a handler
 
-Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the `sensu-slack-handler` dynamic runtime asset.
+Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the sensu/sensu-slack-handler dynamic runtime asset.
 Edit the sensuctl command below to include your Slack webhook URL and the channel where you want to receive observation event data.
 For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -158,7 +158,7 @@ spec:
 ## Assign the hook to a check
 
 {{% notice note %}}
-**NOTE**: Before you proceed, make sure you have added the [sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
+**NOTE**: Before you proceed, make sure you have added the [sensu/sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and the [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
 The hook you create in this step relies on the `nginx_service` check.
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][17] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][17] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,8 +55,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-To power the check to collect service metrics, you will use a check in the [http-checks][7] dynamic runtime asset.
-Use sensuctl to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+To power the check to collect service metrics, you will use a check in the [sensu/http-checks][7] dynamic runtime asset.
+Use sensuctl to register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.4.0 -r http-checks

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/metrics.md
@@ -30,7 +30,7 @@ For information about HTTP GET access to internal Sensu metrics, read our [/metr
 
 ## Metric check example
 
-This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [Sensu System Check][26] dynamic runtime asset and sends the collected metrics to a metrics handler configured with the [Sensu Go Graphite Handler][12] dynamic runtime asset:
+This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [sensu/system-check][26] dynamic runtime asset and sends the collected metrics to a metrics handler configured with the [sensu/sensu-go-graphite-handler][12] dynamic runtime asset:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -39,11 +39,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][16] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][16] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -63,11 +63,11 @@ You can write shell scripts in the `command` field of your check definitions, bu
 Check plugins must be available on the host where the agent is running for the agent to execute the check.
 This guide uses [dynamic runtime assets][2] to manage plugin installation.
 
-### Register the Sensu CPU usage check asset
+### Register the sensu/check-cpu-usage asset
 
-The [Sensu CPU usage check][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
+The [sensu/check-cpu-usage][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
 
-To register the Sensu CPU usage check dynamic runtime asset, `sensu/check-cpu-usage:0.2.2`, run:
+To register the sensu/check-cpu-usage dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
@@ -102,7 +102,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `check-cpu-usage` and `sensu-processes-check` dynamic runtime assets:
+The response should list the renamed check-cpu-usage and sensu-processes-check dynamic runtime assets:
 
 {{< code text >}}
           Name                                                 URL                                         Hash    
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check to monitor a server
 
-Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the `check-cpu-usage` dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the check-cpu-usage dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -13,12 +13,12 @@ menu:
     parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
-This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
-
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
 Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
+
+You can use the [sensu/sensu-prometheus-collector][19] dynamic runtime asset to create checks that collect [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
+This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 To follow this guide, you’ll need to [install][4] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
 
@@ -26,13 +26,13 @@ The examples in this guide use CentOS 7 as the operating system, with all compon
 Commands and steps may change for different distributions or if components are running on different compute resources.
 
 At the end of this guide, Prometheus will be scraping metrics.
-The Sensu Prometheus Collector will then query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
+The check that uses the sensu/sensu-prometheus-collector asset will query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
 Finally, Grafana will query InfluxDB to display the collected metrics.
 
 ## Configure a Sensu entity
 
 Use [sensuctl][15] to add an `app_tier` [subscription][16] to one of your entities.
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -40,7 +40,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -194,7 +194,7 @@ sudo systemctl start grafana-server
 
 ### Add the Sensu InfluxDB handler asset
 
-To add the [Sensu InfluxDB Handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-influxdb-handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -283,9 +283,9 @@ You could save both the asset and handler definitions in a single file and use `
 
 ## Collect Prometheus metrics with Sensu
 
-### Add the Sensu Prometheus Collector asset
+### Add the sensu/sensu-prometheus-collector asset
 
-To add the [Sensu Prometheus Collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-prometheus-collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-collector
@@ -445,12 +445,11 @@ You should now have a working observability pipeline with Prometheus scraping me
 In this pipeline, Sensu Prometheus Collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
 The `influxdb` handler sends the metrics to InfluxDB, and you can visualize the metrics in a Grafana dashboard.
 
-Add the [Sensu Prometheus Collector][1] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
+Add the [sensu/sensu-prometheus-collector][19] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
 
-[1]: ../../../plugins/featured-integrations/prometheus/#sensu-prometheus-collector
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
 [4]: ../../../operations/deploy-sensu/install-sensu/

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -37,7 +37,7 @@ Instead of creating a different check for every set of thresholds, you can use t
 
 Follow this example to set up a reusable check for disk usage:
 
-1. Add the [Sensu disk usage check][13] dynamic runtime asset, which includes the command you will need for your check:
+1. Add the [sensu/check-disk-usage][13] dynamic runtime asset, which includes the command you will need for your check:
 {{< code shell >}}
 sensuctl asset add sensu/check-disk-usage:0.4.1
 {{< /code >}}

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -23,7 +23,7 @@ No human user needs to log into the service, and the service does not need edit 
 A limited service account can provide only the necessary access and permissions.
 
 Limited service accounts are also useful for performing automated processes.
-This guide explains how to create a limited service account to use with the [Sensu EC2 Handler][3] integration to automatically remove AWS EC2 instances that are not in a pending or running state.
+This guide explains how to create a limited service account to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset to automatically remove AWS EC2 instances that are not in a pending or running state.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including the RBAC resources required to configure a limited service account.
 This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the [`admin` user][2].
@@ -177,11 +177,11 @@ sensuctl api-key grant ec2-service
 
    The response will include an API key that is assigned to the `ec2-service` user, which you will need to configure the EC2 handler.
 
-The `ec2-service` limited service account is now ready to use with the [Sensu EC2 Handler][3] integration.
+The `ec2-service` limited service account is now ready to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset.
 
-## Add the EC2 handler dynamic runtime asset
+## Add the sensu/sensu-ec2-handler dynamic runtime asset
 
-To power the handler to remove AWS EC2 instances, use sensuctl to add the [Sensu Go EC2 Handler][13] [dynamic runtime asset][14]:
+To power the handler to remove AWS EC2 instances, use sensuctl to add the [sensu/sensu-ec2-handler][13] [dynamic runtime asset][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ec2-handler:0.4.0
@@ -319,7 +319,6 @@ Adjust namespaces and permissions if needed by updating the role or cluster role
 
 [1]: ../rbac/
 [2]: ../rbac#default-users
-[3]: ../../../plugins/featured-integrations/aws-ec2/
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../rbac/#role-bindings-and-cluster-role-bindings
 [6]: ../rbac/#rule-attributes

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -143,20 +143,20 @@ As a result, Sensu Go does not include the built-in occurrence-based event filte
 To replicate the Sensu Core occurrence-based filter's functionality, use Sensu Go's [repeated events filter definition][10].
 
 Sensu Go includes three built-in [event filters][9]: [is_incident][63], [not_silenced][61], and [has_metrics][101].
-Sensu Go does not include a built-in check dependencies filter, but you can use the [Core Dependencies Filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
+Sensu Go does not include a built-in check dependencies filter, but you can use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
 
 Sensu Go event filters do not include the `when` event filter attribute.
 Use Sensu query expressions to build [custom functions][106] that provide granular control of time-based filter expressions.
 
 ### Fatigue check filter
 
-The [Sensu Go Fatigue Check Filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
+The [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
 This filter looks for [check and entity annotations][33] in each event it receives and uses the values of those annotations to configure the filter's behavior on a per-event basis.
 
 The [Sensu Translator version 1.1.0][18] retrieves occurrence and refresh values from a Sensu Core check definition and outputs them as annotations in a Sensu Go check definition, compatible with the fatigue check filter.
 
-However, the Sensu Translator doesn't automatically add the [Sensu Go Fatigue Check Filter][11] dynamic runtime asset or the filter configuration you need to run it.
-To use the Sensu Go Fatigue Check Filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
+However, the Sensu Translator doesn't automatically add the [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset or the filter configuration you need to run it.
+To use the sensu/sensu-go-fatigue-check-filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
 
 ## Dynamic runtime assets
 
@@ -184,7 +184,7 @@ The syntax for token substitution changed to [double curly braces][16] in Sensu 
 
 ## Aggregates
 
-Sensu Go supports check aggregates with the [Sensu Go Aggregate Check Plugin][28], which is a [commercial][27] resource.
+Sensu Go supports check aggregates with the [sensu/sensu-aggregate-check][28] dynamic runtime asset, which is a [commercial][27] resource.
 
 ## API
 
@@ -308,9 +308,9 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `metrics: true` | Review the [translate metric checks][71] section.
 `proxy_requests` | Review the [translate proxy requests][72] section.
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
-`aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
+`aggregate` | Check aggregates are supported through the [commercial][27] [sensu/sensu-aggregate-check][28].
 `hooks` | Review the [translate hooks][73] section.
-`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`dependencies`| Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.`, like `sensu.io.json_attributes`, use the `index` function.
@@ -424,9 +424,9 @@ Review your Sensu Core check configuration for the following attributes and make
 
 | Core attribute | Manual updates required in Sensu Go config |
 | -------------- | ------------- |
-`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [Sensu Go Fatigue Check Filter][65].
+`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [sensu/sensu-go-fatigue-check-filter][65].
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
-`filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`filters: check_dependencies` | Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
 `handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [handlers][103].
@@ -516,7 +516,7 @@ Read the [guide to installing plugins with assets][50] to register assets with S
 
 #### Contact routing
 
-Contact routing is available in Sensu Go using the has-contact filter asset.
+Contact routing is available in Sensu Go woth the [sensu/sensu-go-has-contact-filter][30] dynamic runtime asset.
 Read [Route alerts with event filters][90] to set up contact routing in Sensu Go.
 
 #### LDAP
@@ -558,6 +558,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../observability-pipeline/observe-schedule/backend#operation
+[30]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [33]: https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter/#configuration
 [34]: ../../../observability-pipeline/observe-filter/reduce-alert-fatigue/#assign-the-event-filter-to-a-handler
 [36]: https://etcd.io/

--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
@@ -371,9 +371,9 @@ In the [add a handler][19] section, you'll use your `pagerduty_key` secret in yo
 
 ## Add a handler
 
-### Register the PagerDuty Handler dynamic runtime asset
+### Register the sensu/sensu-pagerduty-handler dynamic runtime asset
 
-To begin, register the [Sensu PagerDuty Handler dynamic runtime asset][23] with [`sensuctl asset add`][22]:
+To begin, register the [sensu/sensu-pagerduty-handler][23] dynamic runtime asset with [`sensuctl asset add`][22]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:1.2.0 -r pagerduty-handler

--- a/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.4/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -35,10 +35,10 @@ The checks in this guide monitor the following ports and endpoints:
 
 ## Register dynamic runtime asset
 
-To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [http-checks][5] dynamic runtime asset.
+To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [sensu/http-checks][5] dynamic runtime asset.
 This asset includes the `http-json` plugin, which your checks will rely on.
 
-To register the http-checks dynamic runtime asset, `sensu/http-checks`, run:
+To register the sensu/http-checks dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -63,7 +63,7 @@ To confirm that the asset is ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the http-checks dynamic runtime asset:
+The response should list the renamed http-checks dynamic runtime asset:
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -90,11 +90,11 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -200,8 +200,8 @@ To receive alerts based on your backend health checks, configure a [pipeline][6]
 If your Sensu Go deployment uses an external etcd cluster, you'll need to check the health of the respective etcd instances for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -356,14 +356,14 @@ PostgreSQL data from the `/health` endpoint will look like this example:
 }
 {{< /code >}}
 
-To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset.
+To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
-After you register the http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
+After you register the sensu/http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
 Make sure to update the `--url` value with your backend address before running the commands to create the checks.
 
 Run the following command to add the "healthy" check:
@@ -385,7 +385,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -406,7 +406,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }
@@ -434,7 +434,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -455,7 +455,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -304,8 +304,8 @@ Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][4
 
 ### Dynamic runtime asset build execution
 
-The directory path of each dynamic runtime asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
-Subsequent handler, filter, mutator, or check executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
+The directory path of each dynamic runtime asset listed in a check, event filter, handler, or mutator resource's `runtime_assets` array is appended to the `PATH` before the resource's `command` is executed.
+Subsequent check, event filter, handler, or mutator executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
 
 The following example demonstrates a use case with a Sensu check resource and an asset:
 
@@ -1041,7 +1041,7 @@ headers:
 
 Use the [entity.system attributes][10] in dynamic runtime asset [filters][42] to specify which systems and configurations an asset or asset builds can be used with.
 
-For example, the [Sensu Go Ruby Runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
+For example, the [sensu/sensu-ruby-runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
 
 {{< language-toggle >}}
 
@@ -1258,8 +1258,9 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
-When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
+Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+
+Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/6.4/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.4/sensuctl/sensuctl-bonsai.md
@@ -16,19 +16,21 @@ You can also use `sensuctl command` to install, execute, list, and delete comman
 
 ## Install dynamic runtime asset definitions
 
-To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <namespace/name>:<version>`.
-Replace `<namespace/name>` with the namespace and name of the dynamic runtime asset from Bonsai and `<version>` with the asset version you want to install.
+To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <ASSET_NAME>:<ASSET_VERSION>`.
+Replace `<ASSET_NAME>` with the complete name of the dynamic runtime asset from Bonsai.
+An asset's complete name includes both the part before the forward slash (sometimes called the Bonsai namespace) and the part after the forward slash.
 
-To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <namespace/name>`.
+{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
+
+Replace `<ASSET_VERSION>` with the asset version you want to install.
+To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <ASSET_NAME>`.
 
 {{% notice note %}}
 **NOTE**: Specify the asset version you want to install to maintain the stability of your observability infrastructure.
 If you do not specify a version to install, Sensu automatically installs the latest version, which may include breaking changes.
 {{% /notice %}}
 
-{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
-
-For example, to install version 3.1.1 of the [Sensu InfluxDB Handler][4] dynamic runtime asset:
+For example, to install version 3.1.1 of the [sensu/sensu-influxdb-handler][4] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.1.1
@@ -82,20 +84,20 @@ Use `sensuctl command` to install, execute, list, and delete commands from Bonsa
 To install a sensuctl command from Bonsai or a URL:
 
 {{< code shell >}}
-sensuctl command install <alias> (<namespace/name>:<version> | --url <archive_url> --checksum <archive_checksum>) <flags>
+sensuctl command install <ALIAS> (<ASSET_NAME>:<ASSET_VERSION> | --url <ARCHIVE_URL> --checksum <ARCHIVE_CHECKSUM>) <FLAGS>
 {{< /code >}}
 
 To install a command plugin, use the Bonsai asset name or specify a URL and SHA512 checksum.
 
-**To install a command using the Bonsai asset name**, replace `<namespace/name>` with the name of the asset from Bonsai.
-`:<version>` is only required if you require a specific version or are pinning to a specific version.
+**To install a command using the Bonsai asset name**, replace `<ASSET_NAME>` with the complete name of the asset from Bonsai.
+`:<ASSET_VERSION>` is only required if you require a specific version or are pinning to a specific version.
 If you do not specify a version, sensuctl will fetch the latest version from Bonsai.
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -105,11 +107,11 @@ To install a command from the [Sensu EC2 Discovery Plugin][3] with no flags:
 sensuctl command install sensu-ec2-discovery portertech/sensu-ec2-discovery:0.3.0
 {{< /code >}}
 
-**To install a command from a URL**, replace `<archive_url>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
-Replace `<archive_checksum>` with the checksum you want to use.
-Replace `<alias>` with a unique name for the command.
+**To install a command from a URL**, replace `<ARCHIVE_URL>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
+Replace `<ARCHIVE_CHECKSUM>` with the checksum you want to use.
+Replace `<ALIAS>` with a unique name for the command.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -128,20 +130,20 @@ sensuctl command install command-test --url https://github.com/amdprophet/comman
 To execute a sensuctl command plugin via its dynamic runtime asset's bin/entrypoint executable:
 
 {{< code shell >}}
-sensuctl command exec <alias> <args> <flags>
+sensuctl command exec <ALIAS> <GLOBAL_FLAGS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<GLOBAL_FLAGS>` with the globlal flags you want to use.
+Run `sensuctl command exec -h` to view global flags.
+To pass `<GLOBAL_FLAGS>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
+
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command exec -h` to view flags.
 Flags are optional and apply only to the `exec` command &mdash; they are not saved as part of the command you are executing.
-
-Replace `<args>` with the globlal flags you want to use.
-Run `sensuctl command exec -h` to view global flags.
-To pass `<args>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
 
 {{% notice note %}}
 **NOTE**: When you use `sensuctl command exec`, the [environment variables](../environment-variables) are passed to the command.
@@ -150,7 +152,7 @@ To pass `<args>` flags to the bin/entrypoint executable, make sure to specify th
 For example:
 
 {{< code shell >}}
-sensuctl command exec <command> <arg1> <arg2> --cache-dir /tmp -- --<flag1> --<flag2>=<value>
+sensuctl command exec <COMMAND> <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --cache-dir /tmp -- --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flags after the ` -- `.
@@ -158,7 +160,7 @@ Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flag
 In this example, the full command run by sensuctl exec would be:
 
 {{< code shell >}}
-bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
+bin/entrypoint <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 ### List commands
@@ -166,10 +168,10 @@ bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
 To list installed sensuctl commands: 
 
 {{< code shell >}}
-sensuctl command list <flags>
+sensuctl command list <FLAGS>
 {{< /code >}}
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command list -h` to view flags.
 Flags are optional and apply only to the `list` command.
 
@@ -178,19 +180,18 @@ Flags are optional and apply only to the `list` command.
 To delete sensuctl commands:
 
 {{< code shell >}}
-sensuctl command delete <alias> <flags>
+sensuctl command delete <ALIAS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
-For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+Replace `<ALIAS>` with a unique name for the command.
+For example, for the [sensu/sensu-ec2-handler][3], you might use the alias `sensu-ec2-handler`. 
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command delete -h` to view flags.
 Flags are optional and apply only to the `delete` command.
 
 
 [1]: https://bonsai.sensu.io/
-[2]: /images/sensu-influxdb-handler-namespace.png
-[3]: https://bonsai.sensu.io/assets/portertech/sensu-ec2-discovery
+[3]: https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -35,10 +35,10 @@ Use sensuctl to add the `run_proxies` subscription to the entity the Sensu agent
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -54,10 +54,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ### Register dynamic runtime asset
 
-To power the check, you'll use the [http-checks][16] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][15] will rely on.
+To power the check, you'll use the [sensu/http-checks][16] dynamic runtime asset.
+This community-tier asset includes the http status check command that [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Use [`sensuctl asset add`][21] to register the dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.4.0 -r http-checks
@@ -84,7 +84,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -104,7 +104,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ### Create the check
 
-Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the `http-checks` dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
+Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the [sensu/http-checks][16] dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
 
 The check includes the [`round_robin` attribute][18] set to `true` to distribute the check execution across all agents subscribed to the `run_proxies` subscription and avoid duplicate events.
 
@@ -422,9 +422,9 @@ The response should include the `check-http` check:
 
 ### Validate the check
 
-Before you validate the check, make sure that you've [registered the `http-checks` dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
+Before you validate the check, make sure that you've [registered the sensu/http-checks dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
 
-Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http`, returning a status of `0` (OK):
+Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http` check, returning a status of `0` (OK):
 
 {{< code shell >}}
 sensuctl event list

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -172,7 +172,7 @@ spec:
 
 ### Filter dynamic runtime assets
 
-Sensu event filters can have dynamic runtime assets that are included in their execution context.
+Sensu event filters can include dynamic runtime assets in their execution context.
 When valid dynamic runtime assets are associated with an event filter, Sensu evaluates any files it finds that have a `.js` extension before executing the filter.
 The result of evaluating the scripts is cached for a given asset set for the sake of performance.
 For an example of how to implement an event filter as an asset, read [Reduce alert fatigue][30].

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -34,7 +34,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The examples for both approaches in this guide use the `check_cpu` check from [Monitor server resources with checks][13], which includes the subscription `system`.
 Use [sensuctl][18] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -42,7 +42,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -335,7 +335,7 @@ This will help you understand what dynamic runtime assets are and how they are u
 
 In this approach, the first step is to obtain an event filter dynamic runtime asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use `sensuctl asset add` to register the [fatigue check filter][8] dynamic runtime asset:
+Use `sensuctl asset add` to register the [sensu/sensu-go-fatigue-check-filter][8] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-fatigue-check-filter:0.8.1 -r fatigue-filter
@@ -417,7 +417,7 @@ sensuctl create -f sensu-fatigue-check-filter.json
 
 {{< /language-toggle >}}
 
-Now that you've created the filter dynamic runtime asset, event filter definition, and pipeline, you can create the check annotations you need for the dynamic runtime asset to work properly. 
+Now that you've added the dynamic runtime asset and created the event filter definition and pipeline, you can create the check annotations you need for the dynamic runtime asset to work properly. 
 
 ### Update a check for filter dynamic runtime asset use
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -44,7 +44,7 @@ For an agent to execute a specific check, you must specify the same subscription
 This guide uses an example check that includes the subscription `system`.
 Use [sensuctl][7] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find an entity's name, run `sensuctl entity list`.
@@ -52,7 +52,7 @@ The `ID` is the name of the entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -68,8 +68,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register dynamic runtime assets
 
-Contact routing is powered by the [has-contact filter dynamic runtime asset][12].
-To add the has-contact dynamic runtime asset to Sensu, use [sensuctl asset add][14]:
+Contact routing is powered by the [sensu/sensu-go-has-contact-filter][12] dynamic runtime asset.
+To add the asset to Sensu, use [sensuctl asset add][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
@@ -88,7 +88,7 @@ resource, populate the "runtime_assets" field with ["contact-filter"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `contact-filter`.
 
-Next, add the [Slack handler dynamic runtime asset][8] to Sensu with sensuctl:
+Next, add the [sensu/sensu-slack-handler][8] dynamic runtime asset to Sensu with sensuctl:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create contact filters
 
-The [Bonsai][12] documentation for the asset explains that the has-contact dynamic runtime asset supports two functions:
+The [Bonsai][12] documentation explains that the sensu/sensu-go-has-contact-filter dynamic runtime asset supports two functions:
 
 - `has_contact`, which takes the Sensu event and the contact name as arguments
 - `no_contact`, which is available as a fallback in the absence of contact labels and takes only the event as an argument
@@ -267,8 +267,8 @@ In each handler definition, you will specify:
 
 Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Replace `<alert-ops>`, `<alert-dev>`, and `<alert-all>` with the names of the channels you want to use to receive alerts in your Slack instance.
-- Replace `<slack_webhook_url>` with your Slack webhook URL.
+- Replace `<ALERT_OPS>`, `<ALERT_DEV>`, and `<ALERT_ALL>` with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace `<SLACK_WEBHOOK_URL>` with your Slack webhook URL.
 
 After you update the code to use your preferred Slack channels and webhook URL, run:
 
@@ -281,7 +281,7 @@ api_version: core/v2
 metadata:
   name: ops_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-ops>"
+  command: sensu-slack-handler --channel "#<ALERT_OPS>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -296,7 +296,7 @@ api_version: core/v2
 metadata:
   name: dev_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-dev>"
+  command: sensu-slack-handler --channel "#<ALERT_DEV>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -311,7 +311,7 @@ api_version: core/v2
 metadata:
   name: fallback_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-fallback>"
+  command: sensu-slack-handler --channel "#<ALERT_ALL>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -330,7 +330,7 @@ echo '{
     "name": "ops_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-ops>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_OPS>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -350,7 +350,7 @@ echo '{
     "name": "dev_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-dev>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_DEV>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -370,7 +370,7 @@ echo '{
     "name": "fallback_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-fallback>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_ALL>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -400,9 +400,9 @@ The response should list the new `dev_handler`, `ops_handler`, and `fallback_han
 {{< code text >}}
         Name         Type   Timeout   Filters   Mutator                       Execute                                                   Environment Variables                            Assets         
 ─────────────────── ────── ───────── ───────── ───────── ───────────────────────────────────────────────────────── ───────────────────────────────────────────────────────────── ──────────────────────
-  dev_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<alert_dev>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
-  fallback_handler   pipe         0                       RUN:  sensu-slack-handler --channel "#<alert-fallback>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
-  ops_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<alert-ops>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  dev_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_DEV>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  fallback_handler   pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_ALL>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  ops_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_OPS>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
 {{< /code >}}
 
 ## Create a pipeline

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handler-templates.md
@@ -80,7 +80,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 ## Template toolkit command
 
-The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
+The [sensu/template-toolkit-command][8] dynamic runtime asset provides a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
 The template toolkit command uses event data you supply via stdin in JSON format.
 
@@ -222,12 +222,12 @@ Sensu<br>
 
 {{< /code >}}
 
-The Sensu Email Handler plugin also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
-Read the [Sensu Email Handler Bonsai page][9] for details.
+The sensu/sensu-email-handler dynamic runtime asset also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
+Read the [sensu/sensu-email-handler Bonsai page][9] for details.
 
 ## Sensu PagerDuty Handler example
 
-The [Sensu PagerDuty Handler plugin][10] includes a basic template for the PagerDuty alert summary:
+The [sensu/sensu-pagerduty-handler][10] dynamic runtime asset includes a basic template for the PagerDuty alert summary:
 
 {{< code shell >}}
 "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}"

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -237,11 +237,9 @@ With these event filters and handlers configured, you can create a [handler set]
 You can also list the three handlers in the [handlers array][33] in your check definition instead.
 
 {{% notice protip %}}
-{{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
 For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
 The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
-{{% /notice %}}
 {{% /notice %}}
 
 ## Keepalive event handlers

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -237,9 +237,11 @@ With these event filters and handlers configured, you can create a [handler set]
 You can also list the three handlers in the [handlers array][33] in your check definition instead.
 
 {{% notice protip %}}
+{{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
-For example, you can use the `is_incident` event filter in conjunction with the [Sensu Go Fatigue Check Filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
-Sensu's [Ansible](../../../plugins/featured-integrations/ansible/), [Rundeck](../../../plugins/featured-integrations/rundeck/), and [Saltstack](../../../plugins/featured-integrations/saltstack/) auto-remediation integrations and the [Sensu Remediation Handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
+The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+{{% /notice %}}
 {{% /notice %}}
 
 ## Keepalive event handlers
@@ -767,7 +769,7 @@ secret: sensu-ansible-host
 ## Send Slack alerts
 
 This handler will send alerts to a channel named `monitoring` with the configured webhook URL, using the `handler-slack` executable command.
-The handler uses the [Sensu Slack Handler][34] dynamic runtime asset.
+The handler uses the [sensu/sensu-slack-handler][34] dynamic runtime asset.
 Read [Send Slack alerts with handlers][35] for detailed instructions for adding the required asset and configuring this handler.
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/plan-maintenance.md
@@ -36,10 +36,10 @@ Use sensuctl to add the `website` subscription to an entity the Sensu agent is o
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,10 +55,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [http-checks][12] dynamic runtime asset.
+To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
 This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
 
-Register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -73,7 +73,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -28,7 +28,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The example in this guide uses the `prometheus_metrics` check from [Collect Prometheus metrics with Sensu][10], which includes the subscription `app_tier`.
 Use [sensuctl][15] to add an `app_tier` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -36,7 +36,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -53,9 +53,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][12] are shareable, reusable packages that make it easier to deploy Sensu plugins.
-This example uses the [Sensu InfluxDB Handler][13] dynamic runtime asset to power an InfluxDB handler.
+This example uses the [sensu/sensu-influxdb-handler][13] dynamic runtime asset to power an InfluxDB handler.
 
-Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynamic runtime asset:
+Use [`sensuctl asset add`][5] to register the [sensu/sensu-influxdb-handler][13] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -85,7 +85,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create the handler
 
-Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
+Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the sensu/sensu-influxdb-handler dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
 For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -38,11 +38,11 @@ sensuctl entity list
 The `ID` in the response is the entity name.
 Select one of the listed entities.
 
-Before you run the following sensuctl command, replace `<entity_name>` with the name of your entity.
+Before you run the following sensuctl command, replace `<ENTITY_NAME>` with the name of your entity.
 Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -58,9 +58,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu Sumo Logic Handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
+The [sensu/sensu-sumologic-handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
 
-To add the Sumo Logic handler asset, run:
+To add the sensu/sensu-sumologic-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-sumologic-handler:0.3.0 -r sumologic-handler
@@ -85,7 +85,7 @@ To confirm that the asset was added to your Sensu backend, run:
 sensuctl asset info sumologic-handler
 {{< /code >}}
 
-The response will list the available builds for the Sensu Sumo Logic Handler dynamic runtime asset.
+The response will list the available builds for the sensu/sensu-sumologic-handler dynamic runtime asset.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -143,7 +143,7 @@ You will use this URL in the next step as the `SUMOLOGIC_URL` value for the secr
 
 ## Add the Sumo Logic handler
 
-Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [Sensu Sumo Logic Handler asset][8] to send observability data to Sumo Logic.
+Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [sensu/sensu-sumologic-handler][8] dynamic runtime asset to send observability data to Sumo Logic.
 
 The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
@@ -570,7 +570,7 @@ You have a successful workflow that sends Sensu observability data to your Sumo 
 
 To share and reuse the check, handler, and pipeline like code, [save them to files][6] and start building a [monitoring as code repository][7].
 
-Learn more about the [Sensu Sumo Logic Handler][19] dynamic runtime asset.
+Learn more about the [sensu/sensu-sumologic-handler][19] dynamic runtime asset.
 You can also configure a [Sumo Logic dashboard][10] to search, view, and analyze the Sensu data you're sending to your Sumo Logic HTTP Logs and Metrics Source.
 
 In addition to the traditional handler we used in this example, you can use [Sensu Plus][17], our built-in integration, to send metrics to Sumo Logic with a streaming [Sumo Logic metrics handler][18].

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -27,9 +27,9 @@ The pipeline will also include an [event filter][5] to make sure you only receiv
 ## Add the email handler dynamic runtime asset
 
 [Dynamic runtime assets][8] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Go Email Handler][3] dynamic runtime asset to power an `email` handler.
+In this guide, you'll use the [sensu/sensu-email-handler][3] dynamic runtime asset to power an `email` handler.
 
-Use the following sensuctl example to register the [Sensu Go Email Handler][3] dynamic runtime asset:
+Use the following sensuctl example to register the [sensu/sensu-email-handler][3] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler:1.2.2 -r email-handler
@@ -63,7 +63,7 @@ For a detailed list of everything related to the asset that Sensu added automati
 sensuctl asset info email-handler
 {{< /code >}}
 
-The dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
+The sensu/sensu-email-handler dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -130,7 +130,7 @@ EOF
 
 ## Create the email handler definition
 
-After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
+After you add an event filter, create the email handler definition to specify the email address where the handler will send notifications.
 In the handler definition's `command` value, you'll need to change a few things:
 
 - `<sender@example.com>`: Replace with the email address you want to use to send email alerts.

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -37,11 +37,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][12] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][12] command below.
 Then run the command to add the `system` [subscription][13] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -57,9 +57,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu PagerDuty Handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
+The [sensu/sensu-pagerduty-handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
 
-To add the PagerDuty handler asset, run:
+To add the sensu/sensu-pagerduty-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler
@@ -95,14 +95,14 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 Now that you've added the dynamic runtime asset, you can create a [handler][9] that uses the asset to send non-OK events to PagerDuty.
 
-In the following command, replace `<pagerduty_key>` with your [PagerDuty API integration key][1].
+In the following command, replace `<PAGERDUTY_KEY>` with your [PagerDuty API integration key][1].
 Then run the updated command:
 
 {{< code shell >}}
 sensuctl handler create pagerduty \
 --type pipe \
 --runtime-assets pagerduty-handler \
---command "sensu-pagerduty-handler -t <pagerduty_key>"
+--command "sensu-pagerduty-handler -t <PAGERDUTY_KEY>"
 {{< /code >}}
 
 {{% notice note %}}
@@ -137,7 +137,7 @@ api_version: core/v2
 metadata:
   name: pagerduty
 spec:
-  command: sensu-pagerduty-handler -t <pagerduty_key>
+  command: sensu-pagerduty-handler -t <PAGERDUTY_KEY>
   env_vars: null
   handlers: null
   runtime_assets:
@@ -155,7 +155,7 @@ spec:
     "name": "pagerduty"
   },
   "spec": {
-    "command": "sensu-pagerduty-handler -t <pagerduty_key>",
+    "command": "sensu-pagerduty-handler -t <PAGERDUTY_KEY>",
     "env_vars": null,
     "handlers": null,
     "runtime_assets": [
@@ -179,7 +179,7 @@ spec:
 With your handler configured, you can add it to a [pipeline][17] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the PagerDuty handler you've already configured.
+In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the `pagerduty` handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][20] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
 Then run the command to add the `system` [subscription][21] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -56,9 +56,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Slack Handler][14] dynamic runtime asset to power a `slack` handler.
+In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic runtime asset:
+Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -93,7 +93,7 @@ After you save your webhook, you can find the webhook URL under **Integration Se
 
 ## Create a handler
 
-Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the `sensu-slack-handler` dynamic runtime asset.
+Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the sensu/sensu-slack-handler dynamic runtime asset.
 Before you run the sensuctl command below, edit it to include your Slack webhook URL and the channel where you want to receive events:
 
 {{< code shell >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -158,7 +158,7 @@ spec:
 ## Assign the hook to a check
 
 {{% notice note %}}
-**NOTE**: Before you proceed, make sure you have added the [sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
+**NOTE**: Before you proceed, make sure you have added the [sensu/sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and the [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
 The hook you create in this step relies on the `nginx_service` check.
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][17] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][17] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,8 +55,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-To power the check to collect service metrics, you will use a check in the [http-checks][7] dynamic runtime asset.
-Use sensuctl to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+To power the check to collect service metrics, you will use a check in the [sensu/http-checks][7] dynamic runtime asset.
+Use sensuctl to register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.4.0 -r http-checks

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -30,7 +30,7 @@ For information about HTTP GET access to internal Sensu metrics, read our [/metr
 
 ## Metric check example
 
-This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [Sensu System Check][26] dynamic runtime asset and sends the collected metrics to a pipeline configured with handlers that use the [Sensu Go Graphite Handler][12] dynamic runtime asset:
+This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [sensu/system-check][26] dynamic runtime asset and sends the collected metrics to a pipeline configured with handlers that use the [sensu/sensu-go-graphite-handler][12] dynamic runtime asset:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -39,11 +39,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][16] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][16] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -63,11 +63,11 @@ You can write shell scripts in the `command` field of your check definitions, bu
 Check plugins must be available on the host where the agent is running for the agent to execute the check.
 This guide uses [dynamic runtime assets][2] to manage plugin installation.
 
-### Register the Sensu CPU usage check asset
+### Register the sensu/check-cpu-usage asset
 
-The [Sensu CPU usage check][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
+The [sensu/check-cpu-usage][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
 
-To register the Sensu CPU usage check dynamic runtime asset, `sensu/check-cpu-usage:0.2.2`, run:
+To register the sensu/check-cpu-usage dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
@@ -102,7 +102,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `check-cpu-usage` and `sensu-processes-check` dynamic runtime assets:
+The response should list the renamed check-cpu-usage and sensu-processes-check dynamic runtime assets:
 
 {{< code text >}}
           Name                                                 URL                                         Hash    
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check to monitor a server
 
-Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the `check-cpu-usage` dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the check-cpu-usage dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -13,12 +13,12 @@ menu:
     parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
-This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
-
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
 Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
+
+You can use the [sensu/sensu-prometheus-collector][19] dynamic runtime asset to create checks that collect [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
+This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 To follow this guide, you’ll need to [install][4] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
 
@@ -26,13 +26,13 @@ The examples in this guide use CentOS 7 as the operating system, with all compon
 Commands and steps may change for different distributions or if components are running on different compute resources.
 
 At the end of this guide, Prometheus will be scraping metrics.
-The Sensu Prometheus Collector will then query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
+The check that uses the sensu/sensu-prometheus-collector asset will query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
 Finally, Grafana will query InfluxDB to display the collected metrics.
 
 ## Configure a Sensu entity
 
 Use [sensuctl][15] to add an `app_tier` [subscription][16] to one of your entities.
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -40,7 +40,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -194,7 +194,7 @@ sudo systemctl start grafana-server
 
 ### Add the Sensu InfluxDB handler asset
 
-To add the [Sensu InfluxDB Handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-influxdb-handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -338,9 +338,9 @@ Now you can add the `prometheus_metrics_workflows` pipeline to a check for check
 
 ## Collect Prometheus metrics with Sensu
 
-### Add the Sensu Prometheus Collector asset
+### Add the sensu/sensu-prometheus-collector asset
 
-To add the [Sensu Prometheus Collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-prometheus-collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-collector
@@ -387,7 +387,7 @@ The response should list the `sensu-prometheus-collector` dynamic runtime asset 
 
 ### Add a Sensu check that references the pipeline
 
-To add the [check][13] definition that uses the Sensu Prometheus Collector dynamic runtime asset and your `prometheus_metrics_workflows` pipeline, run:
+To add the [check][13] definition that uses the sensu/sensu-prometheus-collector dynamic runtime asset and your `prometheus_metrics_workflows` pipeline, run:
 
 {{< language-toggle >}}
 
@@ -503,17 +503,17 @@ The page should include a graph with initial metrics, similar to this example:
 ## Next steps
 
 You should now have a working observability pipeline with Prometheus scraping metrics.
-The Sensu Prometheus Collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
+You should now have a working observability pipeline with Prometheus scraping metrics.
+The sensu/sensu-prometheus-collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
 
 The check sends metrics to the `prometheus_metrics_workflows` pipeline, and the `influxdb` handler sends the metrics to InfluxDB.
 You can visualize the metrics in a Grafana dashboard.
 
-Add the [Sensu Prometheus Collector][1] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
+Add the [sensu/sensu-prometheus-collector][19] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
 
-[1]: ../../../plugins/featured-integrations/prometheus/#sensu-prometheus-collector
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
 [4]: ../../../operations/deploy-sensu/install-sensu/

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -37,7 +37,7 @@ Instead of creating a different check for every set of thresholds, you can use t
 
 Follow this example to set up a reusable check for disk usage:
 
-1. Add the [Sensu disk usage check][13] dynamic runtime asset, which includes the command you will need for your check:
+1. Add the [sensu/check-disk-usage][13] dynamic runtime asset, which includes the command you will need for your check:
 {{< code shell >}}
 sensuctl asset add sensu/check-disk-usage:0.6.0
 {{< /code >}}

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -23,7 +23,7 @@ No human user needs to log into the service, and the service does not need edit 
 A limited service account can provide only the necessary access and permissions.
 
 Limited service accounts are also useful for performing automated processes.
-This guide explains how to create a limited service account to use with the [Sensu EC2 Handler][3] integration to automatically remove AWS EC2 instances that are not in a pending or running state.
+This guide explains how to create a limited service account to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset to automatically remove AWS EC2 instances that are not in a pending or running state.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including the RBAC resources required to configure a limited service account.
 This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the [`admin` user][2].
@@ -177,11 +177,11 @@ sensuctl api-key grant ec2-service
 
    The response will include an API key that is assigned to the `ec2-service` user, which you will need to configure the EC2 handler.
 
-The `ec2-service` limited service account is now ready to use with the [Sensu EC2 Handler][3] integration.
+The `ec2-service` limited service account is now ready to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset.
 
-## Add the EC2 handler dynamic runtime asset
+## Add the sensu/sensu-ec2-handler dynamic runtime asset
 
-To power the handler to remove AWS EC2 instances, use sensuctl to add the [Sensu Go EC2 Handler][13] [dynamic runtime asset][14]:
+To power the handler to remove AWS EC2 instances, use sensuctl to add the [sensu/sensu-ec2-handler][13] [dynamic runtime asset][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ec2-handler:0.4.0
@@ -319,7 +319,6 @@ Adjust namespaces and permissions if needed by updating the role or cluster role
 
 [1]: ../rbac/
 [2]: ../rbac#default-users
-[3]: ../../../plugins/featured-integrations/aws-ec2/
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../rbac/#role-bindings-and-cluster-role-bindings
 [6]: ../rbac/#rule-attributes

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -145,20 +145,20 @@ As a result, Sensu Go does not include the built-in occurrence-based event filte
 To replicate the Sensu Core occurrence-based filter's functionality, use Sensu Go's [repeated events filter definition][10].
 
 Sensu Go includes three built-in [event filters][9]: [is_incident][63], [not_silenced][61], and [has_metrics][101].
-Sensu Go does not include a built-in check dependencies filter, but you can use the [Core Dependencies Filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
+Sensu Go does not include a built-in check dependencies filter, but you can use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
 
 Sensu Go event filters do not include the `when` event filter attribute.
 Use Sensu query expressions to build [custom functions][106] that provide granular control of time-based filter expressions.
 
 ### Fatigue check filter
 
-The [Sensu Go Fatigue Check Filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
+The [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
 This filter looks for [check and entity annotations][33] in each event it receives and uses the values of those annotations to configure the filter's behavior on a per-event basis.
 
 The [Sensu Translator version 1.1.0][18] retrieves occurrence and refresh values from a Sensu Core check definition and outputs them as annotations in a Sensu Go check definition, compatible with the fatigue check filter.
 
-However, the Sensu Translator doesn't automatically add the [Sensu Go Fatigue Check Filter][11] dynamic runtime asset or the filter configuration you need to run it.
-To use the Sensu Go Fatigue Check Filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
+However, the Sensu Translator doesn't automatically add the [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset or the filter configuration you need to run it.
+To use the sensu/sensu-go-fatigue-check-filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
 
 ## Dynamic runtime assets
 
@@ -186,7 +186,7 @@ The syntax for token substitution changed to [double curly braces][16] in Sensu 
 
 ## Aggregates
 
-Sensu Go supports check aggregates with the [Sensu Go Aggregate Check Plugin][28], which is a [commercial][27] resource.
+Sensu Go supports check aggregates with the [sensu/sensu-aggregate-check][28] dynamic runtime asset, which is a [commercial][27] resource.
 
 ## API
 
@@ -310,9 +310,9 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `metrics: true` | Review the [translate metric checks][71] section.
 `proxy_requests` | Review the [translate proxy requests][72] section.
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
-`aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
+`aggregate` | Check aggregates are supported through the [commercial][27] [sensu/sensu-aggregate-check][28].
 `hooks` | Review the [translate hooks][73] section.
-`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`dependencies`| Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.`, like `sensu.io.json_attributes`, use the `index` function.
@@ -426,9 +426,9 @@ Review your Sensu Core check configuration for the following attributes and make
 
 | Core attribute | Manual updates required in Sensu Go config |
 | -------------- | ------------- |
-`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [Sensu Go Fatigue Check Filter][65].
+`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [sensu/sensu-go-fatigue-check-filter][65].
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
-`filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`filters: check_dependencies` | Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
 `handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [pipelines][100].
@@ -518,7 +518,7 @@ Read the [guide to installing plugins with assets][50] to register assets with S
 
 #### Contact routing
 
-Contact routing is available in Sensu Go using the has-contact filter asset.
+Contact routing is available in Sensu Go woth the [sensu/sensu-go-has-contact-filter][30] dynamic runtime asset.
 Read [Route alerts with event filters][90] to set up contact routing in Sensu Go.
 
 #### LDAP
@@ -560,6 +560,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../observability-pipeline/observe-schedule/backend#operation
+[30]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [33]: https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter/#configuration
 [34]: ../../../observability-pipeline/observe-filter/reduce-alert-fatigue/#add-the-event-filter-to-a-pipeline
 [36]: https://etcd.io/

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -371,9 +371,9 @@ In the [add a handler][19] section, you'll use your `pagerduty_key` secret in yo
 
 ## Add a handler
 
-### Register the PagerDuty Handler dynamic runtime asset
+### Register the sensu/sensu-pagerduty-handler dynamic runtime asset
 
-To begin, register the [Sensu PagerDuty Handler dynamic runtime asset][23] with [`sensuctl asset add`][22]:
+To begin, register the [sensu/sensu-pagerduty-handler][23] dynamic runtime asset with [`sensuctl asset add`][22]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler

--- a/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.5/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -35,10 +35,10 @@ The checks in this guide monitor the following ports and endpoints:
 
 ## Register dynamic runtime asset
 
-To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [http-checks][5] dynamic runtime asset.
+To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [sensu/http-checks][5] dynamic runtime asset.
 This asset includes the `http-json` plugin, which your checks will rely on.
 
-To register the http-checks dynamic runtime asset, `sensu/http-checks`, run:
+To register the sensu/http-checks dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -63,7 +63,7 @@ To confirm that the asset is ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the http-checks dynamic runtime asset:
+The response should list the renamed http-checks dynamic runtime asset:
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -90,11 +90,11 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -200,8 +200,8 @@ To receive alerts based on your backend health checks, configure a [pipeline][6]
 If your Sensu Go deployment uses an external etcd cluster, you'll need to check the health of the respective etcd instances for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -356,14 +356,14 @@ PostgreSQL data from the `/health` endpoint will look like this example:
 }
 {{< /code >}}
 
-To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset.
+To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
-After you register the http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
+After you register the sensu/http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
 Make sure to update the `--url` value with your backend address before running the commands to create the checks.
 
 Run the following command to add the "healthy" check:
@@ -385,7 +385,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -406,7 +406,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }
@@ -434,7 +434,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -455,7 +455,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -304,8 +304,8 @@ Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][4
 
 ### Dynamic runtime asset build execution
 
-The directory path of each dynamic runtime asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
-Subsequent handler, filter, mutator, or check executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
+The directory path of each dynamic runtime asset listed in a check, event filter, handler, or mutator resource's `runtime_assets` array is appended to the `PATH` before the resource's `command` is executed.
+Subsequent check, event filter, handler, or mutator executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
 
 The following example demonstrates a use case with a Sensu check resource and an asset:
 
@@ -1041,7 +1041,7 @@ headers:
 
 Use the [entity.system attributes][10] in dynamic runtime asset [filters][42] to specify which systems and configurations an asset or asset builds can be used with.
 
-For example, the [Sensu Go Ruby Runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
+For example, the [sensu/sensu-ruby-runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
 
 {{< language-toggle >}}
 
@@ -1258,8 +1258,9 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
-When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
+Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+
+Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -233,7 +233,7 @@ EOF
 Your pipeline resource is now properly configured, but it’s not processing any events because no Sensu [checks][9] are sending events to it.
 To get your Sensu observability data flowing through the new pipeline, add the pipeline by reference in at least one check definition.
 
-This example check definition uses the [Sensu System Check][13] dynamic runtime asset.
+This example check definition uses the [sensu/system-check][13] dynamic runtime asset.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
@@ -242,16 +242,16 @@ Read the [assets reference](../plugins/assets/) for more information about dynam
 
 Follow these steps to configure the required system check:
 
-1. Add the [Sensu System Check][13] dynamic runtime asset:
+1. Add the [sensu/system-check][13] dynamic runtime asset:
 {{< code shell >}}
 sensuctl asset add sensu/system-check:0.1.1 -r system-check
 {{< /code >}}
 
 2. Update at least one Sensu entity to use the `system` subscription.
-In the following command, replace `<entity_name>` with the name of the entity on your system.
+In the following command, replace `<ENTITY_NAME>` with the name of the entity on your system.
 Then, run:
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
     - For `Entity Class`, press enter.

--- a/content/sensu-go/6.5/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.5/sensuctl/sensuctl-bonsai.md
@@ -16,19 +16,21 @@ You can also use `sensuctl command` to install, execute, list, and delete comman
 
 ## Install dynamic runtime asset definitions
 
-To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <namespace/name>:<version>`.
-Replace `<namespace/name>` with the namespace and name of the dynamic runtime asset from Bonsai and `<version>` with the asset version you want to install.
+To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <ASSET_NAME>:<ASSET_VERSION>`.
+Replace `<ASSET_NAME>` with the complete name of the dynamic runtime asset from Bonsai.
+An asset's complete name includes both the part before the forward slash (sometimes called the Bonsai namespace) and the part after the forward slash.
 
-To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <namespace/name>`.
+{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
+
+Replace `<ASSET_VERSION>` with the asset version you want to install.
+To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <ASSET_NAME>`.
 
 {{% notice note %}}
 **NOTE**: Specify the asset version you want to install to maintain the stability of your observability infrastructure.
 If you do not specify a version to install, Sensu automatically installs the latest version, which may include breaking changes.
 {{% /notice %}}
 
-{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
-
-For example, to install version 3.7.0 of the [Sensu InfluxDB Handler][4] dynamic runtime asset:
+For example, to install version 3.7.0 of the [sensu/sensu-influxdb-handler][4] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0
@@ -82,20 +84,20 @@ Use `sensuctl command` to install, execute, list, and delete commands from Bonsa
 To install a sensuctl command from Bonsai or a URL:
 
 {{< code shell >}}
-sensuctl command install <alias> (<namespace/name>:<version> | --url <archive_url> --checksum <archive_checksum>) <flags>
+sensuctl command install <ALIAS> (<ASSET_NAME>:<ASSET_VERSION> | --url <ARCHIVE_URL> --checksum <ARCHIVE_CHECKSUM>) <FLAGS>
 {{< /code >}}
 
 To install a command plugin, use the Bonsai asset name or specify a URL and SHA512 checksum.
 
-**To install a command using the Bonsai asset name**, replace `<namespace/name>` with the name of the asset from Bonsai.
-`:<version>` is only required if you require a specific version or are pinning to a specific version.
+**To install a command using the Bonsai asset name**, replace `<ASSET_NAME>` with the complete name of the asset from Bonsai.
+`:<ASSET_VERSION>` is only required if you require a specific version or are pinning to a specific version.
 If you do not specify a version, sensuctl will fetch the latest version from Bonsai.
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -105,11 +107,11 @@ To install a command from the [Sensu EC2 Discovery Plugin][3] with no flags:
 sensuctl command install sensu-ec2-discovery portertech/sensu-ec2-discovery:0.3.0
 {{< /code >}}
 
-**To install a command from a URL**, replace `<archive_url>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
-Replace `<archive_checksum>` with the checksum you want to use.
-Replace `<alias>` with a unique name for the command.
+**To install a command from a URL**, replace `<ARCHIVE_URL>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
+Replace `<ARCHIVE_CHECKSUM>` with the checksum you want to use.
+Replace `<ALIAS>` with a unique name for the command.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -128,20 +130,20 @@ sensuctl command install command-test --url https://github.com/amdprophet/comman
 To execute a sensuctl command plugin via its dynamic runtime asset's bin/entrypoint executable:
 
 {{< code shell >}}
-sensuctl command exec <alias> <args> <flags>
+sensuctl command exec <ALIAS> <GLOBAL_FLAGS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<GLOBAL_FLAGS>` with the globlal flags you want to use.
+Run `sensuctl command exec -h` to view global flags.
+To pass `<GLOBAL_FLAGS>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
+
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command exec -h` to view flags.
 Flags are optional and apply only to the `exec` command &mdash; they are not saved as part of the command you are executing.
-
-Replace `<args>` with the globlal flags you want to use.
-Run `sensuctl command exec -h` to view global flags.
-To pass `<args>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
 
 {{% notice note %}}
 **NOTE**: When you use `sensuctl command exec`, the [environment variables](../environment-variables) are passed to the command.
@@ -150,7 +152,7 @@ To pass `<args>` flags to the bin/entrypoint executable, make sure to specify th
 For example:
 
 {{< code shell >}}
-sensuctl command exec <command> <arg1> <arg2> --cache-dir /tmp -- --<flag1> --<flag2>=<value>
+sensuctl command exec <COMMAND> <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --cache-dir /tmp -- --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flags after the ` -- `.
@@ -158,7 +160,7 @@ Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flag
 In this example, the full command run by sensuctl exec would be:
 
 {{< code shell >}}
-bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
+bin/entrypoint <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 ### List commands
@@ -166,10 +168,10 @@ bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
 To list installed sensuctl commands: 
 
 {{< code shell >}}
-sensuctl command list <flags>
+sensuctl command list <FLAGS>
 {{< /code >}}
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command list -h` to view flags.
 Flags are optional and apply only to the `list` command.
 
@@ -178,19 +180,18 @@ Flags are optional and apply only to the `list` command.
 To delete sensuctl commands:
 
 {{< code shell >}}
-sensuctl command delete <alias> <flags>
+sensuctl command delete <ALIAS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
-For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+Replace `<ALIAS>` with a unique name for the command.
+For example, for the [sensu/sensu-ec2-handler][3], you might use the alias `sensu-ec2-handler`. 
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command delete -h` to view flags.
 Flags are optional and apply only to the `delete` command.
 
 
 [1]: https://bonsai.sensu.io/
-[2]: /images/sensu-influxdb-handler-namespace.png
-[3]: https://bonsai.sensu.io/assets/portertech/sensu-ec2-discovery
+[3]: https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -35,10 +35,10 @@ Use sensuctl to add the `run_proxies` subscription to the entity the Sensu agent
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -54,10 +54,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ### Register dynamic runtime asset
 
-To power the check, you'll use the [http-checks][16] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][15] will rely on.
+To power the check, you'll use the [sensu/http-checks][16] dynamic runtime asset.
+This community-tier asset includes the http status check command that [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Use [`sensuctl asset add`][21] to register the dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -84,7 +84,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -104,7 +104,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ### Create the check
 
-Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the `http-checks` dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
+Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the [sensu/http-checks][16] dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
 
 The check includes the [`round_robin` attribute][18] set to `true` to distribute the check execution across all agents subscribed to the `run_proxies` subscription and avoid duplicate events.
 
@@ -422,9 +422,9 @@ The response should include the `check-http` check:
 
 ### Validate the check
 
-Before you validate the check, make sure that you've [registered the `http-checks` dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
+Before you validate the check, make sure that you've [registered the sensu/http-checks dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
 
-Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http`, returning a status of `0` (OK):
+Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http` check, returning a status of `0` (OK):
 
 {{< code shell >}}
 sensuctl event list

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -172,7 +172,7 @@ spec:
 
 ### Filter dynamic runtime assets
 
-Sensu event filters can have dynamic runtime assets that are included in their execution context.
+Sensu event filters can include dynamic runtime assets in their execution context.
 When valid dynamic runtime assets are associated with an event filter, Sensu evaluates any files it finds that have a `.js` extension before executing the filter.
 The result of evaluating the scripts is cached for a given asset set for the sake of performance.
 For an example of how to implement an event filter as an asset, read [Reduce alert fatigue][30].

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -34,7 +34,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The examples for both approaches in this guide use the `check_cpu` check from [Monitor server resources with checks][13], which includes the subscription `system`.
 Use [sensuctl][18] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -42,7 +42,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -335,7 +335,7 @@ This will help you understand what dynamic runtime assets are and how they are u
 
 In this approach, the first step is to obtain an event filter dynamic runtime asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use `sensuctl asset add` to register the [fatigue check filter][8] dynamic runtime asset:
+Use `sensuctl asset add` to register the [sensu/sensu-go-fatigue-check-filter][8] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-fatigue-check-filter:0.8.1 -r fatigue-filter
@@ -417,7 +417,7 @@ sensuctl create -f sensu-fatigue-check-filter.json
 
 {{< /language-toggle >}}
 
-Now that you've created the filter dynamic runtime asset, event filter definition, and pipeline, you can create the check annotations you need for the dynamic runtime asset to work properly. 
+Now that you've added the dynamic runtime asset and created the event filter definition and pipeline, you can create the check annotations you need for the dynamic runtime asset to work properly. 
 
 ### Update a check for filter dynamic runtime asset use
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
@@ -44,7 +44,7 @@ For an agent to execute a specific check, you must specify the same subscription
 This guide uses an example check that includes the subscription `system`.
 Use [sensuctl][7] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find an entity's name, run `sensuctl entity list`.
@@ -52,7 +52,7 @@ The `ID` is the name of the entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -68,8 +68,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register dynamic runtime assets
 
-Contact routing is powered by the [has-contact filter dynamic runtime asset][12].
-To add the has-contact dynamic runtime asset to Sensu, use [sensuctl asset add][14]:
+Contact routing is powered by the [sensu/sensu-go-has-contact-filter][12] dynamic runtime asset.
+To add the asset to Sensu, use [sensuctl asset add][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
@@ -88,7 +88,7 @@ resource, populate the "runtime_assets" field with ["contact-filter"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `contact-filter`.
 
-Next, add the [Slack handler dynamic runtime asset][8] to Sensu with sensuctl:
+Next, add the [sensu/sensu-slack-handler][8] dynamic runtime asset to Sensu with sensuctl:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create contact filters
 
-The [Bonsai][12] documentation for the asset explains that the has-contact dynamic runtime asset supports two functions:
+The [Bonsai][12] documentation explains that the sensu/sensu-go-has-contact-filter dynamic runtime asset supports two functions:
 
 - `has_contact`, which takes the Sensu event and the contact name as arguments
 - `no_contact`, which is available as a fallback in the absence of contact labels and takes only the event as an argument
@@ -267,8 +267,8 @@ In each handler definition, you will specify:
 
 Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Replace `<alert-ops>`, `<alert-dev>`, and `<alert-all>` with the names of the channels you want to use to receive alerts in your Slack instance.
-- Replace `<slack_webhook_url>` with your Slack webhook URL.
+- Replace `<ALERT_OPS>`, `<ALERT_DEV>`, and `<ALERT_ALL>` with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace `<SLACK_WEBHOOK_URL>` with your Slack webhook URL.
 
 After you update the code to use your preferred Slack channels and webhook URL, run:
 
@@ -281,7 +281,7 @@ api_version: core/v2
 metadata:
   name: ops_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-ops>"
+  command: sensu-slack-handler --channel "#<ALERT_OPS>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -296,7 +296,7 @@ api_version: core/v2
 metadata:
   name: dev_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-dev>"
+  command: sensu-slack-handler --channel "#<ALERT_DEV>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -311,7 +311,7 @@ api_version: core/v2
 metadata:
   name: fallback_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-fallback>"
+  command: sensu-slack-handler --channel "#<ALERT_ALL>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -330,7 +330,7 @@ echo '{
     "name": "ops_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-ops>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_OPS>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -350,7 +350,7 @@ echo '{
     "name": "dev_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-dev>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_DEV>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -370,7 +370,7 @@ echo '{
     "name": "fallback_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-fallback>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_ALL>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -400,9 +400,9 @@ The response should list the new `dev_handler`, `ops_handler`, and `fallback_han
 {{< code text >}}
         Name         Type   Timeout   Filters   Mutator                       Execute                                                   Environment Variables                            Assets         
 ─────────────────── ────── ───────── ───────── ───────── ───────────────────────────────────────────────────────── ───────────────────────────────────────────────────────────── ──────────────────────
-  dev_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<alert_dev>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
-  fallback_handler   pipe         0                       RUN:  sensu-slack-handler --channel "#<alert-fallback>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
-  ops_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<alert-ops>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  dev_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_DEV>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  fallback_handler   pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_ALL>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  ops_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_OPS>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
 {{< /code >}}
 
 ## Create a pipeline

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handler-templates.md
@@ -80,7 +80,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 ## Template toolkit command
 
-The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
+The [sensu/template-toolkit-command][8] dynamic runtime asset provides a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
 The template toolkit command uses event data you supply via stdin in JSON format.
 
@@ -222,12 +222,12 @@ Sensu<br>
 
 {{< /code >}}
 
-The Sensu Email Handler plugin also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
-Read the [Sensu Email Handler Bonsai page][9] for details.
+The sensu/sensu-email-handler dynamic runtime asset also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
+Read the [sensu/sensu-email-handler Bonsai page][9] for details.
 
 ## Sensu PagerDuty Handler example
 
-The [Sensu PagerDuty Handler plugin][10] includes a basic template for the PagerDuty alert summary:
+The [sensu/sensu-pagerduty-handler][10] dynamic runtime asset includes a basic template for the PagerDuty alert summary:
 
 {{< code shell >}}
 "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}"

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -237,11 +237,9 @@ With these event filters and handlers configured, you can create a [handler set]
 You can also list the three handlers in the [handlers array][33] in your check definition instead.
 
 {{% notice protip %}}
-{{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
 For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
 The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
-{{% /notice %}}
 {{% /notice %}}
 
 ## Keepalive event handlers

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -237,9 +237,11 @@ With these event filters and handlers configured, you can create a [handler set]
 You can also list the three handlers in the [handlers array][33] in your check definition instead.
 
 {{% notice protip %}}
+{{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
-For example, you can use the `is_incident` event filter in conjunction with the [Sensu Go Fatigue Check Filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
-Sensu's [Ansible](../../../plugins/featured-integrations/ansible/), [Rundeck](../../../plugins/featured-integrations/rundeck/), and [Saltstack](../../../plugins/featured-integrations/saltstack/) auto-remediation integrations and the [Sensu Remediation Handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
+The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+{{% /notice %}}
 {{% /notice %}}
 
 ## Keepalive event handlers
@@ -767,7 +769,7 @@ secret: sensu-ansible-host
 ## Send Slack alerts
 
 This handler will send alerts to a channel named `monitoring` with the configured webhook URL, using the `handler-slack` executable command.
-The handler uses the [Sensu Slack Handler][34] dynamic runtime asset.
+The handler uses the [sensu/sensu-slack-handler][34] dynamic runtime asset.
 Read [Send Slack alerts with handlers][35] for detailed instructions for adding the required asset and configuring this handler.
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
@@ -36,10 +36,10 @@ Use sensuctl to add the `website` subscription to an entity the Sensu agent is o
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,10 +55,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [http-checks][12] dynamic runtime asset.
+To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
 This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
 
-Register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -73,7 +73,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -28,7 +28,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The example in this guide uses the `prometheus_metrics` check from [Collect Prometheus metrics with Sensu][10], which includes the subscription `app_tier`.
 Use [sensuctl][15] to add an `app_tier` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -36,7 +36,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -53,9 +53,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][12] are shareable, reusable packages that make it easier to deploy Sensu plugins.
-This example uses the [Sensu InfluxDB Handler][13] dynamic runtime asset to power an InfluxDB handler.
+This example uses the [sensu/sensu-influxdb-handler][13] dynamic runtime asset to power an InfluxDB handler.
 
-Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynamic runtime asset:
+Use [`sensuctl asset add`][5] to register the [sensu/sensu-influxdb-handler][13] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -85,7 +85,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create the handler
 
-Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
+Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the sensu/sensu-influxdb-handler dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
 For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -38,11 +38,11 @@ sensuctl entity list
 The `ID` in the response is the entity name.
 Select one of the listed entities.
 
-Before you run the following sensuctl command, replace `<entity_name>` with the name of your entity.
+Before you run the following sensuctl command, replace `<ENTITY_NAME>` with the name of your entity.
 Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -58,9 +58,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu Sumo Logic Handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
+The [sensu/sensu-sumologic-handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
 
-To add the Sumo Logic handler asset, run:
+To add the sensu/sensu-sumologic-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-sumologic-handler:0.3.0 -r sumologic-handler
@@ -85,7 +85,7 @@ To confirm that the asset was added to your Sensu backend, run:
 sensuctl asset info sumologic-handler
 {{< /code >}}
 
-The response will list the available builds for the Sensu Sumo Logic Handler dynamic runtime asset.
+The response will list the available builds for the sensu/sensu-sumologic-handler dynamic runtime asset.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -143,7 +143,7 @@ You will use this URL in the next step as the `SUMOLOGIC_URL` value for the secr
 
 ## Add the Sumo Logic handler
 
-Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [Sensu Sumo Logic Handler asset][8] to send observability data to Sumo Logic.
+Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [sensu/sensu-sumologic-handler][8] dynamic runtime asset to send observability data to Sumo Logic.
 
 The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
@@ -570,7 +570,7 @@ You have a successful workflow that sends Sensu observability data to your Sumo 
 
 To share and reuse the check, handler, and pipeline like code, [save them to files][6] and start building a [monitoring as code repository][7].
 
-Learn more about the [Sensu Sumo Logic Handler][19] dynamic runtime asset.
+Learn more about the [sensu/sensu-sumologic-handler][19] dynamic runtime asset.
 You can also configure a [Sumo Logic dashboard][10] to search, view, and analyze the Sensu data you're sending to your Sumo Logic HTTP Logs and Metrics Source.
 
 In addition to the traditional handler we used in this example, you can use [Sensu Plus][17], our built-in integration, to send metrics to Sumo Logic with a streaming [Sumo Logic metrics handler][18].

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
@@ -27,9 +27,9 @@ The pipeline will also include an [event filter][5] to make sure you only receiv
 ## Add the email handler dynamic runtime asset
 
 [Dynamic runtime assets][8] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Go Email Handler][3] dynamic runtime asset to power an `email` handler.
+In this guide, you'll use the [sensu/sensu-email-handler][3] dynamic runtime asset to power an `email` handler.
 
-Use the following sensuctl example to register the [Sensu Go Email Handler][3] dynamic runtime asset:
+Use the following sensuctl example to register the [sensu/sensu-email-handler][3] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler:1.2.2 -r email-handler
@@ -63,7 +63,7 @@ For a detailed list of everything related to the asset that Sensu added automati
 sensuctl asset info email-handler
 {{< /code >}}
 
-The dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
+The sensu/sensu-email-handler dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -130,7 +130,7 @@ EOF
 
 ## Create the email handler definition
 
-After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
+After you add an event filter, create the email handler definition to specify the email address where the handler will send notifications.
 In the handler definition's `command` value, you'll need to change a few things:
 
 - `<sender@example.com>`: Replace with the email address you want to use to send email alerts.

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -37,11 +37,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][12] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][12] command below.
 Then run the command to add the `system` [subscription][13] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -57,9 +57,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu PagerDuty Handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
+The [sensu/sensu-pagerduty-handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
 
-To add the PagerDuty handler asset, run:
+To add the sensu/sensu-pagerduty-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler
@@ -95,14 +95,14 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 Now that you've added the dynamic runtime asset, you can create a [handler][9] that uses the asset to send non-OK events to PagerDuty.
 
-In the following command, replace `<pagerduty_key>` with your [PagerDuty API integration key][1].
+In the following command, replace `<PAGERDUTY_KEY>` with your [PagerDuty API integration key][1].
 Then run the updated command:
 
 {{< code shell >}}
 sensuctl handler create pagerduty \
 --type pipe \
 --runtime-assets pagerduty-handler \
---command "sensu-pagerduty-handler -t <pagerduty_key>"
+--command "sensu-pagerduty-handler -t <PAGERDUTY_KEY>"
 {{< /code >}}
 
 {{% notice note %}}
@@ -137,7 +137,7 @@ api_version: core/v2
 metadata:
   name: pagerduty
 spec:
-  command: sensu-pagerduty-handler -t <pagerduty_key>
+  command: sensu-pagerduty-handler -t <PAGERDUTY_KEY>
   env_vars: null
   handlers: null
   runtime_assets:
@@ -155,7 +155,7 @@ spec:
     "name": "pagerduty"
   },
   "spec": {
-    "command": "sensu-pagerduty-handler -t <pagerduty_key>",
+    "command": "sensu-pagerduty-handler -t <PAGERDUTY_KEY>",
     "env_vars": null,
     "handlers": null,
     "runtime_assets": [
@@ -179,7 +179,7 @@ spec:
 With your handler configured, you can add it to a [pipeline][17] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the PagerDuty handler you've already configured.
+In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the `pagerduty` handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][20] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
 Then run the command to add the `system` [subscription][21] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -56,9 +56,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Slack Handler][14] dynamic runtime asset to power a `slack` handler.
+In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic runtime asset:
+Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -93,7 +93,7 @@ After you save your webhook, you can find the webhook URL under **Integration Se
 
 ## Create a handler
 
-Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the `sensu-slack-handler` dynamic runtime asset.
+Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the sensu/sensu-slack-handler dynamic runtime asset.
 Before you run the sensuctl command below, edit it to include your Slack webhook URL and the channel where you want to receive events:
 
 {{< code shell >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -158,7 +158,7 @@ spec:
 ## Assign the hook to a check
 
 {{% notice note %}}
-**NOTE**: Before you proceed, make sure you have added the [sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
+**NOTE**: Before you proceed, make sure you have added the [sensu/sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and the [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
 The hook you create in this step relies on the `nginx_service` check.
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][17] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][17] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,8 +55,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-To power the check to collect service metrics, you will use a check in the [http-checks][7] dynamic runtime asset.
-Use sensuctl to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+To power the check to collect service metrics, you will use a check in the [sensu/http-checks][7] dynamic runtime asset.
+Use sensuctl to register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -30,7 +30,7 @@ For information about HTTP GET access to internal Sensu metrics, read our [/metr
 
 ## Metric check example
 
-This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [Sensu System Check][26] dynamic runtime asset and sends the collected metrics to a pipeline configured with handlers that use the [Sensu Go Graphite Handler][12] dynamic runtime asset:
+This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [sensu/system-check][26] dynamic runtime asset and sends the collected metrics to a pipeline configured with handlers that use the [sensu/sensu-go-graphite-handler][12] dynamic runtime asset:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -39,11 +39,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][16] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][16] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -63,11 +63,11 @@ You can write shell scripts in the `command` field of your check definitions, bu
 Check plugins must be available on the host where the agent is running for the agent to execute the check.
 This guide uses [dynamic runtime assets][2] to manage plugin installation.
 
-### Register the Sensu CPU usage check asset
+### Register the sensu/check-cpu-usage asset
 
-The [Sensu CPU usage check][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
+The [sensu/check-cpu-usage][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
 
-To register the Sensu CPU usage check dynamic runtime asset, `sensu/check-cpu-usage:0.2.2`, run:
+To register the sensu/check-cpu-usage dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
@@ -102,7 +102,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `check-cpu-usage` and `sensu-processes-check` dynamic runtime assets:
+The response should list the renamed check-cpu-usage and sensu-processes-check dynamic runtime assets:
 
 {{< code text >}}
           Name                                                 URL                                         Hash    
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check to monitor a server
 
-Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the `check-cpu-usage` dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the check-cpu-usage dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -13,12 +13,12 @@ menu:
     parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
-This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
-
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
 Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
+
+You can use the [sensu/sensu-prometheus-collector][19] dynamic runtime asset to create checks that collect [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
+This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 To follow this guide, you’ll need to [install][4] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
 
@@ -26,13 +26,13 @@ The examples in this guide use CentOS 7 as the operating system, with all compon
 Commands and steps may change for different distributions or if components are running on different compute resources.
 
 At the end of this guide, Prometheus will be scraping metrics.
-The Sensu Prometheus Collector will then query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
+The check that uses the sensu/sensu-prometheus-collector asset will query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
 Finally, Grafana will query InfluxDB to display the collected metrics.
 
 ## Configure a Sensu entity
 
 Use [sensuctl][15] to add an `app_tier` [subscription][16] to one of your entities.
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -40,7 +40,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -194,7 +194,7 @@ sudo systemctl start grafana-server
 
 ### Add the Sensu InfluxDB handler asset
 
-To add the [Sensu InfluxDB Handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-influxdb-handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -338,9 +338,9 @@ Now you can add the `prometheus_metrics_workflows` pipeline to a check for check
 
 ## Collect Prometheus metrics with Sensu
 
-### Add the Sensu Prometheus Collector asset
+### Add the sensu/sensu-prometheus-collector asset
 
-To add the [Sensu Prometheus Collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-prometheus-collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-collector
@@ -387,7 +387,7 @@ The response should list the `sensu-prometheus-collector` dynamic runtime asset 
 
 ### Add a Sensu check that references the pipeline
 
-To add the [check][13] definition that uses the Sensu Prometheus Collector dynamic runtime asset and your `prometheus_metrics_workflows` pipeline, run:
+To add the [check][13] definition that uses the sensu/sensu-prometheus-collector dynamic runtime asset and your `prometheus_metrics_workflows` pipeline, run:
 
 {{< language-toggle >}}
 
@@ -503,17 +503,17 @@ The page should include a graph with initial metrics, similar to this example:
 ## Next steps
 
 You should now have a working observability pipeline with Prometheus scraping metrics.
-The Sensu Prometheus Collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
+You should now have a working observability pipeline with Prometheus scraping metrics.
+The sensu/sensu-prometheus-collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
 
 The check sends metrics to the `prometheus_metrics_workflows` pipeline, and the `influxdb` handler sends the metrics to InfluxDB.
 You can visualize the metrics in a Grafana dashboard.
 
-Add the [Sensu Prometheus Collector][1] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
+Add the [sensu/sensu-prometheus-collector][19] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
 
-[1]: ../../../plugins/featured-integrations/prometheus/#sensu-prometheus-collector
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
 [4]: ../../../operations/deploy-sensu/install-sensu/

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
@@ -37,7 +37,7 @@ Instead of creating a different check for every set of thresholds, you can use t
 
 Follow this example to set up a reusable check for disk usage:
 
-1. Add the [Sensu disk usage check][13] dynamic runtime asset, which includes the command you will need for your check:
+1. Add the [sensu/check-disk-usage][13] dynamic runtime asset, which includes the command you will need for your check:
 {{< code shell >}}
 sensuctl asset add sensu/check-disk-usage:0.6.0
 {{< /code >}}

--- a/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
@@ -23,7 +23,7 @@ No human user needs to log into the service, and the service does not need edit 
 A limited service account can provide only the necessary access and permissions.
 
 Limited service accounts are also useful for performing automated processes.
-This guide explains how to create a limited service account to use with the [Sensu EC2 Handler][3] integration to automatically remove AWS EC2 instances that are not in a pending or running state.
+This guide explains how to create a limited service account to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset to automatically remove AWS EC2 instances that are not in a pending or running state.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including the RBAC resources required to configure a limited service account.
 This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the [`admin` user][2].
@@ -177,11 +177,11 @@ sensuctl api-key grant ec2-service
 
    The response will include an API key that is assigned to the `ec2-service` user, which you will need to configure the EC2 handler.
 
-The `ec2-service` limited service account is now ready to use with the [Sensu EC2 Handler][3] integration.
+The `ec2-service` limited service account is now ready to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset.
 
-## Add the EC2 handler dynamic runtime asset
+## Add the sensu/sensu-ec2-handler dynamic runtime asset
 
-To power the handler to remove AWS EC2 instances, use sensuctl to add the [Sensu Go EC2 Handler][13] [dynamic runtime asset][14]:
+To power the handler to remove AWS EC2 instances, use sensuctl to add the [sensu/sensu-ec2-handler][13] [dynamic runtime asset][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ec2-handler:0.4.0
@@ -319,7 +319,6 @@ Adjust namespaces and permissions if needed by updating the role or cluster role
 
 [1]: ../rbac/
 [2]: ../rbac#default-users
-[3]: ../../../plugins/featured-integrations/aws-ec2/
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../rbac/#role-bindings-and-cluster-role-bindings
 [6]: ../rbac/#rule-attributes

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -145,20 +145,20 @@ As a result, Sensu Go does not include the built-in occurrence-based event filte
 To replicate the Sensu Core occurrence-based filter's functionality, use Sensu Go's [repeated events filter definition][10].
 
 Sensu Go includes three built-in [event filters][9]: [is_incident][63], [not_silenced][61], and [has_metrics][101].
-Sensu Go does not include a built-in check dependencies filter, but you can use the [Core Dependencies Filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
+Sensu Go does not include a built-in check dependencies filter, but you can use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
 
 Sensu Go event filters do not include the `when` event filter attribute.
 Use Sensu query expressions to build [custom functions][106] that provide granular control of time-based filter expressions.
 
 ### Fatigue check filter
 
-The [Sensu Go Fatigue Check Filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
+The [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
 This filter looks for [check and entity annotations][33] in each event it receives and uses the values of those annotations to configure the filter's behavior on a per-event basis.
 
 The [Sensu Translator version 1.1.0][18] retrieves occurrence and refresh values from a Sensu Core check definition and outputs them as annotations in a Sensu Go check definition, compatible with the fatigue check filter.
 
-However, the Sensu Translator doesn't automatically add the [Sensu Go Fatigue Check Filter][11] dynamic runtime asset or the filter configuration you need to run it.
-To use the Sensu Go Fatigue Check Filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
+However, the Sensu Translator doesn't automatically add the [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset or the filter configuration you need to run it.
+To use the sensu/sensu-go-fatigue-check-filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
 
 ## Dynamic runtime assets
 
@@ -186,7 +186,7 @@ The syntax for token substitution changed to [double curly braces][16] in Sensu 
 
 ## Aggregates
 
-Sensu Go supports check aggregates with the [Sensu Go Aggregate Check Plugin][28], which is a [commercial][27] resource.
+Sensu Go supports check aggregates with the [sensu/sensu-aggregate-check][28] dynamic runtime asset, which is a [commercial][27] resource.
 
 ## API
 
@@ -310,9 +310,9 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `metrics: true` | Review the [translate metric checks][71] section.
 `proxy_requests` | Review the [translate proxy requests][72] section.
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
-`aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
+`aggregate` | Check aggregates are supported through the [commercial][27] [sensu/sensu-aggregate-check][28].
 `hooks` | Review the [translate hooks][73] section.
-`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`dependencies`| Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.`, like `sensu.io.json_attributes`, use the `index` function.
@@ -426,9 +426,9 @@ Review your Sensu Core check configuration for the following attributes and make
 
 | Core attribute | Manual updates required in Sensu Go config |
 | -------------- | ------------- |
-`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [Sensu Go Fatigue Check Filter][65].
+`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [sensu/sensu-go-fatigue-check-filter][65].
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
-`filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`filters: check_dependencies` | Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
 `handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [pipelines][100].
@@ -518,7 +518,7 @@ Read the [guide to installing plugins with assets][50] to register assets with S
 
 #### Contact routing
 
-Contact routing is available in Sensu Go using the has-contact filter asset.
+Contact routing is available in Sensu Go woth the [sensu/sensu-go-has-contact-filter][30] dynamic runtime asset.
 Read [Route alerts with event filters][90] to set up contact routing in Sensu Go.
 
 #### LDAP
@@ -560,6 +560,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../observability-pipeline/observe-schedule/backend#operation
+[30]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [33]: https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter/#configuration
 [34]: ../../../observability-pipeline/observe-filter/reduce-alert-fatigue/#add-the-event-filter-to-a-pipeline
 [36]: https://etcd.io/

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
@@ -373,9 +373,9 @@ In the [add a handler][19] section, you'll use your `pagerduty_key` secret in yo
 
 ## Add a handler
 
-### Register the PagerDuty Handler dynamic runtime asset
+### Register the sensu/sensu-pagerduty-handler dynamic runtime asset
 
-To begin, register the [Sensu PagerDuty Handler dynamic runtime asset][23] with [`sensuctl asset add`][22]:
+To begin, register the [sensu/sensu-pagerduty-handler][23] dynamic runtime asset with [`sensuctl asset add`][22]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler

--- a/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.6/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -35,10 +35,10 @@ The checks in this guide monitor the following ports and endpoints:
 
 ## Register dynamic runtime asset
 
-To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [http-checks][5] dynamic runtime asset.
+To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [sensu/http-checks][5] dynamic runtime asset.
 This asset includes the `http-json` plugin, which your checks will rely on.
 
-To register the http-checks dynamic runtime asset, `sensu/http-checks`, run:
+To register the sensu/http-checks dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -63,7 +63,7 @@ To confirm that the asset is ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the http-checks dynamic runtime asset:
+The response should list the renamed http-checks dynamic runtime asset:
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -90,11 +90,11 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -200,8 +200,8 @@ To receive alerts based on your backend health checks, configure a [pipeline][6]
 If your Sensu Go deployment uses an external etcd cluster, you'll need to check the health of the respective etcd instances for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -356,14 +356,14 @@ PostgreSQL data from the `/health` endpoint will look like this example:
 }
 {{< /code >}}
 
-To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset.
+To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
-After you register the http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
+After you register the sensu/http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
 Make sure to update the `--url` value with your backend address before running the commands to create the checks.
 
 Run the following command to add the "healthy" check:
@@ -385,7 +385,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -406,7 +406,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }
@@ -434,7 +434,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -455,7 +455,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }

--- a/content/sensu-go/6.6/plugins/assets.md
+++ b/content/sensu-go/6.6/plugins/assets.md
@@ -304,8 +304,8 @@ Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][4
 
 ### Dynamic runtime asset build execution
 
-The directory path of each dynamic runtime asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
-Subsequent handler, filter, mutator, or check executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
+The directory path of each dynamic runtime asset listed in a check, event filter, handler, or mutator resource's `runtime_assets` array is appended to the `PATH` before the resource's `command` is executed.
+Subsequent check, event filter, handler, or mutator executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
 
 The following example demonstrates a use case with a Sensu check resource and an asset:
 
@@ -1041,7 +1041,7 @@ headers:
 
 Use the [entity.system attributes][10] in dynamic runtime asset [filters][42] to specify which systems and configurations an asset or asset builds can be used with.
 
-For example, the [Sensu Go Ruby Runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
+For example, the [sensu/sensu-ruby-runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
 
 {{< language-toggle >}}
 
@@ -1258,8 +1258,9 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
-When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
+Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+
+Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/6.6/sensu-plus.md
+++ b/content/sensu-go/6.6/sensu-plus.md
@@ -233,7 +233,7 @@ EOF
 Your pipeline resource is now properly configured, but it’s not processing any events because no Sensu [checks][9] are sending events to it.
 To get your Sensu observability data flowing through the new pipeline, add the pipeline by reference in at least one check definition.
 
-This example check definition uses the [Sensu System Check][13] dynamic runtime asset.
+This example check definition uses the [sensu/system-check][13] dynamic runtime asset.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
@@ -242,16 +242,16 @@ Read the [assets reference](../plugins/assets/) for more information about dynam
 
 Follow these steps to configure the required system check:
 
-1. Add the [Sensu System Check][13] dynamic runtime asset:
+1. Add the [sensu/system-check][13] dynamic runtime asset:
 {{< code shell >}}
 sensuctl asset add sensu/system-check:0.1.1 -r system-check
 {{< /code >}}
 
 2. Update at least one Sensu entity to use the `system` subscription.
-In the following command, replace `<entity_name>` with the name of the entity on your system.
+In the following command, replace `<ENTITY_NAME>` with the name of the entity on your system.
 Then, run:
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
     - For `Entity Class`, press enter.

--- a/content/sensu-go/6.6/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.6/sensuctl/sensuctl-bonsai.md
@@ -16,19 +16,21 @@ You can also use `sensuctl command` to install, execute, list, and delete comman
 
 ## Install dynamic runtime asset definitions
 
-To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <namespace/name>:<version>`.
-Replace `<namespace/name>` with the namespace and name of the dynamic runtime asset from Bonsai and `<version>` with the asset version you want to install.
+To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <ASSET_NAME>:<ASSET_VERSION>`.
+Replace `<ASSET_NAME>` with the complete name of the dynamic runtime asset from Bonsai.
+An asset's complete name includes both the part before the forward slash (sometimes called the Bonsai namespace) and the part after the forward slash.
 
-To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <namespace/name>`.
+{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
+
+Replace `<ASSET_VERSION>` with the asset version you want to install.
+To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <ASSET_NAME>`.
 
 {{% notice note %}}
 **NOTE**: Specify the asset version you want to install to maintain the stability of your observability infrastructure.
 If you do not specify a version to install, Sensu automatically installs the latest version, which may include breaking changes.
 {{% /notice %}}
 
-{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
-
-For example, to install version 3.7.0 of the [Sensu InfluxDB Handler][4] dynamic runtime asset:
+For example, to install version 3.7.0 of the [sensu/sensu-influxdb-handler][4] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0
@@ -82,20 +84,20 @@ Use `sensuctl command` to install, execute, list, and delete commands from Bonsa
 To install a sensuctl command from Bonsai or a URL:
 
 {{< code shell >}}
-sensuctl command install <alias> (<namespace/name>:<version> | --url <archive_url> --checksum <archive_checksum>) <flags>
+sensuctl command install <ALIAS> (<ASSET_NAME>:<ASSET_VERSION> | --url <ARCHIVE_URL> --checksum <ARCHIVE_CHECKSUM>) <FLAGS>
 {{< /code >}}
 
 To install a command plugin, use the Bonsai asset name or specify a URL and SHA512 checksum.
 
-**To install a command using the Bonsai asset name**, replace `<namespace/name>` with the name of the asset from Bonsai.
-`:<version>` is only required if you require a specific version or are pinning to a specific version.
+**To install a command using the Bonsai asset name**, replace `<ASSET_NAME>` with the complete name of the asset from Bonsai.
+`:<ASSET_VERSION>` is only required if you require a specific version or are pinning to a specific version.
 If you do not specify a version, sensuctl will fetch the latest version from Bonsai.
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -105,11 +107,11 @@ To install a command from the [Sensu EC2 Discovery Plugin][3] with no flags:
 sensuctl command install sensu-ec2-discovery portertech/sensu-ec2-discovery:0.3.0
 {{< /code >}}
 
-**To install a command from a URL**, replace `<archive_url>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
-Replace `<archive_checksum>` with the checksum you want to use.
-Replace `<alias>` with a unique name for the command.
+**To install a command from a URL**, replace `<ARCHIVE_URL>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
+Replace `<ARCHIVE_CHECKSUM>` with the checksum you want to use.
+Replace `<ALIAS>` with a unique name for the command.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -128,20 +130,20 @@ sensuctl command install command-test --url https://github.com/amdprophet/comman
 To execute a sensuctl command plugin via its dynamic runtime asset's bin/entrypoint executable:
 
 {{< code shell >}}
-sensuctl command exec <alias> <args> <flags>
+sensuctl command exec <ALIAS> <GLOBAL_FLAGS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<GLOBAL_FLAGS>` with the globlal flags you want to use.
+Run `sensuctl command exec -h` to view global flags.
+To pass `<GLOBAL_FLAGS>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
+
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command exec -h` to view flags.
 Flags are optional and apply only to the `exec` command &mdash; they are not saved as part of the command you are executing.
-
-Replace `<args>` with the globlal flags you want to use.
-Run `sensuctl command exec -h` to view global flags.
-To pass `<args>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
 
 {{% notice note %}}
 **NOTE**: When you use `sensuctl command exec`, the [environment variables](../environment-variables) are passed to the command.
@@ -150,7 +152,7 @@ To pass `<args>` flags to the bin/entrypoint executable, make sure to specify th
 For example:
 
 {{< code shell >}}
-sensuctl command exec <command> <arg1> <arg2> --cache-dir /tmp -- --<flag1> --<flag2>=<value>
+sensuctl command exec <COMMAND> <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --cache-dir /tmp -- --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flags after the ` -- `.
@@ -158,7 +160,7 @@ Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flag
 In this example, the full command run by sensuctl exec would be:
 
 {{< code shell >}}
-bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
+bin/entrypoint <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 ### List commands
@@ -166,10 +168,10 @@ bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
 To list installed sensuctl commands: 
 
 {{< code shell >}}
-sensuctl command list <flags>
+sensuctl command list <FLAGS>
 {{< /code >}}
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command list -h` to view flags.
 Flags are optional and apply only to the `list` command.
 
@@ -178,19 +180,18 @@ Flags are optional and apply only to the `list` command.
 To delete sensuctl commands:
 
 {{< code shell >}}
-sensuctl command delete <alias> <flags>
+sensuctl command delete <ALIAS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
-For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+Replace `<ALIAS>` with a unique name for the command.
+For example, for the [sensu/sensu-ec2-handler][3], you might use the alias `sensu-ec2-handler`. 
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command delete -h` to view flags.
 Flags are optional and apply only to the `delete` command.
 
 
 [1]: https://bonsai.sensu.io/
-[2]: /images/sensu-influxdb-handler-namespace.png
-[3]: https://bonsai.sensu.io/assets/portertech/sensu-ec2-discovery
+[3]: https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -130,10 +130,10 @@ Use sensuctl to add the `run_proxies` subscription to the entity the Sensu agent
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -149,10 +149,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ### Register dynamic runtime asset
 
-To power the check, you'll use the [http-checks][16] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][15] will rely on.
+To power the check, you'll use the [sensu/http-checks][16] dynamic runtime asset.
+This community-tier asset includes the http status check command that [your check][15] will rely on.
 
-Use [`sensuctl asset add`][21] to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Use [`sensuctl asset add`][21] to register the dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -179,7 +179,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -199,7 +199,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ### Create the check
 
-Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the `http-checks` dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
+Now that the dynamic runtime asset is registered, you can create a check named `check-sensu-site` to run the command `http-check --url https://sensu.io` with the [sensu/http-checks][16] dynamic runtime asset, at an interval of 15 seconds, for all agents subscribed to the `run_proxies` subscription, using the `sensu-site` proxy entity name.
 
 The check includes the [`round_robin` attribute][18] set to `true` to distribute the check execution across all agents subscribed to the `run_proxies` subscription and avoid duplicate events.
 
@@ -517,9 +517,9 @@ The response should include the `check-http` check:
 
 ### Validate the check
 
-Before you validate the check, make sure that you've [registered the `http-checks` dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
+Before you validate the check, make sure that you've [registered the sensu/http-checks dynamic runtime asset][13] and [added the `run_proxies` subscription to a Sensu agent][14].
 
-Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http`, returning a status of `0` (OK):
+Use sensuctl to confirm that Sensu is monitoring docs.sensu.io, packagecloud.io, and github.com with the `check-http` check, returning a status of `0` (OK):
 
 {{< code shell >}}
 sensuctl event list

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -172,7 +172,7 @@ spec:
 
 ## Filter dynamic runtime assets
 
-Sensu event filters can have dynamic runtime assets that are included in their execution context.
+Sensu event filters can include dynamic runtime assets in their execution context.
 When valid dynamic runtime assets are associated with an event filter, Sensu evaluates any files it finds that have a `.js` extension before executing the filter.
 The result of evaluating the scripts is cached for a given asset set for the sake of performance.
 For an example of how to implement an event filter as an asset, read [Reduce alert fatigue][30].

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -34,7 +34,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The examples for both approaches in this guide use the `check_cpu` check from [Monitor server resources with checks][13], which includes the subscription `system`.
 Use [sensuctl][18] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -42,7 +42,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -335,7 +335,7 @@ This will help you understand what dynamic runtime assets are and how they are u
 
 In this approach, the first step is to obtain an event filter dynamic runtime asset that will allow you to replicate the behavior of the `hourly` event filter created in [Approach 1 via `sensuctl`][4].
 
-Use `sensuctl asset add` to register the [fatigue check filter][8] dynamic runtime asset:
+Use `sensuctl asset add` to register the [sensu/sensu-go-fatigue-check-filter][8] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-fatigue-check-filter:0.8.1 -r fatigue-filter
@@ -417,7 +417,7 @@ sensuctl create -f sensu-fatigue-check-filter.json
 
 {{< /language-toggle >}}
 
-Now that you've created the filter dynamic runtime asset, event filter definition, and pipeline, you can create the check annotations you need for the dynamic runtime asset to work properly. 
+Now that you've added the dynamic runtime asset and created the event filter definition and pipeline, you can create the check annotations you need for the dynamic runtime asset to work properly. 
 
 ### Update a check for filter dynamic runtime asset use
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
@@ -44,7 +44,7 @@ For an agent to execute a specific check, you must specify the same subscription
 This guide uses an example check that includes the subscription `system`.
 Use [sensuctl][7] to add a `system` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find an entity's name, run `sensuctl entity list`.
@@ -52,7 +52,7 @@ The `ID` is the name of the entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -68,8 +68,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register dynamic runtime assets
 
-Contact routing is powered by the [has-contact filter dynamic runtime asset][12].
-To add the has-contact dynamic runtime asset to Sensu, use [sensuctl asset add][14]:
+Contact routing is powered by the [sensu/sensu-go-has-contact-filter][12] dynamic runtime asset.
+To add the asset to Sensu, use [sensuctl asset add][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-go-has-contact-filter:0.3.0 -r contact-filter
@@ -88,7 +88,7 @@ resource, populate the "runtime_assets" field with ["contact-filter"].
 
 This example uses the `-r` (rename) flag to specify a shorter name for the asset: `contact-filter`.
 
-Next, add the [Slack handler dynamic runtime asset][8] to Sensu with sensuctl:
+Next, add the [sensu/sensu-slack-handler][8] dynamic runtime asset to Sensu with sensuctl:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create contact filters
 
-The [Bonsai][12] documentation for the asset explains that the has-contact dynamic runtime asset supports two functions:
+The [Bonsai][12] documentation explains that the sensu/sensu-go-has-contact-filter dynamic runtime asset supports two functions:
 
 - `has_contact`, which takes the Sensu event and the contact name as arguments
 - `no_contact`, which is available as a fallback in the absence of contact labels and takes only the event as an argument
@@ -267,8 +267,8 @@ In each handler definition, you will specify:
 
 Before you run the following code to create the handlers with sensuctl, make these changes:
 
-- Replace `<alert-ops>`, `<alert-dev>`, and `<alert-all>` with the names of the channels you want to use to receive alerts in your Slack instance.
-- Replace `<slack_webhook_url>` with your Slack webhook URL.
+- Replace `<ALERT_OPS>`, `<ALERT_DEV>`, and `<ALERT_ALL>` with the names of the channels you want to use to receive alerts in your Slack instance.
+- Replace `<SLACK_WEBHOOK_URL>` with your Slack webhook URL.
 
 After you update the code to use your preferred Slack channels and webhook URL, run:
 
@@ -281,7 +281,7 @@ api_version: core/v2
 metadata:
   name: ops_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-ops>"
+  command: sensu-slack-handler --channel "#<ALERT_OPS>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -296,7 +296,7 @@ api_version: core/v2
 metadata:
   name: dev_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-dev>"
+  command: sensu-slack-handler --channel "#<ALERT_DEV>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -311,7 +311,7 @@ api_version: core/v2
 metadata:
   name: fallback_handler
 spec:
-  command: sensu-slack-handler --channel "#<alert-fallback>"
+  command: sensu-slack-handler --channel "#<ALERT_ALL>"
   env_vars:
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx
   handlers: null
@@ -330,7 +330,7 @@ echo '{
     "name": "ops_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-ops>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_OPS>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -350,7 +350,7 @@ echo '{
     "name": "dev_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-dev>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_DEV>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -370,7 +370,7 @@ echo '{
     "name": "fallback_handler"
   },
   "spec": {
-    "command": "sensu-slack-handler --channel \"#<alert-fallback>\"",
+    "command": "sensu-slack-handler --channel \"#<ALERT_ALL>\"",
     "env_vars": [
       "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx"
     ],
@@ -400,9 +400,9 @@ The response should list the new `dev_handler`, `ops_handler`, and `fallback_han
 {{< code text >}}
         Name         Type   Timeout   Filters   Mutator                       Execute                                                   Environment Variables                            Assets         
 ─────────────────── ────── ───────── ───────── ───────── ───────────────────────────────────────────────────────── ───────────────────────────────────────────────────────────── ──────────────────────
-  dev_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<alert_dev>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
-  fallback_handler   pipe         0                       RUN:  sensu-slack-handler --channel "#<alert-fallback>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
-  ops_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<alert-ops>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  dev_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_DEV>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  fallback_handler   pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_ALL>"   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
+  ops_handler        pipe         0                       RUN:  sensu-slack-handler --channel "#<ALERT_OPS>"        SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx   sensu-slack-handler  
 {{< /code >}}
 
 ## Create a pipeline

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handler-templates.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handler-templates.md
@@ -80,7 +80,7 @@ You can also use the [template toolkit command][11] to print available event att
 
 ## Template toolkit command
 
-The [Sensu template toolkit command][8] is a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
+The [sensu/template-toolkit-command][8] dynamic runtime asset provides a sensuctl command plugin you can use to print a list of available event attributes in handler template dot notation syntax and validate your handler template output.
 
 The template toolkit command uses event data you supply via stdin in JSON format.
 
@@ -222,12 +222,12 @@ Sensu<br>
 
 {{< /code >}}
 
-The Sensu Email Handler plugin also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
-Read the [Sensu Email Handler Bonsai page][9] for details.
+The sensu/sensu-email-handler dynamic runtime asset also includes a UnixTime function that allows you to print timestamp values from events in human-readable format.
+Read the [sensu/sensu-email-handler Bonsai page][9] for details.
 
 ## Sensu PagerDuty Handler example
 
-The [Sensu PagerDuty Handler plugin][10] includes a basic template for the PagerDuty alert summary:
+The [sensu/sensu-pagerduty-handler][10] dynamic runtime asset includes a basic template for the PagerDuty alert summary:
 
 {{< code shell >}}
 "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}"

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
@@ -238,8 +238,8 @@ You can also list the three handlers in the [handlers array][33] in your check d
 
 {{% notice protip %}}
 **PRO TIP**: This scenario relies on six different resources, three event filters and three handlers, to describe the handler stack concept, but you can use Sensu dynamic runtime assets and integrations to achieve the same escalating alert levels in other ways.<br><br>
-For example, you can use the `is_incident` event filter in conjunction with the [Sensu Go Fatigue Check Filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
-Sensu's [Ansible](../../../plugins/featured-integrations/ansible/), [Rundeck](../../../plugins/featured-integrations/rundeck/), and [Saltstack](../../../plugins/featured-integrations/saltstack/) auto-remediation integrations and the [Sensu Remediation Handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
+For example, you can use the `is_incident` event filter in conjunction with the [sensu/sensu-go-fatigue-check-filter](https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter) asset to control event escalation.
+The [sensu/sensu-ansible-handler](https://bonsai.sensu.io/assets/sensu/sensu-ansible-handler), [sensu/sensu-rundeck-handler](https://bonsai.sensu.io/assets/sensu/sensu-rundeck-handler), and [sensu/sensu-saltstack-handler](https://bonsai.sensu.io/assets/sensu/sensu-saltstack-handler) auto-remediation integrations and the [sensu/sensu-remediation-handler](https://bonsai.sensu.io/assets/sensu/sensu-remediation-handler) asset also include built-in occurrence- and severity-based event filtering.
 {{% /notice %}}
 
 ## Keepalive event handlers
@@ -767,7 +767,7 @@ secret: sensu-ansible-host
 ## Send Slack alerts
 
 This handler will send alerts to a channel named `monitoring` with the configured webhook URL, using the `handler-slack` executable command.
-The handler uses the [Sensu Slack Handler][34] dynamic runtime asset.
+The handler uses the [sensu/sensu-slack-handler][34] dynamic runtime asset.
 Read [Send Slack alerts with handlers][35] for detailed instructions for adding the required asset and configuring this handler.
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
@@ -36,10 +36,10 @@ Use sensuctl to add the `website` subscription to an entity the Sensu agent is o
 The `ID` is the name of your entity.
 {{% /notice %}}
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,10 +55,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [http-checks][12] dynamic runtime asset.
+To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
 This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
 
-Register the http-checks dynamic runtime asset, `sensu/http-checks`:
+Register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -73,7 +73,7 @@ Use sensuctl to confirm that the dynamic runtime asset is ready to use:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `http-checks` dynamic runtime asset:
+The response should list the sensu/http-checks dynamic runtime asset (renamed to `http-checks`):
 
 {{< code text >}}
      Name                                       URL                                    Hash    

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -28,7 +28,7 @@ For an agent to execute a specific check, you must specify the same subscription
 The example in this guide uses the `prometheus_metrics` check from [Collect Prometheus metrics with Sensu][10], which includes the subscription `app_tier`.
 Use [sensuctl][15] to add an `app_tier` subscription to one of your entities.
 
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -36,7 +36,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -53,9 +53,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][12] are shareable, reusable packages that make it easier to deploy Sensu plugins.
-This example uses the [Sensu InfluxDB Handler][13] dynamic runtime asset to power an InfluxDB handler.
+This example uses the [sensu/sensu-influxdb-handler][13] dynamic runtime asset to power an InfluxDB handler.
 
-Use [`sensuctl asset add`][5] to register the [Sensu InfluxDB Handler][13] dynamic runtime asset:
+Use [`sensuctl asset add`][5] to register the [sensu/sensu-influxdb-handler][13] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -85,7 +85,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create the handler
 
-Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the `sensu-influxdb-handler` dynamic runtime asset.
+Now that you have registered the dynamic runtime asset, use sensuctl to create a handler called `influxdb-handler` that pipes observation data (events) to InfluxDB with the sensu/sensu-influxdb-handler dynamic runtime asset.
 Edit the command below to replace the placeholders for database name, address, username, and password with the information for your own InfluxDB database.
 For more information about the Sensu InfluxDB handler, read the [asset page in Bonsai][13].
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -38,11 +38,11 @@ sensuctl entity list
 The `ID` in the response is the entity name.
 Select one of the listed entities.
 
-Before you run the following sensuctl command, replace `<entity_name>` with the name of your entity.
+Before you run the following sensuctl command, replace `<ENTITY_NAME>` with the name of your entity.
 Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -58,9 +58,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu Sumo Logic Handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
+The [sensu/sensu-sumologic-handler][8] [dynamic runtime asset][5] includes the scripts your [handler][9] will need to send observability data to Sumo Logic.
 
-To add the Sumo Logic handler asset, run:
+To add the sensu/sensu-sumologic-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-sumologic-handler:0.3.0 -r sumologic-handler
@@ -85,7 +85,7 @@ To confirm that the asset was added to your Sensu backend, run:
 sensuctl asset info sumologic-handler
 {{< /code >}}
 
-The response will list the available builds for the Sensu Sumo Logic Handler dynamic runtime asset.
+The response will list the available builds for the sensu/sensu-sumologic-handler dynamic runtime asset.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -143,7 +143,7 @@ You will use this URL in the next step as the `SUMOLOGIC_URL` value for the secr
 
 ## Add the Sumo Logic handler
 
-Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [Sensu Sumo Logic Handler asset][8] to send observability data to Sumo Logic.
+Now that you've set up a Sumo Logic HTTP Logs and Metrics Source, you can create a [handler][9] that uses the [sensu/sensu-sumologic-handler][8] dynamic runtime asset to send observability data to Sumo Logic.
 
 The Sensu Sumo Logic Handler asset requires a `SUMOLOGIC_URL` variable.
 The value for the `SUMOLOGIC_URL` variable is the Sumo Logic HTTP Source Address URL, which you retrieved in the last step of [setting up an HTTP Logs and Metrics Source][12].
@@ -570,7 +570,7 @@ You have a successful workflow that sends Sensu observability data to your Sumo 
 
 To share and reuse the check, handler, and pipeline like code, [save them to files][6] and start building a [monitoring as code repository][7].
 
-Learn more about the [Sensu Sumo Logic Handler][19] dynamic runtime asset.
+Learn more about the [sensu/sensu-sumologic-handler][19] dynamic runtime asset.
 You can also configure a [Sumo Logic dashboard][10] to search, view, and analyze the Sensu data you're sending to your Sumo Logic HTTP Logs and Metrics Source.
 
 In addition to the traditional handler we used in this example, you can use [Sensu Plus][17], our built-in integration, to send metrics to Sumo Logic with a streaming [Sumo Logic metrics handler][18].

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
@@ -27,9 +27,9 @@ The pipeline will also include an [event filter][5] to make sure you only receiv
 ## Add the email handler dynamic runtime asset
 
 [Dynamic runtime assets][8] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Go Email Handler][3] dynamic runtime asset to power an `email` handler.
+In this guide, you'll use the [sensu/sensu-email-handler][3] dynamic runtime asset to power an `email` handler.
 
-Use the following sensuctl example to register the [Sensu Go Email Handler][3] dynamic runtime asset:
+Use the following sensuctl example to register the [sensu/sensu-email-handler][3] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-email-handler:1.2.2 -r email-handler
@@ -63,7 +63,7 @@ For a detailed list of everything related to the asset that Sensu added automati
 sensuctl asset info email-handler
 {{< /code >}}
 
-The dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
+The sensu/sensu-email-handler dynamic runtime asset includes the `sensu-email-handler` command, which you will use when you [create the email handler definition][18] later in this guide.
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
@@ -130,7 +130,7 @@ EOF
 
 ## Create the email handler definition
 
-After you add an event filter, create the email handler definition to specify the email address where the `sensu/sensu-email-handler` dynamic runtime asset will send notifications.
+After you add an event filter, create the email handler definition to specify the email address where the handler will send notifications.
 In the handler definition's `command` value, you'll need to change a few things:
 
 - `<sender@example.com>`: Replace with the email address you want to use to send email alerts.
@@ -187,7 +187,7 @@ EOF
 
 {{< /language-toggle >}}
 
-The [Sensu Go Email Handler][3] dynamic runtime asset makes it possible to [add a template][14] that provides context for your email notifications.
+The [sensu/sensu-email-handler][3] dynamic runtime asset makes it possible to [add a template][14] that provides context for your email notifications.
 The email template functionality uses tokens to populate the values provided by the event, and you can use HTML to format the email.
 
 ## Create a pipeline

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -37,11 +37,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][12] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][12] command below.
 Then run the command to add the `system` [subscription][13] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -57,9 +57,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-The [Sensu PagerDuty Handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
+The [sensu/sensu-pagerduty-handler][8] dynamic runtime asset includes the scripts you will need to send events to PagerDuty.
 
-To add the PagerDuty handler asset, run:
+To add the sensu/sensu-pagerduty-handler asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler
@@ -95,14 +95,14 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 Now that you've added the dynamic runtime asset, you can create a [handler][9] that uses the asset to send non-OK events to PagerDuty.
 
-In the following command, replace `<pagerduty_key>` with your [PagerDuty API integration key][1].
+In the following command, replace `<PAGERDUTY_KEY>` with your [PagerDuty API integration key][1].
 Then run the updated command:
 
 {{< code shell >}}
 sensuctl handler create pagerduty \
 --type pipe \
 --runtime-assets pagerduty-handler \
---command "sensu-pagerduty-handler -t <pagerduty_key>"
+--command "sensu-pagerduty-handler -t <PAGERDUTY_KEY>"
 {{< /code >}}
 
 {{% notice note %}}
@@ -137,7 +137,7 @@ api_version: core/v2
 metadata:
   name: pagerduty
 spec:
-  command: sensu-pagerduty-handler -t <pagerduty_key>
+  command: sensu-pagerduty-handler -t <PAGERDUTY_KEY>
   env_vars: null
   handlers: null
   runtime_assets:
@@ -155,7 +155,7 @@ spec:
     "name": "pagerduty"
   },
   "spec": {
-    "command": "sensu-pagerduty-handler -t <pagerduty_key>",
+    "command": "sensu-pagerduty-handler -t <PAGERDUTY_KEY>",
     "env_vars": null,
     "handlers": null,
     "runtime_assets": [
@@ -179,7 +179,7 @@ spec:
 With your handler configured, you can add it to a [pipeline][17] workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the PagerDuty handler you've already configured.
+In this case, the pipeline includes the built-in [is_incident][21] and [not_silenced][22] event filters, as well as the `pagerduty` handler you've already configured.
 To create the pipeline, run:
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<entity_name>` with the name of your entity in the [sensuctl][20] command below.
+Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
 Then run the command to add the `system` [subscription][21] to your entity:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -56,9 +56,9 @@ The response should indicate `active (running)` for both the Sensu backend and a
 ## Register the dynamic runtime asset
 
 [Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [Sensu Slack Handler][14] dynamic runtime asset to power a `slack` handler.
+In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [Sensu Slack Handler][14] dynamic runtime asset:
+Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -93,7 +93,7 @@ After you save your webhook, you can find the webhook URL under **Integration Se
 
 ## Create a handler
 
-Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the `sensu-slack-handler` dynamic runtime asset.
+Use sensuctl to create a handler called `slack` that pipes observation data (events) to Slack using the sensu/sensu-slack-handler dynamic runtime asset.
 Before you run the sensuctl command below, edit it to include your Slack webhook URL and the channel where you want to receive events:
 
 {{< code shell >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/augment-event-data-with-hooks.md
@@ -158,7 +158,7 @@ spec:
 ## Assign the hook to a check
 
 {{% notice note %}}
-**NOTE**: Before you proceed, make sure you have added the [sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
+**NOTE**: Before you proceed, make sure you have added the [sensu/sensu-processes-check](../monitor-server-resources/#register-the-sensu-processes-check-asset) dynamic runtime asset and the [`nginx_service` check](../monitor-server-resources/#create-a-check-to-monitor-a-webserver) from the [Monitor server resources](../monitor-server-resources/) guide.
 The hook you create in this step relies on the `nginx_service` check.
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -35,11 +35,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][17] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][17] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -55,8 +55,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-To power the check to collect service metrics, you will use a check in the [http-checks][7] dynamic runtime asset.
-Use sensuctl to register the http-checks dynamic runtime asset, `sensu/http-checks`:
+To power the check to collect service metrics, you will use a check in the [sensu/http-checks][7] dynamic runtime asset.
+Use sensuctl to register the sensu/http-checks dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
@@ -30,7 +30,7 @@ For information about HTTP GET access to internal Sensu metrics, read our [/metr
 
 ## Metric check example
 
-This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [Sensu System Check][26] dynamic runtime asset and sends the collected metrics to a pipeline configured with handlers that use the [Sensu Go Graphite Handler][12] dynamic runtime asset:
+This check definition collects metrics in Graphite Plaintext Protocol [format][9] using the [sensu/system-check][26] dynamic runtime asset and sends the collected metrics to a pipeline configured with handlers that use the [sensu/sensu-go-graphite-handler][12] dynamic runtime asset:
 
 {{< language-toggle >}}
 
@@ -1084,7 +1084,7 @@ output_metric_tags:
 Metric threshold evaluation extends Sensu's service check and metrics processing capabilities so you can get real-time alerts based on the metrics your Sensu checks collect.
 The Sensu agent analyzes output metrics against the thresholds you specify and overrides the event [check status][36] if the metrics values exceed the threshold values.
  
-For example, the [check][34] from the Sensu Plus guide uses the [Sensu System Check][35] dynamic runtime asset to collect baseline system metrics.
+For example, the [check][34] from the Sensu Plus guide uses the [sensu/system-check][35] dynamic runtime asset to collect baseline system metrics.
 Add the [`output_metric_thresholds`][33] array to get alerts based on the Sensu System Check metrics `system_mem_used` (percent of memory used) and `system_host_processes` (number of host processes):
 
 {{< language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -39,11 +39,11 @@ sensuctl entity list
 
 The `ID` is the name of your entity.
 
-Replace `<entity_name>` with the name of your agent entity in the following [sensuctl][16] command.
+Replace `<ENTITY_NAME>` with the name of your agent entity in the following [sensuctl][16] command.
 Run:
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -63,11 +63,11 @@ You can write shell scripts in the `command` field of your check definitions, bu
 Check plugins must be available on the host where the agent is running for the agent to execute the check.
 This guide uses [dynamic runtime assets][2] to manage plugin installation.
 
-### Register the Sensu CPU usage check asset
+### Register the sensu/check-cpu-usage asset
 
-The [Sensu CPU usage check][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
+The [sensu/check-cpu-usage][1] dynamic runtime asset includes the `check-cpu-usage` command, which your CPU check will rely on.
 
-To register the Sensu CPU usage check dynamic runtime asset, `sensu/check-cpu-usage:0.2.2`, run:
+To register the sensu/check-cpu-usage dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/check-cpu-usage:0.2.2 -r check-cpu-usage
@@ -88,9 +88,9 @@ This example uses the `-r` (rename) flag to specify a shorter name for the dynam
 
 You can also download dynamic runtime asset definitions from [Bonsai][14] and register the asset with `sensuctl create --file filename.yml`.
 
-### Register the Sensu Processes Check asset
+### Register the sensu/sensu-processes-check asset
 
-Then, use this command to register the [Sensu Processes Check][15] dynamic runtime asset, which you'll use later for your webserver check:
+Then, use this command to register the [sensu/sensu-processes-check][15] dynamic runtime asset, which you'll use later for your webserver check:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-processes-check:0.2.0 -r sensu-processes-check
@@ -102,7 +102,7 @@ To confirm that both dynamic runtime assets are ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the `check-cpu-usage` and `sensu-processes-check` dynamic runtime assets:
+The response should list the renamed check-cpu-usage and sensu-processes-check dynamic runtime assets:
 
 {{< code text >}}
           Name                                                 URL                                         Hash    
@@ -130,7 +130,7 @@ Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds)
 
 ## Create a check to monitor a server
 
-Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the `check-cpu-usage` dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
+Now that the dynamic runtime assets are registered, create a check named `check_cpu` that runs the command `check-cpu-usage -w 75 -c 90` with the check-cpu-usage dynamic runtime asset at an interval of 60 seconds for all entities subscribed to the `system` subscription.
 This check generates a warning event (`-w`) when CPU usage reaches 75% and a critical alert (`-c`) at 90%.
 
 {{< code shell >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -13,12 +13,12 @@ menu:
     parent: observe-schedule
 ---
 
-The [Sensu Prometheus Collector][1] is a check plugin that collects [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
-This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
-
 The Prometheus ecosystem contains a number of actively maintained exporters, such as the [node exporter][5] for reporting hardware and operating system metrics or Google's [cAdvisor exporter][6] for monitoring containers.
 These exporters expose metrics that Sensu can collect and route to one or more time-series databases.
 Sensu and Prometheus can run in parallel, complementing each other and making use of environments where Prometheus is already deployed.
+
+You can use the [sensu/sensu-prometheus-collector][19] dynamic runtime asset to create checks that collect [metrics][10] from a [Prometheus exporter][2] or the [Prometheus query API][3].
+This allows Sensu to route the collected metrics to one or more time-series databases, such as InfluxDB or Graphite.
 
 To follow this guide, you’ll need to [install][4] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
 
@@ -26,13 +26,13 @@ The examples in this guide use CentOS 7 as the operating system, with all compon
 Commands and steps may change for different distributions or if components are running on different compute resources.
 
 At the end of this guide, Prometheus will be scraping metrics.
-The Sensu Prometheus Collector will then query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
+The check that uses the sensu/sensu-prometheus-collector asset will query the Prometheus API as a Sensu check and send the metrics to an InfluxDB Sensu handler, which will send metrics to an InfluxDB instance.
 Finally, Grafana will query InfluxDB to display the collected metrics.
 
 ## Configure a Sensu entity
 
 Use [sensuctl][15] to add an `app_tier` [subscription][16] to one of your entities.
-Before you run the following code, replace `<entity_name>` with the name of the entity on your system.
+Before you run the following code, replace `<ENTITY_NAME>` with the name of the entity on your system.
 
 {{% notice note %}}
 **NOTE**: To find your entity name, run `sensuctl entity list`.
@@ -40,7 +40,7 @@ The `ID` is the name of your entity.
 {{% /notice %}}
 
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
 - For `Entity Class`, press enter.
@@ -194,7 +194,7 @@ sudo systemctl start grafana-server
 
 ### Add the Sensu InfluxDB handler asset
 
-To add the [Sensu InfluxDB Handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-influxdb-handler][18] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0 -r sensu-influxdb-handler
@@ -338,9 +338,9 @@ Now you can add the `prometheus_metrics_workflows` pipeline to a check for check
 
 ## Collect Prometheus metrics with Sensu
 
-### Add the Sensu Prometheus Collector asset
+### Add the sensu/sensu-prometheus-collector asset
 
-To add the [Sensu Prometheus Collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
+To add the [sensu/sensu-prometheus-collector][19] [dynamic runtime asset][11] to Sensu, run the following command:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-prometheus-collector:1.3.2 -r sensu-prometheus-collector
@@ -387,7 +387,7 @@ The response should list the `sensu-prometheus-collector` dynamic runtime asset 
 
 ### Add a Sensu check that references the pipeline
 
-To add the [check][13] definition that uses the Sensu Prometheus Collector dynamic runtime asset and your `prometheus_metrics_workflows` pipeline, run:
+To add the [check][13] definition that uses the sensu/sensu-prometheus-collector dynamic runtime asset and your `prometheus_metrics_workflows` pipeline, run:
 
 {{< language-toggle >}}
 
@@ -503,17 +503,16 @@ The page should include a graph with initial metrics, similar to this example:
 ## Next steps
 
 You should now have a working observability pipeline with Prometheus scraping metrics.
-The Sensu Prometheus Collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
+The sensu/sensu-prometheus-collector dynamic runtime asset runs via the `prometheus_metrics` Sensu check and collects metrics from the Prometheus API.
 
 The check sends metrics to the `prometheus_metrics_workflows` pipeline, and the `influxdb` handler sends the metrics to InfluxDB.
 You can visualize the metrics in a Grafana dashboard.
 
-Add the [Sensu Prometheus Collector][1] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
+Add the [sensu/sensu-prometheus-collector][19] to your Sensu ecosystem and include it in your [monitoring as code][9] repository.
 Use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
 
 
-[1]: ../../../plugins/featured-integrations/prometheus/#sensu-prometheus-collector
 [2]: https://prometheus.io/docs/instrumenting/exporters/
 [3]: https://prometheus.io/docs/prometheus/latest/querying/api/
 [4]: ../../../operations/deploy-sensu/install-sensu/

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
@@ -37,7 +37,7 @@ Instead of creating a different check for every set of thresholds, you can use t
 
 Follow this example to set up a reusable check for disk usage:
 
-1. Add the [Sensu disk usage check][13] dynamic runtime asset, which includes the command you will need for your check:
+1. Add the [sensu/check-disk-usage][13] dynamic runtime asset, which includes the command you will need for your check:
 {{< code shell >}}
 sensuctl asset add sensu/check-disk-usage:0.6.0
 {{< /code >}}

--- a/content/sensu-go/6.7/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.7/operations/control-access/create-limited-service-accounts.md
@@ -23,7 +23,7 @@ No human user needs to log into the service, and the service does not need edit 
 A limited service account can provide only the necessary access and permissions.
 
 Limited service accounts are also useful for performing automated processes.
-This guide explains how to create a limited service account to use with the [Sensu EC2 Handler][3] integration to automatically remove AWS EC2 instances that are not in a pending or running state.
+This guide explains how to create a limited service account to use with the [sensu/sensu-ec2-handler][3] integration to automatically remove AWS EC2 instances that are not in a pending or running state.
 
 By default, Sensu includes a `default` namespace and an `admin` user with full permissions to create, modify, and delete resources within Sensu, including the RBAC resources required to configure a limited service account.
 This guide requires a running Sensu backend and a sensuctl instance configured to connect to the backend as the [`admin` user][2].
@@ -177,11 +177,11 @@ sensuctl api-key grant ec2-service
 
    The response will include an API key that is assigned to the `ec2-service` user, which you will need to configure the EC2 handler.
 
-The `ec2-service` limited service account is now ready to use with the [Sensu EC2 Handler][3] integration.
+The `ec2-service` limited service account is now ready to use with the [sensu/sensu-ec2-handler][13] dynamic runtime asset.
 
-## Add the EC2 handler dynamic runtime asset
+## Add the sensu/sensu-ec2-handler dynamic runtime asset
 
-To power the handler to remove AWS EC2 instances, use sensuctl to add the [Sensu Go EC2 Handler][13] [dynamic runtime asset][14]:
+To power the handler to remove AWS EC2 instances, use sensuctl to add the [sensu/sensu-ec2-handler][13] [dynamic runtime asset][14]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-ec2-handler:0.4.0
@@ -319,7 +319,6 @@ Adjust namespaces and permissions if needed by updating the role or cluster role
 
 [1]: ../rbac/
 [2]: ../rbac#default-users
-[3]: ../../../plugins/featured-integrations/aws-ec2/
 [4]: ../rbac/#roles-and-cluster-roles
 [5]: ../rbac/#role-bindings-and-cluster-role-bindings
 [6]: ../rbac/#rule-attributes

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -147,20 +147,20 @@ As a result, Sensu Go does not include the built-in occurrence-based event filte
 To replicate the Sensu Core occurrence-based filter's functionality, use Sensu Go's [repeated events filter definition][10].
 
 Sensu Go includes three built-in [event filters][9]: [is_incident][63], [not_silenced][61], and [has_metrics][101].
-Sensu Go does not include a built-in check dependencies filter, but you can use the [Core Dependencies Filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
+Sensu Go does not include a built-in check dependencies filter, but you can use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset to replicate the built-in check dependencies filter functionality from Sensu Core.
 
 Sensu Go event filters do not include the `when` event filter attribute.
 Use [Sensu query expressions][108] to build [custom functions][106] that provide granular control of time-based filter expressions.
 
 ### Fatigue check filter
 
-The [Sensu Go Fatigue Check Filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
+The [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset is a JavaScript implementation of the `occurrences` filter from Sensu Core.
 This filter looks for [check and entity annotations][33] in each event it receives and uses the values of those annotations to configure the filter's behavior on a per-event basis.
 
 The [Sensu Translator version 1.1.0][18] retrieves occurrence and refresh values from a Sensu Core check definition and outputs them as annotations in a Sensu Go check definition, compatible with the fatigue check filter.
 
-However, the Sensu Translator doesn't automatically add the [Sensu Go Fatigue Check Filter][11] dynamic runtime asset or the filter configuration you need to run it.
-To use the Sensu Go Fatigue Check Filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
+However, the Sensu Translator doesn't automatically add the [sensu/sensu-go-fatigue-check-filter][11] dynamic runtime asset or the filter configuration you need to run it.
+To use the sensu/sensu-go-fatigue-check-filter dynamic runtime asset, you must [register it][15], create a correctly configured [event filter definition][19], and [add the event filter][34] to the list of filters on applicable handlers.
 
 ## Dynamic runtime assets
 
@@ -188,7 +188,7 @@ The syntax for token substitution changed to [double curly braces][16] in Sensu 
 
 ## Aggregates
 
-Sensu Go supports check aggregates with the [Sensu Go Aggregate Check Plugin][28], which is a [commercial][27] resource.
+Sensu Go supports check aggregates with the [sensu/sensu-aggregate-check][28] dynamic runtime asset, which is a [commercial][27] resource.
 
 ## API
 
@@ -312,9 +312,9 @@ Review your Sensu Core check configuration for the following attributes, and mak
 `metrics: true` | Review the [translate metric checks][71] section.
 `proxy_requests` | Review the [translate proxy requests][72] section.
 `subscribers: roundrobin...` | Remove `roundrobin` from the subscription name, and add the `round_robin` check attribute set to `true`.
-`aggregate` | Check aggregates are supported through the [commercial][27] [Sensu Go Aggregate Check Plugin][28].
+`aggregate` | Check aggregates are supported through the [commercial][27] [sensu/sensu-aggregate-check][28].
 `hooks` | Review the [translate hooks][73] section.
-`dependencies`| Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`dependencies`| Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 
 {{% notice protip %}}
 **PRO TIP**: When using token substitution in Sensu Go and accessing labels or annotations that include `.`, like `sensu.io.json_attributes`, use the `index` function.
@@ -428,9 +428,9 @@ Review your Sensu Core check configuration for the following attributes and make
 
 | Core attribute | Manual updates required in Sensu Go config |
 | -------------- | ------------- |
-`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [Sensu Go Fatigue Check Filter][65].
+`filters: occurrences` | Replicate the built-in occurrences filter in Sensu Core with the [sensu/sensu-go-fatigue-check-filter][65].
 `type: transport` | Achieve similar functionailty to transport handlers in Sensu Core with a Sensu Go pipe handler that connects to a message bus and injects event data into a queue.
-`filters: check_dependencies` | Use the [Core Dependencies Filter][23] dynamic runtime asset.
+`filters: check_dependencies` | Use the [sensu/sensu-dependencies-filter][23] dynamic runtime asset.
 `severities` | Sensu Go does not support severities.
 `handle_silenced` | Silencing is disabled by default in Sensu Go and must be explicitly enabled using sensuctl, the web UI, or core/v2/silenced API endpoints.
 `handle_flapping` | All check results are considered events in Sensu Go and are processed by [pipelines][100].
@@ -520,7 +520,7 @@ Read the [guide to installing plugins with assets][50] to register assets with S
 
 #### Contact routing
 
-Contact routing is available in Sensu Go using the has-contact filter asset.
+Contact routing is available in Sensu Go woth the [sensu/sensu-go-has-contact-filter][30] dynamic runtime asset.
 Read [Route alerts with event filters][90] to set up contact routing in Sensu Go.
 
 #### LDAP
@@ -562,6 +562,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [27]: ../../../commercial/
 [28]: https://bonsai.sensu.io/assets/sensu/sensu-aggregate-check/
 [29]: ../../../observability-pipeline/observe-schedule/backend#operation
+[30]: https://bonsai.sensu.io/assets/sensu/sensu-go-has-contact-filter
 [33]: https://bonsai.sensu.io/assets/sensu/sensu-go-fatigue-check-filter/#configuration
 [34]: ../../../observability-pipeline/observe-filter/reduce-alert-fatigue/#add-the-event-filter-to-a-pipeline
 [36]: https://etcd.io/

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
@@ -373,9 +373,9 @@ In the [add a handler][19] section, you'll use your `pagerduty_key` secret in yo
 
 ## Add a handler
 
-### Register the PagerDuty Handler dynamic runtime asset
+### Register the sensu/sensu-pagerduty-handler dynamic runtime asset
 
-To begin, register the [Sensu PagerDuty Handler dynamic runtime asset][23] with [`sensuctl asset add`][22]:
+To begin, register the [sensu/sensu-pagerduty-handler][23] dynamic runtime asset with [`sensuctl asset add`][22]:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-pagerduty-handler:2.2.0 -r pagerduty-handler

--- a/content/sensu-go/6.7/operations/monitor-sensu/monitor-sensu-with-sensu.md
+++ b/content/sensu-go/6.7/operations/monitor-sensu/monitor-sensu-with-sensu.md
@@ -35,10 +35,10 @@ The checks in this guide monitor the following ports and endpoints:
 
 ## Register dynamic runtime asset
 
-To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [http-checks][5] dynamic runtime asset.
+To power the checks to monitor your Sensu backend, external etcd, and PostgreSQL instances, add the [sensu/http-checks][5] dynamic runtime asset.
 This asset includes the `http-json` plugin, which your checks will rely on.
 
-To register the http-checks dynamic runtime asset, `sensu/http-checks`, run:
+To register the sensu/http-checks dynamic runtime asset, run:
 
 {{< code shell >}}
 sensuctl asset add sensu/http-checks:0.5.0 -r http-checks
@@ -63,7 +63,7 @@ To confirm that the asset is ready to use, run:
 sensuctl asset list
 {{< /code >}}
 
-The response should list the http-checks dynamic runtime asset:
+The response should list the renamed http-checks dynamic runtime asset:
 
 {{< code text >}}
      Name                                       URL                                    Hash    
@@ -90,11 +90,11 @@ Monitor the host running the `sensu-backend` *locally* by a `sensu-agent` proces
 For Sensu components that must be running for Sensu to create events, you should also monitor the `sensu-backend` remotely from an independent Sensu instance.
 This will allow you to monitor whether your Sensu event pipeline is working.
 
-To do this, add checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
+To do this, add checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset to query Sensu's [/health API][2] for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -200,8 +200,8 @@ To receive alerts based on your backend health checks, configure a [pipeline][6]
 If your Sensu Go deployment uses an external etcd cluster, you'll need to check the health of the respective etcd instances for your primary (Backend Alpha) and secondary (Backend Beta) backends.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
 {{< language-toggle >}}
@@ -356,14 +356,14 @@ PostgreSQL data from the `/health` endpoint will look like this example:
 }
 {{< /code >}}
 
-To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [http-checks][5] dynamic runtime asset.
+To monitor PostgreSQL's health from Sensu, create checks that use the `http-json` plugin from the [sensu/http-checks][5] dynamic runtime asset.
 
 {{% notice note %}}
-**NOTE**: These examples use the [http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
-Follow the instructions above to [register the http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
+**NOTE**: These examples use the [sensu/http-checks](https://bonsai.sensu.io/assets/sensu/http-checks) dynamic runtime asset.
+Follow the instructions above to [register the sensu/http-checks dynamic runtime asset](#register-dynamic-runtime-asset) if you did not previously register it.
 {{% /notice %}}
 
-After you register the http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
+After you register the sensu/http-checks dynamic runtime asset, create two checks ("healthy" and "active") to monitor PostgreSQL's health from Sensu.
 Make sure to update the `--url` value with your backend address before running the commands to create the checks.
 
 Run the following command to add the "healthy" check:
@@ -385,7 +385,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -406,7 +406,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }
@@ -434,7 +434,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - sensu/http-checks
+  - http-checks
 EOF
 {{< /code >}}
 
@@ -455,7 +455,7 @@ cat << EOF | sensuctl create
       "system"
     ],
     "runtime_assets": [
-      "sensu/http-checks"
+      "http-checks"
     ]
   }
 }

--- a/content/sensu-go/6.7/plugins/assets.md
+++ b/content/sensu-go/6.7/plugins/assets.md
@@ -304,8 +304,8 @@ Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][4
 
 ### Dynamic runtime asset build execution
 
-The directory path of each dynamic runtime asset defined in `runtime_assets` is appended to the `PATH` before the handler, filter, mutator, or check `command` is executed.
-Subsequent handler, filter, mutator, or check executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
+The directory path of each dynamic runtime asset listed in a check, event filter, handler, or mutator resource's `runtime_assets` array is appended to the `PATH` before the resource's `command` is executed.
+Subsequent check, event filter, handler, or mutator executions look for the dynamic runtime asset in the local cache and ensure that the contents match the configured checksum.
 
 The following example demonstrates a use case with a Sensu check resource and an asset:
 
@@ -1041,7 +1041,7 @@ headers:
 
 Use the [entity.system attributes][10] in dynamic runtime asset [filters][42] to specify which systems and configurations an asset or asset builds can be used with.
 
-For example, the [Sensu Go Ruby Runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
+For example, the [sensu/sensu-ruby-runtime][43] dynamic runtime asset definition includes several builds, each with filters for several `entity.system` attributes:
 
 {{< language-toggle >}}
 
@@ -1258,8 +1258,9 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with the `/assets (DELETE)` endpoint or via `sensuctl` (`sensuctl asset delete`).
-When you remove a dynamic runtime asset from Sensu, this _*does not*_ remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
+Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+
+Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
 Failure to do so will result in errors like `sh: asset.sh: command not found`. 
 

--- a/content/sensu-go/6.7/sensu-plus.md
+++ b/content/sensu-go/6.7/sensu-plus.md
@@ -194,21 +194,21 @@ EOF
 Your pipeline resource is now properly configured, but it’s not processing any events because no Sensu [checks][9] are sending events to it.
 To get your Sensu observability data flowing through the new pipeline, add the pipeline by reference in at least one check definition.
 
-This example check definition uses the [Sensu System Check][13] dynamic runtime asset.
+This example check definition uses the [sensu/system-check][13] dynamic runtime asset.
 [Dynamic runtime assets][20] are shareable, reusable packages that make it easier to deploy Sensu plugins.
 
 Follow these steps to configure the required system check:
 
-1. Add the [Sensu System Check][13] dynamic runtime asset:
+1. Add the [sensu/system-check][13] dynamic runtime asset:
 {{< code shell >}}
 sensuctl asset add sensu/system-check:0.1.1 -r system-check
 {{< /code >}}
 
 2. Update at least one Sensu entity to use the `system` subscription.
-In the following command, replace `<entity_name>` with the name of the entity on your system.
+In the following command, replace `<ENTITY_NAME>` with the name of the entity on your system.
 Then, run:
 {{< code shell >}}
-sensuctl entity update <entity_name>
+sensuctl entity update <ENTITY_NAME>
 {{< /code >}}
 
     - For `Entity Class`, press enter.

--- a/content/sensu-go/6.7/sensuctl/sensuctl-bonsai.md
+++ b/content/sensu-go/6.7/sensuctl/sensuctl-bonsai.md
@@ -16,19 +16,21 @@ You can also use `sensuctl command` to install, execute, list, and delete comman
 
 ## Install dynamic runtime asset definitions
 
-To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <namespace/name>:<version>`.
-Replace `<namespace/name>` with the namespace and name of the dynamic runtime asset from Bonsai and `<version>` with the asset version you want to install.
+To install a dynamic runtime asset definition directly from Bonsai, use `sensuctl asset add <ASSET_NAME>:<ASSET_VERSION>`.
+Replace `<ASSET_NAME>` with the complete name of the dynamic runtime asset from Bonsai.
+An asset's complete name includes both the part before the forward slash (sometimes called the Bonsai namespace) and the part after the forward slash.
 
-To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <namespace/name>`.
+{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
+
+Replace `<ASSET_VERSION>` with the asset version you want to install.
+To automatically install the latest version of the plugin, you do not need to specify the version: `sensuctl asset add <ASSET_NAME>`.
 
 {{% notice note %}}
 **NOTE**: Specify the asset version you want to install to maintain the stability of your observability infrastructure.
 If you do not specify a version to install, Sensu automatically installs the latest version, which may include breaking changes.
 {{% /notice %}}
 
-{{< figure src="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" alt="Bonsai page for the Sensu InfluxDB handler showing the location of the asset namespace and name" link="/images/go/sensuctl_bonsai/name_namespace_location_bonsai_asset.png" target="_blank" >}}
-
-For example, to install version 3.7.0 of the [Sensu InfluxDB Handler][4] dynamic runtime asset:
+For example, to install version 3.7.0 of the [sensu/sensu-influxdb-handler][4] dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-influxdb-handler:3.7.0
@@ -82,20 +84,20 @@ Use `sensuctl command` to install, execute, list, and delete commands from Bonsa
 To install a sensuctl command from Bonsai or a URL:
 
 {{< code shell >}}
-sensuctl command install <alias> (<namespace/name>:<version> | --url <archive_url> --checksum <archive_checksum>) <flags>
+sensuctl command install <ALIAS> (<ASSET_NAME>:<ASSET_VERSION> | --url <ARCHIVE_URL> --checksum <ARCHIVE_CHECKSUM>) <FLAGS>
 {{< /code >}}
 
 To install a command plugin, use the Bonsai asset name or specify a URL and SHA512 checksum.
 
-**To install a command using the Bonsai asset name**, replace `<namespace/name>` with the name of the asset from Bonsai.
-`:<version>` is only required if you require a specific version or are pinning to a specific version.
+**To install a command using the Bonsai asset name**, replace `<ASSET_NAME>` with the complete name of the asset from Bonsai.
+`:<ASSET_VERSION>` is only required if you require a specific version or are pinning to a specific version.
 If you do not specify a version, sensuctl will fetch the latest version from Bonsai.
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -105,11 +107,11 @@ To install a command from the [Sensu EC2 Discovery Plugin][3] with no flags:
 sensuctl command install sensu-ec2-discovery portertech/sensu-ec2-discovery:0.3.0
 {{< /code >}}
 
-**To install a command from a URL**, replace `<archive_url>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
-Replace `<archive_checksum>` with the checksum you want to use.
-Replace `<alias>` with a unique name for the command.
+**To install a command from a URL**, replace `<ARCHIVE_URL>` with a command URL that points to a tarball (for example, https://path/to/asset.tar.gz).
+Replace `<ARCHIVE_CHECKSUM>` with the checksum you want to use.
+Replace `<ALIAS>` with a unique name for the command.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command install -h` to view flags.
 Flags are optional and apply only to the `install` command &mdash; they are not saved as part of the command you are installing.
 
@@ -128,20 +130,20 @@ sensuctl command install command-test --url https://github.com/amdprophet/comman
 To execute a sensuctl command plugin via its dynamic runtime asset's bin/entrypoint executable:
 
 {{< code shell >}}
-sensuctl command exec <alias> <args> <flags>
+sensuctl command exec <ALIAS> <GLOBAL_FLAGS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
+Replace `<ALIAS>` with a unique name for the command.
 For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<GLOBAL_FLAGS>` with the globlal flags you want to use.
+Run `sensuctl command exec -h` to view global flags.
+To pass `<GLOBAL_FLAGS>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
+
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command exec -h` to view flags.
 Flags are optional and apply only to the `exec` command &mdash; they are not saved as part of the command you are executing.
-
-Replace `<args>` with the globlal flags you want to use.
-Run `sensuctl command exec -h` to view global flags.
-To pass `<args>` flags to the bin/entrypoint executable, make sure to specify them after a double dash surrounded by spaces.
 
 {{% notice note %}}
 **NOTE**: When you use `sensuctl command exec`, the [environment variables](../environment-variables) are passed to the command.
@@ -150,7 +152,7 @@ To pass `<args>` flags to the bin/entrypoint executable, make sure to specify th
 For example:
 
 {{< code shell >}}
-sensuctl command exec <command> <arg1> <arg2> --cache-dir /tmp -- --<flag1> --<flag2>=<value>
+sensuctl command exec <COMMAND> <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --cache-dir /tmp -- --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flags after the ` -- `.
@@ -158,7 +160,7 @@ Sensuctl will parse the --cache-dir flag, but bin/entrypoint will parse all flag
 In this example, the full command run by sensuctl exec would be:
 
 {{< code shell >}}
-bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
+bin/entrypoint <GLOBAL_FLAG_1> <GLOBAL_FLAG_2> --<FLAG_1> --<FLAG_2>=<value>
 {{< /code >}}
 
 ### List commands
@@ -166,10 +168,10 @@ bin/entrypoint <arg1> <arg2> --<flag1> --<flag2>=<value>
 To list installed sensuctl commands: 
 
 {{< code shell >}}
-sensuctl command list <flags>
+sensuctl command list <FLAGS>
 {{< /code >}}
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command list -h` to view flags.
 Flags are optional and apply only to the `list` command.
 
@@ -178,18 +180,18 @@ Flags are optional and apply only to the `list` command.
 To delete sensuctl commands:
 
 {{< code shell >}}
-sensuctl command delete <alias> <flags>
+sensuctl command delete <ALIAS> <FLAGS>
 {{< /code >}}
 
-Replace `<alias>` with a unique name for the command.
-For example, for the [Sensu EC2 Discovery Plugin][3], you might use the alias `sensu-ec2-discovery`. 
-`<alias>` is required.
+Replace `<ALIAS>` with a unique name for the command.
+For example, for the [sensu/sensu-ec2-handler][3], you might use the alias `sensu-ec2-handler`. 
+`<ALIAS>` is required.
 
-Replace `<flags>` with the flags you want to use.
+Replace `<FLAGS>` with the flags you want to use.
 Run `sensuctl command delete -h` to view flags.
 Flags are optional and apply only to the `delete` command.
 
 
 [1]: https://bonsai.sensu.io/
-[3]: https://bonsai.sensu.io/assets/portertech/sensu-ec2-discovery
+[3]: https://bonsai.sensu.io/assets/sensu/sensu-ec2-handler
 [4]: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler


### PR DESCRIPTION
## Description
Standardizes references to asset names(removes mention of the Bonsai namespace as separate from the name; uses `sensu/asset_name` as the linked or reference text for all assets) throughout the docs.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3915

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>