### PR TITLE
Add links and Catalog info in plugins and asset docs

### DIFF
--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -1258,7 +1258,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+Delete dynamic runtime assets with a DELETE request to the [`/assets` API endpoint][47] or with the [`sensuctl asset delete` command][48].
 
 Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
@@ -1313,3 +1313,5 @@ You must remove the archive and downloaded files from the asset cache manually.
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1
 [46]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage
+[47]: ../../api/core/assets/
+[48]: ../../sensuctl/create-manage-resources/#delete-resources

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -1258,7 +1258,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+Delete dynamic runtime assets with a DELETE request to the [`/assets` API endpoint][47] or with the [`sensuctl asset delete` command][48].
 
 Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
@@ -1313,3 +1313,5 @@ You must remove the archive and downloaded files from the asset cache manually.
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1
 [46]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage
+[47]: ../../api/core/assets/
+[48]: ../../sensuctl/create-manage-resources/#delete-resources

--- a/content/sensu-go/6.6/plugins/assets.md
+++ b/content/sensu-go/6.6/plugins/assets.md
@@ -1258,7 +1258,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+Delete dynamic runtime assets with a DELETE request to the [`/assets` API endpoint][47] or with the [`sensuctl asset delete` command][48].
 
 Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
@@ -1313,3 +1313,5 @@ You must remove the archive and downloaded files from the asset cache manually.
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1
 [46]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage
+[47]: ../../api/core/assets/
+[48]: ../../sensuctl/create-manage-resources/#delete-resources

--- a/content/sensu-go/6.7/get-started.md
+++ b/content/sensu-go/6.7/get-started.md
@@ -20,7 +20,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 - [**Install Sensu Go**][2] with a commercial package and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100
 - Find the [Sensu architecture][18] that best meets your needs
-- Discover Sensu dynamic runtime assets for deploying plugins on [Bonsai, the Sensu asset hub][6]
+- Discover Sensu dynamic runtime assets for deploying plugins in the [Sensu Catalog][23] and [Bonsai, the Sensu asset hub][6]
 - [Migrate from Sensu Core and Sensu Enterprise to Sensu Go][13]
 
 ## Learn Sensu
@@ -74,3 +74,4 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [20]: ../platforms/
 [21]: https://sensu.io/learn
 [22]: ../observability-pipeline/
+[23]: ../web-ui/sensu-catalog/

--- a/content/sensu-go/6.7/plugins/_index.md
+++ b/content/sensu-go/6.7/plugins/_index.md
@@ -19,7 +19,10 @@ Each plugin has self-contained documentation with in-depth information about how
 
 ## Find Sensu plugins
 
-Search [Bonsai, the Sensu asset hub][2], to find Sensu plugins.
+Use the [Sensu Catalog][10] to find and enable many plugins directly from your browser.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+
+To find many more available Sensu plugins, search [Bonsai, the Sensu asset hub][2].
 Bonsai lists hundreds of Sensu plugins with installation instructions and usage examples.
 
 We also list popular Sensu plugins in the [featured integrations][3] section.
@@ -46,3 +49,4 @@ Sensu allows you to bring new life to the 50+ plugins in the official [Nagios Pl
 [7]: https://exchange.nagios.org/
 [8]: https://github.com/sensu-plugins/community
 [9]: https://github.com/sensu-community/sensu-plugin-sdk
+[10]: ../web-ui/sensu-catalog/

--- a/content/sensu-go/6.7/plugins/assets.md
+++ b/content/sensu-go/6.7/plugins/assets.md
@@ -17,7 +17,10 @@ Dynamic runtime assets are shareable, reusable packages that make it easier to d
 You can use dynamic runtime assets to provide the plugins, libraries, and runtimes you need to automate your monitoring workflows.
 Sensu supports dynamic runtime assets for [checks][6], [filters][7], [mutators][8], and [handlers][9].
 
-You can discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
+Use the [Sensu Catalog][33] to find, configure, and install many dynamic runtime assets directly from your browser.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+
+You can also discover, download, and share dynamic runtime assets using [Bonsai, the Sensu asset hub][16].
 Read [Use assets to install plugins][23] to get started.
 
 {{% notice note %}}
@@ -1258,7 +1261,7 @@ example      | {{< code yml >}}
 
 ## Delete dynamic runtime assets
 
-Delete dynamic runtime assets with a DELETE request to the `/assets` API endpoint or with the `sensuctl asset delete` command.
+Delete dynamic runtime assets with a DELETE request to the [`/assets` API endpoint][47] or with the [`sensuctl asset delete` command][48].
 
 Removing a dynamic runtime asset from Sensu *does not* remove references to the deleted asset in any other resource (including checks, filters, mutators, handlers, and hooks).
 You must also update resources and remove any reference to the deleted dynamic runtime asset.
@@ -1303,6 +1306,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [30]: ../../observability-pipeline/observe-schedule/agent#disable-assets
 [31]: ../../platforms/#docker-images
 [32]: ../../platforms/#supported-packages
+[33]: ../../web-ui/sensu-catalog/
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../web-ui/search#search-for-labels
@@ -1313,3 +1317,5 @@ You must remove the archive and downloaded files from the asset cache manually.
 [44]: https://devblogs.microsoft.com/oldnewthing/20060823-00/?p=29993
 [45]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1
 [46]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage
+[47]: ../../api/core/assets/
+[48]: ../../sensuctl/create-manage-resources/#delete-resources

--- a/content/sensu-go/6.7/plugins/install-plugins.md
+++ b/content/sensu-go/6.7/plugins/install-plugins.md
@@ -15,18 +15,18 @@ Extend Sensu's functionality with plugins, which provide executables for perform
 ## Install plugins with dynamic runtime assets
 
 Dynamic runtime assets are shareable, reusable packages that make it easier to deploy Sensu plugins.
-To start using and deploying assets, read [Use dynamic runtime assets to install plugins][7] to become familiar with workflows that involve assets.
+Read [Use dynamic runtime assets to install plugins][7] to become familiar with workflows that involve assets.
 
 {{% notice note %}}
 **NOTE**: Dynamic runtime assets are not required to use Sensu Go.
 You can install Sensu plugins using the [sensu-install](#install-plugins-with-the-sensu-install-tool) tool or a [configuration management](../../operations/deploy-sensu/configuration-management/) solution.
 {{% /notice %}}
 
-## Use Bonsai, the Sensu asset hub
+Use the [Sensu Catalog][10] to find, configure, and install many plugins directly from your browser.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
 
-[Bonsai, the Sensu asset hub][8], is a centralized place for downloading and sharing dynamic runtime assets.
-Make Bonsai your first stop when you need to find an asset.
-Bonsai includes plugins, libraries, and runtimes you need to automate your monitoring workflows.
+You can also use [Bonsai, the Sensu asset hub][8], a centralized place for downloading and sharing dynamic runtime assets.
+Bonsai lists hundreds of plugins, libraries, and runtimes with instructions and examples to help you automate your monitoring workflows.
 You can also [share your asset on Bonsai][9].
 
 ## Install plugins with the sensu-install tool
@@ -139,3 +139,4 @@ sudo yum groupinstall "Development Tools"
 [7]: ../use-assets-to-install-plugins/
 [8]: https://bonsai.sensu.io/
 [9]: ../assets#share-an-asset-on-bonsai
+[10]: ../../web-ui/sensu-catalog/


### PR DESCRIPTION
## Description
- Adds links to other helpful info in the asset reference.
- Adds Catalog info and links in several docs in the plugins category.
- Adds Catalog info to the get started page.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3922

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>