### PR TITLE
6.7.3: Add missing link for check scope in release notes

### DIFF
--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -2432,3 +2432,4 @@ To get started with Sensu Go:
 [288]: /sensu-go/6.7/web-ui/view-manage-resources/webconfig-reference/#sign-in-message
 [289]: /sensu-go/6.7/web-ui/sensu-catalog/#duplicate-integrations-and-existing-resources
 [290]: /sensu-go/6.7/web-ui/sensu-catalog/
+[291]: /sensu-go/6.7/observability-pipeline/observe-events/events/#check-scope


### PR DESCRIPTION
## Description
I forgot to add the link for the check scope in the 6.7.3 release notes

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>