### PR TITLE
Add Sensu Catalog tip to Jira, Saltstack, and ServiceNow integration pages

### DIFF
--- a/content/sensu-go/6.7/plugins/featured-integrations/jira.md
+++ b/content/sensu-go/6.7/plugins/featured-integrations/jira.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 
 The [Sensu Jira Handler plugin][4] is a Sensu [handler][1] that creates and updates Jira issues based on observation data from Sensu events.
 
-{{% notice note %}}
-**NOTE**: The Sensu Jira Handler plugin is an example of Sensu's alerting and incident management integrations.
-To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
+{{% notice protip %}}
+**PRO TIP**: Use the [Sensu Catalog](../../../web-ui/sensu-catalog/) to enable this integration directly from your browser.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
 {{% /notice %}}
 
 ## Features

--- a/content/sensu-go/6.7/plugins/featured-integrations/saltstack.md
+++ b/content/sensu-go/6.7/plugins/featured-integrations/saltstack.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 
 The [Sensu SaltStack Handler plugin][4] is a Sensu [handler][1] that launches SaltStack functions for automated remediation based on Sensu event data.
 
-{{% notice note %}}
-**NOTE**: The Sensu SaltStack Handler plugin is an example of Sensu's auto-remediation integrations.
-To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
+{{% notice protip %}}
+**PRO TIP**: Use the [Sensu Catalog](../../../web-ui/sensu-catalog/) to enable this integration directly from your browser.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
 {{% /notice %}}
 
 ## Features

--- a/content/sensu-go/6.7/plugins/featured-integrations/servicenow.md
+++ b/content/sensu-go/6.7/plugins/featured-integrations/servicenow.md
@@ -16,9 +16,9 @@ For more information, read [Get started with commercial features](../../../comme
 
 The [Sensu ServiceNow Handler plugin][4] is a Sensu [handler][1] that creates and updates ServiceNow incidents and events based on observation data from Sensu events.
 
-{{% notice note %}}
-**NOTE**: The Sensu ServiceNow Handler plugin is an example of Sensu's alerting and incident management integrations.
-To find more integrations, search [Bonsai, the Sensu asset hub](https://bonsai.sensu.io/).
+{{% notice protip %}}
+**PRO TIP**: Use the [Sensu Catalog](../../../web-ui/sensu-catalog/) to enable this integration directly from your browser.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
 {{% /notice %}}
 
 ## Features


### PR DESCRIPTION
## Description
Adds the note about using the Sensu Catalog to the Jira, Saltstack, and ServiceNow pages in the Featured integrations subcategories.

## Motivation and Context
New integrations added

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>