### PR TITLE
Add missing rows in subdues attribute description table

### DIFF
--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
@@ -1675,6 +1675,8 @@ subdue: null
 |subdues     |      |
 -------------|------
 description  | Specific periods of time when Sensu should not send alerts based on the events the check produces. Use to schedule alert-free periods of time, such as during sleeping hours, weekends, or special maintenance periods. Read [subdues attributes][83] for more information.
+required     | false
+type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 subdues:


### PR DESCRIPTION
## Description
Adds missing rows for `required` and `type` in the subdues attribute description table in the check reference.

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>