### PR TITLE
Add note about admin privileges for some service management commands

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -579,6 +579,10 @@ As long as the agent can successfully send one event to any backend within the t
 
 ## Service management
 
+{{% notice note %}}
+**NOTE**: Service management commands may require administrative privileges.
+{{% /notice %}}
+
 ### Start the service
 
 Use the `sensu-agent` tool to start the agent and apply configuration flags.

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1780,6 +1780,10 @@ log-level: debug
 
 ## Service management
 
+{{% notice note %}}
+**NOTE**: Service management commands may require administrative privileges.
+{{% /notice %}}
+
 ### Start the service
 
 Use the `sensu-agent` tool to start the agent and apply configuration flags.

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -1780,6 +1780,10 @@ log-level: debug
 
 ## Service management
 
+{{% notice note %}}
+**NOTE**: Service management commands may require administrative privileges.
+{{% /notice %}}
+
 ### Start the service
 
 Use the `sensu-agent` tool to start the agent and apply configuration flags.

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -1838,6 +1838,10 @@ log-level: debug
 
 ## Service management
 
+{{% notice note %}}
+**NOTE**: Service management commands may require administrative privileges.
+{{% /notice %}}
+
 ### Start the service
 
 Use the `sensu-agent` tool to start the agent and apply configuration flags.


### PR DESCRIPTION
## Description
Adds a note about needing admin privileges for some service management commands in the agent reference

## Motivation and Context
Consistency with backend reference

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>