### PR TITLE
Standardize plural usage for reference titles

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -1,6 +1,6 @@
 ---
-title: "Entity reference"
-linkTitle: "Entity Reference"
+title: "Entities reference"
+linkTitle: "Entities Reference"
 reference_title: "Entities"
 type: "reference"
 description: "Read this reference to learn about Sensu entities, which represent anything that needs to be monitored, including a full range of apps and infrastructure."

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -1,6 +1,6 @@
 ---
-title: "Event filter reference"
-linkTitle: "Event Filter Reference"
+title: "Event filters reference"
+linkTitle: "Event Filters Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -661,7 +661,7 @@ Now when the `check_cpu` check generates an incident, Sensu will filter the even
 ### Entities
 
 You can also specify contacts using an entity label.
-For more information about managing entity labels, read the [entity reference][10].
+For more information about managing entity labels, read the [entities reference][10].
 
 If contact labels are present in both the check and entity, the check contacts override the entity contacts.
 In this example, the `dev` label in the check configuration overrides the `ops` label in the agent definition, resulting in an alert sent to #<ALERT_DEV> but not to #<ALERT_OPS> or #<ALERT_ALL>.

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -119,7 +119,7 @@ Read the [subscriptions reference][28] for more information.
 Sensu proxy entities allow Sensu to monitor external resources on systems or devices where a Sensu agent cannot be installed (such a network switch).
 The [Sensu backend][2] stores proxy entity definitions (unlike agent entities, which the agent stores).
 When the backend requests a check that includes a [`proxy_entity_name`][32], the agent includes the provided entity information in the observation data in events in place of the agent entity data.
-read the [entity reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
+read the [entities reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
 
 ## Create observability events using the agent API
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/checks.md
@@ -441,7 +441,7 @@ Combine `proxy_requests` attributes with with [token substitution][39] as shown 
 The following proxy check runs every 60 seconds, cycling through the agents with the `run_proxies` subscription alphabetically according to the agent name, for all existing proxy entities with the custom label `proxy_type` set to `website`.
 
 This check uses [token substitution][39] to import the value of the custom entity label `url` to complete the check command.
-Read the [entity reference][40] for information about adding custom labels to entities.
+Read the [entities reference][40] for information about adding custom labels to entities.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/tokens.md
@@ -221,7 +221,7 @@ After you save your changes, for this entity, the hook will substitute the direc
 ## Manage entity labels
 
 You can use token substitution with any defined [entity attributes][4], including custom labels.
-read the [entity reference][6] for information about managing entity labels for proxy entities and agent entities.
+read the [entities reference][6] for information about managing entity labels for proxy entities and agent entities.
 
 ## Manage dynamic runtime assets
 

--- a/content/sensu-go/6.4/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ad-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Active Directory (AD) reference"
-linktitle: "AD Reference"
+linkTitle: "AD Reference"
 reference_title: "Active Directory (AD)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Microsoft Active Directory (AD)."

--- a/content/sensu-go/6.4/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/ldap-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Lightweight Directory Access Protocol (LDAP) reference"
-linktitle: "LDAP Reference"
+linkTitle: "LDAP Reference"
 reference_title: "Lightweight Directory Access Protocol (LDAP)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Lightweight Directory Access Protocol (LDAP)."

--- a/content/sensu-go/6.4/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.4/operations/control-access/oidc-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenID Connect 1.0 protocol (OIDC) reference"
-linktitle: "OIDC Reference"
+linkTitle: "OIDC Reference"
 reference_title: "OpenID Connect 1.0 protocol (OIDC)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using OpenID Connect 1.0 protocol (OIDC)."

--- a/content/sensu-go/6.4/operations/control-access/sso.md
+++ b/content/sensu-go/6.4/operations/control-access/sso.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure single sign-on (SSO) authentication"
-linktitle: "Configure SSO Authentication"
+linkTitle: "Configure SSO Authentication"
 description: "Configure single sign-on (SSO) auth for Sensu with Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC)."
 weight: 10
 version: "6.4"

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -98,7 +98,7 @@ Clients are represented within Sensu Go as abstract [entities][96] that can desc
 Sensu Go includes [agent entities][92] that run a Sensu agent and the familiar [proxy entities][93].
 Sensu Go also includes [service entities][94], which represent business services in the [business service monitoring (BSM)][95] feature.
 
-Read the [entity reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
+Read the [entities reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
 
 ## Checks
 
@@ -333,7 +333,7 @@ Read the [guide to metric output][57] to update your metric checks with the `out
 **Translate proxy requests and proxy entities**
 
 Read [Monitor external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
-read the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
+read the [entities reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
 <a id="translate-hooks"></a>
 
@@ -357,7 +357,7 @@ Ruby eval logic used in Sensu Core filters is replaced with JavaScript expressio
 As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used.
-Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
+Then, follow the [event filters reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
 Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
 Sensu Core hourly filter:

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -1,6 +1,6 @@
 ---
-title: "Entity reference"
-linkTitle: "Entity Reference"
+title: "Entities reference"
+linkTitle: "Entities Reference"
 reference_title: "Entities"
 type: "reference"
 description: "Read this reference to learn about Sensu entities, which represent anything that needs to be monitored, including a full range of apps and infrastructure."

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -1,6 +1,6 @@
 ---
-title: "Event filter reference"
-linkTitle: "Event Filter Reference"
+title: "Event filters reference"
+linkTitle: "Event Filters Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -783,7 +783,7 @@ Now when the `check_cpu` check generates an event, Sensu will filter the event a
 
 You can specify contacts in entity labels instead of in check labels.
 The check definition should still include the pipeline.
-For more information about managing entity labels, read the [entity reference][10].
+For more information about managing entity labels, read the [entities reference][10].
 
 If contact labels are present in both the check and entity, the check contacts override the entity contacts.
 In this example, the `dev` label in the check configuration overrides the `ops` label in the agent definition, resulting in an alert sent to #dev but not to #ops or #fallback:

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -61,7 +61,7 @@ Now that you know how to feed StatsD metrics into Sensu, check out these resourc
 
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
 * [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
-* [Pipeline reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
+* [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/pipelines.md
@@ -1,7 +1,7 @@
 ---
-title: "Pipeline reference"
-linkTitle: "Pipeline Reference"
-reference_title: "Pipeline"
+title: "Pipelines reference"
+linkTitle: "Pipelines Reference"
+reference_title: "Pipelines"
 type: "reference"
 description: "Pipelines are observation event processing workflows made up of filters, mutators, and handlers. Read the reference doc to learn about pipelines."
 weight: 40

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -447,7 +447,7 @@ Replace the `pipelines: []` line with the following array:
     name: sensu_to_sumo
 {{< /code >}}
 
-To confirm that the updated `check_cpu` resource definition includes the pipeline reference, run:
+To confirm that the updated `check_cpu` resource definition includes the pipelines reference, run:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-email-alerts.md
@@ -407,7 +407,7 @@ Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Learn how to use the event filter, handler, and pipeline resources you created to start developing a [monitoring as code][15] repository.
-- Read the [pipeline reference][6] for in-depth pipeline documentation.
+- Read the [pipelines reference][6] for in-depth pipeline documentation.
 - Check out [Route alerts with event filters][7] for a complex pipeline example that includes several workflows with different event filters and handlers.
 
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -467,7 +467,7 @@ Adding the is_incident filter to your pipeline should quickly reduce the number 
 
 ## Next steps
 
-Now that you know how to apply a pipeline to a check and take action on events, read the [pipeline reference][8] for in-depth documentation.
+Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
 For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -230,7 +230,7 @@ Proxy entities allow Sensu to monitor external resources on systems or devices w
 The [Sensu backend][2] stores proxy entity definitions (unlike agent entities, which the agent stores).
 When the backend requests a check that includes a [`proxy_entity_name`][32], the agent includes the provided entity information in the observation data in events in place of the agent entity data.
 
-Read the [entity reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
+Read the [entities reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
 
 ## Create observability events using the agent API
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/checks.md
@@ -441,7 +441,7 @@ Combine `proxy_requests` attributes with with [token substitution][39] as shown 
 The following proxy check runs every 60 seconds, cycling through the agents with the `run_proxies` subscription alphabetically according to the agent name, for all existing proxy entities with the custom label `proxy_type` set to `website`.
 
 This check uses [token substitution][39] to import the value of the custom entity label `url` to complete the check command.
-Read the [entity reference][40] for information about adding custom labels to entities.
+Read the [entities reference][40] for information about adding custom labels to entities.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -453,7 +453,7 @@ If you add the debug handler and configure the `collect-metrics` check to use it
 Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
 For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
 
-Read the [pipeline reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+Read the [pipelines reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 You can also learn to use Sensu to [collect Prometheus metrics][14].
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -1089,7 +1089,7 @@ Use [Bonsai][8], the Sensu asset hub, to discover, download, and share dynamic r
 
 To handle both metrics and status events without applying conditional filter logic, configure a pipeline with different workflows for metrics and status.
 The events reference includes an [example event with check and metric data][20].
-Read the [pipeline reference][27] for more information about configuring a pipeline with multiple workflows.
+Read the [pipelines reference][27] for more information about configuring a pipeline with multiple workflows.
 
 You do not need to add a mutator to your check definition to process metrics with an event handler.
 The [metrics attribute][5] format automatically reduces metrics data complexity so event handlers can process metrics effectively.

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -522,7 +522,7 @@ Or, learn how to [monitor external resources with proxy checks and entities][5].
 
 You can also create [pipelines][10] to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
 
-Read the [pipeline reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 
 [1]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/tokens.md
@@ -221,7 +221,7 @@ After you save your changes, for this entity, the hook will substitute the direc
 ## Manage entity labels
 
 You can use token substitution with any defined [entity attributes][4], including custom labels.
-read the [entity reference][6] for information about managing entity labels for proxy entities and agent entities.
+read the [entities reference][6] for information about managing entity labels for proxy entities and agent entities.
 
 ## Manage dynamic runtime assets
 

--- a/content/sensu-go/6.5/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.5/operations/control-access/ad-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Active Directory (AD) reference"
-linktitle: "AD Reference"
+linkTitle: "AD Reference"
 reference_title: "Active Directory (AD)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Microsoft Active Directory (AD)."

--- a/content/sensu-go/6.5/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.5/operations/control-access/ldap-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Lightweight Directory Access Protocol (LDAP) reference"
-linktitle: "LDAP Reference"
+linkTitle: "LDAP Reference"
 reference_title: "Lightweight Directory Access Protocol (LDAP)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Lightweight Directory Access Protocol (LDAP)."

--- a/content/sensu-go/6.5/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.5/operations/control-access/oidc-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenID Connect 1.0 protocol (OIDC) reference"
-linktitle: "OIDC Reference"
+linkTitle: "OIDC Reference"
 reference_title: "OpenID Connect 1.0 protocol (OIDC)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using OpenID Connect 1.0 protocol (OIDC)."

--- a/content/sensu-go/6.5/operations/control-access/sso.md
+++ b/content/sensu-go/6.5/operations/control-access/sso.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure single sign-on (SSO) authentication"
-linktitle: "Configure SSO Authentication"
+linkTitle: "Configure SSO Authentication"
 description: "Configure single sign-on (SSO) auth for Sensu with Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC)."
 weight: 10
 version: "6.5"

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -98,7 +98,7 @@ Clients are represented within Sensu Go as abstract [entities][96] that can desc
 Sensu Go includes [agent entities][92] that run a Sensu agent and the familiar [proxy entities][93].
 Sensu Go also includes [service entities][94], which represent business services in the [business service monitoring (BSM)][95] feature.
 
-Read the [entity reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
+Read the [entities reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
 
 ## Checks
 
@@ -335,7 +335,7 @@ Read the [guide to metric output][57] to update your metric checks with the `out
 **Translate proxy requests and proxy entities**
 
 Read [Monitor external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
-read the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
+read the [entities reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
 <a id="translate-hooks"></a>
 
@@ -359,7 +359,7 @@ Ruby eval logic used in Sensu Core filters is replaced with JavaScript expressio
 As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used.
-Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
+Then, follow the [event filters reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
 Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
 Sensu Core hourly filter:

--- a/content/sensu-go/6.5/sensu-plus.md
+++ b/content/sensu-go/6.5/sensu-plus.md
@@ -166,7 +166,7 @@ With your handler definition configured, you’re ready to create a [pipeline][8
 
 {{% notice note %}}
 **NOTE**: Sensu pipelines use event filters, mutators, and handlers as the building blocks for event processing workflows.
-Read the [pipeline reference](../observability-pipeline/observe-process/pipelines/) for detailed information about pipelines.
+Read the [pipelines reference](../observability-pipeline/observe-process/pipelines/) for detailed information about pipelines.
 {{% /notice %}}
 
 To configure event processing via your sumo_logic_http_metrics handler, add this example pipeline definition.

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -1,6 +1,6 @@
 ---
-title: "Entity reference"
-linkTitle: "Entity Reference"
+title: "Entities reference"
+linkTitle: "Entities Reference"
 reference_title: "Entities"
 type: "reference"
 description: "Read this reference to learn about Sensu entities, which represent anything that needs to be monitored, including a full range of apps and infrastructure."

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -1,6 +1,6 @@
 ---
-title: "Event filter reference"
-linkTitle: "Event Filter Reference"
+title: "Event filters reference"
+linkTitle: "Event Filters Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
@@ -783,7 +783,7 @@ Now when the `check_cpu` check generates an event, Sensu will filter the event a
 
 You can specify contacts in entity labels instead of in check labels.
 The check definition should still include the pipeline.
-For more information about managing entity labels, read the [entity reference][10].
+For more information about managing entity labels, read the [entities reference][10].
 
 If contact labels are present in both the check and entity, the check contacts override the entity contacts.
 In this example, the `dev` label in the check configuration overrides the `ops` label in the agent definition, resulting in an alert sent to #dev but not to #ops or #fallback:

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -61,7 +61,7 @@ Now that you know how to feed StatsD metrics into Sensu, check out these resourc
 
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
 * [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
-* [Pipeline reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
+* [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
@@ -1,7 +1,7 @@
 ---
-title: "Pipeline reference"
-linkTitle: "Pipeline Reference"
-reference_title: "Pipeline"
+title: "Pipelines reference"
+linkTitle: "Pipelines Reference"
+reference_title: "Pipelines"
 type: "reference"
 description: "Pipelines are observation event processing workflows made up of filters, mutators, and handlers. Read the reference doc to learn about pipelines."
 weight: 40

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -447,7 +447,7 @@ Replace the `pipelines: []` line with the following array:
     name: sensu_to_sumo
 {{< /code >}}
 
-To confirm that the updated `check_cpu` resource definition includes the pipeline reference, run:
+To confirm that the updated `check_cpu` resource definition includes the pipelines reference, run:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-email-alerts.md
@@ -407,7 +407,7 @@ Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Learn how to use the event filter, handler, and pipeline resources you created to start developing a [monitoring as code][15] repository.
-- Read the [pipeline reference][6] for in-depth pipeline documentation.
+- Read the [pipelines reference][6] for in-depth pipeline documentation.
 - Check out [Route alerts with event filters][7] for a complex pipeline example that includes several workflows with different event filters and handlers.
 
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -467,7 +467,7 @@ Adding the is_incident filter to your pipeline should quickly reduce the number 
 
 ## Next steps
 
-Now that you know how to apply a pipeline to a check and take action on events, read the [pipeline reference][8] for in-depth documentation.
+Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
 For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -230,7 +230,7 @@ Proxy entities allow Sensu to monitor external resources on systems or devices w
 The [Sensu backend][2] stores proxy entity definitions (unlike agent entities, which the agent stores).
 When the backend requests a check that includes a [`proxy_entity_name`][32], the agent includes the provided entity information in the observation data in events in place of the agent entity data.
 
-Read the [entity reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
+Read the [entities reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
 
 ## Create observability events using the agent API
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/checks.md
@@ -441,7 +441,7 @@ Combine `proxy_requests` attributes with with [token substitution][39] as shown 
 The following proxy check runs every 60 seconds, cycling through the agents with the `run_proxies` subscription alphabetically according to the agent name, for all existing proxy entities with the custom label `proxy_type` set to `website`.
 
 This check uses [token substitution][39] to import the value of the custom entity label `url` to complete the check command.
-Read the [entity reference][40] for information about adding custom labels to entities.
+Read the [entities reference][40] for information about adding custom labels to entities.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -453,7 +453,7 @@ If you add the debug handler and configure the `collect-metrics` check to use it
 Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
 For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
 
-Read the [pipeline reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+Read the [pipelines reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 You can also learn to use Sensu to [collect Prometheus metrics][14].
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -1089,7 +1089,7 @@ Use [Bonsai][8], the Sensu asset hub, to discover, download, and share dynamic r
 
 To handle both metrics and status events without applying conditional filter logic, configure a pipeline with different workflows for metrics and status.
 The events reference includes an [example event with check and metric data][20].
-Read the [pipeline reference][27] for more information about configuring a pipeline with multiple workflows.
+Read the [pipelines reference][27] for more information about configuring a pipeline with multiple workflows.
 
 You do not need to add a mutator to your check definition to process metrics with an event handler.
 The [metrics attribute][5] format automatically reduces metrics data complexity so event handlers can process metrics effectively.

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -522,7 +522,7 @@ Or, learn how to [monitor external resources with proxy checks and entities][5].
 
 You can also create [pipelines][10] to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
 
-Read the [pipeline reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 
 [1]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/tokens.md
@@ -221,7 +221,7 @@ After you save your changes, for this entity, the hook will substitute the direc
 ## Manage entity labels
 
 You can use token substitution with any defined [entity attributes][4], including custom labels.
-read the [entity reference][6] for information about managing entity labels for proxy entities and agent entities.
+read the [entities reference][6] for information about managing entity labels for proxy entities and agent entities.
 
 ## Manage dynamic runtime assets
 

--- a/content/sensu-go/6.6/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ad-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Active Directory (AD) reference"
-linktitle: "AD Reference"
+linkTitle: "AD Reference"
 reference_title: "Active Directory (AD)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Microsoft Active Directory (AD)."

--- a/content/sensu-go/6.6/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ldap-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Lightweight Directory Access Protocol (LDAP) reference"
-linktitle: "LDAP Reference"
+linkTitle: "LDAP Reference"
 reference_title: "Lightweight Directory Access Protocol (LDAP)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Lightweight Directory Access Protocol (LDAP)."

--- a/content/sensu-go/6.6/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/oidc-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenID Connect 1.0 protocol (OIDC) reference"
-linktitle: "OIDC Reference"
+linkTitle: "OIDC Reference"
 reference_title: "OpenID Connect 1.0 protocol (OIDC)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using OpenID Connect 1.0 protocol (OIDC)."

--- a/content/sensu-go/6.6/operations/control-access/sso.md
+++ b/content/sensu-go/6.6/operations/control-access/sso.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure single sign-on (SSO) authentication"
-linktitle: "Configure SSO Authentication"
+linkTitle: "Configure SSO Authentication"
 description: "Configure single sign-on (SSO) auth for Sensu with Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC)."
 weight: 10
 version: "6.6"

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -98,7 +98,7 @@ Clients are represented within Sensu Go as abstract [entities][96] that can desc
 Sensu Go includes [agent entities][92] that run a Sensu agent and the familiar [proxy entities][93].
 Sensu Go also includes [service entities][94], which represent business services in the [business service monitoring (BSM)][95] feature.
 
-Read the [entity reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
+Read the [entities reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
 
 ## Checks
 
@@ -335,7 +335,7 @@ Read the [guide to metric output][57] to update your metric checks with the `out
 **Translate proxy requests and proxy entities**
 
 Read [Monitor external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
-read the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
+read the [entities reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
 <a id="translate-hooks"></a>
 
@@ -359,7 +359,7 @@ Ruby eval logic used in Sensu Core filters is replaced with JavaScript expressio
 As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used.
-Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
+Then, follow the [event filters reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
 Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
 Sensu Core hourly filter:

--- a/content/sensu-go/6.6/sensu-plus.md
+++ b/content/sensu-go/6.6/sensu-plus.md
@@ -166,7 +166,7 @@ With your handler definition configured, you’re ready to create a [pipeline][8
 
 {{% notice note %}}
 **NOTE**: Sensu pipelines use event filters, mutators, and handlers as the building blocks for event processing workflows.
-Read the [pipeline reference](../observability-pipeline/observe-process/pipelines/) for detailed information about pipelines.
+Read the [pipelines reference](../observability-pipeline/observe-process/pipelines/) for detailed information about pipelines.
 {{% /notice %}}
 
 To configure event processing via your sumo_logic_http_metrics handler, add this example pipeline definition.

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
@@ -1,6 +1,6 @@
 ---
-title: "Entity reference"
-linkTitle: "Entity Reference"
+title: "Entities reference"
+linkTitle: "Entities Reference"
 reference_title: "Entities"
 type: "reference"
 description: "Read this reference to learn about Sensu entities, which represent anything that needs to be monitored, including a full range of apps and infrastructure."

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -1,6 +1,6 @@
 ---
-title: "Event filter reference"
-linkTitle: "Event Filter Reference"
+title: "Event filters reference"
+linkTitle: "Event Filters Reference"
 reference_title: "Event filters"
 type: "reference"
 description: "Read this reference to use Sensu's built-in event filters (or create your own) to control which events Sensu handlers will take action on."

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
@@ -783,7 +783,7 @@ Now when the `check_cpu` check generates an event, Sensu will filter the event a
 
 You can specify contacts in entity labels instead of in check labels.
 The check definition should still include the pipeline.
-For more information about managing entity labels, read the [entity reference][10].
+For more information about managing entity labels, read the [entities reference][10].
 
 If contact labels are present in both the check and entity, the check contacts override the entity contacts.
 In this example, the `dev` label in the check configuration overrides the `ops` label in the agent definition, resulting in an alert sent to #dev but not to #ops or #fallback:

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -61,7 +61,7 @@ Now that you know how to feed StatsD metrics into Sensu, check out these resourc
 
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
 * [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
-* [Pipeline reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
+* [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
@@ -1,7 +1,7 @@
 ---
-title: "Pipeline reference"
-linkTitle: "Pipeline Reference"
-reference_title: "Pipeline"
+title: "Pipelines reference"
+linkTitle: "Pipelines Reference"
+reference_title: "Pipelines"
 type: "reference"
 description: "Pipelines are observation event processing workflows made up of filters, mutators, and handlers. Read the reference doc to learn about pipelines."
 weight: 40

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -447,7 +447,7 @@ Replace the `pipelines: []` line with the following array:
     name: sensu_to_sumo
 {{< /code >}}
 
-To confirm that the updated `check_cpu` resource definition includes the pipeline reference, run:
+To confirm that the updated `check_cpu` resource definition includes the pipelines reference, run:
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
@@ -407,7 +407,7 @@ Now that you know how to apply a handler to a check and take action on events:
 
 - Reuse this email handler with the `check_cpu` check from our [Monitor server resources][2] guide.
 - Learn how to use the event filter, handler, and pipeline resources you created to start developing a [monitoring as code][15] repository.
-- Read the [pipeline reference][6] for in-depth pipeline documentation.
+- Read the [pipelines reference][6] for in-depth pipeline documentation.
 - Check out [Route alerts with event filters][7] for a complex pipeline example that includes several workflows with different event filters and handlers.
 
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
@@ -467,7 +467,7 @@ Adding the is_incident filter to your pipeline should quickly reduce the number 
 
 ## Next steps
 
-Now that you know how to apply a pipeline to a check and take action on events, read the [pipeline reference][8] for in-depth documentation.
+Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
 For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -257,7 +257,7 @@ Proxy entities allow Sensu to monitor external resources on systems or devices w
 The [Sensu backend][2] stores proxy entity definitions (unlike agent entities, which the agent stores).
 When the backend requests a check that includes a [`proxy_entity_name`][32], the agent includes the provided entity information in the observation data in events in place of the agent entity data.
 
-Read the [entity reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
+Read the [entities reference][3] and [Monitor external resources][33] for more information about monitoring proxy entities.
 
 ## Create observability events using the agent API
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/checks.md
@@ -441,7 +441,7 @@ Combine `proxy_requests` attributes with with [token substitution][39] as shown 
 The following proxy check runs every 60 seconds, cycling through the agents with the `run_proxies` subscription alphabetically according to the agent name, for all existing proxy entities with the custom label `proxy_type` set to `website`.
 
 This check uses [token substitution][39] to import the value of the custom entity label `url` to complete the check command.
-Read the [entity reference][40] for information about adding custom labels to entities.
+Read the [entities reference][40] for information about adding custom labels to entities.
 
 {{< language-toggle >}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -453,7 +453,7 @@ If you add the debug handler and configure the `collect-metrics` check to use it
 Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
 For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
 
-Read the [pipeline reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+Read the [pipelines reference][15] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 You can also learn to use Sensu to [collect Prometheus metrics][14].
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
@@ -1396,7 +1396,7 @@ Use [Bonsai][8], the Sensu asset hub, to discover, download, and share dynamic r
 
 To handle both metrics and status events without applying conditional filter logic, configure a pipeline with different workflows for metrics and status.
 The events reference includes an [example event with check and metric data][20].
-Read the [pipeline reference][27] for more information about configuring a pipeline with multiple workflows.
+Read the [pipelines reference][27] for more information about configuring a pipeline with multiple workflows.
 
 You do not need to add a mutator to your check definition to process metrics with an event handler.
 The [metrics attribute][5] format automatically reduces metrics data complexity so event handlers can process metrics effectively.

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -522,7 +522,7 @@ Or, learn how to [monitor external resources with proxy checks and entities][5].
 
 You can also create [pipelines][10] to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
 
-Read the [pipeline reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
+Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 
 [1]: https://bonsai.sensu.io/assets/sensu/check-cpu-usage

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/tokens.md
@@ -221,7 +221,7 @@ After you save your changes, for this entity, the hook will substitute the direc
 ## Manage entity labels
 
 You can use token substitution with any defined [entity attributes][4], including custom labels.
-read the [entity reference][6] for information about managing entity labels for proxy entities and agent entities.
+read the [entities reference][6] for information about managing entity labels for proxy entities and agent entities.
 
 ## Manage dynamic runtime assets
 

--- a/content/sensu-go/6.7/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ad-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Active Directory (AD) reference"
-linktitle: "AD Reference"
+linkTitle: "AD Reference"
 reference_title: "Active Directory (AD)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Microsoft Active Directory (AD)."

--- a/content/sensu-go/6.7/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ldap-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "Lightweight Directory Access Protocol (LDAP) reference"
-linktitle: "LDAP Reference"
+linkTitle: "LDAP Reference"
 reference_title: "Lightweight Directory Access Protocol (LDAP)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using Lightweight Directory Access Protocol (LDAP)."

--- a/content/sensu-go/6.7/operations/control-access/oidc-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/oidc-auth.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenID Connect 1.0 protocol (OIDC) reference"
-linktitle: "OIDC Reference"
+linkTitle: "OIDC Reference"
 reference_title: "OpenID Connect 1.0 protocol (OIDC)"
 type: "reference"
 description: "Read this reference to configure single sign-on (SSO) authentication for Sensu using OpenID Connect 1.0 protocol (OIDC)."

--- a/content/sensu-go/6.7/operations/control-access/sso.md
+++ b/content/sensu-go/6.7/operations/control-access/sso.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure single sign-on (SSO) authentication"
-linktitle: "Configure SSO Authentication"
+linkTitle: "Configure SSO Authentication"
 description: "Configure single sign-on (SSO) auth for Sensu with Lightweight Directory Access Protocol (LDAP), Active Directory (AD), or OpenID Connect 1.0 protocol (OIDC)."
 weight: 10
 version: "6.7"

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -98,7 +98,7 @@ Clients are represented within Sensu Go as abstract [entities][96] that can desc
 Sensu Go includes [agent entities][92] that run a Sensu agent and the familiar [proxy entities][93].
 Sensu Go also includes [service entities][94], which represent business services in the [business service monitoring (BSM)][95] feature.
 
-Read the [entity reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
+Read the [entities reference][6] and the guide to [monitoring external resources][7] for more information about Sensu Go entities.
 
 ## Checks
 
@@ -108,7 +108,7 @@ The Sensu backend coordinates check execution by comparing the [subscriptions][9
 ### Subdue
 
 Sensu Go checks include a `subdues` attribute that allows you to set specific periods of time when Sensu will not execute the check.
-Read [Subdues][109] in the check reference for more information and examples.
+Read [Subdues][109] in the checks reference for more information and examples.
 
 You can also use [cron scheduling][99] in Sensu Go checks to specify when checks **should** be executed.
 
@@ -337,7 +337,7 @@ Read the [guide to metric output][57] to update your metric checks with the `out
 **Translate proxy requests and proxy entities**
 
 Read [Monitor external resources][7] to re-configure `proxy_requests` attributes and update your proxy check configuration.
-read the [entity reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
+read the [entities reference][6] to re-create your proxy client configurations as Sensu Go proxy entities.
 
 <a id="translate-hooks"></a>
 
@@ -361,7 +361,7 @@ Ruby eval logic used in Sensu Core filters is replaced with JavaScript expressio
 As a result, you'll need to rewrite your Sensu Core filters in Sensu Go format.
 
 First, review your Core handlers to identify which filters are being used.
-Then, follow the [filter reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
+Then, follow the [event filters reference][9] and [guide to using filters][60] to re-write your filters using Sensu Go expressions and [event data][61].
 Check out the [blog post on filters][62] for a deep dive into Sensu Go filter capabilities.
 
 Sensu Core hourly filter:


### PR DESCRIPTION
## Description
Standardizes reference titles and link text throughout the docs to use plural (e.g. pipelines reference instead of pipeline reference)

## Motivation and Context
Noticed lack of consistency when working on something else.

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>